### PR TITLE
feat(tray): 系统托盘常驻 + 窗口关闭隐藏 + Dock 恢复

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ src-tauri/src/          后端（Rust）
   cron.rs               定时任务系统（调度器 + CronDB + 任务执行 + 日历查询）
   dashboard.rs          数据大盘聚合查询（7 个 Tauri 命令 + SQL 聚合 + 费用估算 + DashboardFilter 多维筛选 + 系统指标采集）
   sandbox.rs            Docker 沙箱系统（安全加固容器执行 + 环境变量过滤 + 挂载路径校验 + 配置持久化 + Tauri 命令）
+  tray.rs               系统托盘（菜单栏常驻图标 + 上下文菜单 + 窗口显示/隐藏 + 退出控制）
   browser_state.rs      浏览器连接状态管理（全局单例 + CDP 生命周期 + Profile 隔离）
   permissions.rs        macOS 系统权限检测 & 申请（15 项权限，JXA + 框架 API 检测）
   context_compact.rs    上下文压缩系统（4 层渐进式压缩 + Token 估算校准 + 工具结果截断 + 上下文裁剪 + LLM 摘要 + 溢出恢复）
@@ -120,6 +121,7 @@ src-tauri/src/          后端（Rust）
 - **Docker 沙箱系统**：`sandbox.rs` 实现安全加固的 Docker 容器沙箱执行。`exec` 工具 `sandbox=true` 参数或 Agent `behavior.sandbox` 配置触发。默认镜像 `debian:bookworm-slim`。安全加固：只读根文件系统（`--read-only`）+ capability 全部移除（`--cap-drop ALL`）+ 禁止新权限（`--no-new-privileges`）+ 网络隔离（`--network none`）+ 进程数限制（`--pids-limit 256`）+ tmpfs 可写临时目录。环境变量过滤：`sanitize_env()` 拦截 20+ 种敏感变量模式（API_KEY/TOKEN/SECRET/PASSWORD 等），白名单放行 PATH/HOME/LANG 等。挂载路径校验：`validate_bind_mount()` 禁止挂载 `/etc`、`/proc`、`/sys`、`/dev`、`/root`、Docker socket 等系统路径，canonicalize 防 symlink 逃逸。`SandboxConfig` 持久化在 `~/.opencomputer/sandbox.json`（8 个可配置参数）。系统提示词 Section ⑪ 条件注入沙箱说明。设置面板 `SandboxPanel` 管理（Docker 可用性检测 + 镜像/资源/安全配置）。3 个 Tauri 命令（`get_sandbox_config` / `set_sandbox_config` / `check_sandbox_available`）
 - **ACP 协议支持**：`acp/` 模块实现原生 Agent Client Protocol 服务器，IDE（Zed/VS Code 等）通过 stdio + NDJSON（JSON-RPC 2.0）直连 OpenComputer Agent。`opencomputer acp` 子命令启动（`--verbose`/`--agent-id`）。完整会话生命周期（new/load/list/close）+ prompt 执行（流式事件映射）+ 历史重放（loadSession 从 SessionDB 重建完整对话）+ 多 Agent 模式切换 + failover 降级。共享 SessionDB 实现桌面端与 IDE 会话互通
 - **自愈式自动重启**：`main.rs` 实现 Guardian Process 架构，同一二进制通过 `OPENCOMPUTER_CHILD` 环境变量区分 Guardian/Child 模式。Guardian 监控子进程退出码，捕获所有崩溃类型（panic/segfault/OOM/abort），指数退避重启。连续崩溃 5 次触发 `backup.rs` 配置备份 + `self_diagnosis.rs` LLM 自诊断（多 Provider Failover + 基础分析降级），保守自动修复（仅 config/logs.db 损坏）。崩溃记录持久化到 `crash_journal.json`（JSON 格式，最近 50 条）。信号转发确保 Force Quit 不误判。退出码：0=正常、42=请求重启、其他=崩溃。设置面板 `CrashHistoryPanel` 管理崩溃历史和备份
