### PR TITLE
fix: align slash command behavior between frontend and channel contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **对齐斜杠命令在 Channel 对话中的执行行为**
+  - `/model`、`/think` 在 Channel 中执行后实际切换模型/推理强度，并通过 `slash:model_switched`、`slash:effort_changed` 事件同步前端 UI
+  - `/stop` 支持通过 `ChannelCancelRegistry` 取消 Channel 中正在进行的流式输出
+  - `/compact` 在 Channel 中直接执行上下文压缩（之前仅返回文本不执行）
+  - `/clear` 执行后 emit `slash:session_cleared` 事件，前端消息列表和侧边栏同步刷新
+  - `/export` 在 Channel 中自动写入 `~/.opencomputer/exports/` 目录并返回路径
+  - `/permission` 在 Channel 中返回"不适用"提示（Channel 固定 auto-approve）
+  - `/plan` 系列命令执行后 emit `slash:plan_changed` 事件同步前端 plan 状态
+  - Channel worker 的 `reasoning_effort` 改为从 `AppState` 读取（之前硬编码 `None`）
+  - 提取 `set_active_model_core`、`set_reasoning_effort_core`、`compact_context_now_core` 三个 core 函数供 Channel worker 复用
+
 ### Added
 
 - **系统提示词查看功能**

