### PR TITLE
fix: send button click not working due to MouseEvent passed as directText

### DIFF
--- a/src/QuickChatWindow.tsx
+++ b/src/QuickChatWindow.tsx
@@ -150,7 +150,7 @@ export default function QuickChatWindow() {
           <ChatInput
             input={stream.input}
             onInputChange={stream.setInput}
-            onSend={stream.handleSend}
+            onSend={() => stream.handleSend()}
             loading={session.loading}
             availableModels={session.availableModels}
             activeModel={session.activeModel}

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -467,7 +467,7 @@ export default function ChatScreen({
         <ChatInput
           input={stream.input}
           onInputChange={stream.setInput}
-          onSend={stream.handleSend}
+          onSend={() => stream.handleSend()}
           loading={session.loading}
           availableModels={availableModels}
           activeModel={activeModel}

--- a/src/components/chat/QuickChatDialog.tsx
+++ b/src/components/chat/QuickChatDialog.tsx
@@ -169,7 +169,7 @@ export default function QuickChatDialog({
           <ChatInput
             input={stream.input}
             onInputChange={stream.setInput}
-            onSend={stream.handleSend}
+            onSend={() => stream.handleSend()}
             loading={session.loading}
             availableModels={session.availableModels}
             activeModel={session.activeModel}


### PR DESCRIPTION
When `onSend={stream.handleSend}` is used directly, React's onClick passes
the MouseEvent as the first argument to handleSend(directText?). Since the
event is truthy, `directText ?? input` returns the event object, and calling
`.trim()` on it throws a TypeError silently. Wrapping with an arrow function
ensures handleSend() is called with no arguments, matching the keyboard Enter
behavior.

https://claude.ai/code/session_01E9jAHG84KCX9nfxCbQLXP9