### PR TITLE
Show elapsed times and improve streaming UX for Thinking/Tool blocks; record tool durations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ src-tauri/src/          后端（Rust）
 - 避免不必要的重渲染（`React.memo`、`useMemo`、`useCallback`）
 - **Tooltip 必须使用 `@/components/ui/tooltip`**，禁止用 HTML 原生 `title` 属性。优先使用 `<IconTip label={...}>` 简洁包裹
 - **保存按钮统一三态交互**：saving（Loader2 旋转 + disabled）→ saved（绿色 + Check 图标，2 秒恢复）→ failed（红色，2 秒恢复）。使用 `saveStatus: "idle" | "saved" | "failed"` + `saving: boolean` 管理
+- **Think / Tool 流式块展示约定**：内容块必须设置合理 `max-height`，超出后内部滚动；流式增量期间需自动滚动至底部，并实时显示耗时（结束后保留最终耗时）
 
 ### 后端（Rust）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **聊天 Think/Tool 运行态展示优化（前端）**
+  - Think 内容区域新增最大高度限制，超出后在内部滚动，避免思考块无限撑高消息气泡
+  - Think 流式更新时自动滚动到底部，便于持续跟踪最新推理片段
+  - Think 头部新增耗时显示，流式阶段按 100ms 粒度实时刷新，结束后保留最终耗时
+  - Tool 调用项（单条与分组）新增耗时显示：运行中实时更新，完成后展示后端返回的最终 duration
+  - Tool 调用流事件补充 `startedAtMs`/`durationMs` 前端字段，统一支持实时耗时与完成态耗时展示
+  - Tool 完成时若后端未返回 `duration_ms`，前端会基于 `startedAtMs` 自动补算并写入最终耗时；历史消息回放也会读取 `toolDurationMs` 还原工具耗时
 - **System Prompt 工具描述重构 + 行为指导增强**（参考 Claude Code System Prompts）
   - 工具描述从单一 60 行常量拆分为 31 个独立 per-tool 常量，每个工具包含详细使用指南、最佳实践和常见陷阱
   - `build_tools_section()` 重写为按 agent allow/deny 配置动态组装，只注入授权工具的描述，减少无关 token 消耗

