### PR TITLE
fix(plan): render inline markdown in plan step titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Plan 步骤标题 Markdown 渲染**：修复 `PlanStepItem` 把 `**HTML 结构**` 等步骤标题里的行内 markdown 当成纯文本展示的问题。新增轻量行内 markdown 解析器，支持 `**bold**` / `*italic*` / `` `code` `` / `~~strike~~` / `\` 转义，同时应用于 `step.title` 和 `step.description`。故意不走 Streamdown / MarkdownRenderer 以避免把单行标题塞进 `<p>` 块级包装，保持列表密度
+
 ### Added
 
 - **通用 `ask_user_question` 工具**：把原 Plan Mode 专用的 `plan_question` 升级为全局可用的交互式追问工具，任何对话（普通聊天 / Plan Mode / 子 Agent / Skill）中都可以让模型向用户提出结构化问题。相比 claude-code 的 `AskUserQuestion` 增强了 4 点能力：(1) **IM 渠道原生按钮**，Telegram / Slack / 飞书 / QQ Bot / Discord / LINE / Google Chat 收到按钮，WeChat / Signal / iMessage / IRC / WhatsApp 收到文本 fallback（`1a`/`2b` 或 `done`）；(2) **Markdown 富预览**，`option.preview` 支持 markdown / 图片 URL / mermaid，复用 Streamdown 轻量栈，单选时右侧 side-by-side 展示；(3) **per-question 超时 + 默认值**，`timeout_secs` + `default_values` 到点自动回退，适合 cron / 后台 / IM 异步；(4) **持久化 + 断点续答**，pending 组写入 session SQLite `ask_user_questions` 表，`start_background_tasks` 启动时重放未完成事件。新增字段 `header`（≤12 字符 chip 标签）、`preview` / `previewKind`。工具名 `ask_user_question` 成为主名称，`plan_question` 保留为 dispatcher alias + 事件别名以兼容历史会话。新增 Tauri 命令 `respond_ask_user` 和 HTTP 路由 `POST /ask_user/respond`，前端 `PlanQuestionBlock` 同步渲染倒计时、preview 面板、header chip、default badge。IM 端新增 `crates/oc-core/src/channel/worker/ask_user.rs` worker 模块，统一通过 `try_dispatch_interactive_callback` 在各渠道插件路由 approval / ask_user 两类回调

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Plan 步骤标题 Markdown 渲染**：修复 `PlanStepItem` 把 `**HTML 结构**` 等步骤标题里的行内 markdown 当成纯文本展示的问题。新增轻量行内 markdown 解析器，支持 `**bold**` / `*italic*` / `` `code` `` / `~~strike~~` / `\` 转义，同时应用于 `step.title` 和 `step.description`。故意不走 Streamdown / MarkdownRenderer 以避免把单行标题塞进 `<p>` 块级包装，保持列表密度
+- **Plan 步骤标题 Markdown 渲染**：修复 `PlanStepItem` 把 `**HTML 结构**` 等步骤标题里的行内 markdown 当成纯文本展示的问题。复用 `PlanQuestionBlock` 的 Streamdown 轻量栈（只加载 `code` + `cjk` 插件），新增 `InlineMarkdown` 包装组件，通过 `className="contents"`（让 Streamdown 外层 `<div class="space-y-4 …">` 从布局中消失）+ `components={{ p: Fragment }}`（剥掉默认 `<p>` 包装）让单行标题以纯 inline 节点流入父级 `<span>`，保持列表密度。同时应用于 `step.title` 和 `step.description`
 
 ### Added
 

--- a/src/components/chat/plan-mode/PlanStepItem.tsx
+++ b/src/components/chat/plan-mode/PlanStepItem.tsx
@@ -1,5 +1,9 @@
-import type { ReactNode } from "react"
+import { Fragment, type ReactNode } from "react"
 import { Circle, Loader2, CheckCircle, XCircle, MinusCircle } from "lucide-react"
+import { Streamdown } from "streamdown"
+import { code } from "@streamdown/code"
+import { cjk } from "@streamdown/cjk"
+import "streamdown/styles.css"
 import { cn } from "@/lib/utils"
 import { formatDuration, type ParsedPlanStep } from "./planParser"
 import type { PlanStep } from "./usePlanMode"
@@ -11,101 +15,32 @@ interface PlanStepItemProps {
   detailed?: boolean
 }
 
-/**
- * Lightweight inline markdown renderer for plan step titles/descriptions.
- *
- * Supports `**bold**`, `*italic*`, `` `code` ``, `~~strike~~` and leaves
- * everything else as plain text. Block-level markdown is intentionally not
- * supported since step titles are single-line.
- */
-function renderInlineMarkdown(text: string): ReactNode[] {
-  const nodes: ReactNode[] = []
-  let buffer = ""
-  let i = 0
-  let key = 0
+// ── Inline markdown via Streamdown ────────────────────────────────
+// Streamdown has no native `inline` mode; by default it wraps content
+// in `<div class="space-y-4 ..."><p>…</p></div>`. For single-line step
+// titles we unwrap both layers:
+//   1. `className="contents"` on Streamdown hides the outer div from
+//      layout (`display: contents`), so its block-ness / margin classes
+//      don't affect flow.
+//   2. `components={{ p: Fragment }}` removes the `<p>` wrapper, so
+//      inline children (<strong>, <em>, <code>, text) flow inline.
+// Only `code` + `cjk` plugins are loaded — same minimal bundle that
+// PlanQuestionBlock uses per AGENTS.md.
+const inlinePlugins = { code, cjk }
+const inlineComponents = {
+  p: ({ children }: { children?: ReactNode }) => <Fragment>{children}</Fragment>,
+}
 
-  const flushBuffer = () => {
-    if (buffer) {
-      nodes.push(buffer)
-      buffer = ""
-    }
-  }
-
-  while (i < text.length) {
-    const ch = text[i]
-
-    // Backslash escape (\* \` etc.)
-    if (ch === "\\" && i + 1 < text.length) {
-      buffer += text[i + 1]
-      i += 2
-      continue
-    }
-
-    // **bold**
-    if (ch === "*" && text[i + 1] === "*") {
-      const end = text.indexOf("**", i + 2)
-      if (end > i + 2) {
-        flushBuffer()
-        nodes.push(
-          <strong key={key++} className="font-semibold">
-            {renderInlineMarkdown(text.slice(i + 2, end))}
-          </strong>
-        )
-        i = end + 2
-        continue
-      }
-    }
-
-    // *italic* (require non-space after opening and non-space before closing)
-    if (ch === "*" && text[i + 1] && text[i + 1] !== "*" && text[i + 1] !== " ") {
-      const end = text.indexOf("*", i + 1)
-      if (end > i + 1 && text[end - 1] !== " ") {
-        flushBuffer()
-        nodes.push(
-          <em key={key++}>{renderInlineMarkdown(text.slice(i + 1, end))}</em>
-        )
-        i = end + 1
-        continue
-      }
-    }
-
-    // `inline code`
-    if (ch === "`") {
-      const end = text.indexOf("`", i + 1)
-      if (end > i + 1) {
-        flushBuffer()
-        nodes.push(
-          <code
-            key={key++}
-            className="px-1 py-0.5 rounded bg-muted text-[0.85em] font-mono"
-          >
-            {text.slice(i + 1, end)}
-          </code>
-        )
-        i = end + 1
-        continue
-      }
-    }
-
-    // ~~strikethrough~~
-    if (ch === "~" && text[i + 1] === "~") {
-      const end = text.indexOf("~~", i + 2)
-      if (end > i + 2) {
-        flushBuffer()
-        nodes.push(
-          <s key={key++}>{renderInlineMarkdown(text.slice(i + 2, end))}</s>
-        )
-        i = end + 2
-        continue
-      }
-    }
-
-    buffer += ch
-    i++
-  }
-
-  flushBuffer()
-  return nodes
+function InlineMarkdown({ text }: { text: string }) {
+  return (
+    <Streamdown
+      className="contents"
+      plugins={inlinePlugins}
+      components={inlineComponents}
+    >
+      {text}
+    </Streamdown>
+  )
 }
 
 export function PlanStepItem({ step, detailed }: PlanStepItemProps) {
@@ -141,11 +76,11 @@ export function PlanStepItem({ step, detailed }: PlanStepItemProps) {
             step.status === "completed" && "line-through text-muted-foreground"
           )}
         >
