### PR TITLE
feat: 斜杠命令参数选项增强 + Channel 对齐 + Telegram 内联按钮

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **斜杠命令参数选项 (arg_options) 交互增强**
+  - `/think` 新增 `xhigh` 超高强度思考等级
+  - `/plan` 注册表补齐 `pause`、`resume` 选项
+  - 前端 `SlashCommandMenu` 新增可展开子菜单，命令有 `arg_options` 时点击或回车可展开选项列表，键盘导航选择
+  - Telegram 等 IM 渠道：无参数发送有 `arg_options` 的命令时返回 inline keyboard 按钮，用户可直接点选
+  - `/model` 无参数时在 Telegram 返回所有可用模型的 inline keyboard 按钮（当前模型标记 ✓），点击即切换
+  - Telegram polling 新增 `CallbackQuery` 处理，将 `slash:<cmd> <arg>` 格式的回调数据转换为标准斜杠命令执行
+
 ### Fixed
 
 - **对齐斜杠命令在 Channel 对话中的执行行为**

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -120,6 +120,7 @@ sequenceDiagram
 | `low` | 低强度思考 |
 | `medium` | 中等强度思考 |
 | `high` | 高强度思考 |
+| `xhigh` | 超高强度思考 |
 
 ### 🧠 Memory — 记忆管理
 
@@ -226,6 +227,45 @@ stateDiagram-v2
 > **前端事件说明**：Channel 执行状态变更类命令后，会通过 Tauri `emit()` 发送 `slash:*` 事件通知前端 UI 同步更新（如模型选择器、effort 指示器、消息列表等）。前端在 `ChatScreen.tsx` 中统一监听这些事件。
 >
 > **⚡ 标注说明**：`/permission` 在 Channel 中不适用，因为 Channel 对话固定使用 auto-approve 模式，不需要交互式权限审批。
+
+---
+
+## 参数选项 (arg_options)
+
+部分命令定义了 `arg_options`——预设的可选参数列表。在不同端有不同的交互方式：
+
+### 前端 UI
+
+`SlashCommandMenu` 对 `arg_options` 命令渲染可展开子菜单：
+
+- 用户输入 `/<cmd>` 后回车或点击命令 → 展开选项子菜单
+- 键盘方向键在选项间导航，回车执行选定选项
+- Escape / 左箭头 返回命令列表
+- 仍可手动输入参数（如 `/think high`）跳过子菜单
+
+### IM 渠道 (Telegram)
+
+Channel 对有 `arg_options` 的命令提供 inline keyboard 按钮：
+
+- 用户发送无参数的命令（如 `/think`）→ 返回选项按钮，每个选项一行
+- 按钮 `callback_data` 格式：`slash:<command> <option>`（如 `slash:think high`）
+- 用户点击按钮 → Telegram 发送 `CallbackQuery` → `polling.rs` 转换为 `/<command> <option>` 文本
+- `dispatch_slash_for_channel` 正常执行命令
+
+**特殊处理 — `/model` 无参数**：
+
+- 返回所有可用模型的 inline keyboard 按钮（每行最多 2 个）
+- 当前活跃模型标记 `✓` 前缀
+- 按钮 `callback_data` 格式：`slash:model <model_name>`
+- 最多展示 20 个模型
+
+### 有 arg_options 的命令
+
+| 命令 | 选项 |
+|---|---|
+| `/think` | `off`, `low`, `medium`, `high`, `xhigh` |
+| `/plan` | `enter`, `exit`, `show`, `approve`, `pause`, `resume` |
+| `/permission` | `auto`, `ask`, `full` |
 
 ---
 

--- a/src-tauri/src/channel/telegram/api.rs
+++ b/src-tauri/src/channel/telegram/api.rs
@@ -2,9 +2,10 @@ use anyhow::Result;
 use std::time::Duration;
 use teloxide::prelude::*;
 use teloxide::types::{
-    ChatAction, ChatId, InputFile, Me, MessageId, ParseMode as TgParseMode, ReplyParameters,
-    ThreadId,
+    ChatAction, ChatId, InlineKeyboardButton, InlineKeyboardMarkup, InputFile, Me, MessageId,
+    ParseMode as TgParseMode, ReplyParameters, ThreadId,
 };
