### PR TITLE
feat: 添加 Option+Space 全局快捷键快速唤起快捷对话浮层

### DIFF
--- a/.agent/rules/default.md
+++ b/.agent/rules/default.md
@@ -19,7 +19,7 @@ node scripts/sync-i18n.mjs --apply   # 从翻译文件补齐缺失翻译
 ```
 src/                    前端（React + TypeScript）
   components/
-    chat/               聊天相关组件（消息列表/输入框/审批对话框/思考块/工具调用块）
+    chat/               聊天相关组件（消息列表/输入框/审批对话框/思考块/工具调用块/快捷对话浮层）
     settings/           设置面板（Provider/Agent/外观/语言/模型/技能/用户资料/系统）
     common/             共享组件（导航栏/Markdown 渲染/Provider 图标）
     dashboard/          数据大盘（概览卡片/Token 用量/工具使用/会话分析/异常监控/任务统计/系统监控，recharts 图表）
@@ -117,6 +117,7 @@ src-tauri/src/          后端（Rust）
 - **Docker 沙箱系统**：`sandbox.rs` 实现安全加固的 Docker 容器沙箱执行。`exec` 工具 `sandbox=true` 参数或 Agent `behavior.sandbox` 配置触发。默认镜像 `debian:bookworm-slim`。安全加固：只读根文件系统（`--read-only`）+ capability 全部移除（`--cap-drop ALL`）+ 禁止新权限（`--no-new-privileges`）+ 网络隔离（`--network none`）+ 进程数限制（`--pids-limit 256`）+ tmpfs 可写临时目录。环境变量过滤：`sanitize_env()` 拦截 20+ 种敏感变量模式（API_KEY/TOKEN/SECRET/PASSWORD 等），白名单放行 PATH/HOME/LANG 等。挂载路径校验：`validate_bind_mount()` 禁止挂载 `/etc`、`/proc`、`/sys`、`/dev`、`/root`、Docker socket 等系统路径，canonicalize 防 symlink 逃逸。`SandboxConfig` 持久化在 `~/.opencomputer/sandbox.json`（8 个可配置参数）。系统提示词 Section ⑪ 条件注入沙箱说明。设置面板 `SandboxPanel` 管理（Docker 可用性检测 + 镜像/资源/安全配置）。3 个 Tauri 命令（`get_sandbox_config` / `set_sandbox_config` / `check_sandbox_available`）
 - **ACP 协议支持**：`acp/` 模块实现原生 Agent Client Protocol 服务器，IDE（Zed/VS Code 等）通过 stdio + NDJSON（JSON-RPC 2.0）直连 OpenComputer Agent。`opencomputer acp` 子命令启动（`--verbose`/`--agent-id`）。完整会话生命周期（new/load/list/close）+ prompt 执行（流式事件映射）+ 历史重放（loadSession 从 SessionDB 重建完整对话）+ 多 Agent 模式切换 + failover 降级。共享 SessionDB 实现桌面端与 IDE 会话互通
 - **自愈式自动重启**：`main.rs` 实现 Guardian Process 架构，同一二进制通过 `OPENCOMPUTER_CHILD` 环境变量区分 Guardian/Child 模式。Guardian 监控子进程退出码，捕获所有崩溃类型（panic/segfault/OOM/abort），指数退避重启。连续崩溃 5 次触发 `backup.rs` 配置备份 + `self_diagnosis.rs` LLM 自诊断（多 Provider Failover + 基础分析降级），保守自动修复（仅 config/logs.db 损坏）。崩溃记录持久化到 `crash_journal.json`（JSON 格式，最近 50 条）。信号转发确保 Force Quit 不误判。退出码：0=正常、42=请求重启、其他=崩溃。设置面板 `CrashHistoryPanel` 管理崩溃历史和备份
+- **快捷对话快捷键**：全局 Option+Space（Alt+Space）快捷键快速唤起 Spotlight 风格浮动对话框。`tauri-plugin-global-shortcut` 后端注册快捷键，Rust handler 显示/聚焦主窗口并发射 `quick-chat-toggle` 事件。前端 `QuickChatDialog.tsx` 浮层组件（`createPortal` 渲染到 body）+ `useQuickChatSession.ts` 独立会话管理 Hook + `QuickChatMessages.tsx` 简化消息列表。复用 `ChatInput` 完整功能（模型选择/斜杠命令/文件附件）和 `useChatStream` 流式对话。Agent 快捷选择器支持切换 Agent 并自动保存/恢复会话（localStorage 持久化 `quickchat:lastSession:{agentId}`）。连续唤起加载上次会话，支持新建会话和"查看完整对话"跳转
 
 ## 编码规范
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ node scripts/sync-i18n.mjs --apply   # 从翻译文件补齐缺失翻译
 ```
 src/                    前端（React + TypeScript）
   components/
-    chat/               聊天相关组件（消息列表/输入框/审批对话框/思考块/工具调用块）
+    chat/               聊天相关组件（消息列表/输入框/审批对话框/思考块/工具调用块/快捷对话浮层）
     settings/           设置面板（Provider/Agent/外观/语言/模型/技能/用户资料/系统）
     common/             共享组件（导航栏/Markdown 渲染/Provider 图标）
     dashboard/          数据大盘（概览卡片/Token 用量/工具使用/会话分析/异常监控/任务统计/系统监控，recharts 图表）
