### PR TITLE
feat(channel): sync slash commands to Telegram bot menu via setMyCommands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ src-tauri/src/          后端（Rust）
 - **温度配置**：三层覆盖架构（会话 > Agent > 全局）。全局存储在 `config.json` 的 `temperature` 字段，Agent 级存储在 `agent.json` 的 `model.temperature` 字段，会话级通过 `chat` 命令的 `temperatureOverride` 参数传递。`AssistantAgent.temperature` 字段在四种 Provider 的 API 请求中统一注入。范围 0.0–2.0，`None` 表示使用 API 默认值
 - **Tool Loop**：请求 → 解析 tool_call → 执行 → 回传 → 继续，最多 10 轮
 - **数据存储**：所有数据统一在 `~/.opencomputer/`，`paths.rs` 集中管理
-- **IM Channel 架构**：`channel/` 目录统一承载 Telegram / WeChat 等渠道插件；Telegram 走 Bot API 轮询，WeChat 走 OpenClaw 兼容的二维码登录 + iLink HTTP 长轮询协议，渠道状态文件统一落在 `~/.opencomputer/channels/`。入站媒体管道：polling 收集 `InboundMedia` → worker 转为 `Attachment`（图片 base64 / 文件 path）→ `ChatEngineParams.attachments` → `agent.chat()` 多模态接口。WeChat 通道完整能力：typing 指示器（24h TTL + 5s keepalive + cancel）、入站媒体下载解密（图片/视频/语音/文件）、出站媒体 AES-128-ECB 加密上传 CDN（3 次 5xx 重试）、会话过期暂停 1h、QR 登录自动刷新 3 次
+- **IM Channel 架构**：`channel/` 目录统一承载 Telegram / WeChat 等渠道插件；Telegram 走 Bot API 轮询，WeChat 走 OpenClaw 兼容的二维码登录 + iLink HTTP 长轮询协议，渠道状态文件统一落在 `~/.opencomputer/channels/`。入站媒体管道：polling 收集 `InboundMedia` → worker 转为 `Attachment`（图片 base64 / 文件 path）→ `ChatEngineParams.attachments` → `agent.chat()` 多模态接口。WeChat 通道完整能力：typing 指示器（24h TTL + 5s keepalive + cancel）、入站媒体下载解密（图片/视频/语音/文件）、出站媒体 AES-128-ECB 加密上传 CDN（3 次 5xx 重试）、会话过期暂停 1h、QR 登录自动刷新 3 次。**斜杠命令同步**：Telegram Bot 启动时自动调用 `setMyCommands` 同步内置命令到 Bot 菜单，`SlashCommandDef::description_en()` 提供英文描述
 - **SearXNG Docker 代理注入**：`web_search.searxng_docker_use_proxy` 控制是否向 Docker SearXNG 写入 `settings.yml` 的 `outgoing.proxies` 和代理环境变量；适用于系统 VPN 场景，修改后在下次启动或重新部署容器时生效
 - **降级策略**：ContextOverflow 终止 → RateLimit/Overloaded/Timeout 指数退避重试 2 次 → Auth/Billing/ModelNotFound 跳下一模型
 - **连续消息合并**：`push_user_message()` 自动合并连续 user 消息，兼容 Anthropic role 交替要求

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Telegram 斜杠命令菜单同步**
+  - Bot 启动认证后自动调用 `setMyCommands` 将所有内置斜杠命令同步到 Telegram 的 `/` 命令菜单
+  - 用户在 Telegram 中输入 `/` 即可看到所有可用命令及英文描述
+  - `SlashCommandDef` 新增 `description_en()` 方法，为渠道 API 提供英文描述（无需 i18n 系统）
+  - 同步失败不阻塞 Bot 启动，仅记录警告日志
+
 - **天气地区自动定位**
   - 设置面板城市搜索框旁新增定位按钮（LocateFixed 图标）
   - macOS 优先使用 CoreLocation 系统定位（精确），通过 `objc2` FFI 直接调用，权限对话框显示应用名 "OpenComputer"

--- a/src-tauri/src/channel/telegram/api.rs
+++ b/src-tauri/src/channel/telegram/api.rs
@@ -3,8 +3,8 @@ use anyhow::Result;
 use std::time::Duration;
 use teloxide::prelude::*;
 use teloxide::types::{
-    ChatAction, ChatId, InlineKeyboardButton, InlineKeyboardMarkup, InputFile, Me, MessageId,
-    ParseMode as TgParseMode, ReplyParameters, ThreadId,
+    BotCommand, ChatAction, ChatId, InlineKeyboardButton, InlineKeyboardMarkup, InputFile, Me,
+    MessageId, ParseMode as TgParseMode, ReplyParameters, ThreadId,
 };
 
 /// Thin wrapper around teloxide's `Bot` to isolate framework details.