+use crate::channel::types::InlineButton;
 
 /// Thin wrapper around teloxide's `Bot` to isolate framework details.
 pub struct TelegramBotApi {
@@ -55,7 +56,7 @@ impl TelegramBotApi {
             .map_err(|e| anyhow::anyhow!("getMe failed: {}", e))
     }
 
-    /// Send a text message.
+    /// Send a text message, optionally with inline keyboard buttons.
     pub async fn send_text(
         &self,
         chat_id: i64,
@@ -63,6 +64,7 @@ impl TelegramBotApi {
         parse_mode: Option<TgParseMode>,
         reply_to: Option<i32>,
         thread_id: Option<i32>,
+        buttons: &[Vec<InlineButton>],
     ) -> Result<teloxide::types::Message> {
         let mut req = self.bot.send_message(ChatId(chat_id), text);
 
@@ -75,29 +77,34 @@ impl TelegramBotApi {
         if let Some(tid) = thread_id {
             req = req.message_thread_id(ThreadId(teloxide::types::MessageId(tid)));
         }
+        if !buttons.is_empty() {
+            let keyboard = build_inline_keyboard(buttons);
+            req = req.reply_markup(keyboard);
+        }
 
         req.await
             .map_err(|e| anyhow::anyhow!("sendMessage failed: {}", e))
     }
 
-    /// Send a text message, falling back to plain text if parse mode fails.
+    /// Send a text message with optional inline buttons, falling back to plain text if parse mode fails.
     pub async fn send_text_with_fallback(
         &self,
         chat_id: i64,
         text: &str,
         reply_to: Option<i32>,
         thread_id: Option<i32>,
+        buttons: &[Vec<InlineButton>],
     ) -> Result<teloxide::types::Message> {
         // Try with HTML first
         match self
-            .send_text(chat_id, text, Some(TgParseMode::Html), reply_to, thread_id)
+            .send_text(chat_id, text, Some(TgParseMode::Html), reply_to, thread_id, buttons)
             .await
         {
             Ok(msg) => Ok(msg),
             Err(_) => {
                 // Fallback: strip HTML tags and send as plain text
                 let plain = strip_html_tags(text);
-                self.send_text(chat_id, &plain, None, reply_to, thread_id)
+                self.send_text(chat_id, &plain, None, reply_to, thread_id, buttons)
                     .await
             }
         }
@@ -296,6 +303,32 @@ fn build_send_message_draft_body(
     }
 
     body
+}
+
+/// Convert our `InlineButton` rows into teloxide's `InlineKeyboardMarkup`.
+fn build_inline_keyboard(buttons: &[Vec<InlineButton>]) -> InlineKeyboardMarkup {
+    let rows: Vec<Vec<InlineKeyboardButton>> = buttons
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|b| {
+                    if let Some(ref url) = b.url {
+                        InlineKeyboardButton::url(
+                            b.text.clone(),
+                            url.parse().unwrap_or_else(|_| "https://example.com".parse().unwrap()),
+                        )
+                    } else {
+                        let cb = b
+                            .callback_data
+                            .clone()
+                            .unwrap_or_else(|| b.text.clone());
+                        InlineKeyboardButton::callback(b.text.clone(), cb)
+                    }
+                })
+                .collect()
+        })
+        .collect();
+    InlineKeyboardMarkup::new(rows)
 }
 
 /// Strip HTML tags from text (simple implementation for fallback).

--- a/src-tauri/src/channel/telegram/mod.rs
+++ b/src-tauri/src/channel/telegram/mod.rs
@@ -199,7 +199,7 @@ impl ChannelPlugin for TelegramPlugin {
             }
 
             let msg = api
-                .send_text_with_fallback(chat_id_num, text, reply_to, thread_id)
+                .send_text_with_fallback(chat_id_num, text, reply_to, thread_id, &payload.buttons)
                 .await?;
 
             return Ok(DeliveryResult::ok(msg.id.0.to_string()));

--- a/src-tauri/src/channel/telegram/polling.rs
+++ b/src-tauri/src/channel/telegram/polling.rs
@@ -98,6 +98,7 @@ fn convert_update(
     match &update.kind {
         UpdateKind::Message(msg) => convert_message(msg, account_id, bot_id, bot_username),
         UpdateKind::EditedMessage(msg) => convert_message(msg, account_id, bot_id, bot_username),
+        UpdateKind::CallbackQuery(cb) => convert_callback_query(cb, account_id),
         _ => None,
     }
 }
@@ -197,6 +198,71 @@ fn convert_message(
         reply_to_message_id: reply_to,
         timestamp: msg.date,
         raw: serde_json::json!({ "update_id": 0 }), // minimal raw payload
+    })
+}
+
+/// Convert a Telegram CallbackQuery (inline button click) into a MsgContext.
+///
+/// Callback data with format "slash:<command> <arg>" is converted to "/<command> <arg>"
+/// so the worker processes it as a normal slash command.
+fn convert_callback_query(
+    cb: &teloxide::types::CallbackQuery,
+    account_id: &str,
+) -> Option<MsgContext> {
+    let data = cb.data.as_ref()?;
+    let msg = cb.message.as_ref()?.regular_message()?;
+
+    // Convert "slash:think high" → "/think high"
+    let text = if let Some(rest) = data.strip_prefix("slash:") {
+        format!("/{}", rest)
+    } else {
+        return None; // Unknown callback format, ignore
+    };
+
+    let from = &cb.from;
+
+    let chat_type = match msg.chat.kind {
+        teloxide::types::ChatKind::Private(_) => ChatType::Dm,
+        teloxide::types::ChatKind::Public(ref public) => match public.kind {
+            teloxide::types::PublicChatKind::Supergroup(ref sg) => {
+                if sg.is_forum {
+                    ChatType::Forum
+                } else {
+                    ChatType::Group
+                }
+            }
+            teloxide::types::PublicChatKind::Group => ChatType::Group,
+            teloxide::types::PublicChatKind::Channel(_) => ChatType::Channel,
+        },
+    };
+
+    let thread_id = msg.thread_id.map(|tid| tid.to_string());
+
+    let sender_name = {
+        let mut name = from.first_name.clone();
+        if let Some(ref last) = from.last_name {
+            name.push(' ');
+            name.push_str(last);
+        }
+        name
+    };
+
+    Some(MsgContext {
+        channel_id: ChannelId::Telegram,
+        account_id: account_id.to_string(),
+        sender_id: from.id.0.to_string(),
+        sender_name: Some(sender_name),
+        sender_username: from.username.clone(),
+        chat_id: msg.chat.id.0.to_string(),
+        chat_type,
+        chat_title: msg.chat.title().map(|t| t.to_string()),
+        thread_id,
+        message_id: msg.id.0.to_string(),
+        text: Some(text),
+        media: Vec::new(),
+        reply_to_message_id: None,
+        timestamp: msg.date,
+        raw: serde_json::json!({ "callback_query_id": cb.id }),
     })
 }
 

