### PR TITLE
feat: translate tool names in dashboard

### DIFF
--- a/src/components/dashboard/ToolUsageSection.tsx
+++ b/src/components/dashboard/ToolUsageSection.tsx
@@ -41,6 +41,8 @@ const ToolUsageSection = React.memo(function ToolUsageSection({
   const [sortKey, setSortKey] = useState<SortKey>("callCount")
   const [sortDir, setSortDir] = useState<SortDir>("desc")
 
+  const getToolLabel = useCallback((name: string) => t(`tools.${name}`, name), [t])
+
   const frequencyData = useMemo(() => {
     if (!data) return []
     return [...data]
@@ -135,6 +137,7 @@ const ToolUsageSection = React.memo(function ToolUsageSection({
                 tick={{ fontSize: 11 }}
                 width={80}
                 className="fill-muted-foreground"
+                tickFormatter={getToolLabel}
               />
               <RechartsTooltip
                 contentStyle={{
@@ -143,6 +146,7 @@ const ToolUsageSection = React.memo(function ToolUsageSection({
                   borderRadius: "8px",
                   fontSize: "12px",
                 }}
+                labelFormatter={getToolLabel}
                 formatter={(value: number, name: string) => [
                   formatNumber(value),
                   name === "callCount"
@@ -181,6 +185,7 @@ const ToolUsageSection = React.memo(function ToolUsageSection({
                   tick={{ fontSize: 11 }}
                   width={80}
                   className="fill-muted-foreground"
+                  tickFormatter={getToolLabel}
                 />
                 <RechartsTooltip
                   contentStyle={{
@@ -189,6 +194,7 @@ const ToolUsageSection = React.memo(function ToolUsageSection({
                     borderRadius: "8px",
                     fontSize: "12px",
                   }}
+                  labelFormatter={getToolLabel}
                   formatter={(value: number) => [
                     formatDuration(value),
                     t("dashboard.tool.avgDuration"),
@@ -273,7 +279,7 @@ const ToolUsageSection = React.memo(function ToolUsageSection({
                   key={tool.toolName}
                   className="grid grid-cols-6 gap-2 text-xs py-2 border-b border-border/50 hover:bg-muted/50"
                 >
-                  <div className="truncate font-medium">{tool.toolName}</div>
+                  <div className="truncate font-medium">{getToolLabel(tool.toolName)}</div>
                   <div className="text-right">{formatNumber(tool.callCount)}</div>
                   <div
                     className={cn(


### PR DESCRIPTION
## Summary
- Dashboard tool usage section now displays translated tool names instead of raw code names (e.g., "网页搜索" / "Web Search" instead of "web_search")
- Reuses existing `tools.*` i18n keys already used by chat message bubbles, ensuring consistency across the app
- Applied to both bar charts (frequency + duration) axis labels, chart tooltips, and the details table

## Test plan
- [ ] Switch language to Chinese, open dashboard → tool usage tab, verify tool names show Chinese translations in charts and table
- [ ] Switch to English, verify English display names appear
- [ ] Hover over chart bars, verify tooltip labels are also translated
- [ ] Expand details table, verify tool name column shows translated names
- [ ] Verify tools without a translation key gracefully fall back to raw name

https://claude.ai/code/session_01JBRJFqEhk4G8ntNDthFhnU