### PR TITLE
feat: add /prompts slash command and system prompt viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **系统提示词查看功能**
+  - 新增 `/prompts` 斜杠命令，可在对话中快速查看当前会话的完整系统提示词
+  - 对话界面右上角状态面板新增「查看系统提示词」按钮入口
+  - 系统提示词以弹窗形式展示，支持一键复制
+  - 新增 `get_system_prompt` Tauri 命令，根据当前 Agent 和模型动态构建并返回系统提示词
+
 ### Changed
 
 - **System Prompt 工具描述重构 + 行为指导增强**（参考 Claude Code System Prompts）

--- a/src-tauri/src/agent/config.rs
+++ b/src-tauri/src/agent/config.rs
@@ -196,7 +196,7 @@ pub(super) fn apply_thinking_to_chat_body(
 /// Build the full system prompt.
 /// Uses the new system_prompt module with AgentDefinition if available,
 /// otherwise falls back to legacy behavior for backward compatibility.
-pub(super) fn build_system_prompt(agent_id: &str, model: &str, provider: &str) -> String {
+pub(crate) fn build_system_prompt(agent_id: &str, model: &str, provider: &str) -> String {
     // Try loading the agent definition
     if let Ok(definition) = crate::agent_loader::load_agent(agent_id) {
         // Build memory context if enabled

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -8,7 +8,7 @@ mod providers;
 mod types;
 
 // Re-export public API
-pub use config::{build_api_url, get_codex_models, USER_AGENT};
+pub use config::{build_api_url, build_system_prompt, get_codex_models, USER_AGENT};
 pub use types::{AssistantAgent, Attachment, CodexModel, LlmProvider, PlanAgentMode};
 
 use std::sync::atomic::AtomicBool;

--- a/src-tauri/src/channel/worker.rs
+++ b/src-tauri/src/channel/worker.rs
@@ -868,6 +868,32 @@ async fn dispatch_slash_for_channel(
             })
         }
 
+        // ViewSystemPrompt — build and return the system prompt text directly.
+        Some(CommandAction::ViewSystemPrompt) => {
+            let (model, provider) = {
+                let store = app_state.provider_store.lock().await;
+                if let Some(ref active) = store.active_model {
+                    let prov = store
+                        .providers
+                        .iter()
+                        .find(|p| p.id == active.provider_id);
+                    let model_id = active.model_id.clone();
+                    let provider_name = prov
+                        .map(|p| p.api_type.display_name().to_string())
+                        .unwrap_or_else(|| "Unknown".to_string());
+                    (model_id, provider_name)
+                } else {
+                    ("unknown".to_string(), "Unknown".to_string())
+                }
+            };
+            let prompt =
+                crate::agent::build_system_prompt(agent_id, &model, &provider);
+            Ok(ChannelSlashOutcome::Reply {
+                content: format!("**System Prompt**\n\n```\n{}\n```", prompt),
+                new_session_id: None,
+            })
+        }
+
         // All other actions (DisplayOnly, SwitchModel, SetEffort, SessionCleared,
         // Compact, StopStream, EnterPlanMode, ExitPlanMode, ...) are UI-side only
         // or not applicable in an IM context — just return the content as a reply.

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -709,6 +709,40 @@ pub async fn respond_to_approval(request_id: String, response: String) -> Result
         .map_err(|e| e.to_string())
 }
 
+// ── System Prompt ────────────────────────────────────────────────
+
+/// Return the assembled system prompt for the current agent + model.
+#[tauri::command]
+pub async fn get_system_prompt(
+    agent_id: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<String, String> {
+    let aid = match agent_id {
+        Some(id) => id,
+        None => state.current_agent_id.lock().await.clone(),
+    };
+
+    // Resolve model and provider name from active model
+    let (model, provider) = {
+        let store = state.provider_store.lock().await;
+        if let Some(ref active) = store.active_model {
+            let prov = store
+                .providers
+                .iter()
+                .find(|p| p.id == active.provider_id);
+            let model_id = active.model_id.clone();
+            let provider_name = prov
+                .map(|p| p.api_type.display_name().to_string())
+                .unwrap_or_else(|| "Unknown".to_string());
+            (model_id, provider_name)
+        } else {
+            ("unknown".to_string(), "Unknown".to_string())
+        }
+    };
+
+    Ok(crate::agent::build_system_prompt(&aid, &model, &provider))
+}
+
 // ── Tools Info Commands ───────────────────────────────────────────
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -865,6 +865,8 @@ pub fn run() {
             commands::chat::stop_chat,
             // Command approval
             commands::chat::respond_to_approval,
+            // System prompt
+            commands::chat::get_system_prompt,
             // Tools info
             commands::chat::list_builtin_tools,
             // Skills

--- a/src-tauri/src/slash_commands/handlers/mod.rs
+++ b/src-tauri/src/slash_commands/handlers/mod.rs
@@ -69,6 +69,7 @@ pub async fn dispatch(
         "export" => utility::handle_export(&state.session_db, session_id),
         "usage" => utility::handle_usage(&state.session_db, session_id),
         "search" => utility::handle_search(args),
+        "prompts" => Ok(utility::handle_prompts()),
 
         _ => {
             // Check if it matches a user-invocable skill command

--- a/src-tauri/src/slash_commands/handlers/utility.rs
+++ b/src-tauri/src/slash_commands/handlers/utility.rs
@@ -210,6 +210,14 @@ pub fn handle_search(args: &str) -> Result<CommandResult, String> {
     })
 }
 
+/// /prompts — Open the system prompt viewer.
+pub fn handle_prompts() -> CommandResult {
+    CommandResult {
+        content: String::new(),
+        action: Some(CommandAction::ViewSystemPrompt),
+    }
+}
+
 /// Simple filename sanitization.
 fn sanitize_filename(name: &str) -> String {
     name.chars()

--- a/src-tauri/src/slash_commands/registry.rs
+++ b/src-tauri/src/slash_commands/registry.rs
@@ -185,6 +185,15 @@ pub fn all_commands() -> Vec<SlashCommandDef> {
             arg_options: None,
             description_raw: None,
         },
+        SlashCommandDef {
+            name: "prompts".into(),
+            category: CommandCategory::Utility,
+            description_key: "slashCommands.prompts.description".into(),
+            has_args: false,
+            arg_placeholder: None,
+            arg_options: None,
+            description_raw: None,
+        },
     ]
 }
 

--- a/src-tauri/src/slash_commands/types.rs
+++ b/src-tauri/src/slash_commands/types.rs
@@ -93,4 +93,6 @@ pub enum CommandAction {
     PausePlan,
     /// Resume plan execution.
     ResumePlan,
+    /// Open system prompt viewer.
+    ViewSystemPrompt,
 }

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -29,6 +29,7 @@ import { useChatSession } from "./useChatSession"
 import { useChatStream } from "./useChatStream"
 import { useAutoScroll } from "./useAutoScroll"
 import { usePlanMode } from "./plan-mode/usePlanMode"
+import SystemPromptDialog from "./SystemPromptDialog"
 import { PlanPanel } from "./plan-mode/PlanPanel"
 
 interface ChatScreenProps {
@@ -66,6 +67,11 @@ export default function ChatScreen({
 
   // Context compact state
   const [compacting, setCompacting] = useState(false)
+
+  // System prompt viewer state
+  const [showSystemPrompt, setShowSystemPrompt] = useState(false)
+  const [systemPromptContent, setSystemPromptContent] = useState("")
+  const [systemPromptLoading, setSystemPromptLoading] = useState(false)
 
   // Plan mode state (declared early so useChatStream can access it)
   const [planModeState, setPlanModeState] = useState<"off" | "planning" | "review" | "executing" | "paused" | "completed">("off")
@@ -263,6 +269,22 @@ export default function ChatScreen({
     return () => el.removeEventListener("scroll", onScroll)
   }, [session.handleLoadMore]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ── Load system prompt ──────────────────────────────────────────
+  const loadSystemPrompt = useCallback(async () => {
+    setSystemPromptLoading(true)
+    try {
+      const prompt = await invoke<string>("get_system_prompt", {
+        agentId: session.currentAgentId,
+      })
+      setSystemPromptContent(prompt)
+      setShowSystemPrompt(true)
+    } catch (e) {
+      logger.error("ui", "ChatScreen::loadSystemPrompt", "Failed to load system prompt", e)
+    } finally {
+      setSystemPromptLoading(false)
+    }
+  }, [session.currentAgentId])
+
   // ── Slash Command Action Handler ──────────────────────────────
   const handleCommandAction = useCallback(
     async (result: CommandResult) => {
@@ -370,9 +392,12 @@ export default function ChatScreen({
           planMode.resumeExecution()
           planMode.setShowPanel(true)
           break
+        case "viewSystemPrompt":
+          loadSystemPrompt()
+          break
       }
     },
-    [session, stream, handleModelChange, handleEffortChange, compacting, planMode], // eslint-disable-line react-hooks/exhaustive-deps
+    [session, stream, handleModelChange, handleEffortChange, compacting, planMode, loadSystemPrompt], // eslint-disable-line react-hooks/exhaustive-deps
   )
 
   // ── Plan Approve Handler ───────────────────────────────────────
@@ -451,6 +476,13 @@ export default function ChatScreen({
         </AlertDialogContent>
       </AlertDialog>
 
+      {/* System Prompt Viewer Dialog */}
+      <SystemPromptDialog
+        open={showSystemPrompt}
+        onOpenChange={setShowSystemPrompt}
+        content={systemPromptContent}
+      />
+
       {/* Chat Area */}
       <div className="flex-1 flex flex-col min-w-0">
         <ChatTitleBar
@@ -467,6 +499,8 @@ export default function ChatScreen({
           setCompacting={setCompacting}
           onOpenAgentSettings={onOpenAgentSettings}
           onRenameSession={handleRenameSession}
+          onViewSystemPrompt={loadSystemPrompt}
+          systemPromptLoading={systemPromptLoading}
         />
 
         <CrashRecoveryBanner />

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -3,7 +3,7 @@ import { invoke } from "@tauri-apps/api/core"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { IconTip } from "@/components/ui/tooltip"
-import { Settings, Copy, BarChart3, Pencil, Zap, Check, X } from "lucide-react"
+import { Settings, Copy, BarChart3, Pencil, Zap, Check, X, FileText, Loader2 } from "lucide-react"
 import ChannelIcon from "@/components/common/ChannelIcon"
 import { formatMessageTime } from "./chatUtils"
 import { logger } from "@/lib/logger"
@@ -23,6 +23,8 @@ interface ChatTitleBarProps {
   setCompacting: (v: boolean) => void
   onOpenAgentSettings?: (agentId: string) => void
   onRenameSession?: (sessionId: string, title: string) => void
+  onViewSystemPrompt?: () => void
+  systemPromptLoading?: boolean
 }
 
 export default function ChatTitleBar({
@@ -39,6 +41,8 @@ export default function ChatTitleBar({
   setCompacting,
   onRenameSession,
   onOpenAgentSettings,
+  onViewSystemPrompt,
+  systemPromptLoading,
 }: ChatTitleBarProps) {
   const { t } = useTranslation()
   const [showStatus, setShowStatus] = useState(false)
@@ -422,6 +426,27 @@ export default function ChatTitleBar({
                       </div>
                     )
                   })()}
+                {/* View System Prompt */}
+                {onViewSystemPrompt && (
+                  <>
+                    <div className="border-t border-border" />
+                    <button
+                      className="w-full px-2 py-1 text-[11px] rounded-md border border-border/50 text-muted-foreground hover:text-foreground hover:bg-secondary/60 transition-colors disabled:opacity-50 flex items-center justify-center gap-1.5"
+                      disabled={systemPromptLoading}
+                      onClick={() => {
+                        onViewSystemPrompt()
+                        setShowStatus(false)
+                      }}
+                    >
+                      {systemPromptLoading ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <FileText className="h-3 w-3" />
+                      )}
+                      {t("chat.viewSystemPrompt")}
+                    </button>
+                  </>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/chat/SystemPromptDialog.tsx
+++ b/src/components/chat/SystemPromptDialog.tsx
@@ -1,0 +1,57 @@
+import { useCallback } from "react"
+import { useTranslation } from "react-i18next"
+import { Copy, Check } from "lucide-react"
+import { useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface SystemPromptDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  content: string
+}
+
+export default function SystemPromptDialog({
+  open,
+  onOpenChange,
+  content,
+}: SystemPromptDialogProps) {
+  const { t } = useTranslation()
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(content)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [content])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[80vh] flex flex-col">
+        <DialogHeader className="flex flex-row items-center justify-between gap-2 pr-8">
+          <DialogTitle>{t("chat.systemPrompt")}</DialogTitle>
+          <button
+            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-secondary"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-green-500" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            {copied ? t("chat.copied") : t("chat.copy")}
+          </button>
+        </DialogHeader>
+        <div className="flex-1 overflow-y-auto min-h-0">
+          <pre className="text-xs leading-relaxed text-foreground/90 whitespace-pre-wrap break-words font-mono bg-secondary/30 rounded-lg p-4">
+            {content}
+          </pre>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/chat/slash-commands/types.ts
+++ b/src/components/chat/slash-commands/types.ts
@@ -30,6 +30,7 @@ export type CommandAction =
   | { type: "exitPlanMode"; planContent?: string }
   | { type: "approvePlan"; planContent?: string }
   | { type: "showPlan"; planContent: string }
+  | { type: "viewSystemPrompt" }
 
 /** Matches Rust CommandResult struct */
 export interface CommandResult {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -62,6 +62,9 @@
     "deleteSessionTitle": "Delete Conversation",
     "deleteSessionWarning": "This will permanently delete this conversation and all its messages. This action cannot be undone. Are you sure?",
     "copy": "Copy",
+    "copied": "Copied",
+    "systemPrompt": "System Prompt",
+    "viewSystemPrompt": "View System Prompt",
     "details": "Details",
     "duration": "Duration",
     "modifiedFiles": "Modified files",
@@ -1243,6 +1246,7 @@
     "search": { "description": "Search the web" },
     "permission": { "description": "Set tool permission mode (auto/ask/full)" },
     "plan": { "description": "Enter/exit plan mode" },
+    "prompts": { "description": "View system prompt" },
     "categories": {
       "session": "Session",
       "model": "Model",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -62,6 +62,9 @@
     "deleteSessionTitle": "删除对话",
     "deleteSessionWarning": "此操作将永久删除该对话及其所有消息记录，且无法恢复。请确认是否继续？",
     "copy": "复制",
+    "copied": "已复制",
+    "systemPrompt": "系统提示词",
+    "viewSystemPrompt": "查看系统提示词",
     "details": "详情",
     "duration": "耗时",
     "modifiedFiles": "修改的文件",
@@ -1243,6 +1246,7 @@
     "search": { "description": "搜索网络" },
     "permission": { "description": "设置工具权限模式（auto/ask/full）" },
     "plan": { "description": "进入/退出计划模式" },
+    "prompts": { "description": "查看系统提示词" },
     "categories": {
       "session": "会话",
       "model": "模型",


### PR DESCRIPTION
Add ability to view the current session's assembled system prompt via:
- `/prompts` slash command that opens a fullscreen dialog
- "View System Prompt" button in the session status panel (top-right)

New backend `get_system_prompt` Tauri command builds and returns the
complete system prompt for the current agent and model configuration.

https://claude.ai/code/session_01ULXHTfy18jincqhw4MwNfH