--- a/src-tauri/src/channel/worker.rs
+++ b/src-tauri/src/channel/worker.rs
@@ -200,6 +200,7 @@ async fn handle_inbound_message(
             Ok(ChannelSlashOutcome::Reply {
                 content,
                 new_session_id,
+                buttons,
             }) => {
                 let effective_sid = new_session_id.as_deref().unwrap_or(&session_id);
                 // Only persist reply to the OLD session; skip for new sessions
@@ -217,6 +218,7 @@ async fn handle_inbound_message(
                     reply_to_message_id: Some(msg.message_id.clone()),
                     thread_id: msg.thread_id.clone(),
                     parse_mode: Some(ParseMode::Html),
+                    buttons,
                     ..ReplyPayload::text("")
                 };
                 let _ = plugin.send_message(&account.id, &msg.chat_id, &payload).await;
@@ -799,9 +801,11 @@ enum ChannelSlashOutcome {
     /// Send `content` as a direct reply; no LLM call needed.
     /// `new_session_id` is set when the command created a fresh session that should
     /// replace the current channel → session mapping.
+    /// `buttons` provides optional inline keyboard buttons for IM channels that support them.
     Reply {
         content: String,
         new_session_id: Option<String>,
+        buttons: Vec<Vec<crate::channel::types::InlineButton>>,
     },
     /// The command (e.g. a skill invocation) asks to pass a transformed message
     /// through to the LLM instead of the original "/" text.
@@ -826,6 +830,32 @@ async fn dispatch_slash_for_channel(
     use crate::slash_commands::{handlers, parser};
 
     let (name, args) = parser::parse(text).map_err(|e| anyhow::anyhow!(e))?;
+
+    // For commands with fixed arg_options and no args provided, return inline buttons
+    // so IM channel users (e.g. Telegram) can tap to select an option.
+    if args.trim().is_empty() {
+        use crate::slash_commands::registry;
+        let commands = registry::all_commands();
+        if let Some(cmd) = commands.iter().find(|c| c.name == name) {
+            if let Some(ref options) = cmd.arg_options {
+                let buttons: Vec<Vec<crate::channel::types::InlineButton>> = options
+                    .iter()
+                    .map(|opt| {
+                        vec![crate::channel::types::InlineButton {
+                            text: opt.clone(),
+                            callback_data: Some(format!("slash:{} {}", name, opt)),
+                            url: None,
+                        }]
+                    })
+                    .collect();
+                return Ok(ChannelSlashOutcome::Reply {
+                    content: format!("Select an option for /{}:", name),
+                    new_session_id: None,
+                    buttons,
+                });
+            }
+        }
+    }
 
     // Obtain a reference to the global AppState so we can reuse the shared handlers.
     let app_handle = crate::get_app_handle()
@@ -863,6 +893,7 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: result.content,
                 new_session_id: Some(new_sid),
+                buttons: vec![],
             })
         }
 
@@ -888,6 +919,7 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: result.content,
                 new_session_id: Some(new_sid),
+                buttons: vec![],
             })
         }
 
@@ -914,6 +946,7 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: format!("**System Prompt**\n\n```\n{}\n```", prompt),
                 new_session_id: None,
+                buttons: vec![],
             })
         }
 
@@ -942,6 +975,7 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: result.content,
                 new_session_id: None,
+                buttons: vec![],
             })
         }
 
@@ -957,6 +991,7 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: result.content,
                 new_session_id: None,
+                buttons: vec![],
             })
         }
 
@@ -971,6 +1006,7 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: msg,
                 new_session_id: None,
+                buttons: vec![],
             })
         }
 
@@ -985,11 +1021,13 @@ async fn dispatch_slash_for_channel(
                     Ok(ChannelSlashOutcome::Reply {
                         content: msg,
                         new_session_id: None,
+                        buttons: vec![],
                     })
                 }
                 Err(e) => Ok(ChannelSlashOutcome::Reply {
                     content: format!("Compaction failed: {}", e),
                     new_session_id: None,
+                    buttons: vec![],
                 }),
             }
         }