--- a/src-tauri/src/channel/cancel.rs
+++ b/src-tauri/src/channel/cancel.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+// ── Channel Cancel Registry ─────────────────────────────────────
+
+/// In-memory registry for active channel stream cancel flags, keyed by session ID.
+/// Follows the same pattern as `SubagentCancelRegistry`.
+pub struct ChannelCancelRegistry {
+    flags: Mutex<HashMap<String, Arc<AtomicBool>>>,
+}
+
+impl ChannelCancelRegistry {
+    pub fn new() -> Self {
+        Self {
+            flags: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Register a cancel flag for a session, returning the Arc<AtomicBool>.
+    pub fn register(&self, session_id: &str) -> Arc<AtomicBool> {
+        let flag = Arc::new(AtomicBool::new(false));
+        if let Ok(mut map) = self.flags.lock() {
+            map.insert(session_id.to_string(), flag.clone());
+        }
+        flag
+    }
+
+    /// Signal cancellation for a specific session's active stream.
+    pub fn cancel(&self, session_id: &str) -> bool {
+        if let Ok(map) = self.flags.lock() {
+            if let Some(flag) = map.get(session_id) {
+                flag.store(true, Ordering::SeqCst);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Remove a completed session from the registry.
+    pub fn remove(&self, session_id: &str) {
+        if let Ok(mut map) = self.flags.lock() {
+            map.remove(session_id);
+        }
+    }
+}

--- a/src-tauri/src/channel/mod.rs
+++ b/src-tauri/src/channel/mod.rs
@@ -1,3 +1,4 @@
+pub mod cancel;
 pub mod config;
 pub mod db;
 pub mod registry;
@@ -6,6 +7,7 @@ pub mod traits;
 pub mod types;
 pub mod worker;
 
+pub use cancel::ChannelCancelRegistry;
 pub use config::ChannelStoreConfig;
 pub use db::ChannelDB;
 pub use registry::ChannelRegistry;

--- a/src-tauri/src/channel/worker.rs
+++ b/src-tauri/src/channel/worker.rs
@@ -358,8 +358,25 @@ async fn handle_inbound_message(
         canvas_enabled,
         compact_config: store.compact.clone(),
         extra_system_context: Some(channel_context),
-        reasoning_effort: None,
-        cancel: Arc::new(AtomicBool::new(false)),
+        reasoning_effort: {
+            let app_handle = crate::get_app_handle();
+            if let Some(ref h) = app_handle {
+                let st = h.state::<crate::AppState>();
+                let eff = st.reasoning_effort.lock().await.clone();
+                if eff == "none" { None } else { Some(eff) }
+            } else {
+                None
+            }
+        },
+        cancel: {
+            let app_handle = crate::get_app_handle();
+            if let Some(ref h) = app_handle {
+                let st = h.state::<crate::AppState>();
+                st.channel_cancels.register(&session_id)
+            } else {
+                Arc::new(AtomicBool::new(false))
+            }
+        },
         plan_agent_mode: None,
         plan_mode_allow_paths: None,
         event_sink: Arc::new(crate::chat_engine::ChannelStreamSink::new(
@@ -373,6 +390,12 @@ async fn handle_inbound_message(
 
     // 9. Run shared chat engine (streaming, failover, tool persistence, etc.)
     let result = crate::chat_engine::run_chat_engine(engine_params).await;
+
+    // Remove cancel handle now that engine is done
+    if let Some(ref h) = crate::get_app_handle() {
+        let st = h.state::<crate::AppState>();
+        st.channel_cancels.remove(&session_id);
+    }
 
     // Drop the sink's sender is implicit — engine_params is consumed.
     // Wait for the streaming background task to finish.
@@ -894,9 +917,150 @@ async fn dispatch_slash_for_channel(
             })
         }
 
-        // All other actions (DisplayOnly, SwitchModel, SetEffort, SessionCleared,
-        // Compact, StopStream, EnterPlanMode, ExitPlanMode, ...) are UI-side only
-        // or not applicable in an IM context — just return the content as a reply.
+        // ── Model switch — persist + notify frontend ──
+        Some(CommandAction::SwitchModel {
+            provider_id,
+            model_id,
+        }) => {
+            if let Err(e) = crate::commands::provider::set_active_model_core(
+                &provider_id,
+                &model_id,
+                app_state,
+            )
+            .await
+            {
+                app_warn!("channel", "worker", "Failed to switch model: {}", e);
+            } else if let Some(handle) = crate::get_app_handle() {
+                let _ = handle.emit(
+                    "slash:model_switched",
+                    serde_json::json!({
+                        "providerId": provider_id,
+                        "modelId": model_id,
+                    }),
+                );
+            }
+            Ok(ChannelSlashOutcome::Reply {
+                content: result.content,
+                new_session_id: None,
+            })
+        }
+
+        // ── Reasoning effort — persist + notify frontend ──
+        Some(CommandAction::SetEffort { effort }) => {
+            if let Err(e) =
+                crate::commands::auth::set_reasoning_effort_core(&effort, app_state).await
+            {
+                app_warn!("channel", "worker", "Failed to set effort: {}", e);
+            } else if let Some(handle) = crate::get_app_handle() {
+                let _ = handle.emit("slash:effort_changed", &effort);
+            }
+            Ok(ChannelSlashOutcome::Reply {
+                content: result.content,
+                new_session_id: None,
+            })
+        }
+
+        // ── Stop stream — cancel via registry ──
+        Some(CommandAction::StopStream) => {
+            let cancelled = app_state.channel_cancels.cancel(session_id);
+            let msg = if cancelled {
+                "Stopping current stream...".to_string()
+            } else {
+                "No active stream to stop.".to_string()
+            };
+            Ok(ChannelSlashOutcome::Reply {
+                content: msg,
+                new_session_id: None,
+            })
+        }
+
+        // ── Compact — run compaction ──
+        Some(CommandAction::Compact) => {
+            match crate::commands::config::compact_context_now_core(session_id, app_state).await {
+                Ok(r) => {
+                    let msg = format!(
+                        "Compacted: {} → {} tokens ({} messages affected)",
+                        r.tokens_before, r.tokens_after, r.messages_affected
+                    );
+                    Ok(ChannelSlashOutcome::Reply {
+                        content: msg,
+                        new_session_id: None,
+                    })
+                }
+                Err(e) => Ok(ChannelSlashOutcome::Reply {
+                    content: format!("Compaction failed: {}", e),
+                    new_session_id: None,
+                }),
+            }
+        }
+
+        // ── Session cleared — notify frontend ──
+        Some(CommandAction::SessionCleared) => {
+            if let Some(handle) = crate::get_app_handle() {
+                let _ = handle.emit("slash:session_cleared", session_id);
+            }
+            Ok(ChannelSlashOutcome::Reply {
+                content: result.content,
+                new_session_id: None,
+            })
+        }
+
+        // ── Export — write to file ──
+        Some(CommandAction::ExportFile { content, filename }) => {
+            let msg = match crate::paths::root_dir() {
+                Ok(root) => {
+                    let export_dir = root.join("exports");
+                    let _ = std::fs::create_dir_all(&export_dir);
+                    let path = export_dir.join(&filename);
+                    match std::fs::write(&path, &content) {
+                        Ok(_) => format!("Exported to `{}`", path.display()),
+                        Err(e) => format!("Export failed: {}", e),
+                    }
+                }
+                Err(e) => format!("Export failed: {}", e),
+            };
+            Ok(ChannelSlashOutcome::Reply {
+                content: msg,
+                new_session_id: None,
+            })
+        }
+
+        // ── Tool permission — not applicable in channel context ──
+        Some(CommandAction::SetToolPermission { mode }) => Ok(ChannelSlashOutcome::Reply {
+            content: format!(
+                "Tool permission `{}` is not applicable in channel context (auto-approve).",
+                mode
+            ),
+            new_session_id: None,
+        }),
+
+        // ── Plan: show plan content ──
+        Some(CommandAction::ShowPlan { plan_content }) => {
+            if let Some(handle) = crate::get_app_handle() {
+                let _ = handle.emit("slash:plan_changed", session_id);
+            }
+            Ok(ChannelSlashOutcome::Reply {
+                content: format!("**Current Plan**\n\n{}", plan_content),
+                new_session_id: None,
+            })
+        }
+
+        // ── Plan: state transitions (DB already persisted by handler) ──
+        Some(CommandAction::EnterPlanMode)
+        | Some(CommandAction::ExitPlanMode { .. })
+        | Some(CommandAction::ApprovePlan { .. })
+        | Some(CommandAction::PausePlan)
+        | Some(CommandAction::ResumePlan) => {
+            if let Some(handle) = crate::get_app_handle() {
+                let _ = handle.emit("slash:plan_changed", session_id);
+            }
+            Ok(ChannelSlashOutcome::Reply {
+                content: result.content,
+                new_session_id: None,
+            })
+        }
+
+        // ── DisplayOnly and any unhandled actions — just return text ──
         _ => Ok(ChannelSlashOutcome::Reply {
             content: result.content,
             new_session_id: None,

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -331,18 +331,27 @@ pub async fn set_codex_model(model: String, state: State<'_, AppState>) -> Resul
     Ok(())
 }
 
-#[tauri::command]
-pub async fn set_reasoning_effort(
-    effort: String,
-    state: State<'_, AppState>,
+/// Core logic for setting reasoning effort. Usable from both Tauri commands
+/// and internal callers (e.g. channel worker).
+pub(crate) async fn set_reasoning_effort_core(
+    effort: &str,
+    state: &AppState,
 ) -> Result<(), String> {
     let valid = ["none", "low", "medium", "high", "xhigh"];
-    if !valid.contains(&effort.as_str()) {
+    if !valid.contains(&effort) {
         return Err(format!(
             "Invalid reasoning effort: {}. Valid: {:?}",
             effort, valid
         ));
     }
-    *state.reasoning_effort.lock().await = effort;
+    *state.reasoning_effort.lock().await = effort.to_string();
     Ok(())
+}
+
+#[tauri::command]
+pub async fn set_reasoning_effort(
+    effort: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    set_reasoning_effort_core(&effort, &state).await
 }

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -79,12 +79,11 @@ pub async fn save_image_generate_config(
     provider::save_store(&store).map_err(|e| e.to_string())
 }
 
-/// Manually trigger context compaction on the current session.
-/// Returns the compaction result for frontend display.
-#[tauri::command]
-pub async fn compact_context_now(
-    session_id: String,
-    state: tauri::State<'_, AppState>,
+/// Core logic for manual context compaction. Usable from both Tauri commands
+/// and internal callers (e.g. channel worker).
+pub(crate) async fn compact_context_now_core(
+    session_id: &str,
+    state: &AppState,
 ) -> Result<context_compact::CompactResult, String> {
     let agent = state.agent.lock().await;
     let agent = agent.as_ref().ok_or("No active agent")?;
@@ -132,7 +131,7 @@ pub async fn compact_context_now(
 
         if forced_result.messages_affected > 0 {
             agent.set_conversation_history(history);
-            save_agent_context(&state.session_db, &session_id, agent);
+            save_agent_context(&state.session_db, session_id, agent);
 
             if let Some(logger) = crate::get_logger() {
                 logger.log(
@@ -155,7 +154,7 @@ pub async fn compact_context_now(
     }
 
     agent.set_conversation_history(history);
-    save_agent_context(&state.session_db, &session_id, agent);
+    save_agent_context(&state.session_db, session_id, agent);
 
     if let Some(logger) = crate::get_logger() {
         logger.log(
@@ -176,6 +175,16 @@ pub async fn compact_context_now(
     }
 
     Ok(result)
+}
+
+/// Manually trigger context compaction on the current session.
+/// Returns the compaction result for frontend display.
+#[tauri::command]
+pub async fn compact_context_now(
+    session_id: String,
+    state: tauri::State<'_, AppState>,
+) -> Result<context_compact::CompactResult, String> {
+    compact_context_now_core(&session_id, &state).await
 }
 
 // ── Shortcuts ────────────────────────────────────────────────────

--- a/src-tauri/src/commands/provider.rs
+++ b/src-tauri/src/commands/provider.rs
@@ -940,11 +940,12 @@ pub async fn get_active_model(state: State<'_, AppState>) -> Result<Option<Activ
     Ok(store.active_model.clone())
 }
 
-#[tauri::command]
-pub async fn set_active_model(
-    provider_id: String,
-    model_id: String,
-    state: State<'_, AppState>,
+/// Core logic for switching the active model. Usable from both Tauri commands
+/// and internal callers (e.g. channel worker).
+pub(crate) async fn set_active_model_core(
+    provider_id: &str,
+    model_id: &str,
+    state: &AppState,
 ) -> Result<(), String> {
     let mut store = state.provider_store.lock().await;
 
@@ -964,21 +965,30 @@ pub async fn set_active_model(
     if provider.api_type == ApiType::Codex {
         let token_info = state.codex_token.lock().await.clone();
         if let Some((access_token, account_id)) = token_info {
-            let agent = AssistantAgent::new_openai(&access_token, &account_id, &model_id);
+            let agent = AssistantAgent::new_openai(&access_token, &account_id, model_id);
             *state.agent.lock().await = Some(agent);
         }
     } else {
         // For other providers, create agent from config
-        let agent = AssistantAgent::new_from_provider(provider, &model_id);
+        let agent = AssistantAgent::new_from_provider(provider, model_id);
         *state.agent.lock().await = Some(agent);
     }
 
     store.active_model = Some(ActiveModel {
-        provider_id,
-        model_id,
+        provider_id: provider_id.to_string(),
+        model_id: model_id.to_string(),
     });
     provider::save_store(&store).map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[tauri::command]
+pub async fn set_active_model(
+    provider_id: String,
+    model_id: String,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    set_active_model_core(&provider_id, &model_id, &state).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -235,6 +235,8 @@ pub(crate) struct AppState {
     pub(crate) cron_db: Arc<cron::CronDB>,
     /// Sub-agent cancel registry
     pub(crate) subagent_cancels: Arc<subagent::SubagentCancelRegistry>,
+    /// Channel stream cancel registry
+    pub(crate) channel_cancels: Arc<channel::ChannelCancelRegistry>,
 }
 
 /// Execute a shortcut action by its id (shared by single-combo and chord paths).
@@ -748,6 +750,9 @@ pub fn run() {
             let _ = SUBAGENT_CANCELS.set(subagent_cancels.clone());
             let _ = SESSION_DB.set(session_db.clone());
 
+            // Initialize channel cancel registry
+            let channel_cancels = Arc::new(channel::ChannelCancelRegistry::new());
+
             // Clean up orphan sub-agent runs from previous app session
             subagent::cleanup_orphan_runs(&session_db);
 
@@ -828,6 +833,7 @@ pub fn run() {
                 logger,
                 cron_db,
                 subagent_cancels,
+                channel_cancels,
             }
         })
         .invoke_handler(tauri::generate_handler![

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -178,6 +178,52 @@ export default function ChatScreen({
     return () => { unlisten?.() }
   }, [handleNewChat, currentAgentId])
 
+  // Listen for channel slash command state-sync events
+  useEffect(() => {
+    const unlisteners: Promise<UnlistenFn>[] = []
+
+    // Model switched from channel (/model)
+    unlisteners.push(
+      listen("slash:model_switched", (event) => {
+        const { providerId, modelId } = event.payload as {
+          providerId: string
+          modelId: string
+        }
+        setActiveModel({ providerId, modelId })
+        applyModelForDisplay(providerId, modelId)
+      }),
+    )
+
+    // Effort changed from channel (/think)
+    unlisteners.push(
+      listen("slash:effort_changed", (event) => {
+        setReasoningEffort(event.payload as string)
+      }),
+    )
+
+    // Session cleared from channel (/clear)
+    unlisteners.push(
+      listen("slash:session_cleared", (event) => {
+        const clearedSid = event.payload as string
+        if (clearedSid === session.currentSessionId) {
+          session.setMessages([])
+        }
+        session.reloadSessions()
+      }),
+    )
+
+    // Plan state changed from channel (/plan)
+    unlisteners.push(
+      listen("slash:plan_changed", () => {
+        session.reloadSessions()
+      }),
+    )
+
+    return () => {
+      unlisteners.forEach((p) => p.then((fn) => fn()))
+    }
+  }, [session.currentSessionId]) // eslint-disable-line react-hooks/exhaustive-deps
+
   // Fetch models and current settings on mount
   useEffect(() => {
     ;(async () => {


### PR DESCRIPTION
Previously, most slash commands in channel (IM) context only returned
text replies without executing their side effects. This commit adds
proper action handling for all CommandAction variants in the channel
dispatch function.

Key changes:
- Extract core functions (set_active_model_core, set_reasoning_effort_core,
  compact_context_now_core) from Tauri commands for reuse by channel worker
- Add ChannelCancelRegistry for /stop support in channel streams
- Handle SwitchModel, SetEffort, StopStream, Compact, SessionCleared,
  ExportFile, SetToolPermission, and Plan actions in channel dispatch
- Emit slash:* Tauri events for frontend state sync (model, effort,
  session cleared, plan changes)
- Channel worker reads reasoning_effort from AppState instead of
  hardcoding None
- Frontend listens for slash:* events to update UI components

https://claude.ai/code/session_01J2KuS96ZhnoNxzH5qLBhWM