@@ -120,6 +120,7 @@ src-tauri/src/          后端（Rust）
 - **Docker 沙箱系统**：`sandbox.rs` 实现安全加固的 Docker 容器沙箱执行。`exec` 工具 `sandbox=true` 参数或 Agent `behavior.sandbox` 配置触发。默认镜像 `debian:bookworm-slim`。安全加固：只读根文件系统（`--read-only`）+ capability 全部移除（`--cap-drop ALL`）+ 禁止新权限（`--no-new-privileges`）+ 网络隔离（`--network none`）+ 进程数限制（`--pids-limit 256`）+ tmpfs 可写临时目录。环境变量过滤：`sanitize_env()` 拦截 20+ 种敏感变量模式（API_KEY/TOKEN/SECRET/PASSWORD 等），白名单放行 PATH/HOME/LANG 等。挂载路径校验：`validate_bind_mount()` 禁止挂载 `/etc`、`/proc`、`/sys`、`/dev`、`/root`、Docker socket 等系统路径，canonicalize 防 symlink 逃逸。`SandboxConfig` 持久化在 `~/.opencomputer/sandbox.json`（8 个可配置参数）。系统提示词 Section ⑪ 条件注入沙箱说明。设置面板 `SandboxPanel` 管理（Docker 可用性检测 + 镜像/资源/安全配置）。3 个 Tauri 命令（`get_sandbox_config` / `set_sandbox_config` / `check_sandbox_available`）
 - **ACP 协议支持**：`acp/` 模块实现原生 Agent Client Protocol 服务器，IDE（Zed/VS Code 等）通过 stdio + NDJSON（JSON-RPC 2.0）直连 OpenComputer Agent。`opencomputer acp` 子命令启动（`--verbose`/`--agent-id`）。完整会话生命周期（new/load/list/close）+ prompt 执行（流式事件映射）+ 历史重放（loadSession 从 SessionDB 重建完整对话）+ 多 Agent 模式切换 + failover 降级。共享 SessionDB 实现桌面端与 IDE 会话互通
 - **自愈式自动重启**：`main.rs` 实现 Guardian Process 架构，同一二进制通过 `OPENCOMPUTER_CHILD` 环境变量区分 Guardian/Child 模式。Guardian 监控子进程退出码，捕获所有崩溃类型（panic/segfault/OOM/abort），指数退避重启。连续崩溃 5 次触发 `backup.rs` 配置备份 + `self_diagnosis.rs` LLM 自诊断（多 Provider Failover + 基础分析降级），保守自动修复（仅 config/logs.db 损坏）。崩溃记录持久化到 `crash_journal.json`（JSON 格式，最近 50 条）。信号转发确保 Force Quit 不误判。退出码：0=正常、42=请求重启、其他=崩溃。设置面板 `CrashHistoryPanel` 管理崩溃历史和备份