@@ -1002,6 +1040,7 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: result.content,
                 new_session_id: None,
+                buttons: vec![],
             })
         }
 
@@ -1022,6 +1061,7 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: msg,
                 new_session_id: None,
+                buttons: vec![],
             })
         }
 
@@ -1032,6 +1072,7 @@ async fn dispatch_slash_for_channel(
                 mode
             ),
             new_session_id: None,
+            buttons: vec![],
         }),
 
         // ── Plan: show plan content ──
@@ -1042,6 +1083,7 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: format!("**Current Plan**\n\n{}", plan_content),
                 new_session_id: None,
+                buttons: vec![],
             })
         }
 
@@ -1057,6 +1099,17 @@ async fn dispatch_slash_for_channel(
             Ok(ChannelSlashOutcome::Reply {
                 content: result.content,
                 new_session_id: None,
+                buttons: vec![],
+            })
+        }
+
+        // ── DisplayOnly: for /model with no args, attach model list as inline buttons ──
+        Some(CommandAction::DisplayOnly) if name == "model" && args.trim().is_empty() => {
+            let model_buttons = build_model_buttons(app_state).await;
+            Ok(ChannelSlashOutcome::Reply {
+                content: result.content,
+                new_session_id: None,
+                buttons: model_buttons,
             })
         }
 
@@ -1064,8 +1117,56 @@ async fn dispatch_slash_for_channel(
         _ => Ok(ChannelSlashOutcome::Reply {
             content: result.content,
             new_session_id: None,
+            buttons: vec![],
         }),
     }
+}
+
+/// Build inline keyboard buttons for the model list.
+/// Each available model gets a button with callback_data `slash:model <model_name>`.
+/// Telegram limits inline keyboard callback_data to 64 bytes, so we use model_name
+/// (the display name the fuzzy matcher accepts) rather than model_id.
+async fn build_model_buttons(
+    app_state: &crate::AppState,
+) -> Vec<Vec<crate::channel::types::InlineButton>> {
+    let store = app_state.provider_store.lock().await;
+    let models = crate::provider::build_available_models(&store.providers);
+
+    // Group up to 2 models per row, max 20 buttons (Telegram limit is 100 but keep it tidy)
+    let mut rows: Vec<Vec<crate::channel::types::InlineButton>> = Vec::new();
+    let mut row: Vec<crate::channel::types::InlineButton> = Vec::new();
+
+    for m in models.iter().take(20) {
+        let is_active = store
+            .active_model
+            .as_ref()
+            .map(|a| a.provider_id == m.provider_id && a.model_id == m.model_id)
+            .unwrap_or(false);
+        let label = if is_active {
+            format!("✓ {}", m.model_name)
+        } else {
+            m.model_name.clone()
+        };
+        // Telegram callback_data max is 64 bytes; truncate if needed
+        let cb = format!("slash:model {}", m.model_name);
+        let cb = if cb.len() > 64 {
+            format!("slash:model {}", &m.model_id)
+        } else {
+            cb
+        };
+        row.push(crate::channel::types::InlineButton {
+            text: label,
+            callback_data: Some(cb),
+            url: None,
+        });
+        if row.len() >= 2 {
+            rows.push(std::mem::take(&mut row));
+        }
+    }
+    if !row.is_empty() {
+        rows.push(row);
+    }
+    rows
 }
 
 #[cfg(test)]

--- a/src-tauri/src/slash_commands/handlers/model.rs
+++ b/src-tauri/src/slash_commands/handlers/model.rs
@@ -55,14 +55,14 @@ pub fn handle_model(store: &ProviderStore, args: &str) -> Result<CommandResult, 
 /// /think <level> — Set reasoning effort.
 pub fn handle_think(args: &str) -> Result<CommandResult, String> {
     let level = args.trim().to_lowercase();
-    let valid = ["off", "none", "low", "medium", "high"];
+    let valid = ["off", "none", "low", "medium", "high", "xhigh"];
     let effort = if level == "off" || level == "none" {
         "none".to_string()
     } else if valid.contains(&level.as_str()) {
         level
     } else {
         return Err(format!(
-            "Invalid thinking level: `{}`. Use: off, low, medium, high",
+            "Invalid thinking level: `{}`. Use: off, low, medium, high, xhigh",
             args.trim()
         ));
     };

--- a/src-tauri/src/slash_commands/registry.rs
+++ b/src-tauri/src/slash_commands/registry.rs
@@ -70,6 +70,7 @@ pub fn all_commands() -> Vec<SlashCommandDef> {
                 "low".into(),
                 "medium".into(),
                 "high".into(),
+                "xhigh".into(),
             ]),
             description_raw: None,
         },