--- a/src/components/chat/ThinkingBlock.tsx
+++ b/src/components/chat/ThinkingBlock.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { ChevronRight, BrainCircuit } from "lucide-react"
@@ -13,8 +13,22 @@ interface ThinkingBlockProps {
 export default function ThinkingBlock({ content, isStreaming }: ThinkingBlockProps) {
   const { t } = useTranslation()
   const [autoExpand, setAutoExpand] = useState(getCachedAutoExpandThinking() ?? true)
-  const [isOpen, setIsOpen] = useState(!!isStreaming)
-  const [prevStreaming, setPrevStreaming] = useState(isStreaming)
+  const [manualOpen, setManualOpen] = useState<boolean | null>(null)
+  const [elapsedMs, setElapsedMs] = useState(0)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const startedAtRef = useRef<number | null>(null)
+  const isOpen = manualOpen ?? (isStreaming ? autoExpand : false)
+
+  const formatElapsed = useMemo(
+    () => (ms: number) => {
+      if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+      const totalSeconds = Math.floor(ms / 1000)
+      const minutes = Math.floor(totalSeconds / 60)
+      const seconds = totalSeconds % 60
+      return `${minutes}m ${seconds}s`
+    },
+    [],
+  )
 
   // Load auto-expand setting
   useEffect(() => {
@@ -22,29 +36,48 @@ export default function ThinkingBlock({ content, isStreaming }: ThinkingBlockPro
       getAutoExpandThinking().then((v) => {
         setAutoExpand(v)
         // If setting loaded as false and not streaming, ensure collapsed
-        if (!v && !isStreaming) {
-          setIsOpen(false)
-        }
       })
     }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [])
 
-  // Auto-expand while streaming (only when autoExpand is on), auto-collapse when done
-  if (isStreaming !== prevStreaming) {
-    setPrevStreaming(isStreaming)
-    if (isStreaming && autoExpand) {
-      setIsOpen(true)
-    } else if (!isStreaming && content) {
-      setIsOpen(false)
+  useEffect(() => {
+    if (isStreaming && !startedAtRef.current) {
+      startedAtRef.current = Date.now()
     }
-  }
+  }, [isStreaming])
+
+  // Realtime elapsed timer while streaming
+  useEffect(() => {
+    if (!isStreaming || !startedAtRef.current) return
+    const update = () => {
+      setElapsedMs(Date.now() - startedAtRef.current!)
+    }
+    update()
+    const timer = window.setInterval(update, 100)
+    return () => window.clearInterval(timer)
+  }, [isStreaming])
+
+  // Keep elapsed frozen after complete
+  useEffect(() => {
+    if (!isStreaming && startedAtRef.current) {
+      setElapsedMs(Date.now() - startedAtRef.current)
+    }
+  }, [isStreaming])
+
+  // Auto-scroll inside thinking area when content grows
+  useEffect(() => {
+    if (!isOpen) return
+    const container = contentRef.current
+    if (!container) return
+    container.scrollTop = container.scrollHeight
+  }, [content, isOpen])
 
   if (!content) return null
 
   return (
     <div className="mb-3">
       <button
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => setManualOpen((prev) => !(prev ?? (isStreaming ? autoExpand : false)))}
         className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors py-1 group"
       >
         <ChevronRight
@@ -54,16 +87,22 @@ export default function ThinkingBlock({ content, isStreaming }: ThinkingBlockPro
           className={cn("h-3.5 w-3.5", isStreaming && "animate-pulse text-purple-400")}
         />
         <span>{t("thinking.label")}</span>
+        {(isStreaming || elapsedMs > 0) && (
+          <span className="text-[10px] text-muted-foreground/70">{t("thinking.elapsed", { time: formatElapsed(elapsedMs) })}</span>
+        )}
         {isStreaming && <span className="text-[10px] text-purple-400 animate-pulse">···</span>}
       </button>
 
       <div
         className={cn(
           "overflow-hidden transition-all duration-300 ease-in-out",
-          isOpen ? "max-h-[2000px] opacity-100" : "max-h-0 opacity-0",
+          isOpen ? "max-h-[360px] opacity-100" : "max-h-0 opacity-0",
         )}
       >
-        <div className="ml-1 pl-3 border-l-2 border-purple-400/30 text-xs text-muted-foreground/80 leading-relaxed">
+        <div
+          ref={contentRef}
+          className="ml-1 pl-3 border-l-2 border-purple-400/30 text-xs text-muted-foreground/80 leading-relaxed max-h-[320px] overflow-y-auto pr-2"
+        >
           <MarkdownRenderer content={content} isStreaming={isStreaming} />
         </div>
       </div>

--- a/src/components/chat/ToolCallBlock.tsx
+++ b/src/components/chat/ToolCallBlock.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react"
+import { useState, useMemo, useCallback, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { invoke, convertFileSrc } from "@tauri-apps/api/core"
 import {
@@ -170,7 +170,24 @@ export default function ToolCallBlock({ tool }: { tool: ToolCall }) {
   const { openLightbox } = useLightbox()
   const [expanded, setExpanded] = useState(false)
   const [showRaw, setShowRaw] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
   const isRunning = tool.result === undefined
+  const startedAtMs = tool.startedAtMs || 0
+  const elapsedMs = tool.durationMs ?? (isRunning && startedAtMs ? now - startedAtMs : undefined)
+  const elapsedText = useMemo(() => {
+    if (elapsedMs == null || elapsedMs < 0) return null
+    if (elapsedMs < 60_000) return `${(elapsedMs / 1000).toFixed(1)}s`
+    const totalSeconds = Math.floor(elapsedMs / 1000)
+    const minutes = Math.floor(totalSeconds / 60)
+    const seconds = totalSeconds % 60
+    return `${minutes}m ${seconds}s`
+  }, [elapsedMs])
+
+  useEffect(() => {
+    if (!isRunning || !startedAtMs) return
+    const timer = window.setInterval(() => setNow(Date.now()), 100)
+    return () => window.clearInterval(timer)
+  }, [isRunning, startedAtMs])
 
   // Detect subagent spawn — render SubagentBlock instead
   const subagentSpawn = useMemo(() => {
@@ -265,11 +282,16 @@ export default function ToolCallBlock({ tool }: { tool: ToolCall }) {
         <span className="text-muted-foreground/60 truncate font-mono text-[11px]">
           {displayArgs}
         </span>
+        {elapsedText && (
+          <span className="ml-auto shrink-0 text-[10px] text-muted-foreground/60 tabular-nums">
+            {t("tools.elapsed", { time: elapsedText })}
+          </span>
+        )}
 
         <IconTip label={t("tools.rawCall", "查看原始调用")}>
           <span
             role="button"
-            className="ml-auto shrink-0 p-0.5 rounded hover:bg-secondary text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors opacity-0 group-hover:opacity-100"
+            className="shrink-0 p-0.5 rounded hover:bg-secondary text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors opacity-0 group-hover:opacity-100"
             onClick={(e) => {
               e.stopPropagation()
               setShowRaw(!showRaw)

--- a/src/components/chat/ToolCallGroup.tsx
+++ b/src/components/chat/ToolCallGroup.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   ChevronRight,
@@ -39,6 +39,14 @@ const CATEGORY_MAP: Record<string, ToolCategory> = {
 
 function getToolCategory(name: string): ToolCategory {
   return CATEGORY_MAP[name] || "other"
+}
+
+function formatElapsed(ms: number): string {
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`
+  const totalSeconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}m ${seconds}s`
 }
 
 /** Icon per category */
@@ -154,6 +162,7 @@ function GroupItem({ tool }: { tool: ToolCall }) {
   const { t } = useTranslation()
   const [showResult, setShowResult] = useState(false)
   const [showRaw, setShowRaw] = useState(false)
+  const [now, setNow] = useState(() => Date.now())
   const isRunning = tool.result === undefined
   const skillName = getSkillName(tool)
   const fullTarget = skillName ? "" : getFullTarget(tool)
@@ -163,6 +172,18 @@ function GroupItem({ tool }: { tool: ToolCall }) {
   const preview = skillName ? null : getResultPreview(tool.result)
   const cat = getToolCategory(tool.name)
   const CatIcon = CATEGORY_ICONS[cat]
+  const startedAtMs = tool.startedAtMs || 0
+  const elapsedMs = tool.durationMs ?? (isRunning && startedAtMs ? now - startedAtMs : undefined)
+  const elapsedText = useMemo(
+    () => (elapsedMs != null && elapsedMs >= 0 ? formatElapsed(elapsedMs) : null),
+    [elapsedMs],
+  )
+
+  useEffect(() => {
+    if (!isRunning || !startedAtMs) return
+    const timer = window.setInterval(() => setNow(Date.now()), 100)
+    return () => window.clearInterval(timer)
+  }, [isRunning, startedAtMs])
 
   return (
     <div className="text-[11px]">
@@ -189,10 +210,15 @@ function GroupItem({ tool }: { tool: ToolCall }) {
             {preview}
           </span>
         )}
+        {elapsedText && (
+          <span className="ml-auto shrink-0 text-[10px] text-muted-foreground/60 tabular-nums">
+            {t("tools.elapsed", { time: elapsedText })}
+          </span>
+        )}
         <IconTip label={t("tools.rawCall", "查看原始调用")}>
           <span
             role="button"
-            className="ml-auto shrink-0 p-0.5 rounded hover:bg-secondary text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors opacity-0 group-hover/item:opacity-100"
+            className="shrink-0 p-0.5 rounded hover:bg-secondary text-muted-foreground/40 hover:text-muted-foreground/80 transition-colors opacity-0 group-hover/item:opacity-100"
             onClick={(e) => {
               e.stopPropagation()
               setShowRaw(!showRaw)

--- a/src/components/chat/chatUtils.ts
+++ b/src/components/chat/chatUtils.ts
@@ -163,6 +163,7 @@ export function parseSessionMessages(
         arguments: msg.toolArguments || "",
         result: msg.toolResult || undefined,
         mediaUrls,
+        durationMs: msg.toolDurationMs || undefined,
       }
       // Check if already exists in pendingTools (merge result)
       const existing = pendingTools.find((c) => c.callId === msg.toolCallId)
@@ -170,6 +171,7 @@ export function parseSessionMessages(
         if (msg.toolResult) existing.result = msg.toolResult
         if (msg.toolName && !existing.name) existing.name = msg.toolName
         if (msg.toolArguments && !existing.arguments) existing.arguments = msg.toolArguments
+        if (msg.toolDurationMs != null) existing.durationMs = msg.toolDurationMs
         // Update matching block too
         const blockIdx = pendingBlocks.findIndex(
           (b) => b.type === "tool_call" && b.tool.callId === msg.toolCallId,

--- a/src/components/chat/useChatSession.ts
+++ b/src/components/chat/useChatSession.ts
@@ -443,6 +443,7 @@ export function useChatSession({
               callId: ev.call_id,
               name: ev.name,
               arguments: ev.arguments || "",
+              startedAtMs: Date.now(),
             }
             calls.push(newTool)
             const blocks: ContentBlock[] = [...(last.contentBlocks || [])]
@@ -458,8 +459,16 @@ export function useChatSession({
             const mediaUrls: string[] | undefined = ev.media_urls?.length ? ev.media_urls : undefined
             const calls = [...(last.toolCalls || [])]
             const idx = calls.findIndex((c) => c.callId === ev.call_id)
+            const resolvedDurationMs = ev.duration_ms ?? (
+              idx >= 0 && calls[idx].startedAtMs ? Date.now() - calls[idx].startedAtMs! : undefined
+            )
             if (idx >= 0) {
-              calls[idx] = { ...calls[idx], result: ev.result, ...(mediaUrls && { mediaUrls }) }
+              calls[idx] = {
+                ...calls[idx],
+                result: ev.result,
+                ...(mediaUrls && { mediaUrls }),
+                ...(resolvedDurationMs != null ? { durationMs: resolvedDurationMs } : {}),
+              }
             }
             const blocks: ContentBlock[] = [...(last.contentBlocks || [])]
             const blockIdx = blocks.findIndex(
@@ -472,7 +481,12 @@ export function useChatSession({
               }
               blocks[blockIdx] = {
                 type: "tool_call",
-                tool: { ...block.tool, result: ev.result, ...(mediaUrls && { mediaUrls }) },
+                tool: {
+                  ...block.tool,
+                  result: ev.result,
+                  ...(mediaUrls && { mediaUrls }),
+                  ...(resolvedDurationMs != null ? { durationMs: resolvedDurationMs } : {}),
+                },
               }
             }
             updated[updated.length - 1] = {

--- a/src/components/chat/useChatStream.ts
+++ b/src/components/chat/useChatStream.ts
@@ -205,6 +205,7 @@ export function useChatStream({
                     callId: ev.call_id,
                     name: ev.name,
                     arguments: ev.arguments || "",
+                    startedAtMs: Date.now(),
                   },
                 ]
                 const blocks = [...(last.contentBlocks || [])]
@@ -228,12 +229,31 @@ export function useChatStream({
               const last = updated[updated.length - 1]
               if (last?.role === "assistant" && last.toolCalls) {
                 const mediaUrls: string[] | undefined = ev.media_urls?.length ? ev.media_urls : undefined
+                const current = last.toolCalls.find((tc) => tc.callId === ev.call_id)
+                const resolvedDurationMs = ev.duration_ms ?? (
+                  current?.startedAtMs ? Date.now() - current.startedAtMs : undefined
+                )
                 const toolCalls = last.toolCalls.map((tc) =>
-                  tc.callId === ev.call_id ? { ...tc, result: ev.result, ...(mediaUrls && { mediaUrls }) } : tc,
+                  tc.callId === ev.call_id
+                    ? {
+                        ...tc,
+                        result: ev.result,
+                        ...(mediaUrls && { mediaUrls }),
+                        ...(resolvedDurationMs != null ? { durationMs: resolvedDurationMs } : {}),
+                      }
+                    : tc,
                 )
                 const blocks = (last.contentBlocks || []).map((b) =>
                   b.type === "tool_call" && b.tool?.callId === ev.call_id
-                    ? { ...b, tool: { ...b.tool!, result: ev.result, ...(mediaUrls && { mediaUrls }) } }
+                    ? {
+                        ...b,
+                        tool: {
+                          ...b.tool!,
+                          result: ev.result,
+                          ...(mediaUrls && { mediaUrls }),
+                          ...(resolvedDurationMs != null ? { durationMs: resolvedDurationMs } : {}),
+                        },
+                      }
                     : b,
                 )
                 updated[updated.length - 1] = {
@@ -556,6 +576,7 @@ export function useChatStream({
                   callId: event.call_id,
                   name: event.name,
                   arguments: event.arguments,
+                  startedAtMs: Date.now(),
                 }
                 calls.push(newTool)
                 const blocks: ContentBlock[] = [...(last.contentBlocks || [])]
@@ -571,8 +592,16 @@ export function useChatStream({
                 const mediaUrls: string[] | undefined = event.media_urls?.length ? event.media_urls : undefined
                 const calls = [...(last.toolCalls || [])]
                 const idx = calls.findIndex((c) => c.callId === event.call_id)
+                const resolvedDurationMs = event.duration_ms ?? (
+                  idx >= 0 && calls[idx].startedAtMs ? Date.now() - calls[idx].startedAtMs! : undefined
+                )
                 if (idx >= 0) {
-                  calls[idx] = { ...calls[idx], result: event.result, ...(mediaUrls && { mediaUrls }) }
+                  calls[idx] = {
+                    ...calls[idx],
+                    result: event.result,
+                    ...(mediaUrls && { mediaUrls }),
+                    ...(resolvedDurationMs != null ? { durationMs: resolvedDurationMs } : {}),
+                  }
                 }
                 const blocks: ContentBlock[] = [...(last.contentBlocks || [])]
                 const blockIdx = blocks.findIndex(
@@ -585,7 +614,12 @@ export function useChatStream({
                   }
                   blocks[blockIdx] = {
                     type: "tool_call",
-                    tool: { ...block.tool, result: event.result, ...(mediaUrls && { mediaUrls }) },
+                    tool: {
+                      ...block.tool,
+                      result: event.result,
+                      ...(mediaUrls && { mediaUrls }),
+                      ...(resolvedDurationMs != null ? { durationMs: resolvedDurationMs } : {}),
+                    },
                   }
                 }
                 updated[updated.length - 1] = {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -219,7 +219,8 @@
     "subagent": "Sub-Agent",
     "update_plan_step": "Update Plan Step",
     "rawCall": "View raw call",
-    "loadingSkill": "Loading skill: {{name}}"
+    "loadingSkill": "Loading skill: {{name}}",
+    "elapsed": "Elapsed {{time}}"
   },
   "toolGroup": {
     "browse": "Browsed {{count}} files",
@@ -1109,7 +1110,8 @@
     "queueIndicator": "{{current}} of {{total}}"
   },
   "thinking": {
-    "label": "Thinking"
+    "label": "Thinking",
+    "elapsed": "Elapsed {{time}}"
   },
   "provider_templates": {
     "anthropic": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -219,7 +219,8 @@
     "subagent": "子 Agent",
     "update_plan_step": "更新计划步骤",
     "rawCall": "查看原始调用",
-    "loadingSkill": "加载技能: {{name}}"
+    "loadingSkill": "加载技能: {{name}}",
+    "elapsed": "耗时 {{time}}"
   },
   "toolGroup": {
     "browse": "已浏览 {{count}} 个文件",
@@ -1109,7 +1110,8 @@
     "queueIndicator": "第 {{current}} 个，共 {{total}} 个"
   },
   "thinking": {
-    "label": "思考过程"
+    "label": "思考过程",
+    "elapsed": "耗时 {{time}}"
   },
   "provider_templates": {
     "anthropic": {

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -4,6 +4,8 @@ export interface ToolCall {
   arguments: string
   result?: string
   mediaUrls?: string[]
+  durationMs?: number
+  startedAtMs?: number
 }
 
 export interface MessageUsage {


### PR DESCRIPTION
### Motivation
- Improve realtime visibility for long-running Think and Tool operations by showing elapsed time and preventing infinite-height streaming blocks. 
- Ensure tool call timings are captured and displayed consistently even when back-end duration is missing. 
- Align UI behavior with new documentation and changelog entries about Think/Tool streaming presentation.

### Description
- Add elapsed-time display and realtime timer for the Thinking block, enable manual open/close, auto-scroll content, and limit max heights to prevent thinking bubbles from growing without bound (`ThinkingBlock.tsx`).
- Record `startedAtMs` when a `tool_call` is emitted and resolve `durationMs` on `tool_result` by using `duration_ms` from the event or by computing `Date.now() - startedAtMs` when missing, and propagate these fields through session state (`useChatStream.ts`, `useChatSession.ts`, `chatUtils.ts`).
- Surface tool elapsed times in single and grouped tool UI components (`ToolCallBlock.tsx`, `ToolCallGroup.tsx`) with a small realtime updater while running, and add `durationMs`/`startedAtMs` to the `ToolCall` type (`types/chat.ts`).
- Update i18n locales (`en.json`, `zh.json`) to include elapsed time strings and add related docs and changelog entries (`AGENTS.md`, `CHANGELOG.md`).

### Testing
- Ran frontend type-check and build to validate TypeScript changes and UI compilation; the build completed successfully. 
- Executed the existing unit/integration test suite for the frontend; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbfab330448321b0ab85662465abf3)