+- **系统托盘常驻**：`tray.rs` 实现系统托盘（菜单栏）常驻。关闭主窗口仅隐藏（`on_window_event` 拦截 `CloseRequested` + `prevent_close`），应用在后台持续运行。托盘菜单提供显示主窗口/快捷对话/新建对话/设置/退出五个操作。左键单击托盘图标直接显示主窗口。macOS 点击 Dock 图标通过 `RunEvent::Reopen` 恢复窗口。Tauri 2 内置 `tray-icon` feature，无需额外插件
 - **快捷对话快捷键**：全局 Option+Space（Alt+Space）快捷键快速唤起 Spotlight 风格浮动对话框。`tauri-plugin-global-shortcut` 后端注册快捷键，Rust handler 显示/聚焦主窗口并发射 `quick-chat-toggle` 事件。前端 `QuickChatDialog.tsx` 浮层组件（`createPortal` 渲染到 body）+ `useQuickChatSession.ts` 独立会话管理 Hook + `QuickChatMessages.tsx` 简化消息列表。复用 `ChatInput` 完整功能（模型选择/斜杠命令/文件附件）和 `useChatStream` 流式对话。Agent 快捷选择器支持切换 Agent 并自动保存/恢复会话（localStorage 持久化 `quickchat:lastSession:{agentId}`）。连续唤起加载上次会话，支持新建会话和"查看完整对话"跳转
 
 ## 编码规范

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **系统托盘常驻（System Tray）**：应用关闭窗口后常驻系统托盘，不再退出
+  - 菜单栏/系统托盘图标，提供快捷菜单（显示主窗口/快捷对话/新建对话/设置/退出）
+  - 关闭主窗口仅隐藏，应用在后台持续运行，全局快捷键始终可用
+  - 左键单击托盘图标直接显示主窗口
+  - macOS: 点击 Dock 图标恢复主窗口（`RunEvent::Reopen`）
+  - 托盘菜单"退出"才会真正退出应用
 - **快捷对话快捷键（Quick Chat Shortcut）**：全局快捷键 Option+Space（Alt+Space）快速唤起 Spotlight 风格浮动对话框
   - 居中浮层对话框，包含聊天输入、消息预览、Agent 快捷选择
   - 连续唤起默认加载上一次快捷会话，支持新建会话

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ src-tauri/src/          后端（Rust）
   cron.rs               定时任务系统（调度器 + CronDB + 任务执行 + 日历查询）
   dashboard.rs          数据大盘聚合查询（7 个 Tauri 命令 + SQL 聚合 + 费用估算 + DashboardFilter 多维筛选 + 系统指标采集）
   sandbox.rs            Docker 沙箱系统（安全加固容器执行 + 环境变量过滤 + 挂载路径校验 + 配置持久化 + Tauri 命令）
+  tray.rs               系统托盘（菜单栏常驻图标 + 上下文菜单 + 窗口显示/隐藏 + 退出控制）
   browser_state.rs      浏览器连接状态管理（全局单例 + CDP 生命周期 + Profile 隔离）
   permissions.rs        macOS 系统权限检测 & 申请（15 项权限，JXA + 框架 API 检测）
   context_compact.rs    上下文压缩系统（4 层渐进式压缩 + Token 估算校准 + 工具结果截断 + 上下文裁剪 + LLM 摘要 + 溢出恢复）
@@ -121,6 +122,7 @@ src-tauri/src/          后端（Rust）
 - **Docker 沙箱系统**：`sandbox.rs` 实现安全加固的 Docker 容器沙箱执行。`exec` 工具 `sandbox=true` 参数或 Agent `behavior.sandbox` 配置触发。默认镜像 `debian:bookworm-slim`。安全加固：只读根文件系统（`--read-only`）+ capability 全部移除（`--cap-drop ALL`）+ 禁止新权限（`--no-new-privileges`）+ 网络隔离（`--network none`）+ 进程数限制（`--pids-limit 256`）+ tmpfs 可写临时目录。环境变量过滤：`sanitize_env()` 拦截 20+ 种敏感变量模式（API_KEY/TOKEN/SECRET/PASSWORD 等），白名单放行 PATH/HOME/LANG 等。挂载路径校验：`validate_bind_mount()` 禁止挂载 `/etc`、`/proc`、`/sys`、`/dev`、`/root`、Docker socket 等系统路径，canonicalize 防 symlink 逃逸。`SandboxConfig` 持久化在 `~/.opencomputer/sandbox.json`（8 个可配置参数）。系统提示词 Section ⑪ 条件注入沙箱说明。设置面板 `SandboxPanel` 管理（Docker 可用性检测 + 镜像/资源/安全配置）。3 个 Tauri 命令（`get_sandbox_config` / `set_sandbox_config` / `check_sandbox_available`）
 - **ACP 协议支持**：`acp/` 模块实现原生 Agent Client Protocol 服务器，IDE（Zed/VS Code 等）通过 stdio + NDJSON（JSON-RPC 2.0）直连 OpenComputer Agent。`opencomputer acp` 子命令启动（`--verbose`/`--agent-id`）。完整会话生命周期（new/load/list/close）+ prompt 执行（流式事件映射）+ 历史重放（loadSession 从 SessionDB 重建完整对话）+ 多 Agent 模式切换 + failover 降级。共享 SessionDB 实现桌面端与 IDE 会话互通
 - **自愈式自动重启**：`main.rs` 实现 Guardian Process 架构，同一二进制通过 `OPENCOMPUTER_CHILD` 环境变量区分 Guardian/Child 模式。Guardian 监控子进程退出码，捕获所有崩溃类型（panic/segfault/OOM/abort），指数退避重启。连续崩溃 5 次触发 `backup.rs` 配置备份 + `self_diagnosis.rs` LLM 自诊断（多 Provider Failover + 基础分析降级），保守自动修复（仅 config/logs.db 损坏）。崩溃记录持久化到 `crash_journal.json`（JSON 格式，最近 50 条）。信号转发确保 Force Quit 不误判。退出码：0=正常、42=请求重启、其他=崩溃。设置面板 `CrashHistoryPanel` 管理崩溃历史和备份