@@ -126,8 +127,8 @@ pub fn all_commands() -> Vec<SlashCommandDef> {
             category: CommandCategory::Session,
             description_key: "slashCommands.plan.description".into(),
             has_args: true,
-            arg_placeholder: Some("[exit|show|approve]".into()),
-            arg_options: Some(vec!["exit".into(), "show".into(), "approve".into()]),
+            arg_placeholder: Some("[enter|exit|show|approve|pause|resume]".into()),
+            arg_options: Some(vec!["enter".into(), "exit".into(), "show".into(), "approve".into(), "pause".into(), "resume".into()]),
             description_raw: None,
         },
         // ── Utility ──

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -195,9 +195,13 @@ export default function ChatInput({
           {/* Slash Command Menu */}
           {slash.isOpen && (
             <SlashCommandMenu
-              commands={slash.filteredCommands}
+              commands={slash.expandedCmd ? [] : slash.filteredCommands}
               selectedIndex={slash.selectedIndex}
               onSelect={slash.executeCommand}
+              expandedCmd={slash.expandedCmd}
+              filteredOptions={slash.filteredOptions}
+              selectedOptionIndex={slash.selectedOptionIndex}
+              onSelectOption={slash.executeOption}
             />
           )}
           {/* Attached files preview */}

--- a/src/components/chat/slash-commands/SlashCommandMenu.tsx
+++ b/src/components/chat/slash-commands/SlashCommandMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
+import { ChevronRight } from "lucide-react"
 import type { SlashCommandDef, CommandCategory } from "./types"
 import { CATEGORY_ORDER } from "./types"
 
@@ -8,6 +9,14 @@ interface SlashCommandMenuProps {
   commands: SlashCommandDef[]
   selectedIndex: number
   onSelect: (cmd: SlashCommandDef) => void
+  /** Currently expanded command (showing arg options submenu) */
+  expandedCmd?: SlashCommandDef | null
+  /** Filtered options for the expanded command */
+  filteredOptions?: string[]
+  /** Selected option index in the submenu */
+  selectedOptionIndex?: number
+  /** Execute a specific option from the submenu */
+  onSelectOption?: (cmd: SlashCommandDef, option: string) => void
 }
 
 const CATEGORY_I18N_KEYS: Record<CommandCategory, string> = {
@@ -23,17 +32,41 @@ export default function SlashCommandMenu({
   commands,
   selectedIndex,
   onSelect,
+  expandedCmd,
+  filteredOptions = [],
+  selectedOptionIndex = 0,
+  onSelectOption,
 }: SlashCommandMenuProps) {
   const { t } = useTranslation()
   const menuRef = useRef<HTMLDivElement>(null)
   const selectedRef = useRef<HTMLButtonElement>(null)
+  const selectedOptionRef = useRef<HTMLButtonElement>(null)
 
   // Scroll selected item into view
   useEffect(() => {
-    selectedRef.current?.scrollIntoView({ block: "nearest" })
-  }, [selectedIndex])
+    if (expandedCmd) {
+      selectedOptionRef.current?.scrollIntoView({ block: "nearest" })
+    } else {
+      selectedRef.current?.scrollIntoView({ block: "nearest" })
+    }
+  }, [selectedIndex, selectedOptionIndex, expandedCmd])
 
-  if (commands.length === 0) return null
+  // When showing submenu only (auto-expanded via input), render just the options
+  if (expandedCmd && commands.length === 0) {
+    return (
+      <div
+        ref={menuRef}
+        className="absolute bottom-full left-0 right-0 mb-2 mx-3 bg-popover/95 backdrop-blur-xl border border-border/60 rounded-xl shadow-[0_8px_30px_rgb(0,0,0,0.12)] z-50 max-h-[300px] overflow-y-auto overscroll-contain p-1.5 animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150"
+      >
+        <div className="px-2.5 py-1 text-[11px] font-medium text-muted-foreground/60 uppercase tracking-wider">
+          /{expandedCmd.name}
+        </div>
+        {renderOptions(expandedCmd, filteredOptions, selectedOptionIndex, selectedOptionRef, onSelectOption)}
+      </div>
+    )
+  }
+
+  if (commands.length === 0 && !expandedCmd) return null
 
   // Group by category
   const grouped = new Map<CommandCategory, SlashCommandDef[]>()
@@ -59,35 +92,51 @@ export default function SlashCommandMenu({
             </div>
             {cmds.map((cmd) => {
               const idx = flatIndex++
-              const isSelected = idx === selectedIndex
+              const isSelected = idx === selectedIndex && !expandedCmd
+              const isExpanded = expandedCmd?.name === cmd.name
               return (
-                <button
-                  key={cmd.name}
-                  ref={isSelected ? selectedRef : undefined}
-                  className={cn(
-                    "w-full text-left px-2.5 py-1.5 rounded-md transition-all duration-100 flex items-center gap-2",
-                    isSelected
-                      ? "bg-secondary text-foreground shadow-sm"
-                      : "text-foreground/80 hover:bg-secondary/60 hover:text-foreground",
-                  )}
-                  onClick={() => onSelect(cmd)}
-                  onMouseEnter={(e) => {
-                    // Let mouse hovering also highlight
-                    e.currentTarget.focus()
-                  }}
-                >
-                  <span className="font-mono text-[13px] text-primary/80 shrink-0">
-                    /{cmd.name}
-                  </span>
-                  <span className="text-[12px] text-muted-foreground truncate">
-                    {cmd.descriptionRaw || t(cmd.descriptionKey)}
-                  </span>
-                  {cmd.argPlaceholder && (
-                    <span className="text-[11px] text-muted-foreground/50 ml-auto shrink-0">
-                      {cmd.argPlaceholder}
+                <div key={cmd.name}>
+                  <button
+                    ref={isSelected ? selectedRef : undefined}
+                    className={cn(
+                      "w-full text-left px-2.5 py-1.5 rounded-md transition-all duration-100 flex items-center gap-2",
+                      isSelected
+                        ? "bg-secondary text-foreground shadow-sm"
+                        : isExpanded
+                          ? "bg-secondary/40 text-foreground"
+                          : "text-foreground/80 hover:bg-secondary/60 hover:text-foreground",
+                    )}
+                    onClick={() => onSelect(cmd)}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.focus()
+                    }}
+                  >
+                    <span className="font-mono text-[13px] text-primary/80 shrink-0">
+                      /{cmd.name}
                     </span>
+                    <span className="text-[12px] text-muted-foreground truncate">
+                      {cmd.descriptionRaw || t(cmd.descriptionKey)}
+                    </span>
+                    {cmd.argOptions?.length ? (
+                      <ChevronRight
+                        className={cn(
+                          "w-3 h-3 ml-auto shrink-0 transition-transform",
+                          isExpanded ? "rotate-90 text-primary/60" : "text-muted-foreground/40",
+                        )}
+                      />
+                    ) : cmd.argPlaceholder ? (
+                      <span className="text-[11px] text-muted-foreground/50 ml-auto shrink-0">
+                        {cmd.argPlaceholder}
+                      </span>
+                    ) : null}
+                  </button>
+                  {/* Inline submenu for arg options */}
+                  {isExpanded && filteredOptions.length > 0 && (
+                    <div className="ml-5 my-0.5 border-l-2 border-border/40 pl-1.5">
+                      {renderOptions(cmd, filteredOptions, selectedOptionIndex, selectedOptionRef, onSelectOption)}
+                    </div>
                   )}
-                </button>
+                </div>
               )
             })}
           </div>
@@ -95,4 +144,29 @@ export default function SlashCommandMenu({
       })}
     </div>
   )
+}
+
+/** Render option buttons for a command's argOptions submenu */
+function renderOptions(
+  cmd: SlashCommandDef,
+  options: string[],
+  selectedIdx: number,
+  selectedRef: React.RefObject<HTMLButtonElement | null>,
+  onSelectOption?: (cmd: SlashCommandDef, option: string) => void,
+) {
+  return options.map((opt, i) => (
+    <button
+      key={opt}
+      ref={i === selectedIdx ? selectedRef : undefined}
+      className={cn(
+        "w-full text-left px-2.5 py-1 rounded-md text-[13px] font-mono transition-all duration-100",
+        i === selectedIdx
+          ? "bg-primary/10 text-primary"
+          : "text-foreground/70 hover:bg-secondary/50 hover:text-foreground",
+      )}
+      onClick={() => onSelectOption?.(cmd, opt)}
+    >
+      {opt}
+    </button>
+  ))
 }

--- a/src/components/chat/slash-commands/useSlashCommands.ts
+++ b/src/components/chat/slash-commands/useSlashCommands.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react"
+import { useState, useEffect, useCallback, useRef, useMemo } from "react"
 import { invoke } from "@tauri-apps/api/core"
 import type { SlashCommandDef, CommandResult } from "./types"
 import { CATEGORY_ORDER } from "./types"
@@ -29,6 +29,14 @@ export interface UseSlashCommandsReturn {
   executeCommand: (cmd: SlashCommandDef) => void
   /** Whether a command is currently executing */
   executing: boolean
+  /** Currently expanded command (showing arg options submenu) */
+  expandedCmd: SlashCommandDef | null
+  /** Filtered options for the expanded command */
+  filteredOptions: string[]
+  /** Selected option index in the submenu */
+  selectedOptionIndex: number
+  /** Execute a specific option from the submenu */
+  executeOption: (cmd: SlashCommandDef, option: string) => void
 }
 
 export function useSlashCommands(
@@ -41,6 +49,8 @@ export function useSlashCommands(
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [executing, setExecuting] = useState(false)
   const [forceOpen, setForceOpen] = useState(false)
+  const [expandedCmd, setExpandedCmd] = useState<SlashCommandDef | null>(null)
+  const [selectedOptionIndex, setSelectedOptionIndex] = useState(0)
   const actionsRef = useRef(actions)
   actionsRef.current = actions
 
@@ -101,17 +111,56 @@ export function useSlashCommands(
     })
   }, [commands, getFilterText, input, forceOpen])()
 