@@ -241,6 +241,15 @@ impl TelegramBotApi {
 
         req.await
             .map_err(|e| anyhow::anyhow!("getUpdates failed: {}", e))
+    }
+
+    /// Register bot menu commands via setMyCommands API.
+    pub async fn set_my_commands(&self, commands: Vec<BotCommand>) -> Result<()> {
+        self.bot
+            .set_my_commands(commands)
+            .await
+            .map_err(|e| anyhow::anyhow!("setMyCommands failed: {}", e))?;
+        Ok(())
     }
 
     /// Download a file by file_id (returns the file path on Telegram servers).

--- a/src-tauri/src/channel/telegram/mod.rs
+++ b/src-tauri/src/channel/telegram/mod.rs
@@ -44,6 +44,40 @@ impl TelegramPlugin {
             .ok_or_else(|| anyhow::anyhow!("Missing 'token' in Telegram credentials"))
     }
 
+    /// Sync slash commands to Telegram's bot menu via setMyCommands.
+    /// Called once after successful authentication. Non-fatal on failure.
+    async fn sync_commands_to_menu(api: &TelegramBotApi) {
+        let commands = crate::slash_commands::registry::all_commands();
+
+        let bot_commands: Vec<teloxide::types::BotCommand> = commands
+            .iter()
+            .map(|cmd| teloxide::types::BotCommand {
+                command: cmd.name.clone(),
+                description: cmd.description_en(),
+            })
+            .collect();
+
+        let count = bot_commands.len();
+        match api.set_my_commands(bot_commands).await {
+            Ok(()) => {
+                app_info!(
+                    "channel",
+                    "telegram",
+                    "Synced {} commands to bot menu",
+                    count
+                );
+            }
+            Err(e) => {
+                app_warn!(
+                    "channel",
+                    "telegram",
+                    "Failed to sync bot menu commands: {}",
+                    e
+                );
+            }
+        }
+    }
+
     /// Extract optional proxy URL from settings or global config.
     fn extract_proxy(settings: &serde_json::Value) -> Option<String> {
         // Check channel-level proxy first
@@ -138,6 +172,9 @@ impl ChannelPlugin for TelegramPlugin {
             bot_username,
             bot_id
         );
+
+        // Sync slash commands to Telegram bot menu
+        Self::sync_commands_to_menu(&api).await;
 
         let api = Arc::new(api);
 

--- a/src-tauri/src/slash_commands/types.rs
+++ b/src-tauri/src/slash_commands/types.rs
@@ -107,6 +107,43 @@ pub enum CommandAction {
     ViewSystemPrompt,
 }
 
+impl SlashCommandDef {
+    /// Return an English description for use in channel APIs (e.g. Telegram Bot Menu).
+    ///
+    /// For skill commands, uses `description_raw`. For built-in commands, maps
+    /// the command name to a hardcoded English string (matching en.json values).
+    pub fn description_en(&self) -> String {
+        if let Some(ref raw) = self.description_raw {
+            return raw.clone();
+        }
+        match self.name.as_str() {
+            "new" => "Start a new chat",
+            "clear" => "Clear conversation",
+            "compact" => "Compress context",
+            "stop" => "Stop current reply",
+            "rename" => "Rename session",
+            "model" => "Switch model",
+            "models" => "List all available models",
+            "think" => "Set thinking effort",
+            "remember" => "Save a memory",
+            "forget" => "Delete a memory",
+            "memories" => "List memories",
+            "agent" => "Switch agent",
+            "agents" => "List agents",
+            "help" => "Show all commands",
+            "status" => "Session status",
+            "export" => "Export as Markdown",
+            "usage" => "Token usage",
+            "search" => "Search the web",
+            "permission" => "Set tool permission mode",
+            "plan" => "Enter/exit plan mode",
+            "prompts" => "View system prompt",
+            _ => "Command",
+        }
+        .to_string()
+    }
+}
+
 /// A single model entry for the model picker card.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
Telegram Bot 启动认证后自动调用 setMyCommands API 将所有内置斜杠命令
同步到 Telegram 的 / 命令菜单，用户输入 / 即可看到所有可用命令及描述。

- SlashCommandDef 新增 description_en() 方法提供英文描述
- TelegramBotApi 新增 set_my_commands() 封装 teloxide API
- TelegramPlugin::sync_commands_to_menu() 在 start_account 中调用
- 同步失败不阻塞 Bot 启动，仅记录警告日志

https://claude.ai/code/session_01GSVXJagMdX7bCeyjgytkPF