+- **快捷对话快捷键**：全局 Option+Space（Alt+Space）快捷键快速唤起 Spotlight 风格浮动对话框。`tauri-plugin-global-shortcut` 后端注册快捷键，Rust handler 显示/聚焦主窗口并发射 `quick-chat-toggle` 事件。前端 `QuickChatDialog.tsx` 浮层组件（`createPortal` 渲染到 body）+ `useQuickChatSession.ts` 独立会话管理 Hook + `QuickChatMessages.tsx` 简化消息列表。复用 `ChatInput` 完整功能（模型选择/斜杠命令/文件附件）和 `useChatStream` 流式对话。Agent 快捷选择器支持切换 Agent 并自动保存/恢复会话（localStorage 持久化 `quickchat:lastSession:{agentId}`）。连续唤起加载上次会话，支持新建会话和"查看完整对话"跳转
 
 ## 编码规范
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **快捷对话快捷键（Quick Chat Shortcut）**：全局快捷键 Option+Space（Alt+Space）快速唤起 Spotlight 风格浮动对话框
+  - 居中浮层对话框，包含聊天输入、消息预览、Agent 快捷选择
+  - 连续唤起默认加载上一次快捷会话，支持新建会话
+  - 复用 ChatInput 组件，保留模型选择、斜杠命令、文件附件等完整功能
+  - Agent 切换自动保存/恢复对应会话
+  - "查看完整对话"一键跳转到主聊天界面
+  - 使用 `tauri-plugin-global-shortcut` 实现系统级全局快捷键
 - **Plan Mode（计划模式）**：可视化交互的 Plan Mode，LLM 在执行前先分析需求和探索代码库，制定详细执行计划
   - 三态流转：Off → Planning（只读，禁用 write/edit/apply_patch/canvas）→ Executing（全工具 + 进度追踪）
   - ChatInput 工具栏 Plan 按钮（蓝色/绿色/灰色三态）+ `/plan` 斜杠命令（enter/exit/approve/show）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ node scripts/sync-i18n.mjs --apply   # 从翻译文件补齐缺失翻译
 ```
 src/                    前端（React + TypeScript）
   components/
-    chat/               聊天相关组件（消息列表/输入框/审批对话框/思考块/工具调用块/Plan Mode）
+    chat/               聊天相关组件（消息列表/输入框/审批对话框/思考块/工具调用块/Plan Mode/快捷对话浮层）
       plan-mode/          Plan Mode 组件（PlanBlock 内嵌卡片 + PlanPanel 右侧面板 + usePlanMode hook + planParser 解析器）
     settings/           设置面板（Provider/Agent/外观/语言/模型/技能/用户资料/系统）
     common/             共享组件（导航栏/Markdown 渲染/Provider 图标）
@@ -121,6 +121,7 @@ src-tauri/src/          后端（Rust）
 - **Docker 沙箱系统**：`sandbox.rs` 实现安全加固的 Docker 容器沙箱执行。`exec` 工具 `sandbox=true` 参数或 Agent `behavior.sandbox` 配置触发。默认镜像 `debian:bookworm-slim`。安全加固：只读根文件系统（`--read-only`）+ capability 全部移除（`--cap-drop ALL`）+ 禁止新权限（`--no-new-privileges`）+ 网络隔离（`--network none`）+ 进程数限制（`--pids-limit 256`）+ tmpfs 可写临时目录。环境变量过滤：`sanitize_env()` 拦截 20+ 种敏感变量模式（API_KEY/TOKEN/SECRET/PASSWORD 等），白名单放行 PATH/HOME/LANG 等。挂载路径校验：`validate_bind_mount()` 禁止挂载 `/etc`、`/proc`、`/sys`、`/dev`、`/root`、Docker socket 等系统路径，canonicalize 防 symlink 逃逸。`SandboxConfig` 持久化在 `~/.opencomputer/sandbox.json`（8 个可配置参数）。系统提示词 Section ⑪ 条件注入沙箱说明。设置面板 `SandboxPanel` 管理（Docker 可用性检测 + 镜像/资源/安全配置）。3 个 Tauri 命令（`get_sandbox_config` / `set_sandbox_config` / `check_sandbox_available`）
 - **ACP 协议支持**：`acp/` 模块实现原生 Agent Client Protocol 服务器，IDE（Zed/VS Code 等）通过 stdio + NDJSON（JSON-RPC 2.0）直连 OpenComputer Agent。`opencomputer acp` 子命令启动（`--verbose`/`--agent-id`）。完整会话生命周期（new/load/list/close）+ prompt 执行（流式事件映射）+ 历史重放（loadSession 从 SessionDB 重建完整对话）+ 多 Agent 模式切换 + failover 降级。共享 SessionDB 实现桌面端与 IDE 会话互通
 - **自愈式自动重启**：`main.rs` 实现 Guardian Process 架构，同一二进制通过 `OPENCOMPUTER_CHILD` 环境变量区分 Guardian/Child 模式。Guardian 监控子进程退出码，捕获所有崩溃类型（panic/segfault/OOM/abort），指数退避重启。连续崩溃 5 次触发 `backup.rs` 配置备份 + `self_diagnosis.rs` LLM 自诊断（多 Provider Failover + 基础分析降级），保守自动修复（仅 config/logs.db 损坏）。崩溃记录持久化到 `crash_journal.json`（JSON 格式，最近 50 条）。信号转发确保 Force Quit 不误判。退出码：0=正常、42=请求重启、其他=崩溃。设置面板 `CrashHistoryPanel` 管理崩溃历史和备份
+- **快捷对话快捷键**：全局 Option+Space（Alt+Space）快捷键快速唤起 Spotlight 风格浮动对话框。`tauri-plugin-global-shortcut` 后端注册快捷键，Rust handler 显示/聚焦主窗口并发射 `quick-chat-toggle` 事件。前端 `QuickChatDialog.tsx` 浮层组件（`createPortal` 渲染到 body）+ `useQuickChatSession.ts` 独立会话管理 Hook + `QuickChatMessages.tsx` 简化消息列表。复用 `ChatInput` 完整功能（模型选择/斜杠命令/文件附件）和 `useChatStream` 流式对话。Agent 快捷选择器支持切换 Agent 并自动保存/恢复会话（localStorage 持久化 `quickchat:lastSession:{agentId}`）。连续唤起加载上次会话，支持新建会话和"查看完整对话"跳转
 
 ## 编码规范
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/api": "^2.10.1",
     "@tauri-apps/plugin-dialog": "^2.6.0",
+    "@tauri-apps/plugin-global-shortcut": "^2",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "antd": "^6.3.2",
     "class-variance-authority": "^0.7.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2205,6 +2205,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,6 +2357,24 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "global-hotkey"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
 
 [[package]]
 name = "globset"
@@ -4214,6 +4242,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-dialog",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-process",
@@ -6646,6 +6675,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-log"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8734,6 +8778,29 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml5ever"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-process = "2"
 tauri-plugin-notification = "2"
+tauri-plugin-global-shortcut = "2"
 rusqlite = { version = "0.34", features = ["bundled"] }
 sqlite-vec = "0.1"
 fastembed = "5"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -22,6 +22,7 @@
     "notification:default",
     "notification:allow-is-permission-granted",
     "notification:allow-request-permission",
-    "notification:allow-notify"
+    "notification:allow-notify",
+    "global-shortcut:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -202,6 +202,22 @@ pub fn run() {
             }
         }))
         .plugin(tauri_plugin_process::init())
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(|app_handle, _shortcut, event| {
+                    if event.state == tauri_plugin_global_shortcut::ShortcutState::Pressed {
+                        use tauri::Manager;
+                        if let Some(window) = app_handle.get_webview_window("main") {
+                            let _ = window.show();
+                            let _ = window.unminimize();
+                            let _ = window.set_focus();
+                        }
+                        use tauri::Emitter;
+                        let _ = app_handle.emit("quick-chat-toggle", ());
+                    }
+                })
+                .build(),
+        )
         .setup(|app| {
             // Store global AppHandle for event emission
             let _ = APP_HANDLE.set(app.handle().clone());
@@ -253,6 +269,15 @@ pub fn run() {
 
             // Auto-start Docker SearXNG if previously configured
             auto_start_searxng_docker();
+
+            // Register global shortcut (Alt+Space / Option+Space)
+            {
+                use tauri_plugin_global_shortcut::GlobalShortcutExt;
+                let shortcut = "Alt+Space".parse::<tauri_plugin_global_shortcut::Shortcut>()
+                    .map_err(|e| format!("Failed to parse shortcut: {}", e))?;
+                app.global_shortcut().register(shortcut)
+                    .map_err(|e| format!("Failed to register global shortcut: {}", e))?;
+            }
 
             Ok(())
         })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react"
 import { invoke } from "@tauri-apps/api/core"
+import { listen } from "@tauri-apps/api/event"
 import { logger } from "@/lib/logger"
 import { initLanguageFromConfig } from "@/i18n/i18n"
 import { TooltipProvider } from "@/components/ui/tooltip"
@@ -11,6 +12,7 @@ import ChatScreen from "@/components/chat/ChatScreen"
 import CronCalendarView from "@/components/cron/CronCalendarView"
 import DashboardView from "@/components/dashboard/DashboardView"
 import StarrySky from "@/components/common/StarrySky"
+import QuickChatDialog from "@/components/chat/QuickChatDialog"
 
 export default function App() {
   const [view, setView] = useState<
@@ -21,6 +23,7 @@ export default function App() {
   const [pendingSessionId, setPendingSessionId] = useState<string | undefined>(undefined)
   const [totalUnreadCount, setTotalUnreadCount] = useState(0)
   const [sessionsRefreshTrigger, setSessionsRefreshTrigger] = useState(0)
+  const [quickChatOpen, setQuickChatOpen] = useState(false)
 
   // Load user avatar
   async function fetchUserAvatar() {
@@ -53,10 +56,28 @@ export default function App() {
         e.preventDefault()
         handleOpenSettings()
       }
+      // Alt+Space (Option+Space) to toggle quick chat (in-window fallback)
+      if (e.altKey && e.key === " ") {
+        e.preventDefault()
+        setQuickChatOpen((prev) => !prev)
+      }
     }
     document.addEventListener("keydown", onKeyDown)
     return () => document.removeEventListener("keydown", onKeyDown)
   }, [handleOpenSettings])
+
+  // Listen for global shortcut event from Rust backend
+  useEffect(() => {
+    let unlisten: (() => void) | undefined
+    listen("quick-chat-toggle", () => {
+      setQuickChatOpen((prev) => !prev)
+    }).then((fn) => {
+      unlisten = fn
+    })
+    return () => {
+      unlisten?.()
+    }
+  }, [])
 
   // Try to restore previous session on mount
   useEffect(() => {
@@ -224,6 +245,15 @@ export default function App() {
         />
       </div>
     </div>
+    <QuickChatDialog
+      open={quickChatOpen}
+      onOpenChange={setQuickChatOpen}
+      onNavigateToSession={(sessionId) => {
+        setQuickChatOpen(false)
+        setPendingSessionId(sessionId)
+        setView("chat")
+      }}
+    />
     </LightboxProvider>
     </TooltipProvider>
   )

--- a/src/components/chat/QuickChatDialog.tsx
+++ b/src/components/chat/QuickChatDialog.tsx
@@ -1,0 +1,271 @@
+import React, { useState, useEffect, useCallback, useRef } from "react"
+import { createPortal } from "react-dom"
+import { useTranslation } from "react-i18next"
+import { X, Plus, ChevronDown, MessageSquare } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import ChatInput from "@/components/chat/ChatInput"
+import QuickChatMessages from "@/components/chat/QuickChatMessages"
+import ApprovalDialog from "@/components/chat/ApprovalDialog"
+import { useQuickChatSession } from "./useQuickChatSession"
+import { useChatStream } from "./useChatStream"
+import type { CommandResult } from "./slash-commands/types"
+import type { AgentSummaryForSidebar } from "@/types/chat"
+
+interface QuickChatDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onNavigateToSession?: (sessionId: string) => void
+}
+
+export default function QuickChatDialog({
+  open,
+  onOpenChange,
+  onNavigateToSession,
+}: QuickChatDialogProps) {
+  const { t } = useTranslation()
+  const session = useQuickChatSession(open)
+  const agentMenuRef = useRef<HTMLDivElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // ── Stream Hook ─────────────────────────────────
+  const stream = useChatStream({
+    messages: session.messages,
+    setMessages: session.setMessages,
+    currentSessionId: session.currentSessionId,
+    setCurrentSessionId: session.setCurrentSessionId,
+    currentSessionIdRef: session.currentSessionIdRef,
+    currentAgentId: session.currentAgentId,
+    agentName: session.agentName,
+    loading: session.loading,
+    setLoading: session.setLoading,
+    loadingSessionsRef: session.loadingSessionsRef,
+    setLoadingSessionIds: session.setLoadingSessionIds,
+    sessionCacheRef: session.sessionCacheRef,
+    sessions: session.sessions,
+    agents: session.agents,
+    activeModel: session.activeModel,
+    reloadSessions: session.reloadSessions,
+    updateSessionMessages: session.updateSessionMessages,
+  })
+
+  // ── Keyboard handling ───────────────────────────
+  useEffect(() => {
+    if (!open) return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault()
+        onOpenChange(false)
+      }
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [open, onOpenChange])
+
+  // ── Slash command action handler ────────────────
+  const handleCommandAction = useCallback(
+    (result: CommandResult) => {
+      const action = result.action
+      if (!action) return
+      if (action.type === "switchAgent") {
+        session.handleSwitchAgent(action.agentId)
+      } else if (action.type === "newSession") {
+        session.handleNewChat()
+      }
+    },
+    [session],
+  )
+
+  // ── Navigate to full conversation ───────────────
+  const handleNavigate = useCallback(
+    (sessionId: string) => {
+      onOpenChange(false)
+      onNavigateToSession?.(sessionId)
+    },
+    [onOpenChange, onNavigateToSession],
+  )
+
+  if (!open) return null
+
+  const currentAgent = session.agents.find((a) => a.id === session.currentAgentId)
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onOpenChange(false)
+      }}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm animate-in fade-in duration-150" />
+
+      {/* Dialog */}
+      <div
+        ref={containerRef}
+        className={cn(
+          "relative w-[640px] max-w-[90vw] max-h-[70vh] flex flex-col",
+          "bg-background border border-border rounded-2xl shadow-2xl",
+          "animate-in fade-in slide-in-from-top-4 duration-200",
+        )}
+      >
+        {/* ── Header ─────────────────────────────── */}
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+          {/* Agent selector */}
+          <AgentSelector
+            agents={session.agents}
+            currentAgent={currentAgent}
+            onSelect={session.handleSwitchAgent}
+            menuRef={agentMenuRef}
+          />
+
+          <div className="flex-1" />
+
+          {/* Continuing session hint */}
+          {session.currentSessionId && session.messages.length > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {t("quickChat.continueSession")}
+            </span>
+          )}
+
+          {/* New chat button */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={session.handleNewChat}
+            className="h-7 px-2 text-xs gap-1"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t("quickChat.newChat")}
+          </Button>
+
+          {/* Close button */}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => onOpenChange(false)}
+            className="h-7 w-7"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* ── Messages ──────────────────────────── */}
+        <QuickChatMessages
+          messages={session.messages}
+          loading={session.loading}
+          sessionId={session.currentSessionId}
+          onNavigateToSession={handleNavigate}
+        />
+
+        {/* ── Approval Dialog ────────────────────── */}
+        <ApprovalDialog
+          requests={stream.approvalRequests}
+          onRespond={stream.handleApprovalResponse}
+        />
+
+        {/* ── Input Area ──────────────────────────── */}
+        <div className="border-t border-border px-3 py-2">
+          <ChatInput
+            input={stream.input}
+            onInputChange={stream.setInput}
+            onSend={stream.handleSend}
+            loading={session.loading}
+            availableModels={session.availableModels}
+            activeModel={session.activeModel}
+            reasoningEffort={session.reasoningEffort}
+            onModelChange={session.handleModelChange}
+            onEffortChange={session.handleEffortChange}
+            attachedFiles={stream.attachedFiles}
+            onAttachFiles={stream.setAttachedFiles}
+            onRemoveFile={(i) =>
+              stream.setAttachedFiles((prev) => prev.filter((_, idx) => idx !== i))
+            }
+            pendingMessage={stream.pendingMessage}
+            onCancelPending={() => stream.setPendingMessage(null)}
+            onStop={stream.handleStop}
+            currentSessionId={session.currentSessionId}
+            currentAgentId={session.currentAgentId}
+            onCommandAction={handleCommandAction}
+            toolPermissionMode={stream.toolPermissionMode}
+            onToolPermissionChange={stream.setToolPermissionMode}
+          />
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+// ── Agent Selector Sub-component ─────────────────
+
+function AgentSelector({
+  agents,
+  currentAgent,
+  onSelect,
+  menuRef,
+}: {
+  agents: AgentSummaryForSidebar[]
+  currentAgent?: AgentSummaryForSidebar
+  onSelect: (agentId: string) => void
+  menuRef: React.RefObject<HTMLDivElement | null>
+}) {
+  const { t } = useTranslation()
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!menuOpen) return
+    function onClick(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", onClick)
+    return () => document.removeEventListener("mousedown", onClick)
+  }, [menuOpen, menuRef])
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        onClick={() => setMenuOpen(!menuOpen)}
+        className={cn(
+          "flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-sm",
+          "hover:bg-muted transition-colors",
+          menuOpen && "bg-muted",
+        )}
+      >
+        <MessageSquare className="h-4 w-4 text-muted-foreground" />
+        <span className="font-medium">
+          {currentAgent?.emoji && <span className="mr-1">{currentAgent.emoji}</span>}
+          {currentAgent?.name || t("chat.mainAgent")}
+        </span>
+        <ChevronDown className="h-3 w-3 text-muted-foreground" />
+      </button>
+
+      {menuOpen && agents.length > 0 && (
+        <div className="absolute top-full left-0 mt-1 min-w-[200px] max-h-[240px] overflow-y-auto bg-popover border border-border rounded-lg shadow-lg py-1 z-10">
+          {agents.map((agent) => (
+            <button
+              key={agent.id}
+              onClick={() => {
+                onSelect(agent.id)
+                setMenuOpen(false)
+              }}
+              className={cn(
+                "w-full text-left px-3 py-1.5 text-sm hover:bg-muted transition-colors flex items-center gap-2",
+                agent.id === currentAgent?.id && "bg-muted/50",
+              )}
+            >
+              {agent.emoji && <span>{agent.emoji}</span>}
+              <span className="truncate">{agent.name}</span>
+              {agent.id === currentAgent?.id && (
+                <span className="ml-auto text-xs text-primary">●</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/src/components/chat/QuickChatMessages.tsx
+++ b/src/components/chat/QuickChatMessages.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef } from "react"
+import { useTranslation } from "react-i18next"
+import { ExternalLink } from "lucide-react"
+import type { Message } from "@/types/chat"
+import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+
+interface QuickChatMessagesProps {
+  messages: Message[]
+  loading: boolean
+  sessionId: string | null
+  onNavigateToSession?: (sessionId: string) => void
+}
+
+export default function QuickChatMessages({
+  messages,
+  loading,
+  sessionId,
+  onNavigateToSession,
+}: QuickChatMessagesProps) {
+  const { t } = useTranslation()
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages.length, messages[messages.length - 1]?.content])
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-muted-foreground text-sm">
+        {t("quickChat.noMessages")}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto min-h-0 px-4 py-3 space-y-3">
+      {/* View full conversation link */}
+      {sessionId && onNavigateToSession && (
+        <button
+          onClick={() => onNavigateToSession(sessionId)}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors mx-auto"
+        >
+          <ExternalLink className="h-3 w-3" />
+          {t("quickChat.viewFullChat")}
+        </button>
+      )}
+
+      {messages.map((msg, i) => {
+        if (msg.role === "event") {
+          return (
+            <div key={i} className="text-xs text-center text-muted-foreground py-1">
+              {msg.content}
+            </div>
+          )
+        }
+
+        if (msg.role === "user") {
+          return (
+            <div key={i} className="flex justify-end">
+              <div className="max-w-[80%] rounded-2xl rounded-br-md bg-primary text-primary-foreground px-3.5 py-2 text-sm">
+                {msg.content}
+              </div>
+            </div>
+          )
+        }
+
+        // Assistant message
+        const isLastAssistant = i === messages.length - 1 && msg.role === "assistant"
+        const isStreaming = isLastAssistant && loading
+
+        return (
+          <div key={i} className="flex justify-start">
+            <div className="max-w-[85%] rounded-2xl rounded-bl-md bg-muted px-3.5 py-2 text-sm">
+              {msg.content ? (
+                <div className="prose prose-sm dark:prose-invert max-w-none [&_pre]:max-h-[200px] [&_pre]:overflow-auto">
+                  <MarkdownRenderer content={msg.content} isStreaming={isStreaming} />
+                </div>
+              ) : isStreaming ? (
+                <div className="flex items-center gap-1.5 text-muted-foreground">
+                  <div className="h-1.5 w-1.5 rounded-full bg-current animate-pulse" />
+                  <div className="h-1.5 w-1.5 rounded-full bg-current animate-pulse [animation-delay:0.15s]" />
+                  <div className="h-1.5 w-1.5 rounded-full bg-current animate-pulse [animation-delay:0.3s]" />
+                </div>
+              ) : null}
+
+              {/* Tool calls summary */}
+              {msg.toolCalls && msg.toolCalls.length > 0 && (
+                <div className="mt-1.5 text-xs text-muted-foreground">
+                  {msg.toolCalls.map((tc, j) => (
+                    <span key={j} className="inline-flex items-center gap-1 mr-2">
+                      <span className="opacity-60">⚙</span>
+                      {tc.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        )
+      })}
+
+      <div ref={bottomRef} />
+    </div>
+  )
+}

--- a/src/components/chat/useQuickChatSession.ts
+++ b/src/components/chat/useQuickChatSession.ts
@@ -1,0 +1,318 @@
+import { useState, useRef, useEffect, useCallback } from "react"
+import { invoke } from "@tauri-apps/api/core"
+import { logger } from "@/lib/logger"
+import { parseSessionMessages } from "./chatUtils"
+import type {
+  Message,
+  AvailableModel,
+  ActiveModel,
+  SessionMeta,
+  AgentSummaryForSidebar,
+} from "@/types/chat"
+import type { AgentConfig } from "@/components/settings/types"
+
+const STORAGE_PREFIX = "quickchat:lastSession:"
+const QUICK_CHAT_PAGE_SIZE = 20
+
+function getLastSessionId(agentId: string): string | null {
+  try {
+    return localStorage.getItem(STORAGE_PREFIX + agentId)
+  } catch {
+    return null
+  }
+}
+
+function setLastSessionId(agentId: string, sessionId: string) {
+  try {
+    localStorage.setItem(STORAGE_PREFIX + agentId, sessionId)
+  } catch {
+    // localStorage might not be available
+  }
+}
+
+export interface UseQuickChatSessionReturn {
+  // State
+  messages: Message[]
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>
+  currentSessionId: string | null
+  setCurrentSessionId: React.Dispatch<React.SetStateAction<string | null>>
+  currentSessionIdRef: React.MutableRefObject<string | null>
+  currentAgentId: string
+  agentName: string
+  agents: AgentSummaryForSidebar[]
+  loading: boolean
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>
+  loadingSessionIds: Set<string>
+  setLoadingSessionIds: React.Dispatch<React.SetStateAction<Set<string>>>
+
+  // Refs for useChatStream compatibility
+  sessionCacheRef: React.MutableRefObject<Map<string, Message[]>>
+  loadingSessionsRef: React.MutableRefObject<Set<string>>
+
+  // Model state
+  availableModels: AvailableModel[]
+  activeModel: ActiveModel | null
+  reasoningEffort: string
+  setReasoningEffort: React.Dispatch<React.SetStateAction<string>>
+
+  // Handlers
+  handleNewChat: () => Promise<void>
+  handleSwitchAgent: (agentId: string) => Promise<void>
+  handleModelChange: (key: string) => Promise<void>
+  handleEffortChange: (effort: string) => Promise<void>
+  reloadSessions: () => Promise<void>
+  updateSessionMessages: (sessionId: string, updater: (prev: Message[]) => Message[]) => void
+  initSession: () => Promise<void>
+  sessions: SessionMeta[]
+}
+
+export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [currentSessionId, setCurrentSessionId] = useState<string | null>(null)
+  const currentSessionIdRef = useRef<string | null>(null)
+  const [currentAgentId, setCurrentAgentId] = useState("default")
+  const [agentName, setAgentName] = useState("")
+  const [agents, setAgents] = useState<AgentSummaryForSidebar[]>([])
+  const [loading, setLoading] = useState(false)
+  const [loadingSessionIds, setLoadingSessionIds] = useState<Set<string>>(new Set())
+  const [sessions, setSessions] = useState<SessionMeta[]>([])
+
+  const sessionCacheRef = useRef<Map<string, Message[]>>(new Map())
+  const loadingSessionsRef = useRef<Set<string>>(new Set())
+
+  // Model state
+  const [availableModels, setAvailableModels] = useState<AvailableModel[]>([])
+  const [activeModel, setActiveModel] = useState<ActiveModel | null>(null)
+  const [reasoningEffort, setReasoningEffort] = useState("medium")
+
+  // Keep ref in sync
+  useEffect(() => {
+    currentSessionIdRef.current = currentSessionId
+  }, [currentSessionId])
+
+  // Load agents list
+  const loadAgents = useCallback(async () => {
+    try {
+      const list = await invoke<AgentSummaryForSidebar[]>("list_agents")
+      setAgents(list)
+      return list
+    } catch (e) {
+      logger.error("ui", "QuickChat::loadAgents", "Failed to load agents", e)
+      return []
+    }
+  }, [])
+
+  // Load models and settings
+  const loadModels = useCallback(async () => {
+    try {
+      const [models, active, settings] = await Promise.all([
+        invoke<AvailableModel[]>("get_available_models"),
+        invoke<ActiveModel | null>("get_active_model"),
+        invoke<{ reasoning_effort: string }>("get_current_settings"),
+      ])
+      setAvailableModels(models)
+      setActiveModel(active)
+      setReasoningEffort(settings.reasoning_effort)
+    } catch (e) {
+      logger.error("ui", "QuickChat::loadModels", "Failed to load models", e)
+    }
+  }, [])
+
+  // Load session messages
+  const loadSessionMessages = useCallback(async (sessionId: string) => {
+    try {
+      const [rawMsgs] = await invoke<[unknown[], number]>(
+        "load_session_messages_latest_cmd",
+        { sessionId, limit: QUICK_CHAT_PAGE_SIZE },
+      )
+      const parsed = parseSessionMessages(
+        rawMsgs as import("@/types/chat").SessionMessage[],
+      )
+      setMessages(parsed)
+      sessionCacheRef.current.set(sessionId, parsed)
+    } catch (e) {
+      logger.error("ui", "QuickChat::loadMessages", "Failed to load messages", e)
+      setMessages([])
+    }
+  }, [])
+
+  // Reload sessions list (for useChatStream compatibility)
+  const reloadSessions = useCallback(async () => {
+    try {
+      const list = await invoke<SessionMeta[]>("list_sessions_cmd", {
+        agentId: currentAgentId === "default" ? null : currentAgentId,
+      })
+      setSessions(list)
+    } catch {
+      // ignore
+    }
+  }, [currentAgentId])
+
+  // Update session messages helper (for useChatStream compatibility)
+  const updateSessionMessages = useCallback(
+    (sessionId: string, updater: (prev: Message[]) => Message[]) => {
+      if (sessionId === currentSessionIdRef.current) {
+        setMessages((prev) => {
+          const next = updater(prev)
+          sessionCacheRef.current.set(sessionId, next)
+          return next
+        })
+      }
+    },
+    [],
+  )
+
+  // Initialize/restore session for current agent
+  const initSession = useCallback(async () => {
+    const agentList = await loadAgents()
+    await loadModels()
+
+    // Try to find the agent name
+    const agent = agentList.find((a) => a.id === currentAgentId)
+    if (agent) setAgentName(agent.name)
+
+    // Try to restore last session
+    const lastSid = getLastSessionId(currentAgentId)
+    if (lastSid) {
+      try {
+        // Verify session still exists by loading messages
+        const [rawMsgs] = await invoke<[unknown[], number]>(
+          "load_session_messages_latest_cmd",
+          { sessionId: lastSid, limit: QUICK_CHAT_PAGE_SIZE },
+        )
+        const parsed = parseSessionMessages(
+          rawMsgs as import("@/types/chat").SessionMessage[],
+        )
+        setCurrentSessionId(lastSid)
+        setMessages(parsed)
+        sessionCacheRef.current.set(lastSid, parsed)
+        return
+      } catch {
+        // Session may have been deleted, create new
+      }
+    }
+
+    // No previous session or it was deleted — start empty (session created on first send)
+    setCurrentSessionId(null)
+    setMessages([])
+  }, [currentAgentId, loadAgents, loadModels])
+
+  // Re-init when dialog opens
+  useEffect(() => {
+    if (open) {
+      initSession()
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Create new chat session
+  const handleNewChat = useCallback(async () => {
+    setCurrentSessionId(null)
+    setMessages([])
+    sessionCacheRef.current.clear()
+  }, [])
+
+  // Switch agent
+  const handleSwitchAgent = useCallback(
+    async (agentId: string) => {
+      // Save current session ID for current agent before switching
+      if (currentSessionIdRef.current) {
+        setLastSessionId(currentAgentId, currentSessionIdRef.current)
+      }
+
+      setCurrentAgentId(agentId)
+      const agent = agents.find((a) => a.id === agentId)
+      if (agent) setAgentName(agent.name)
+
+      // Try to load the agent's specific model config
+      try {
+        const agentConfig = await invoke<AgentConfig>("get_agent_config", { id: agentId })
+        if (agentConfig.model.primary) {
+          const [pId, mId] = agentConfig.model.primary.split("::")
+          if (pId && mId) {
+            setActiveModel({ providerId: pId, modelId: mId })
+          }
+        }
+      } catch {
+        // Fall back to global active model
+      }
+
+      // Try to restore last session for new agent
+      const lastSid = getLastSessionId(agentId)
+      if (lastSid) {
+        try {
+          await loadSessionMessages(lastSid)
+          setCurrentSessionId(lastSid)
+          return
+        } catch {
+          // Session deleted, create new
+        }
+      }
+
+      // No previous session
+      setCurrentSessionId(null)
+      setMessages([])
+    },
+    [currentAgentId, agents, loadSessionMessages],
+  )
+
+  // Model change
+  const handleModelChange = useCallback(
+    async (key: string) => {
+      const [providerId, modelId] = key.split("::")
+      if (!providerId || !modelId) return
+      setActiveModel({ providerId, modelId })
+      try {
+        await invoke("set_active_model", { providerId, modelId })
+      } catch (e) {
+        logger.error("ui", "QuickChat::modelChange", "Failed to set model", e)
+      }
+    },
+    [],
+  )
+
+  // Effort change
+  const handleEffortChange = useCallback(async (effort: string) => {
+    setReasoningEffort(effort)
+    try {
+      await invoke("set_reasoning_effort", { effort })
+    } catch (e) {
+      logger.error("ui", "QuickChat::effortChange", "Failed to set effort", e)
+    }
+  }, [])
+
+  // Save session ID when it changes (e.g. after first message creates a session)
+  useEffect(() => {
+    if (currentSessionId) {
+      setLastSessionId(currentAgentId, currentSessionId)
+    }
+  }, [currentSessionId, currentAgentId])
+
+  return {
+    messages,
+    setMessages,
+    currentSessionId,
+    setCurrentSessionId,
+    currentSessionIdRef,
+    currentAgentId,
+    agentName,
+    agents,
+    loading,
+    setLoading,
+    loadingSessionIds,
+    setLoadingSessionIds,
+    sessionCacheRef,
+    loadingSessionsRef,
+    availableModels,
+    activeModel,
+    reasoningEffort,
+    setReasoningEffort,
+    handleNewChat,
+    handleSwitchAgent,
+    handleModelChange,
+    handleEffortChange,
+    reloadSessions,
+    updateSessionMessages,
+    initSession,
+    sessions,
+  }
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1281,5 +1281,14 @@
     },
     "noData": "No data available",
     "loading": "Loading..."
+  },
+  "quickChat": {
+    "title": "Quick Chat",
+    "newChat": "New Chat",
+    "selectAgent": "Select Agent",
+    "viewFullChat": "View full conversation",
+    "placeholder": "Ask anything...",
+    "noMessages": "Start a quick conversation",
+    "continueSession": "Continuing previous session"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1281,5 +1281,14 @@
     },
     "noData": "暂无数据",
     "loading": "加载中..."
+  },
+  "quickChat": {
+    "title": "快捷对话",
+    "newChat": "新建对话",
+    "selectAgent": "选择 Agent",
+    "viewFullChat": "查看完整对话",
+    "placeholder": "问点什么...",
+    "noMessages": "开始一段快捷对话",
+    "continueSession": "继续上次对话"
   }
 }


### PR DESCRIPTION
实现 Spotlight 风格的快捷对话功能，类似 ChatGPT/Claude 桌面客户端：
- 全局快捷键 Option+Space (Alt+Space) 唤起/关闭浮层对话框
- 浮层包含 Agent 快捷选择器、消息预览区、完整 ChatInput 输入框
- 连续唤起默认加载上一次快捷会话，支持新建会话
- Agent 切换自动保存/恢复对应会话 (localStorage 持久化)
- "查看完整对话"一键跳转到主聊天界面
- 使用 tauri-plugin-global-shortcut 实现系统级全局快捷键

https://claude.ai/code/session_01SSS2aqGqesS4CKMSVofnyr