### PR TITLE
perf(frontend): harden hook purity and preview scheduling

### DIFF
--- a/src/components/chat/CanvasPanel.tsx
+++ b/src/components/chat/CanvasPanel.tsx
@@ -36,6 +36,41 @@ export default function CanvasPanel({ panelWidth = 480, onPanelWidthChange }: Ca
   const [refreshKey, setRefreshKey] = useState(0)
   const detachedWindowRef = useRef<WebviewWindow | null>(null)
 
+  const handleSnapshotRequest = useCallback((requestId: string) => {
+    const iframe = iframeRef.current
+    if (!iframe?.contentWindow) {
+      invoke("canvas_submit_snapshot", {
+        requestId,
+        dataUrl: null,
+        error: "Canvas panel is not open or iframe not loaded",
+      }).catch(() => {})
+      return
+    }
+    iframe.contentWindow.postMessage(
+      { type: "canvas_snapshot", requestId },
+      "*",
+    )
+  }, [])
+
+  const handleEvalRequest = useCallback(
+    (requestId: string, code: string) => {
+      const iframe = iframeRef.current
+      if (!iframe?.contentWindow) {
+        invoke("canvas_submit_eval_result", {
+          requestId,
+          result: null,
+          error: "Canvas panel is not open or iframe not loaded",
+        }).catch(() => {})
+        return
+      }
+      iframe.contentWindow.postMessage(
+        { type: "canvas_eval", requestId, code },
+        "*",
+      )
+    },
+    [],
+  )
+
   // Dynamically adjust window min width when canvas is shown/hidden
   useEffect(() => {
     const win = getCurrentWindow()
@@ -130,7 +165,7 @@ export default function CanvasPanel({ panelWidth = 480, onPanelWidthChange }: Ca
     return () => {
       unlisteners.forEach((u) => u())
     }
-  }, [])
+  }, [handleEvalRequest, handleSnapshotRequest])
 
   // Handle messages from iframe (eval results, snapshot results)
   useEffect(() => {
@@ -163,44 +198,9 @@ export default function CanvasPanel({ panelWidth = 480, onPanelWidthChange }: Ca
     if (!canvas && detachedWindowRef.current) {
       detachedWindowRef.current.close().catch(() => {})
       detachedWindowRef.current = null
-      setDetached(false)
+      queueMicrotask(() => setDetached(false))
     }
   }, [canvas])
-
-  const handleSnapshotRequest = useCallback((requestId: string) => {
-    const iframe = iframeRef.current
-    if (!iframe?.contentWindow) {
-      invoke("canvas_submit_snapshot", {
-        requestId,
-        dataUrl: null,
-        error: "Canvas panel is not open or iframe not loaded",
-      }).catch(() => {})
-      return
-    }
-    iframe.contentWindow.postMessage(
-      { type: "canvas_snapshot", requestId },
-      "*",
-    )
-  }, [])
-
-  const handleEvalRequest = useCallback(
-    (requestId: string, code: string) => {
-      const iframe = iframeRef.current
-      if (!iframe?.contentWindow) {
-        invoke("canvas_submit_eval_result", {
-          requestId,
-          result: null,
-          error: "Canvas panel is not open or iframe not loaded",
-        }).catch(() => {})
-        return
-      }
-      iframe.contentWindow.postMessage(
-        { type: "canvas_eval", requestId, code },
-        "*",
-      )
-    },
-    [],
-  )
 
   const handleClose = useCallback(() => {
     // Close detached window if exists

--- a/src/components/chat/plan-mode/PlanBlock.tsx
+++ b/src/components/chat/plan-mode/PlanBlock.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useMemo, useCallback } from "react"
 import { ChevronRight, ClipboardList, PanelRightOpen } from "lucide-react"
 import { invoke } from "@tauri-apps/api/core"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { IconTip } from "@/components/ui/tooltip"
 import { useTranslation } from "react-i18next"
-import { detectPlanContent, type ParsedPlanStep } from "./planParser"
+import { detectPlanContent } from "./planParser"
 import { PlanStepItem } from "./PlanStepItem"
 import type { PlanModeState, PlanStep } from "./usePlanMode"
 
@@ -31,14 +31,9 @@ export function PlanBlock({
 }: PlanBlockProps) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(true)
-  const [parsedSteps, setParsedSteps] = useState<ParsedPlanStep[]>([])
-  const [planTitle, setPlanTitle] = useState<string>("")
-
-  useEffect(() => {
-    const { steps, title } = detectPlanContent(content)
-    setParsedSteps(steps)
-    setPlanTitle(title || t("planMode.plan"))
-  }, [content, t])
+  const parsedPlan = useMemo(() => detectPlanContent(content), [content])
+  const parsedSteps = parsedPlan.steps
+  const planTitle = parsedPlan.title || t("planMode.plan")
 
   // Save plan content to backend when detected
   useEffect(() => {

--- a/src/components/common/StarrySky.tsx
+++ b/src/components/common/StarrySky.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, memo } from "react"
+import { useEffect, useMemo, useRef, useState, memo } from "react"
 
 /**
  * StarrySky — subtle starry background for dark mode.
@@ -7,11 +7,16 @@ import { useEffect, useRef, useState, memo } from "react"
  */
 
 // Generate deterministic star positions via box-shadow strings
-function generateStars(count: number, maxX: number, maxY: number): string {
+function generateStars(count: number, maxX: number, maxY: number, seed = 1): string {
+  let state = seed
+  const next = () => {
+    state = (state * 1664525 + 1013904223) >>> 0
+    return state / 0xffffffff
+  }
   const shadows: string[] = []
   for (let i = 0; i < count; i++) {
-    const x = Math.round(Math.random() * maxX)
-    const y = Math.round(Math.random() * maxY)
+    const x = Math.round(next() * maxX)
+    const y = Math.round(next() * maxY)
     shadows.push(`${x}px ${y}px currentColor`)
   }
   return shadows.join(", ")
@@ -19,22 +24,29 @@ function generateStars(count: number, maxX: number, maxY: number): string {
 
 // Shooting star component with random position and delay
 function ShootingStar({ id, onDone }: { id: number; onDone: (id: number) => void }) {
-  const top = Math.random() * 40 // top 0-40%
-  const left = 50 + Math.random() * 50 // right half of screen
-  const duration = 0.8 + Math.random() * 0.6 // 0.8-1.4s
-  const trailWidth = 120 + Math.random() * 180 // 120-300px trail length
-  const travelDistance = trailWidth * 2.5 // travel proportional to trail
+  const style = useMemo(() => {
+    const seeded = (offset: number) => {
+      const value = Math.sin((id + 1) * 12.9898 + offset * 78.233) * 43758.5453
+      return value - Math.floor(value)
+    }
+    const top = seeded(1) * 40 // top 0-40%
+    const left = 50 + seeded(2) * 50 // right half of screen
+    const duration = 0.8 + seeded(3) * 0.6 // 0.8-1.4s
+    const trailWidth = 120 + seeded(4) * 180 // 120-300px trail length
+    const travelDistance = trailWidth * 2.5 // travel proportional to trail
+    return {
+      top: `${top}%`,
+      left: `${left}%`,
+      animationDuration: `${duration}s`,
+      width: `${trailWidth}px`,
+      ["--travel" as string]: `-${travelDistance}px`,
+    }
+  }, [id])
 
   return (
     <div
       className="starry-shooting-star"
-      style={{
-        top: `${top}%`,
-        left: `${left}%`,
-        animationDuration: `${duration}s`,
-        width: `${trailWidth}px`,
-        ["--travel" as string]: `-${travelDistance}px`,
-      }}
+      style={style}
       onAnimationEnd={() => onDone(id)}
     />
   )
@@ -48,9 +60,9 @@ function StarrySkyInner() {
 
   // Stars are generated once (large virtual canvas, tiled via CSS)
   const [stars] = useState(() => ({
-    small: generateStars(200, 2000, 2000),
-    medium: generateStars(80, 2000, 2000),
-    large: generateStars(30, 2000, 2000),
+    small: generateStars(200, 2000, 2000, 11),
+    medium: generateStars(80, 2000, 2000, 29),
+    large: generateStars(30, 2000, 2000, 47),
   }))
 
   // Watch for .dark class changes on <html>
@@ -65,10 +77,11 @@ function StarrySkyInner() {
   }, [])
 
   // Reduced motion preference
-  const [reducedMotion, setReducedMotion] = useState(false)
+  const [reducedMotion, setReducedMotion] = useState(() =>
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  )
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)")
-    setReducedMotion(mq.matches)
     const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches)
     mq.addEventListener("change", handler)
     return () => mq.removeEventListener("change", handler)

--- a/src/hooks/useUrlPreview.ts
+++ b/src/hooks/useUrlPreview.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect, useRef, useCallback, useMemo } from "react"
 import { invoke } from "@tauri-apps/api/core"
 import { extractUrls } from "@/lib/urlDetect"
 import type { UrlPreviewData } from "@/components/chat/UrlPreviewCard"
@@ -26,6 +26,7 @@ export function useUrlPreview(
   const cacheRef = useRef<Map<string, UrlPreviewData>>(new Map())
   const pendingRef = useRef<Set<string>>(new Set())
   const activeRef = useRef(0)
+  const urls = useMemo(() => (enabled ? extractUrls(text) : []), [enabled, text])
 
   const dismiss = useCallback((url: string) => {
     setDismissedUrls((prev) => new Set(prev).add(url))
@@ -37,14 +38,8 @@ export function useUrlPreview(
   }, [])
 
   useEffect(() => {
-    if (!enabled || !text.trim()) {
-      setPreviews(new Map())
-      return
-    }
-
     const timer = setTimeout(() => {
-      const urls = extractUrls(text)
-      if (urls.length === 0) {
+      if (!enabled || !text.trim() || urls.length === 0) {
         setPreviews(new Map())
         return
       }
@@ -67,8 +62,12 @@ export function useUrlPreview(
       setPreviews(newPreviews)
 
       // Fetch new URLs with concurrency limit
-      for (const url of toFetch) {
-        if (activeRef.current >= MAX_CONCURRENT) break
+      const queue = [...toFetch]
+      const startNext = () => {
+        if (queue.length === 0 || activeRef.current >= MAX_CONCURRENT) return
+        const url = queue.shift()
+        if (!url) return
+
         pendingRef.current.add(url)
         activeRef.current++
 
@@ -92,12 +91,17 @@ export function useUrlPreview(
           .finally(() => {
             pendingRef.current.delete(url)
             activeRef.current--
+            startNext()
           })
+
+        startNext()
       }
+
+      startNext()
     }, debounceMs)
 
     return () => clearTimeout(timer)
-  }, [text, enabled, debounceMs])
+  }, [text, enabled, debounceMs, urls])
 
   return { previews, dismissedUrls, dismiss, reset }
 }


### PR DESCRIPTION
### Motivation

- Reduce UI instability and lint warnings caused by impure operations and stale closures in several interactive frontend components. 
- Prevent unnecessary re-renders and cascading state updates while preserving existing functionality. 
- Make URL preview fetching more robust under concurrency and avoid stalls when many URLs are present.

### Description

- `CanvasPanel`: declared `handleSnapshotRequest` and `handleEvalRequest` before subscribing to backend events and added them to the effect dependency list to avoid stale callback captures, and deferred an effect-local `setState` with `queueMicrotask()` to avoid synchronous state updates inside effects. 
- `PlanBlock`: replaced effect-driven parsing + state with `useMemo(detectPlanContent)` to derive `parsedSteps` and `planTitle` and reduce render churn. 
- `StarrySky`: removed render-time `Math.random()` calls by switching star generation to a seeded PRNG and memoizing shooting-star style via `useMemo`, and initialize `reducedMotion` from `matchMedia` to avoid an extra effect-driven setState. 
- `useUrlPreview`: memoized extracted URLs with `useMemo`, replaced the flat loop with a queued worker (`startNext`) that respects `MAX_CONCURRENT` and drains the queue as slots free up so pending URLs continue fetching when active requests complete.

### Testing

- Ran targeted ESLint on modified files with `npx eslint src/components/chat/CanvasPanel.tsx src/components/chat/plan-mode/PlanBlock.tsx src/components/common/StarrySky.tsx src/hooks/useUrlPreview.ts` and it passed for those files. (✅)
- Type-check performed with `npx tsc --noEmit` and it succeeded. (✅)
- Full repository lint `npm run lint` was executed and still reports existing unrelated pre-existing lint errors in other frontend files not touched by this change. (❌ unrelated files)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbcc4f64d48321947631e89fa4694e)