-          {renderInlineMarkdown(step.title)}
+          <InlineMarkdown text={step.title} />
         </span>
         {detailed && "description" in step && step.description && (
           <p className="text-xs text-muted-foreground mt-0.5">
-            {renderInlineMarkdown(step.description)}
+            <InlineMarkdown text={step.description} />
           </p>
         )}
       </div>

--- a/src/components/chat/plan-mode/PlanStepItem.tsx
+++ b/src/components/chat/plan-mode/PlanStepItem.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react"
 import { Circle, Loader2, CheckCircle, XCircle, MinusCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { formatDuration, type ParsedPlanStep } from "./planParser"
@@ -8,6 +9,103 @@ type StepLike = ParsedPlanStep | PlanStep
 interface PlanStepItemProps {
   step: StepLike
   detailed?: boolean
+}
+
+/**
+ * Lightweight inline markdown renderer for plan step titles/descriptions.
+ *
+ * Supports `**bold**`, `*italic*`, `` `code` ``, `~~strike~~` and leaves
+ * everything else as plain text. Block-level markdown is intentionally not
+ * supported since step titles are single-line.
+ */
+function renderInlineMarkdown(text: string): ReactNode[] {
+  const nodes: ReactNode[] = []
+  let buffer = ""
+  let i = 0
+  let key = 0
+
+  const flushBuffer = () => {
+    if (buffer) {
+      nodes.push(buffer)
+      buffer = ""
+    }
+  }
+
+  while (i < text.length) {
+    const ch = text[i]
+
+    // Backslash escape (\* \` etc.)
+    if (ch === "\\" && i + 1 < text.length) {
+      buffer += text[i + 1]
+      i += 2
+      continue
+    }
+
+    // **bold**
+    if (ch === "*" && text[i + 1] === "*") {
+      const end = text.indexOf("**", i + 2)
+      if (end > i + 2) {
+        flushBuffer()
+        nodes.push(
+          <strong key={key++} className="font-semibold">
+            {renderInlineMarkdown(text.slice(i + 2, end))}
+          </strong>
+        )
+        i = end + 2
+        continue
+      }
+    }
+
+    // *italic* (require non-space after opening and non-space before closing)
+    if (ch === "*" && text[i + 1] && text[i + 1] !== "*" && text[i + 1] !== " ") {
+      const end = text.indexOf("*", i + 1)
+      if (end > i + 1 && text[end - 1] !== " ") {
+        flushBuffer()
+        nodes.push(
+          <em key={key++}>{renderInlineMarkdown(text.slice(i + 1, end))}</em>
+        )
+        i = end + 1
+        continue
+      }
+    }
+
+    // `inline code`
+    if (ch === "`") {
+      const end = text.indexOf("`", i + 1)
+      if (end > i + 1) {
+        flushBuffer()
+        nodes.push(
+          <code
+            key={key++}
+            className="px-1 py-0.5 rounded bg-muted text-[0.85em] font-mono"
+          >
+            {text.slice(i + 1, end)}
+          </code>
+        )
+        i = end + 1
+        continue
+      }
+    }
+
+    // ~~strikethrough~~
+    if (ch === "~" && text[i + 1] === "~") {
+      const end = text.indexOf("~~", i + 2)
+      if (end > i + 2) {
+        flushBuffer()
+        nodes.push(
+          <s key={key++}>{renderInlineMarkdown(text.slice(i + 2, end))}</s>
+        )
+        i = end + 2
+        continue
+      }
+    }
+
+    buffer += ch
+    i++
+  }
+
+  flushBuffer()
+  return nodes
 }
 
 export function PlanStepItem({ step, detailed }: PlanStepItemProps) {
@@ -43,10 +141,12 @@ export function PlanStepItem({ step, detailed }: PlanStepItemProps) {
             step.status === "completed" && "line-through text-muted-foreground"
           )}
         >
-          {step.title}
+          {renderInlineMarkdown(step.title)}
         </span>
         {detailed && "description" in step && step.description && (
-          <p className="text-xs text-muted-foreground mt-0.5">{step.description}</p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {renderInlineMarkdown(step.description)}
+          </p>
         )}
       </div>
 


### PR DESCRIPTION
PlanStepItem rendered step.title and step.description as plain text,
so bold/italic/code markers like `**HTML 结构**` leaked literally into
the UI. Add a small inline markdown parser (supports **bold**, *italic*,
`code`, ~~strike~~, \ escapes) and use it for both fields. Intentionally
avoids Streamdown/MarkdownRenderer so single-line titles aren't wrapped
in a block <p> and the list stays compact.