### PR TITLE
fix: stabilize quick chat window translucency during drag

### DIFF
--- a/src/QuickChatWindow.tsx
+++ b/src/QuickChatWindow.tsx
@@ -106,7 +106,7 @@ export default function QuickChatWindow() {
 
   return (
     <TooltipProvider>
-      <div className="flex flex-col h-screen rounded-2xl bg-background/70 dark:bg-background/60 backdrop-blur-2xl backdrop-saturate-150 shadow-2xl [clip-path:inset(0_round_16px)]">
+      <div className="flex flex-col h-screen rounded-2xl border border-border/60 bg-background/95 shadow-2xl [clip-path:inset(0_round_16px)]">
         {/* ── Title bar (draggable) ─────────────── */}
         <div
           className="flex items-center gap-2 px-4 py-2 shrink-0 select-none"


### PR DESCRIPTION
### Motivation
- 修复快捷弹窗在拖拽或窗口合成时出现“忽透忽不透”抖动的问题，通过移除不稳定的 backdrop 样式改为更稳定的近不透明背景以避免系统合成导致的透明度闪烁。

### Description
- 在 `src/QuickChatWindow.tsx` 中将容器类从 `bg-background/70 dark:bg-background/60 backdrop-blur-2xl backdrop-saturate-150` 替换为 `border border-border/60 bg-background/95`，保留圆角与阴影并保持标题栏的拖拽区域不变。

### Testing
- 运行 `npx eslint src/QuickChatWindow.tsx`，检查通过；
- 运行 `npm run lint`，因仓库中与本次改动无关的历史 lint 问题（`src/components/settings/ToolGeneralPanel.tsx`、`src/components/settings/WeatherSection.tsx`）导致总体 lint 失败。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd102e4ad48321917097b2af9fbdea)