+- **系统托盘常驻**：`tray.rs` 实现系统托盘（菜单栏）常驻。关闭主窗口仅隐藏（`on_window_event` 拦截 `CloseRequested` + `prevent_close`），应用在后台持续运行。托盘菜单提供显示主窗口/快捷对话/新建对话/设置/退出五个操作。左键单击托盘图标直接显示主窗口。macOS 点击 Dock 图标通过 `RunEvent::Reopen` 恢复窗口。Tauri 2 内置 `tray-icon` feature，无需额外插件
 - **快捷对话快捷键**：全局 Option+Space（Alt+Space）快捷键快速唤起 Spotlight 风格浮动对话框。`tauri-plugin-global-shortcut` 后端注册快捷键，Rust handler 显示/聚焦主窗口并发射 `quick-chat-toggle` 事件。前端 `QuickChatDialog.tsx` 浮层组件（`createPortal` 渲染到 body）+ `useQuickChatSession.ts` 独立会话管理 Hook + `QuickChatMessages.tsx` 简化消息列表。复用 `ChatInput` 完整功能（模型选择/斜杠命令/文件附件）和 `useChatStream` 流式对话。Agent 快捷选择器支持切换 Agent 并自动保存/恢复会话（localStorage 持久化 `quickchat:lastSession:{agentId}`）。连续唤起加载上次会话，支持新建会话和"查看完整对话"跳转
 
 ## 编码规范

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.5.6", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.10.3", features = ["protocol-asset", "macos-private-api"] }
+tauri = { version = "2.10.3", features = ["protocol-asset", "macos-private-api", "tray-icon"] }
 tauri-plugin-log = "2"
 tokio = { version = "1", features = ["full"] }
 anyhow = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ pub mod crash_journal;
 pub mod backup;
 pub mod self_diagnosis;
 mod plan;
+mod tray;
 
 use agent::AssistantAgent;
 use oauth::TokenData;
@@ -212,7 +213,7 @@ fn execute_shortcut_action(app_handle: &tauri::AppHandle, action_id: &str, _shor
 }
 
 /// Toggle the independent quick-chat window. Creates it on first use.
-fn toggle_quickchat_window(app_handle: &tauri::AppHandle) {
+pub(crate) fn toggle_quickchat_window(app_handle: &tauri::AppHandle) {
     use tauri::Manager;
 
     if let Some(win) = app_handle.get_webview_window("quickchat") {
@@ -299,9 +300,10 @@ pub fn run() {
             None,
         ))
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            // When a second instance is launched, focus the existing window
+            // When a second instance is launched, show and focus the existing window
             use tauri::Manager;
             if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
                 let _ = window.unminimize();
                 let _ = window.set_focus();
             }
@@ -426,6 +428,16 @@ pub fn run() {
                 })
                 .build(),
         )