+  // Detect if input matches a command with argOptions (for auto-expanding submenu)
+  const inputMatchCmd = useMemo(() => {
+    if (!input.startsWith("/")) return null
+    const spaceIdx = input.indexOf(" ")
+    if (spaceIdx < 0) return null
+    const name = input.slice(1, spaceIdx)
+    return commands.find((c) => c.name === name && c.argOptions?.length) ?? null
+  }, [input, commands])
+
+  // Filter options for the expanded command based on typed input
+  const filteredOptions = useMemo(() => {
+    const cmd = expandedCmd ?? inputMatchCmd
+    if (!cmd?.argOptions) return []
+    const prefix = `/${cmd.name} `
+    if (!input.startsWith(prefix)) return cmd.argOptions
+    const typed = input.slice(prefix.length).toLowerCase()
+    if (!typed) return cmd.argOptions
+    return cmd.argOptions.filter((o) => o.startsWith(typed))
+  }, [expandedCmd, inputMatchCmd, input])
+
+  // Auto-expand submenu when user types "/<cmd-with-options> "
+  useEffect(() => {
+    if (inputMatchCmd && !expandedCmd) {
+      setExpandedCmd(inputMatchCmd)
+      setSelectedOptionIndex(0)
+      setIsOpen(true)
+    } else if (!inputMatchCmd && expandedCmd) {
+      // Input no longer matches — close submenu
+      setExpandedCmd(null)
+    }
+  }, [inputMatchCmd]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Reset option index when filtered options change
+  useEffect(() => {
+    setSelectedOptionIndex(0)
+  }, [filteredOptions.length])
+
   // Determine if menu should be open
   const shouldBeOpen =
     forceOpen ||
+    expandedCmd != null ||
+    inputMatchCmd != null ||
     (input.startsWith("/") && input.indexOf(" ") < 0 && filteredCommands.length > 0)
 
   useEffect(() => {
     setIsOpen(shouldBeOpen)
-    if (shouldBeOpen) {
+    if (shouldBeOpen && !expandedCmd && !inputMatchCmd) {
       setSelectedIndex(0)
     }
-  }, [shouldBeOpen])
+  }, [shouldBeOpen]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const executeCommandInner = useCallback(
     async (cmd: SlashCommandDef) => {
@@ -124,6 +173,7 @@ export function useSlashCommands(
       setInput("")
       setIsOpen(false)
       setForceOpen(false)
+      setExpandedCmd(null)
       setExecuting(true)
 
       try {
@@ -145,16 +195,54 @@ export function useSlashCommands(
     [input, setInput],
   )
 
+  const executeOption = useCallback(
+    (cmd: SlashCommandDef, option: string) => {
+      setInput(`/${cmd.name} ${option}`)
+      setExpandedCmd(null)
+      setIsOpen(false)
+      setForceOpen(false)
+      setExecuting(true)
+
+      const commandText = `/${cmd.name} ${option}`
+      invoke<CommandResult>("execute_slash_command", {
+        sessionId: actionsRef.current.sessionId,
+        agentId: actionsRef.current.agentId,
+        commandText,
+      })
+        .then((result) => actionsRef.current.onCommandAction(result))
+        .catch((err) =>
+          actionsRef.current.onCommandAction({
+            content: `Error: ${err}`,
+            action: { type: "displayOnly" },
+          }),
+        )
+        .finally(() => {
+          setInput("")
+          setExecuting(false)
+        })
+    },
+    [setInput],
+  )
+
   const executeSelected = useCallback(() => {
+    if (expandedCmd && filteredOptions.length > 0) {
+      executeOption(expandedCmd, filteredOptions[selectedOptionIndex])
+      return
+    }
     if (filteredCommands.length > 0 && selectedIndex < filteredCommands.length) {
       executeCommandInner(filteredCommands[selectedIndex])
     }
-  }, [filteredCommands, selectedIndex, executeCommandInner])
+  }, [filteredCommands, selectedIndex, executeCommandInner, expandedCmd, filteredOptions, selectedOptionIndex, executeOption])
 
   const executeCommand = useCallback(
     (cmd: SlashCommandDef) => {
-      if (cmd.hasArgs) {
-        // For commands with args, fill in the command and let user type args
+      if (cmd.argOptions?.length) {
+        // Has built-in options: expand submenu
+        setExpandedCmd(cmd)
+        setSelectedOptionIndex(0)
+        setInput(`/${cmd.name} `)
+      } else if (cmd.hasArgs) {
+        // Has args but no built-in options: fill in command and let user type
         setInput(`/${cmd.name} `)
         setIsOpen(false)
         setForceOpen(false)
@@ -169,6 +257,38 @@ export function useSlashCommands(
     (e: React.KeyboardEvent): boolean => {
       if (!isOpen) return false
 
+      // When submenu is expanded, handle option navigation
+      if (expandedCmd && filteredOptions.length > 0) {
+        switch (e.key) {
+          case "ArrowUp":
+            e.preventDefault()
+            setSelectedOptionIndex((prev) =>
+              prev <= 0 ? filteredOptions.length - 1 : prev - 1,
+            )
+            return true
+          case "ArrowDown":
+            e.preventDefault()
+            setSelectedOptionIndex((prev) =>
+              prev >= filteredOptions.length - 1 ? 0 : prev + 1,
+            )
+            return true
+          case "Tab":
+          case "Enter":
+            e.preventDefault()
+            executeOption(expandedCmd, filteredOptions[selectedOptionIndex])
+            return true
+          case "Escape":
+          case "ArrowLeft":
+            e.preventDefault()
+            setExpandedCmd(null)
+            setInput("/")
+            return true
+          default:
+            return false
+        }
+      }
+
+      // Normal command list navigation
       switch (e.key) {
         case "ArrowUp":
           e.preventDefault()
@@ -197,6 +317,7 @@ export function useSlashCommands(
         case "Escape":
           e.preventDefault()
           setIsOpen(false)
+          setExpandedCmd(null)
           // Only clear input if it was typed (starts with "/"), not button-triggered
           if (!forceOpen && input.startsWith("/")) {
             setInput("")
@@ -208,16 +329,18 @@ export function useSlashCommands(
           return false
       }
     },
-    [isOpen, filteredCommands, selectedIndex, executeCommand, setInput, forceOpen, input],
+    [isOpen, filteredCommands, selectedIndex, executeCommand, setInput, forceOpen, input, expandedCmd, filteredOptions, selectedOptionIndex, executeOption],
   )
 
   const setOpen = useCallback(
     (open: boolean) => {
       if (open) {
         setForceOpen(true)
+        setExpandedCmd(null)
       } else {
         setForceOpen(false)
         setIsOpen(false)
+        setExpandedCmd(null)
       }
     },
     [],
@@ -232,5 +355,9 @@ export function useSlashCommands(
     executeSelected,
     executeCommand,
     executing,
+    expandedCmd,
+    filteredOptions,
+    selectedOptionIndex,
+    executeOption,
   }
 }


### PR DESCRIPTION
## Summary

- **对齐所有斜杠命令在前端和 Channel (Telegram) 的执行行为**：提取 core 函数供 Channel worker 复用，Channel 执行状态变更命令后通过 `slash:*` 事件同步前端 UI
- **新增参数选项 (arg_options) 可选子菜单**：前端 `SlashCommandMenu` 对有预设选项的命令（`/think`、`/plan`、`/permission`）渲染可展开子菜单，支持键盘导航
- **Telegram inline keyboard 按钮**：无参数发送有 `arg_options` 的命令时返回可点击选项按钮；`/model` 无参数返回所有可用模型的按钮列表
- **新增 `xhigh` 思考等级**
- **Telegram CallbackQuery 处理**：点击 inline button 后自动转换为标准斜杠命令执行

## Changes

### Backend (Rust)
- `slash_commands/registry.rs` — `/think` 增加 `xhigh`；`/plan` 增加 `pause`/`resume`
- `slash_commands/handlers/model.rs` — `handle_think` 支持 `xhigh`
- `channel/worker.rs` — `ChannelSlashOutcome::Reply` 增加 `buttons` 字段；无参数命令返回 inline buttons；`/model` 无参数返回 model list buttons；`build_model_buttons()` 辅助函数
- `channel/telegram/api.rs` — `send_text` / `send_text_with_fallback` 支持 inline keyboard
- `channel/telegram/polling.rs` — 处理 `CallbackQuery`，转换 `slash:<cmd> <arg>` 回调为标准命令
- `channel/cancel.rs` — NEW: `ChannelCancelRegistry`（`/stop` 支持）
- `commands/provider.rs`、`commands/auth.rs`、`commands/config.rs` — 提取 `*_core` 函数

### Frontend (TypeScript)
- `useSlashCommands.ts` — 子菜单状态机（expandedCmd / filteredOptions / selectedOptionIndex / executeOption）
- `SlashCommandMenu.tsx` — 可展开选项子菜单 UI，ChevronRight 指示器，键盘导航
- `ChatInput.tsx` — 传递子菜单 props
- `ChatScreen.tsx` — 监听 `slash:model_switched`、`slash:effort_changed`、`slash:session_cleared`、`slash:plan_changed` 事件

### Docs
- `docs/slash-commands.md` — 新增「参数选项 (arg_options)」章节、`xhigh` 等级、Telegram inline buttons 说明
- `CHANGELOG.md` — 记录所有变更

## Test plan
- [ ] 前端输入 `/think` 回车，验证展开 off/low/medium/high/xhigh 子菜单
- [ ] 前端输入 `/think high` 直接执行，验证跳过子菜单
- [ ] 前端输入 `/plan` 回车，验证展开 enter/exit/show/approve/pause/resume 子菜单
- [ ] Telegram 发送 `/think`，验证返回 5 个选项按钮
- [ ] Telegram 点击 `high` 按钮，验证思考强度切换成功
- [ ] Telegram 发送 `/model`，验证返回模型列表按钮，当前模型有 ✓ 标记
- [ ] Telegram 点击模型按钮，验证模型切换成功
- [ ] 验证 Channel 执行 `/stop`、`/compact`、`/clear` 等命令后前端 UI 正常同步

https://claude.ai/code/session_01J2KuS96ZhnoNxzH5qLBhWM