### PR TITLE
Track and persist model information in chat sessions

### DIFF
--- a/src-tauri/src/agent.rs
+++ b/src-tauri/src/agent.rs
@@ -498,13 +498,14 @@ pub struct ChatUsage {
     pub cache_read_input_tokens: u64,
 }
 
-fn emit_usage(on_delta: &(impl Fn(&str) + Send), usage: &ChatUsage) {
+fn emit_usage(on_delta: &(impl Fn(&str) + Send), usage: &ChatUsage, model: &str) {
     emit_event(on_delta, &json!({
         "type": "usage",
         "input_tokens": usage.input_tokens,
         "output_tokens": usage.output_tokens,
         "cache_creation_input_tokens": usage.cache_creation_input_tokens,
         "cache_read_input_tokens": usage.cache_read_input_tokens,
+        "model": model,
     }));
 }
 
@@ -949,7 +950,7 @@ impl AssistantAgent {
         *self.conversation_history.lock().unwrap() = messages;
 
         // Emit accumulated usage
-        emit_usage(on_delta, &total_usage);
+        emit_usage(on_delta, &total_usage, model);
 
         Ok(collected_text)
     }
@@ -1230,7 +1231,7 @@ impl AssistantAgent {
         *self.conversation_history.lock().unwrap() = messages;
 
         // Emit accumulated usage
-        emit_usage(on_delta, &total_usage);
+        emit_usage(on_delta, &total_usage, model);
 
         Ok(collected_text)
     }
@@ -1467,7 +1468,7 @@ impl AssistantAgent {
         *self.conversation_history.lock().unwrap() = input;
 
         // Emit accumulated usage
-        emit_usage(on_delta, &total_usage);
+        emit_usage(on_delta, &total_usage, model);
 
         Ok(collected_text)
     }
@@ -1628,7 +1629,7 @@ impl AssistantAgent {
         *self.conversation_history.lock().unwrap() = input;
 
         // Emit accumulated usage
-        emit_usage(on_delta, &total_usage);
+        emit_usage(on_delta, &total_usage, model);
 
         Ok(collected_text)
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1117,19 +1117,22 @@ async fn chat(
                 let cancel_clone = cancel.clone();
                 let chat_start = std::time::Instant::now();
                 let on_event_clone = on_event.clone();
-                // Shared state to capture token usage from on_delta callback
-                let captured_tokens: Arc<std::sync::Mutex<(Option<i64>, Option<i64>)>> = Arc::new(std::sync::Mutex::new((None, None)));
-                let captured_tokens_clone = captured_tokens.clone();
+                // Shared state to capture token usage and model from on_delta callback
+                let captured_usage: Arc<std::sync::Mutex<(Option<i64>, Option<i64>, Option<String>)>> = Arc::new(std::sync::Mutex::new((None, None, None)));
+                let captured_usage_clone = captured_usage.clone();
                 let result = match agent.chat(&message, &attachments, effort_ref, cancel_clone, move |delta| {
-                    // Intercept usage events to capture token counts
+                    // Intercept usage events to capture token counts and model
                     if let Ok(event) = serde_json::from_str::<serde_json::Value>(delta) {
                         if event.get("type").and_then(|t| t.as_str()) == Some("usage") {
-                            if let Ok(mut tokens) = captured_tokens_clone.lock() {
+                            if let Ok(mut usage) = captured_usage_clone.lock() {
                                 if let Some(it) = event.get("input_tokens").and_then(|v| v.as_i64()) {
-                                    tokens.0 = Some(it);
+                                    usage.0 = Some(it);
                                 }
                                 if let Some(ot) = event.get("output_tokens").and_then(|v| v.as_i64()) {
-                                    tokens.1 = Some(ot);
+                                    usage.1 = Some(ot);
+                                }
+                                if let Some(m) = event.get("model").and_then(|v| v.as_str()) {
+                                    usage.2 = Some(m.to_string());
                                 }
                             }
                         }
@@ -1150,9 +1153,10 @@ async fn chat(
                 // Save assistant reply with duration and tokens
                 let mut assistant_msg = session::NewMessage::assistant(&result);
                 assistant_msg.tool_duration_ms = Some(duration_ms as i64);
-                if let Ok(tokens) = captured_tokens.lock() {
-                    assistant_msg.tokens_in = tokens.0;
-                    assistant_msg.tokens_out = tokens.1;
+                if let Ok(usage) = captured_usage.lock() {
+                    assistant_msg.tokens_in = usage.0;
+                    assistant_msg.tokens_out = usage.1;
+                    assistant_msg.model = usage.2.clone();
                 }
                 let _ = db.append_message(&sid, &assistant_msg);
                 // Persist conversation context for future restoration
@@ -1234,21 +1238,24 @@ async fn chat(
             let sid_for_cb = sid.clone();
             let cancel_clone = cancel.clone();
 
-            // Shared state to capture token usage from on_delta callback
-            let captured_tokens: Arc<std::sync::Mutex<(Option<i64>, Option<i64>)>> = Arc::new(std::sync::Mutex::new((None, None)));
-            let captured_tokens_clone = captured_tokens.clone();
+            // Shared state to capture token usage and model from on_delta callback
+            let captured_usage: Arc<std::sync::Mutex<(Option<i64>, Option<i64>, Option<String>)>> = Arc::new(std::sync::Mutex::new((None, None, None)));
+            let captured_usage_clone = captured_usage.clone();
 
             let chat_start = std::time::Instant::now();
             match agent.chat(&message, &attachments, effort_ref, cancel_clone, move |delta| {
-                // Intercept usage events to capture token counts
+                // Intercept usage events to capture token counts and model
                 if let Ok(event) = serde_json::from_str::<serde_json::Value>(delta) {
                     if event.get("type").and_then(|t| t.as_str()) == Some("usage") {
-                        if let Ok(mut tokens) = captured_tokens_clone.lock() {
+                        if let Ok(mut usage) = captured_usage_clone.lock() {
                             if let Some(it) = event.get("input_tokens").and_then(|v| v.as_i64()) {
-                                tokens.0 = Some(it);
+                                usage.0 = Some(it);
                             }
                             if let Some(ot) = event.get("output_tokens").and_then(|v| v.as_i64()) {
-                                tokens.1 = Some(ot);
+                                usage.1 = Some(ot);
+                            }
+                            if let Some(m) = event.get("model").and_then(|v| v.as_str()) {
+                                usage.2 = Some(m.to_string());
                             }
                         }
                     }
@@ -1263,9 +1270,10 @@ async fn chat(
                     // Save assistant reply to DB with duration and tokens
                     let mut assistant_msg = session::NewMessage::assistant(&result);
                     assistant_msg.tool_duration_ms = Some(duration_ms as i64);
-                    if let Ok(tokens) = captured_tokens.lock() {
-                        assistant_msg.tokens_in = tokens.0;
-                        assistant_msg.tokens_out = tokens.1;
+                    if let Ok(usage) = captured_usage.lock() {
+                        assistant_msg.tokens_in = usage.0;
+                        assistant_msg.tokens_out = usage.1;
+                        assistant_msg.model = usage.2.clone();
                     }
                     let _ = db.append_message(&sid, &assistant_msg);
                     // Persist conversation context for future restoration

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1229,7 +1229,7 @@ async fn chat(
                 let provider_name = store.providers.iter()
                     .find(|p| p.id == model_ref.provider_id)
                     .map(|p| p.name.as_str());
-                let _ = db.update_session_model(&sid, provider_name, Some(&model_ref.model_id));
+                let _ = db.update_session_model(&sid, Some(&model_ref.provider_id), provider_name, Some(&model_ref.model_id));
             }
 
             let effort_ref = if effort_ref_str == "none" { None } else { Some(effort_ref_str.as_str()) };

--- a/src-tauri/src/session.rs
+++ b/src-tauri/src/session.rs
@@ -12,6 +12,7 @@ pub struct SessionMeta {
     pub id: String,
     pub title: Option<String>,
     pub agent_id: String,
+    pub provider_id: Option<String>,
     pub provider_name: Option<String>,
     pub model_id: Option<String>,
     pub created_at: String,
@@ -144,6 +145,9 @@ impl SessionDB {
             CREATE INDEX IF NOT EXISTS idx_sessions_updated_at ON sessions(updated_at DESC);"
         )?;
 
+        // Migration: add provider_id column if not exists
+        let _ = conn.execute_batch("ALTER TABLE sessions ADD COLUMN provider_id TEXT;");
+
         Ok(Self { conn: Mutex::new(conn) })
     }
 
@@ -164,6 +168,7 @@ impl SessionDB {
             id,
             title: None,
             agent_id: agent_id.to_string(),
+            provider_id: None,
             provider_name: None,
             model_id: None,
             created_at: now.clone(),
@@ -181,7 +186,7 @@ impl SessionDB {
 
         if let Some(agent_id) = agent_id {
             let mut stmt = conn.prepare(
-                "SELECT s.id, s.title, s.agent_id, s.provider_name, s.model_id,
+                "SELECT s.id, s.title, s.agent_id, s.provider_id, s.provider_name, s.model_id,
                         s.created_at, s.updated_at,
                         (SELECT COUNT(*) FROM messages m WHERE m.session_id = s.id) as msg_count
                  FROM sessions s
@@ -193,11 +198,12 @@ impl SessionDB {
                     id: row.get(0)?,
                     title: row.get(1)?,
                     agent_id: row.get(2)?,
-                    provider_name: row.get(3)?,
-                    model_id: row.get(4)?,
-                    created_at: row.get(5)?,
-                    updated_at: row.get(6)?,
-                    message_count: row.get(7)?,
+                    provider_id: row.get(3)?,
+                    provider_name: row.get(4)?,
+                    model_id: row.get(5)?,
+                    created_at: row.get(6)?,
+                    updated_at: row.get(7)?,
+                    message_count: row.get(8)?,
                 })
             })?;
             for row in rows {
@@ -205,7 +211,7 @@ impl SessionDB {
             }
         } else {
             let mut stmt = conn.prepare(
-                "SELECT s.id, s.title, s.agent_id, s.provider_name, s.model_id,
+                "SELECT s.id, s.title, s.agent_id, s.provider_id, s.provider_name, s.model_id,
                         s.created_at, s.updated_at,
                         (SELECT COUNT(*) FROM messages m WHERE m.session_id = s.id) as msg_count
                  FROM sessions s
@@ -216,11 +222,12 @@ impl SessionDB {
                     id: row.get(0)?,
                     title: row.get(1)?,
                     agent_id: row.get(2)?,
-                    provider_name: row.get(3)?,
-                    model_id: row.get(4)?,
-                    created_at: row.get(5)?,
-                    updated_at: row.get(6)?,
-                    message_count: row.get(7)?,
+                    provider_id: row.get(3)?,
+                    provider_name: row.get(4)?,
+                    model_id: row.get(5)?,
+                    created_at: row.get(6)?,
+                    updated_at: row.get(7)?,
+                    message_count: row.get(8)?,
                 })
             })?;
             for row in rows {
@@ -327,11 +334,11 @@ impl SessionDB {
     }
 
     /// Update session's provider/model info.
-    pub fn update_session_model(&self, session_id: &str, provider_name: Option<&str>, model_id: Option<&str>) -> Result<()> {
+    pub fn update_session_model(&self, session_id: &str, provider_id: Option<&str>, provider_name: Option<&str>, model_id: Option<&str>) -> Result<()> {
         let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
         conn.execute(
-            "UPDATE sessions SET provider_name = ?1, model_id = ?2 WHERE id = ?3",
-            params![provider_name, model_id, session_id],
+            "UPDATE sessions SET provider_id = ?1, provider_name = ?2, model_id = ?3 WHERE id = ?4",
+            params![provider_id, provider_name, model_id, session_id],
         )?;
         Ok(())
     }
@@ -376,7 +383,7 @@ impl SessionDB {
     pub fn get_session(&self, session_id: &str) -> Result<Option<SessionMeta>> {
         let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
         let mut stmt = conn.prepare(
-            "SELECT s.id, s.title, s.agent_id, s.provider_name, s.model_id,
+            "SELECT s.id, s.title, s.agent_id, s.provider_id, s.provider_name, s.model_id,
                     s.created_at, s.updated_at,
                     (SELECT COUNT(*) FROM messages m WHERE m.session_id = s.id) as msg_count
              FROM sessions s WHERE s.id = ?1"
@@ -387,11 +394,12 @@ impl SessionDB {
                 id: row.get(0)?,
                 title: row.get(1)?,
                 agent_id: row.get(2)?,
-                provider_name: row.get(3)?,
-                model_id: row.get(4)?,
-                created_at: row.get(5)?,
-                updated_at: row.get(6)?,
-                message_count: row.get(7)?,
+                provider_id: row.get(3)?,
+                provider_name: row.get(4)?,
+                model_id: row.get(5)?,
+                created_at: row.get(6)?,
+                updated_at: row.get(7)?,
+                message_count: row.get(8)?,
             })
         })?;
 

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -450,6 +450,16 @@ export default function ChatScreen({ onOpenAgentSettings }: ChatScreenProps) {
       setCurrentAgentId(session.agentId)
       const agent = agents.find(a => a.id === session.agentId)
       if (agent) setAgentName(agent.name)
+
+      // Restore the model used in this session (if still available)
+      if (session.providerId && session.modelId) {
+        const modelExists = availableModels.some(
+          (m) => m.providerId === session.providerId && m.modelId === session.modelId
+        )
+        if (modelExists) {
+          handleModelChange(`${session.providerId}::${session.modelId}`)
+        }
+      }
     }
   }
 

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -149,6 +149,7 @@ function parseSessionMessages(msgs: SessionMessage[]): Message[] {
         toolCalls,
         timestamp: msg.timestamp,
         usage,
+        model: msg.model || undefined,
       })
     } else if (msg.role === "event") {
       displayMessages.push({ role: "event", content: msg.content, timestamp: msg.timestamp })
@@ -690,7 +691,8 @@ export default function ChatScreen({ onOpenAgentSettings }: ChatScreenProps) {
                 ...(event.cache_creation_input_tokens != null ? { cacheCreationInputTokens: event.cache_creation_input_tokens } : {}),
                 ...(event.cache_read_input_tokens != null ? { cacheReadInputTokens: event.cache_read_input_tokens } : {}),
               }
-              updated[updated.length - 1] = { ...last, usage }
+              const model = event.model ? String(event.model) : last.model
+              updated[updated.length - 1] = { ...last, usage, model }
               return updated
             })
             return
@@ -1154,7 +1156,7 @@ export default function ChatScreen({ onOpenAgentSettings }: ChatScreenProps) {
                         <Copy className="h-3.5 w-3.5" />
                       )}
                     </button>
-                    {msg.role === "assistant" && msg.usage && (
+                    {msg.role === "assistant" && (msg.usage || msg.model) && (
                       <div className="relative">
                         <button
                           onClick={() => setDetailsIndex(detailsIndex === i ? null : i)}
@@ -1171,7 +1173,18 @@ export default function ChatScreen({ onOpenAgentSettings }: ChatScreenProps) {
                             className="absolute top-full mt-1 z-50 min-w-[180px] rounded-lg border border-border bg-popover p-2.5 shadow-lg left-0"
                           >
                             <div className="space-y-1.5 text-xs">
-                              {msg.usage.inputTokens != null && (
+                              {msg.model && (
+                                <div className="flex items-center justify-between gap-3">
+                                  <span className="text-muted-foreground">{t("chat.statusModel")}</span>
+                                  <span className="font-medium text-foreground truncate max-w-[160px]" title={msg.model}>
+                                    {msg.model}
+                                  </span>
+                                </div>
+                              )}
+                              {msg.model && msg.usage?.inputTokens != null && (
+                                <div className="border-t border-border" />
+                              )}
+                              {msg.usage?.inputTokens != null && (
                                 <div className="flex items-center justify-between gap-3">
                                   <span className="text-muted-foreground">{t("chat.inputTokens")}</span>
                                   <span className="font-medium text-foreground tabular-nums">
@@ -1179,7 +1192,7 @@ export default function ChatScreen({ onOpenAgentSettings }: ChatScreenProps) {
                                   </span>
                                 </div>
                               )}
-                              {msg.usage.outputTokens != null && (
+                              {msg.usage?.outputTokens != null && (
                                 <div className="flex items-center justify-between gap-3">
                                   <span className="text-muted-foreground">{t("chat.outputTokens")}</span>
                                   <span className="font-medium text-foreground tabular-nums">
@@ -1187,7 +1200,7 @@ export default function ChatScreen({ onOpenAgentSettings }: ChatScreenProps) {
                                   </span>
                                 </div>
                               )}
-                              {msg.usage.inputTokens != null && msg.usage.outputTokens != null && (
+                              {msg.usage?.inputTokens != null && msg.usage?.outputTokens != null && (
                                 <>
                                   <div className="border-t border-border" />
                                   <div className="flex items-center justify-between gap-3">
@@ -1198,7 +1211,7 @@ export default function ChatScreen({ onOpenAgentSettings }: ChatScreenProps) {
                                   </div>
                                 </>
                               )}
-                              {msg.usage.durationMs != null && (
+                              {msg.usage?.durationMs != null && (
                                 <div className="flex items-center justify-between gap-3">
                                   <span className="text-muted-foreground">{t("chat.duration")}</span>
                                   <span className="font-medium text-foreground tabular-nums">

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -64,6 +64,7 @@ export interface SessionMeta {
   id: string
   title?: string | null
   agentId: string
+  providerId?: string | null
   providerName?: string | null
   modelId?: string | null
   createdAt: string

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -27,6 +27,7 @@ export interface Message {
   thinking?: string
   timestamp?: string
   usage?: MessageUsage
+  model?: string
   fallbackEvent?: FallbackEvent
 }
 


### PR DESCRIPTION
## Summary
This PR enhances the chat system to capture and persist the model used during each conversation. The model information is now extracted from usage events, stored in the database, and restored when reopening a session.

## Key Changes

- **Model Tracking in Usage Events**: Modified `emit_usage()` in `agent.rs` to include the model name in usage event JSON, allowing the frontend to capture which model was used for each response.

- **Database Schema Enhancement**: 
  - Added `provider_id` column to the `sessions` table with migration support
  - Updated `SessionMeta` struct to include `provider_id` field
  - Modified `update_session_model()` to accept and persist `provider_id` alongside existing provider and model info

- **Message Model Storage**: Extended `NewMessage` to capture and store the model used for each assistant response in both chat code paths (with and without session persistence).

- **Session Restoration**: When loading a session, the UI now automatically restores the previously used model if it's still available in the current provider list.

- **UI Improvements**:
  - Added model display in the message details popup alongside token usage
  - Updated message parsing to include model information
  - Added visual separator between model and token information in the details view
  - Made the details button appear when either usage or model information is available

## Implementation Details

- Token usage and model information are captured via a shared `Arc<Mutex>` in the `on_delta` callback, similar to the existing token capture mechanism
- The model is extracted from the usage event JSON emitted by the agent
- Database queries were updated to include the new `provider_id` column in all relevant SELECT statements
- The model restoration logic checks if the model still exists before attempting to select it

https://claude.ai/code/session_0155wB835pBNAPXjzrwWRYej