+        .on_window_event(|window, event| {
+            // Intercept window close → hide instead of quit (app stays resident in tray)
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let label = window.label();
+                if label == "main" || label == "quickchat" {
+                    api.prevent_close();
+                    let _ = window.hide();
+                }
+            }
+        })
         .setup(|app| {
             // Store global AppHandle for event emission
             let _ = APP_HANDLE.set(app.handle().clone());
@@ -436,6 +448,9 @@ pub fn run() {
                         .build(),
                 )?;
             }
+
+            // Set up system tray icon with context menu
+            tray::setup_tray(app)?;
 
             // Fix macOS theme-aware background to prevent flash on window resize
             #[cfg(target_os = "macos")]
@@ -845,6 +860,17 @@ pub fn run() {
             commands::acp_control::acp_get_config,
             commands::acp_control::acp_set_config,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // macOS: clicking Dock icon when all windows are hidden → show main window
+            if let tauri::RunEvent::Reopen { .. } = event {
+                use tauri::Manager;
+                if let Some(window) = app_handle.get_webview_window("main") {
+                    let _ = window.show();
+                    let _ = window.unminimize();
+                    let _ = window.set_focus();
+                }
+            }
+        });
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,81 @@
+use tauri::menu::{MenuBuilder, MenuItemBuilder, PredefinedMenuItem};
+use tauri::tray::{TrayIconBuilder, TrayIconEvent, MouseButton, MouseButtonState};
+use tauri::{Manager, Emitter};
+
+/// Show and focus the main window (creates it if needed).
+fn show_main_window(app_handle: &tauri::AppHandle) {
+    if let Some(window) = app_handle.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+/// Set up the system tray icon with context menu.
+pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+    // Build menu items
+    let show_main = MenuItemBuilder::with_id("show_main", "Show Main Window")
+        .build(app)?;
+    let quick_chat = MenuItemBuilder::with_id("quick_chat", "Quick Chat")
+        .build(app)?;
+    let sep1 = PredefinedMenuItem::separator(app)?;
+    let new_session = MenuItemBuilder::with_id("new_session", "New Session")
+        .build(app)?;
+    let open_settings = MenuItemBuilder::with_id("open_settings", "Settings")
+        .build(app)?;
+    let sep2 = PredefinedMenuItem::separator(app)?;
+    let quit_app = MenuItemBuilder::with_id("quit_app", "Quit OpenComputer")
+        .build(app)?;
+
+    let menu = MenuBuilder::new(app)
+        .items(&[
+            &show_main,
+            &quick_chat,
+            &sep1,
+            &new_session,
+            &open_settings,
+            &sep2,
+            &quit_app,
+        ])
+        .build()?;
+
+    let _tray = TrayIconBuilder::new()
+        .tooltip("OpenComputer")
+        .menu(&menu)
+        .on_menu_event(|app_handle, event| {
+            match event.id().as_ref() {
+                "show_main" => {
+                    show_main_window(app_handle);
+                }
+                "quick_chat" => {
+                    crate::toggle_quickchat_window(app_handle);
+                }
+                "new_session" => {
+                    show_main_window(app_handle);
+                    let _ = app_handle.emit("new-session", ());
+                }
+                "open_settings" => {
+                    show_main_window(app_handle);
+                    let _ = app_handle.emit("open-settings", ());
+                }
+                "quit_app" => {
+                    app_handle.exit(0);
+                }
+                _ => {}
+            }
+        })
+        .on_tray_icon_event(|tray, event| {
+            // Left click on tray icon → show main window
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                show_main_window(tray.app_handle());
+            }
+        })
+        .build(app)?;
+
+    Ok(())
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,6 +26,10 @@
         "transparent": true
       }
     ],
+    "trayIcon": {
+      "iconPath": "icons/icon.png",
+      "iconAsTemplate": true
+    },
     "security": {
       "csp": null,
       "assetProtocol": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react"
 import { invoke } from "@tauri-apps/api/core"
+import { listen } from "@tauri-apps/api/event"
 import { logger } from "@/lib/logger"
 import { initLanguageFromConfig } from "@/i18n/i18n"
 import { TooltipProvider } from "@/components/ui/tooltip"
@@ -57,6 +58,20 @@ export default function App() {
     document.addEventListener("keydown", onKeyDown)
     return () => document.removeEventListener("keydown", onKeyDown)
   }, [handleOpenSettings])
+
+  // Listen for system tray events
+  useEffect(() => {
+    const unlistenSettings = listen("open-settings", () => {
+      setView("settings")
+    })
+    const unlistenNewSession = listen("new-session", () => {
+      setView("chat")
+    })
+    return () => {
+      unlistenSettings.then((fn) => fn())
+      unlistenNewSession.then((fn) => fn())
+    }
+  }, [])
 
   // Try to restore previous session on mount
   useEffect(() => {

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -149,6 +149,15 @@ export default function ChatScreen({
     }
   }, [sessionsRefreshTrigger])
 
+  // Listen for tray "new-session" event to trigger new chat
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined
+    listen("new-session", () => {
+      session.handleNewChat(session.currentAgentId)
+    }).then((fn) => { unlisten = fn })
+    return () => { unlisten?.() }
+  }, [session.handleNewChat, session.currentAgentId])
+
   // Fetch models and current settings on mount
   useEffect(() => {
     ;(async () => {


### PR DESCRIPTION
- 新增 tray.rs 系统托盘模块，菜单栏常驻图标（显示主窗口/快捷对话/新建对话/设置/退出）
- 关闭窗口仅隐藏（on_window_event 拦截 CloseRequested + prevent_close），应用后台持续运行
- 左键单击托盘图标显示主窗口
- macOS 点击 Dock 图标通过 RunEvent::Reopen 恢复窗口
- 单实例启动时也 show() 隐藏的窗口
- 前端监听 open-settings / new-session 托盘事件

https://claude.ai/code/session_01KHyZJZLxsLYUUUCaJyJdUL