### PR TITLE
feat(dashboard): 新增综合 Insights 面板、同比 Delta、自动刷新与 CSV 导出

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ src/                    前端（React + TypeScript）
       web-search-panel/ 搜索设置面板
     common/             共享组件（导航栏/Markdown 渲染/Provider 图标）
     ui/                 shadcn/ui 基础组件
-    dashboard/          数据大盘（recharts 图表）
+    dashboard/          数据大盘（recharts 图表 + 综合 Insights 健康度/热力图/Top 会话）
     cron/               定时任务管理组件
   hooks/                全局自定义 hooks（useClickOutside/useTheme/useUrlPreview）
   lib/
@@ -147,7 +147,7 @@ crates/oc-core/src/     核心业务逻辑（零 Tauri 依赖）
   system_prompt/        系统提示词模块化拼装（constants/build/sections/helpers 拆分）
   chat_engine/          聊天引擎（types/context/engine 拆分）
   docker/               Docker 服务管理（status/deploy/lifecycle/helpers/proxy 拆分）
-  dashboard/            数据大盘聚合查询（types/cost/filters/queries/detail_queries 拆分）
+  dashboard/            数据大盘聚合查询（types/cost/filters/queries/detail_queries/insights 拆分）
   logging/              统一日志（types/db/file_writer/app_logger/file_ops/config 拆分）
 ```
 
@@ -226,6 +226,7 @@ src-tauri/src/          Tauri 薄壳（命令层 + 桌面集成）
 - **工具结果磁盘持久化**：工具结果超过阈值（默认 50KB，`config.json` → `toolResultDiskThreshold` 可配置）时写入 `~/.opencomputer/tool_results/{session_id}/`，上下文仅保留 head+tail 预览 + 路径引用
 - **工具审批等待超时**：审批等待时长由 `config.json` 的 `approvalTimeoutSecs` 控制，默认 300 秒，`0` 表示不限时。超时后的动作由 `approvalTimeoutAction` 控制：默认 `deny` 阻止执行，也可设为 `proceed` 在记录 warning 后继续执行工具
 - **数据存储**：所有数据统一在 `~/.opencomputer/`，`paths.rs` 集中管理
+- **数据大盘 Insights**：`dashboard/insights.rs` 提供综合分析查询：`query_overview_with_delta`（同环比 delta，按相同时间跨度左移取 previous baseline）、`query_cost_trend`（日度费用累计 + 峰值/日均）、`query_activity_heatmap`（7×24 活跃度网格）、`query_hourly_distribution`（0–23 时消息 + 峰值时段）、`query_top_sessions`（按 token 消耗的 Top N）、`query_model_efficiency`（每模型 tokens/msg、cost/1k、TTFT 对比）、`query_health_score`（四维加权健康度 0–100）和一次性 `query_insights` orchestrator。前端 Dashboard 默认 Tab 为 `InsightsSection`，同时 Header 提供 `autoRefreshMs` 定时轮询（30s/1m/5m）和 CSV 导出能力；System Tab 客户端持有最多 60 个采样点的环形缓冲绘制 CPU/内存实时曲线
 - **IM Channel 架构**：`channel/` 目录统一承载 Telegram / WeChat 等渠道插件；Telegram 走 Bot API 轮询，WeChat 走 OpenClaw 兼容的二维码登录 + iLink HTTP 长轮询协议，渠道状态文件统一落在 `~/.opencomputer/channels/`。入站媒体管道：polling 收集 `InboundMedia`（Telegram/WeChat 入站媒体下载到 channel inbound-temp）→ worker 转为 `Attachment`（图片 base64 / 文件 path）并复制归档到会话目录 `~/.opencomputer/attachments/{session_id}/` → `ChatEngineParams.attachments` → `agent.chat()` 多模态接口。WeChat 通道完整能力：typing 指示器（24h TTL + 5s keepalive + cancel）、入站媒体下载解密（图片/视频/语音/文件）、出站媒体 AES-128-ECB 加密上传 CDN（3 次 5xx 重试）、会话过期暂停 1h、QR 登录自动刷新 3 次。**斜杠命令同步**：Telegram Bot 启动时自动调用 `setMyCommands` 同步内置命令到 Bot 菜单，`SlashCommandDef::description_en()` 提供英文描述
 - **IM Channel 工具审批交互**：工具需要审批时，`channel/worker/approval.rs` 监听 EventBus `"approval_required"` 事件，通过 `ChannelDB.get_conversation_by_session()` 反查 IM 渠道信息，按 `ChannelCapabilities.supports_buttons` 决定发送方式：支持按钮的渠道（Telegram/Discord/Slack/飞书/QQ Bot/LINE/Google Chat）发送平台原生交互按钮，不支持的渠道（WeChat/Signal/iMessage/IRC/WhatsApp）发送文本提示（回复 1/2/3）。按钮回调通过各渠道原生机制路由回 `submit_approval_response()`。`ChannelAccountConfig.auto_approve_tools` 为 `true` 时，该渠道的所有工具调用自动审批，通过 `ChatEngineParams` → `AssistantAgent` → `ToolExecContext.auto_approve_tools` 传递到执行层，跳过审批门控
 - **SearXNG Docker 代理注入**：`web_search.searxng_docker_use_proxy` 控制是否向 Docker SearXNG 写入 `settings.yml` 的 `outgoing.proxies` 和代理环境变量；适用于系统 VPN 场景，修改后在下次启动或重新部署容器时生效

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **数据大盘"综合概览"升级**：新增 Insights 首屏 Tab，把散落在各 Tab 的关键指标聚合成一屏，让用户一眼看懂系统运行状态：(1) **系统健康度环形仪表**：基于日志错误率、工具错误率、定时任务成功率、子 Agent 成功率四维加权，0–100 分，状态分 excellent/good/warning/critical 四档，后端 `query_health_score()` 内联计算；(2) **费用趋势折线图**：按天聚合消息 token × 模型定价，展示累计/日均/峰值，含日均参考线；(3) **7×24 活跃度热力图**：按周几 × 小时 hover 高亮，紫色强度映射消息密度；(4) **小时分布柱状图**：0–23 时消息量 + 峰值时段；(5) **Top 10 会话排行**：按 token 消耗排序，金银铜牌样式 + 单击 drill-down；(6) **模型效率对比**：每模型消息数、tokens、tokens/msg、cost/1k、TTFT，支持按模型 drill-down 过滤。后端新增 `crates/oc-core/src/dashboard/insights.rs`（`query_insights` / `query_overview_with_delta` / `query_cost_trend` / `query_activity_heatmap` / `query_hourly_distribution` / `query_top_sessions` / `query_model_efficiency` / `query_health_score`），Tauri 命令 `dashboard_insights` + `dashboard_overview_delta`，HTTP 路由 `POST /dashboard/insights` + `POST /dashboard/overview-delta`
+- **Overview Cards 同比 Delta**：9 张关键指标卡新增"较上期"涨跌百分比徽章，后端 `query_overview_with_delta` 自动按相同时间跨度左移一窗取 previous baseline 并返回 `OverviewStatsWithDelta { current, previous }`。前端 `DeltaBadge` 用向上/向下箭头 + 绿红配色区分好坏（错误、TTFT 倒转语义）
+- **仪表盘自动刷新 + CSV 导出**：大盘 Header 新增自动刷新选择器（关闭 / 30 秒 / 1 分钟 / 5 分钟）和导出按钮。自动刷新复用现有加载路径，触发 overview + current tab 数据同步。导出按钮根据当前 Tab 导出 tokens / tools / sessions / errors / insights 的聚合数据为 CSV 文件。Header 新增"最近刷新"时间戳
+- **系统监控实时资源曲线**：System Tab 在自动刷新开启后，客户端持有最多 60 个采样的环形缓冲，渲染 CPU / 内存使用率的面积图（双通道），带时间轴 tooltip，省去后端历史库支持
+
 ### Fixed
 
 - **Plan 步骤标题 Markdown 渲染**：修复 `PlanStepItem` 把 `**HTML 结构**` 等步骤标题里的行内 markdown 当成纯文本展示的问题。复用 `PlanQuestionBlock` 的 Streamdown 轻量栈（只加载 `code` + `cjk` 插件），新增 `InlineMarkdown` 包装组件，通过 `className="contents"`（让 Streamdown 外层 `<div class="space-y-4 …">` 从布局中消失）+ `components={{ p: Fragment }}`（剥掉默认 `<p>` 包装）让单行标题以纯 inline 节点流入父级 `<span>`，保持列表密度。同时应用于 `step.title` 和 `step.description`

--- a/crates/oc-core/src/dashboard/insights.rs
+++ b/crates/oc-core/src/dashboard/insights.rs
@@ -1,0 +1,544 @@
+// ── Insights Queries (Phase 2) ──────────────────────────────────
+//
+// Richer analytics: period-over-period comparison, cost trend,
+// activity heatmap, hourly distribution, top sessions, model
+// efficiency and aggregate health score.
+
+use anyhow::Result;
+use std::sync::Arc;
+
+use crate::cron::CronDB;
+use crate::logging::LogDB;
+use crate::session::SessionDB;
+
+use super::cost::estimate_cost;
+use super::filters::{build_log_filter, build_session_filter, params_ref};
+use super::queries::{query_overview, query_tool_usage};
+use super::types::*;
+
+/// Shift the filter window backward by the same span to obtain the
+/// previous-period baseline. Returns `None` when start/end are unset.
+fn shift_filter_backward(filter: &DashboardFilter) -> Option<DashboardFilter> {
+    let start = filter.start_date.as_deref().filter(|s| !s.is_empty())?;
+    let end = filter.end_date.as_deref().filter(|s| !s.is_empty())?;
+
+    let start_dt = chrono::DateTime::parse_from_rfc3339(start).ok()?;
+    let end_dt = chrono::DateTime::parse_from_rfc3339(end).ok()?;
+    let span = end_dt - start_dt;
+    if span.num_seconds() <= 0 {
+        return None;
+    }
+
+    let prev_start = start_dt - span;
+    let prev_end = start_dt;
+
+    Some(DashboardFilter {
+        start_date: Some(prev_start.to_rfc3339()),
+        end_date: Some(prev_end.to_rfc3339()),
+        agent_id: filter.agent_id.clone(),
+        provider_id: filter.provider_id.clone(),
+        model_id: filter.model_id.clone(),
+    })
+}
+
+/// Overview stats with previous-period baseline for delta display.
+pub fn query_overview_with_delta(
+    session_db: &Arc<SessionDB>,
+    log_db: &Arc<LogDB>,
+    cron_db: &Arc<CronDB>,
+    filter: &DashboardFilter,
+) -> Result<OverviewStatsWithDelta> {
+    let current = query_overview(session_db, log_db, cron_db, filter)?;
+    let previous = if let Some(prev_filter) = shift_filter_backward(filter) {
+        query_overview(session_db, log_db, cron_db, &prev_filter).ok()
+    } else {
+        None
+    };
+    Ok(OverviewStatsWithDelta { current, previous })
+}
+
+/// Daily cost trend derived from messages + per-model pricing.
+pub fn query_cost_trend(
+    session_db: &Arc<SessionDB>,
+    filter: &DashboardFilter,
+) -> Result<DashboardCostTrend> {
+    let conn = session_db
+        .conn
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+
+    let f = build_session_filter(filter, "s", Some("m"));
+    let sql = format!(
+        "SELECT DATE(m.timestamp) as d,
+                COALESCE(s.model_id, 'unknown') as model,
+                COALESCE(SUM(m.tokens_in), 0),
+                COALESCE(SUM(m.tokens_out), 0)
+         FROM messages m
+         JOIN sessions s ON s.id = m.session_id
+         {}
+         GROUP BY d, model
+         ORDER BY d ASC",
+        f.where_sql
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_ref(&f.params).as_slice(), |r| {
+        Ok((
+            r.get::<_, String>(0)?,
+            r.get::<_, String>(1)?,
+            crate::sql_u64(r, 2)?,
+            crate::sql_u64(r, 3)?,
+        ))
+    })?;
+
+    // Aggregate daily costs by summing per-model cost within each day
+    let mut points: Vec<CostTrendPoint> = Vec::new();
+    for row in rows {
+        let (date, model, tokens_in, tokens_out) = row?;
+        let cost = estimate_cost(&model, tokens_in, tokens_out);
+        if let Some(last) = points.last_mut() {
+            if last.date == date {
+                last.cost_usd += cost;
+                last.input_tokens += tokens_in;
+                last.output_tokens += tokens_out;
+                continue;
+            }
+        }
+        points.push(CostTrendPoint {
+            date,
+            cost_usd: cost,
+            input_tokens: tokens_in,
+            output_tokens: tokens_out,
+        });
+    }
+
+    let total_cost_usd: f64 = points.iter().map(|p| p.cost_usd).sum();
+    let (peak_day, peak_cost_usd) = points
+        .iter()
+        .max_by(|a, b| {
+            a.cost_usd
+                .partial_cmp(&b.cost_usd)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|p| (Some(p.date.clone()), p.cost_usd))
+        .unwrap_or((None, 0.0));
+    let avg_daily_cost_usd = if points.is_empty() {
+        0.0
+    } else {
+        total_cost_usd / points.len() as f64
+    };
+
+    Ok(DashboardCostTrend {
+        points,
+        total_cost_usd,
+        peak_day,
+        peak_cost_usd,
+        avg_daily_cost_usd,
+    })
+}
+
+/// 7×24 activity heatmap: message counts per (weekday, hour-of-day).
+pub fn query_activity_heatmap(
+    session_db: &Arc<SessionDB>,
+    filter: &DashboardFilter,
+) -> Result<DashboardHeatmap> {
+    let conn = session_db
+        .conn
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+
+    let f = build_session_filter(filter, "s", Some("m"));
+    let sql = format!(
+        "SELECT CAST(strftime('%w', m.timestamp) AS INTEGER) as wd,
+                CAST(strftime('%H', m.timestamp) AS INTEGER) as h,
+                COUNT(*) as cnt
+         FROM messages m
+         JOIN sessions s ON s.id = m.session_id
+         {}
+         GROUP BY wd, h
+         ORDER BY wd, h",
+        f.where_sql
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_ref(&f.params).as_slice(), |r| {
+        Ok(HeatmapCell {
+            weekday: r.get::<_, i64>(0)? as u8,
+            hour: r.get::<_, i64>(1)? as u8,
+            message_count: crate::sql_u64(r, 2)?,
+        })
+    })?;
+    let cells: Vec<HeatmapCell> = rows.collect::<std::result::Result<_, _>>()?;
+    let max_value = cells.iter().map(|c| c.message_count).max().unwrap_or(0);
+    let total: u64 = cells.iter().map(|c| c.message_count).sum();
+
+    Ok(DashboardHeatmap {
+        cells,
+        max_value,
+        total,
+    })
+}
+
+/// Hourly distribution (0..23) of messages and distinct sessions.
+pub fn query_hourly_distribution(
+    session_db: &Arc<SessionDB>,
+    filter: &DashboardFilter,
+) -> Result<DashboardHourlyDistribution> {
+    let conn = session_db
+        .conn
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+
+    let f = build_session_filter(filter, "s", Some("m"));
+    let sql = format!(
+        "SELECT CAST(strftime('%H', m.timestamp) AS INTEGER) as h,
+                COUNT(*) as msg_cnt,
+                COUNT(DISTINCT s.id) as sess_cnt
+         FROM messages m
+         JOIN sessions s ON s.id = m.session_id
+         {}
+         GROUP BY h
+         ORDER BY h",
+        f.where_sql
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_ref(&f.params).as_slice(), |r| {
+        Ok((
+            r.get::<_, i64>(0)? as u8,
+            crate::sql_u64(r, 1)?,
+            crate::sql_u64(r, 2)?,
+        ))
+    })?;
+
+    // Fill missing hours with zeros
+    let mut map: std::collections::HashMap<u8, (u64, u64)> = std::collections::HashMap::new();
+    for row in rows {
+        let (h, m, s) = row?;
+        map.insert(h, (m, s));
+    }
+    let mut buckets: Vec<HourlyBucket> = (0u8..24)
+        .map(|h| {
+            let (m, s) = map.get(&h).copied().unwrap_or((0, 0));
+            HourlyBucket {
+                hour: h,
+                message_count: m,
+                session_count: s,
+            }
+        })
+        .collect();
+    buckets.sort_by_key(|b| b.hour);
+
+    let (peak_hour, peak_message_count) = buckets
+        .iter()
+        .max_by_key(|b| b.message_count)
+        .map(|b| (Some(b.hour), b.message_count))
+        .unwrap_or((None, 0));
+
+    Ok(DashboardHourlyDistribution {
+        buckets,
+        peak_hour,
+        peak_message_count,
+    })
+}
+
+/// Top sessions ranked by total token consumption.
+pub fn query_top_sessions(
+    session_db: &Arc<SessionDB>,
+    filter: &DashboardFilter,
+    limit: usize,
+) -> Result<Vec<TopSession>> {
+    let conn = session_db
+        .conn
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+
+    let mut f = build_session_filter(filter, "s", None);
+    // Append the limit as a bound parameter so we avoid string interpolation.
+    let limit_box: Box<dyn rusqlite::types::ToSql> =
+        Box::new(limit.max(1).min(1000) as i64);
+    f.params.push(limit_box);
+    let sql = format!(
+        "SELECT s.id,
+                s.title,
+                s.agent_id,
+                s.model_id,
+                COUNT(m.id) as msg_cnt,
+                COALESCE(SUM(m.tokens_in), 0) + COALESCE(SUM(m.tokens_out), 0) as total_tokens,
+                COALESCE(SUM(m.tokens_in), 0),
+                COALESCE(SUM(m.tokens_out), 0),
+                s.updated_at
+         FROM sessions s
+         LEFT JOIN messages m ON m.session_id = s.id
+         {}
+         GROUP BY s.id
+         ORDER BY total_tokens DESC
+         LIMIT ?",
+        f.where_sql
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_ref(&f.params).as_slice(), |r| {
+        let id: String = r.get(0)?;
+        let title: Option<String> = r.get(1)?;
+        let agent_id: String = r.get(2)?;
+        let model_id: Option<String> = r.get(3)?;
+        let message_count: u64 = crate::sql_u64(r, 4)?;
+        let total_tokens: u64 = crate::sql_u64(r, 5)?;
+        let tokens_in: u64 = crate::sql_u64(r, 6)?;
+        let tokens_out: u64 = crate::sql_u64(r, 7)?;
+        let updated_at: String = r.get(8)?;
+        let model_ref = model_id.as_deref().unwrap_or("unknown");
+        let estimated_cost_usd = estimate_cost(model_ref, tokens_in, tokens_out);
+        Ok(TopSession {
+            id,
+            title,
+            agent_id,
+            model_id,
+            total_tokens,
+            message_count,
+            estimated_cost_usd,
+            updated_at,
+        })
+    })?;
+
+    let list: Vec<TopSession> = rows.collect::<std::result::Result<_, _>>()?;
+    Ok(list)
+}
+
+/// Per-model efficiency: tokens, cost, speed, and derived ratios.
+pub fn query_model_efficiency(
+    session_db: &Arc<SessionDB>,
+    filter: &DashboardFilter,
+) -> Result<Vec<ModelEfficiency>> {
+    let conn = session_db
+        .conn
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+
+    let f = build_session_filter(filter, "s", Some("m"));
+    let sql = format!(
+        "SELECT COALESCE(s.model_id, 'unknown'),
+                COALESCE(s.provider_name, 'unknown'),
+                COUNT(m.id) as msg_cnt,
+                COALESCE(SUM(m.tokens_in), 0),
+                COALESCE(SUM(m.tokens_out), 0),
+                AVG(CASE WHEN m.ttft_ms IS NOT NULL AND m.role = 'assistant' THEN m.ttft_ms END)
+         FROM messages m
+         JOIN sessions s ON s.id = m.session_id
+         {}
+         GROUP BY s.model_id, s.provider_name
+         ORDER BY SUM(m.tokens_in) + SUM(m.tokens_out) DESC",
+        f.where_sql
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_ref(&f.params).as_slice(), |r| {
+        let model_id: String = r.get(0)?;
+        let provider_name: String = r.get(1)?;
+        let message_count: u64 = crate::sql_u64(r, 2)?;
+        let input_tokens: u64 = crate::sql_u64(r, 3)?;
+        let output_tokens: u64 = crate::sql_u64(r, 4)?;
+        let avg_ttft_ms: Option<f64> = r.get(5)?;
+        let total_tokens = input_tokens + output_tokens;
+        let total_cost_usd = estimate_cost(&model_id, input_tokens, output_tokens);
+        let avg_tokens_per_message = if message_count > 0 {
+            total_tokens as f64 / message_count as f64
+        } else {
+            0.0
+        };
+        let avg_cost_per_1k_tokens = if total_tokens > 0 {
+            (total_cost_usd / total_tokens as f64) * 1000.0
+        } else {
+            0.0
+        };
+        Ok(ModelEfficiency {
+            model_id,
+            provider_name,
+            total_tokens,
+            total_cost_usd,
+            avg_ttft_ms,
+            message_count,
+            avg_tokens_per_message,
+            avg_cost_per_1k_tokens,
+        })
+    })?;
+    Ok(rows.collect::<std::result::Result<_, _>>()?)
+}
+
+/// Compute an aggregate health score 0..=100.
+/// Weighting:
+/// - log error rate (errors/(errors+warn)) — 25%
+/// - tool error rate — 25%
+/// - cron success rate — 25%
+/// - subagent success rate — 25%
+pub fn query_health_score(
+    session_db: &Arc<SessionDB>,
+    log_db: &Arc<LogDB>,
+    cron_db: &Arc<CronDB>,
+    filter: &DashboardFilter,
+) -> Result<HealthBreakdown> {
+    // Log error rate (lower is better)
+    let log_conn = log_db
+        .conn
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+    let base = build_log_filter(filter);
+    let where_sql = if base.where_sql.is_empty() {
+        "WHERE level IN ('error','warn','info')".to_string()
+    } else {
+        format!("{} AND level IN ('error','warn','info')", base.where_sql)
+    };
+    let sql = format!(
+        "SELECT COALESCE(SUM(CASE WHEN level = 'error' THEN 1 ELSE 0 END), 0),
+                COALESCE(COUNT(*), 0)
+         FROM logs {}",
+        where_sql
+    );
+    let (log_errors, log_total): (u64, u64) =
+        log_conn.query_row(&sql, params_ref(&base.params).as_slice(), |r| {
+            Ok((crate::sql_u64(r, 0)?, crate::sql_u64(r, 1)?))
+        })?;
+    drop(log_conn);
+
+    let log_error_rate_percent = if log_total > 0 {
+        (log_errors as f64 / log_total as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    // Tool error rate
+    let tools = query_tool_usage(session_db, filter)?;
+    let total_tool_calls: u64 = tools.iter().map(|t| t.call_count).sum();
+    let total_tool_errors: u64 = tools.iter().map(|t| t.error_count).sum();
+    let tool_error_rate_percent = if total_tool_calls > 0 {
+        (total_tool_errors as f64 / total_tool_calls as f64) * 100.0
+    } else {
+        0.0
+    };
+
+    // Cron success rate
+    let cron_conn = cron_db
+        .conn
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+    let mut clauses: Vec<String> = Vec::new();
+    let mut cron_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    if let Some(ref s) = filter.start_date {
+        if !s.is_empty() {
+            clauses.push("started_at >= ?".to_string());
+            cron_params.push(Box::new(s.clone()));
+        }
+    }
+    if let Some(ref e) = filter.end_date {
+        if !e.is_empty() {
+            clauses.push("started_at <= ?".to_string());
+            cron_params.push(Box::new(e.clone()));
+        }
+    }
+    let where_sql = if clauses.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", clauses.join(" AND "))
+    };
+    let sql = format!(
+        "SELECT COUNT(*),
+                COALESCE(SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END), 0)
+         FROM cron_run_logs {}",
+        where_sql
+    );
+    let (cron_total, cron_success): (u64, u64) = cron_conn
+        .query_row(&sql, params_ref(&cron_params).as_slice(), |r| {
+            Ok((crate::sql_u64(r, 0)?, crate::sql_u64(r, 1)?))
+        })?;
+    drop(cron_conn);
+    let cron_success_rate_percent = if cron_total > 0 {
+        (cron_success as f64 / cron_total as f64) * 100.0
+    } else {
+        100.0
+    };
+
+    // Subagent success rate
+    let sess_conn = session_db
+        .conn
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+    let mut clauses: Vec<String> = Vec::new();
+    let mut sub_params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    if let Some(ref s) = filter.start_date {
+        if !s.is_empty() {
+            clauses.push("started_at >= ?".to_string());
+            sub_params.push(Box::new(s.clone()));
+        }
+    }
+    if let Some(ref e) = filter.end_date {
+        if !e.is_empty() {
+            clauses.push("started_at <= ?".to_string());
+            sub_params.push(Box::new(e.clone()));
+        }
+    }
+    let where_sql = if clauses.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", clauses.join(" AND "))
+    };
+    let sql = format!(
+        "SELECT COUNT(*),
+                COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0)
+         FROM subagent_runs {}",
+        where_sql
+    );
+    let (sub_total, sub_completed): (u64, u64) = sess_conn
+        .query_row(&sql, params_ref(&sub_params).as_slice(), |r| {
+            Ok((crate::sql_u64(r, 0)?, crate::sql_u64(r, 1)?))
+        })?;
+    drop(sess_conn);
+    let subagent_success_rate_percent = if sub_total > 0 {
+        (sub_completed as f64 / sub_total as f64) * 100.0
+    } else {
+        100.0
+    };
+
+    // Composite score: each dimension contributes 25 points.
+    let log_score = 25.0 * (1.0 - (log_error_rate_percent / 100.0).min(1.0));
+    let tool_score = 25.0 * (1.0 - (tool_error_rate_percent / 100.0).min(1.0));
+    let cron_score = 25.0 * (cron_success_rate_percent / 100.0).clamp(0.0, 1.0);
+    let sub_score = 25.0 * (subagent_success_rate_percent / 100.0).clamp(0.0, 1.0);
+    let total = log_score + tool_score + cron_score + sub_score;
+    let score = total.round().clamp(0.0, 100.0) as u8;
+
+    let status = match score {
+        90..=100 => "excellent",
+        75..=89 => "good",
+        50..=74 => "warning",
+        _ => "critical",
+    }
+    .to_string();
+
+    Ok(HealthBreakdown {
+        score,
+        log_error_rate_percent,
+        tool_error_rate_percent,
+        cron_success_rate_percent,
+        subagent_success_rate_percent,
+        status,
+    })
+}
+
+/// One-shot aggregated insights query powering the Insights tab.
+pub fn query_insights(
+    session_db: &Arc<SessionDB>,
+    log_db: &Arc<LogDB>,
+    cron_db: &Arc<CronDB>,
+    filter: &DashboardFilter,
+) -> Result<DashboardInsights> {
+    let health = query_health_score(session_db, log_db, cron_db, filter)?;
+    let cost_trend = query_cost_trend(session_db, filter)?;
+    let heatmap = query_activity_heatmap(session_db, filter)?;
+    let hourly = query_hourly_distribution(session_db, filter)?;
+    let top_sessions = query_top_sessions(session_db, filter, 10)?;
+    let model_efficiency = query_model_efficiency(session_db, filter)?;
+    Ok(DashboardInsights {
+        health,
+        cost_trend,
+        heatmap,
+        hourly,
+        top_sessions,
+        model_efficiency,
+    })
+}

--- a/crates/oc-core/src/dashboard/mod.rs
+++ b/crates/oc-core/src/dashboard/mod.rs
@@ -7,9 +7,11 @@
 mod cost;
 mod detail_queries;
 mod filters;
+mod insights;
 mod queries;
 mod types;
 
 pub use detail_queries::*;
+pub use insights::*;
 pub use queries::*;
 pub use types::*;

--- a/crates/oc-core/src/dashboard/types.rs
+++ b/crates/oc-core/src/dashboard/types.rs
@@ -26,6 +26,16 @@ pub struct OverviewStats {
     pub avg_ttft_ms: Option<f64>,
 }
 
+/// Current overview + previous-period baseline for delta computation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OverviewStatsWithDelta {
+    pub current: OverviewStats,
+    /// Previous period shifted by the same span as the current range.
+    /// `None` when no valid previous window (e.g. start_date unset).
+    pub previous: Option<OverviewStats>,
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenUsageTrend {
@@ -251,4 +261,108 @@ pub struct DashboardAgentItem {
     pub message_count: u64,
     pub total_tokens: u64,
     pub last_active_at: String,
+}
+
+// ── Insights Types (Phase 2 enhancements) ───────────────────────
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CostTrendPoint {
+    pub date: String,
+    pub cost_usd: f64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardCostTrend {
+    pub points: Vec<CostTrendPoint>,
+    pub total_cost_usd: f64,
+    pub peak_day: Option<String>,
+    pub peak_cost_usd: f64,
+    pub avg_daily_cost_usd: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HeatmapCell {
+    /// 0 = Sunday, 6 = Saturday (SQLite strftime('%w'))
+    pub weekday: u8,
+    pub hour: u8,
+    pub message_count: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardHeatmap {
+    pub cells: Vec<HeatmapCell>,
+    pub max_value: u64,
+    pub total: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HourlyBucket {
+    pub hour: u8,
+    pub message_count: u64,
+    pub session_count: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardHourlyDistribution {
+    pub buckets: Vec<HourlyBucket>,
+    pub peak_hour: Option<u8>,
+    pub peak_message_count: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TopSession {
+    pub id: String,
+    pub title: Option<String>,
+    pub agent_id: String,
+    pub model_id: Option<String>,
+    pub total_tokens: u64,
+    pub message_count: u64,
+    pub estimated_cost_usd: f64,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelEfficiency {
+    pub model_id: String,
+    pub provider_name: String,
+    pub total_tokens: u64,
+    pub total_cost_usd: f64,
+    pub avg_ttft_ms: Option<f64>,
+    pub message_count: u64,
+    pub avg_tokens_per_message: f64,
+    pub avg_cost_per_1k_tokens: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthBreakdown {
+    /// 0..=100 overall score
+    pub score: u8,
+    pub log_error_rate_percent: f64,
+    pub tool_error_rate_percent: f64,
+    pub cron_success_rate_percent: f64,
+    pub subagent_success_rate_percent: f64,
+    /// Status: "excellent" | "good" | "warning" | "critical"
+    pub status: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardInsights {
+    pub health: HealthBreakdown,
+    pub cost_trend: DashboardCostTrend,
+    pub heatmap: DashboardHeatmap,
+    pub hourly: DashboardHourlyDistribution,
+    pub top_sessions: Vec<TopSession>,
+    pub model_efficiency: Vec<ModelEfficiency>,
 }

--- a/crates/oc-server/src/lib.rs
+++ b/crates/oc-server/src/lib.rs
@@ -231,6 +231,11 @@ fn build_router_with_cors(
         )
         .route("/dashboard/error-list", post(routes::dashboard::error_list))
         .route("/dashboard/agent-list", post(routes::dashboard::agent_list))
+        .route(
+            "/dashboard/overview-delta",
+            post(routes::dashboard::overview_delta),
+        )
+        .route("/dashboard/insights", post(routes::dashboard::insights))
         // Plan Mode
         .route("/plan/{sid}/mode", get(routes::plan::get_plan_mode))
         .route("/plan/{sid}/mode", post(routes::plan::set_plan_mode))

--- a/crates/oc-server/src/routes/dashboard.rs
+++ b/crates/oc-server/src/routes/dashboard.rs
@@ -99,3 +99,27 @@ pub async fn agent_list(
         &filter,
     )?))
 }
+
+pub async fn overview_delta(
+    Json(filter): Json<DashboardFilter>,
+) -> Result<Json<OverviewStatsWithDelta>, AppError> {
+    let s = app_state()?;
+    Ok(Json(dashboard::query_overview_with_delta(
+        &s.session_db,
+        &s.log_db,
+        &s.cron_db,
+        &filter,
+    )?))
+}
+
+pub async fn insights(
+    Json(filter): Json<DashboardFilter>,
+) -> Result<Json<DashboardInsights>, AppError> {
+    let s = app_state()?;
+    Ok(Json(dashboard::query_insights(
+        &s.session_db,
+        &s.log_db,
+        &s.cron_db,
+        &filter,
+    )?))
+}

--- a/src-tauri/src/commands/dashboard.rs
+++ b/src-tauri/src/commands/dashboard.rs
@@ -99,3 +99,31 @@ pub async fn dashboard_agent_list(
 ) -> Result<Vec<dashboard::DashboardAgentItem>, String> {
     dashboard::query_agent_list(&state.session_db, &filter).map_err(|e| e.to_string())
 }
+
+#[tauri::command]
+pub async fn dashboard_overview_delta(
+    filter: DashboardFilter,
+    state: State<'_, AppState>,
+) -> Result<dashboard::OverviewStatsWithDelta, String> {
+    dashboard::query_overview_with_delta(
+        &state.session_db,
+        &state.log_db,
+        &state.cron_db,
+        &filter,
+    )
+    .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn dashboard_insights(
+    filter: DashboardFilter,
+    state: State<'_, AppState>,
+) -> Result<dashboard::DashboardInsights, String> {
+    dashboard::query_insights(
+        &state.session_db,
+        &state.log_db,
+        &state.cron_db,
+        &filter,
+    )
+    .map_err(|e| e.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -382,6 +382,8 @@ pub fn run() {
             commands::dashboard::dashboard_tool_call_list,
             commands::dashboard::dashboard_error_list,
             commands::dashboard::dashboard_agent_list,
+            commands::dashboard::dashboard_overview_delta,
+            commands::dashboard::dashboard_insights,
             // Developer tools (thin wrappers over oc-core)
             tauri_wrappers::dev_clear_sessions,
             tauri_wrappers::dev_clear_cron,

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -2,14 +2,27 @@ import { useState, useEffect, useCallback, useRef, useMemo } from "react"
 import { getTransport } from "@/lib/transport-provider"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { ArrowLeft, RefreshCw } from "lucide-react"
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { ArrowLeft, RefreshCw, Download, Play, Pause } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
 import DashboardFilter from "./DashboardFilter"
 import OverviewCards from "./OverviewCards"
 import type { CardAction } from "./OverviewCards"
 import DetailListPanel from "./DetailListPanel"
+import InsightsSection from "./InsightsSection"
 import TokenUsageSection from "./TokenUsageSection"
 import ToolUsageSection from "./ToolUsageSection"
 import SessionSection from "./SessionSection"
@@ -18,16 +31,19 @@ import TaskSection from "./TaskSection"
 import SystemMetricsSection from "./SystemMetricsSection"
 import type {
   DashboardFilter as DashboardFilterState,
-  OverviewStats,
+  OverviewStatsWithDelta,
   DashboardTokenData,
   ToolUsageStats,
   DashboardSessionData,
   DashboardErrorData,
   DashboardTaskData,
   SystemMetrics,
+  DashboardInsights,
   Granularity,
   DetailListType,
+  AutoRefreshInterval,
 } from "./types"
+import { autoRefreshMs } from "./types"
 
 function defaultFilter(): DashboardFilterState {
   const now = new Date()
@@ -42,21 +58,65 @@ function defaultFilter(): DashboardFilterState {
   }
 }
 
+/** Max 60 samples (~30 min at 30s refresh) kept in-memory for sparklines. */
+const SYSTEM_HISTORY_LIMIT = 60
+
+interface SystemHistoryPoint {
+  t: number
+  cpu: number
+  mem: number
+}
+
+/** Escape CSV values. */
+function csvEscape(v: unknown): string {
+  if (v == null) return ""
+  const s = String(v)
+  if (s.includes(",") || s.includes("\n") || s.includes('"')) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}
+
+/** Convert array of records to CSV and trigger download in the browser. */
+function downloadCsv(filename: string, rows: Record<string, unknown>[]) {
+  if (rows.length === 0) return
+  const headers = Object.keys(rows[0])
+  const lines = [
+    headers.join(","),
+    ...rows.map((r) => headers.map((h) => csvEscape(r[h])).join(",")),
+  ]
+  const blob = new Blob([lines.join("\n")], { type: "text/csv;charset=utf-8;" })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
 export default function DashboardView({ onBack }: { onBack: () => void }) {
   const { t } = useTranslation()
   const [filter, setFilter] = useState<DashboardFilterState>(defaultFilter)
-  const [activeTab, setActiveTab] = useState("tokens")
+  const [activeTab, setActiveTab] = useState("insights")
   const [activeList, setActiveList] = useState<DetailListType | null>(null)
   const [loading, setLoading] = useState(true)
-  const [overview, setOverview] = useState<OverviewStats | null>(null)
+  const [overview, setOverview] = useState<OverviewStatsWithDelta | null>(null)
+  const [insightsData, setInsightsData] = useState<DashboardInsights | null>(null)
   const [tokenData, setTokenData] = useState<DashboardTokenData | null>(null)
   const [toolData, setToolData] = useState<ToolUsageStats[] | null>(null)
   const [sessionData, setSessionData] = useState<DashboardSessionData | null>(null)
   const [errorData, setErrorData] = useState<DashboardErrorData | null>(null)
   const [taskData, setTaskData] = useState<DashboardTaskData | null>(null)
   const [systemMetrics, setSystemMetrics] = useState<SystemMetrics | null>(null)
+  const [systemHistory, setSystemHistory] = useState<SystemHistoryPoint[]>([])
   const [granularity, setGranularity] = useState<Granularity>("day")
-  const [agents, setAgents] = useState<{ id: string; name: string; emoji?: string | null }[]>([])
+  const [autoRefresh, setAutoRefresh] = useState<AutoRefreshInterval>("off")
+  const [lastRefreshAt, setLastRefreshAt] = useState<Date | null>(null)
+  const [agents, setAgents] = useState<
+    { id: string; name: string; emoji?: string | null }[]
+  >([])
   const tabsRef = useRef<HTMLDivElement>(null)
 
   const agentNameMap = useMemo(() => {
@@ -69,7 +129,10 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
 
   const loadOverview = useCallback(async () => {
     try {
-      const data = await getTransport().call<OverviewStats>("dashboard_overview", { filter })
+      const data = await getTransport().call<OverviewStatsWithDelta>(
+        "dashboard_overview_delta",
+        { filter },
+      )
       setOverview(data)
     } catch (e) {
       logger.error("dashboard", "loadOverview", `Failed: ${e}`)
@@ -78,7 +141,8 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
 
   // Load agent names once on mount
   useEffect(() => {
-    getTransport().call<{ id: string; name: string; emoji?: string | null }[]>("list_agents")
+    getTransport()
+      .call<{ id: string; name: string; emoji?: string | null }[]>("list_agents")
       .then(setAgents)
       .catch(() => {})
   }, [])
@@ -87,40 +151,71 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
     async (tab: string) => {
       try {
         switch (tab) {
+          case "insights": {
+            const d = await getTransport().call<DashboardInsights>(
+              "dashboard_insights",
+              { filter },
+            )
+            setInsightsData(d)
+            break
+          }
           case "tokens": {
-            const td = await getTransport().call<DashboardTokenData>("dashboard_token_usage", {
-              filter,
-            })
+            const td = await getTransport().call<DashboardTokenData>(
+              "dashboard_token_usage",
+              { filter },
+            )
             setTokenData(td)
             break
           }
           case "tools": {
-            const tld = await getTransport().call<ToolUsageStats[]>("dashboard_tool_usage", { filter })
+            const tld = await getTransport().call<ToolUsageStats[]>(
+              "dashboard_tool_usage",
+              { filter },
+            )
             setToolData(tld)
             break
           }
           case "sessions": {
-            const sd = await getTransport().call<DashboardSessionData>("dashboard_sessions", {
-              filter,
-            })
+            const sd = await getTransport().call<DashboardSessionData>(
+              "dashboard_sessions",
+              { filter },
+            )
             setSessionData(sd)
             break
           }
           case "errors": {
-            const ed = await getTransport().call<DashboardErrorData>("dashboard_errors", {
-              filter,
-            })
+            const ed = await getTransport().call<DashboardErrorData>(
+              "dashboard_errors",
+              { filter },
+            )
             setErrorData(ed)
             break
           }
           case "tasks": {
-            const tkd = await getTransport().call<DashboardTaskData>("dashboard_tasks", { filter })
+            const tkd = await getTransport().call<DashboardTaskData>(
+              "dashboard_tasks",
+              { filter },
+            )
             setTaskData(tkd)
             break
           }
           case "system": {
-            const sm = await getTransport().call<SystemMetrics>("dashboard_system_metrics")
+            const sm = await getTransport().call<SystemMetrics>(
+              "dashboard_system_metrics",
+            )
             setSystemMetrics(sm)
+            setSystemHistory((prev) => {
+              const point: SystemHistoryPoint = {
+                t: Date.now(),
+                cpu: Math.min(sm.processCpuPercent, sm.cpuCount * 100),
+                mem: sm.memory.rssPercent,
+              }
+              const next = [...prev, point]
+              if (next.length > SYSTEM_HISTORY_LIMIT) {
+                next.splice(0, next.length - SYSTEM_HISTORY_LIMIT)
+              }
+              return next
+            })
             break
           }
         }
@@ -131,20 +226,37 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
     [filter],
   )
 
+  // Initial load & filter change reload
   useEffect(() => {
     const timer = setTimeout(() => {
       setLoading(true)
-      Promise.all([loadOverview(), loadTabData(activeTab)]).finally(() => setLoading(false))
+      Promise.all([loadOverview(), loadTabData(activeTab)]).finally(() => {
+        setLoading(false)
+        setLastRefreshAt(new Date())
+      })
     }, 0)
     return () => clearTimeout(timer)
   }, [filter, loadOverview, loadTabData, activeTab])
 
+  // Tab switch reload (skip initial mount since above effect handles it)
   useEffect(() => {
     const timer = setTimeout(() => {
       loadTabData(activeTab)
     }, 0)
     return () => clearTimeout(timer)
   }, [activeTab, granularity, loadTabData])
+
+  // Auto-refresh polling
+  useEffect(() => {
+    const ms = autoRefreshMs(autoRefresh)
+    if (ms <= 0) return
+    const id = window.setInterval(() => {
+      Promise.all([loadOverview(), loadTabData(activeTab)]).finally(() => {
+        setLastRefreshAt(new Date())
+      })
+    }, ms)
+    return () => window.clearInterval(id)
+  }, [autoRefresh, loadOverview, loadTabData, activeTab])
 
   const handleCardClick = useCallback((action: CardAction) => {
     if (action.type === "tab") {
@@ -154,17 +266,102 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
         tabsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })
       })
     } else {
-      // Toggle list: click same card again to close
       setActiveList((prev) => (prev === action.listType ? null : action.listType))
     }
   }, [])
 
   const handleRefresh = useCallback(() => {
     setLoading(true)
-    // Close detail list on refresh so it reloads when reopened
     setActiveList(null)
-    Promise.all([loadOverview(), loadTabData(activeTab)]).finally(() => setLoading(false))
+    Promise.all([loadOverview(), loadTabData(activeTab)]).finally(() => {
+      setLoading(false)
+      setLastRefreshAt(new Date())
+    })
   }, [loadOverview, loadTabData, activeTab])
+
+  /** Export the currently visible tab's data to CSV. */
+  const handleExport = useCallback(() => {
+    const ts = new Date().toISOString().replace(/[:.]/g, "-")
+    switch (activeTab) {
+      case "tokens": {
+        if (!tokenData) return
+        downloadCsv(
+          `oc-tokens-${ts}.csv`,
+          tokenData.byModel.map((m) => ({
+            model: m.modelId,
+            provider: m.providerName,
+            input_tokens: m.inputTokens,
+            output_tokens: m.outputTokens,
+            estimated_cost_usd: m.estimatedCostUsd.toFixed(6),
+            avg_ttft_ms: m.avgTtftMs ?? "",
+          })),
+        )
+        break
+      }
+      case "tools": {
+        if (!toolData) return
+        downloadCsv(
+          `oc-tools-${ts}.csv`,
+          toolData.map((r) => ({
+            tool: r.toolName,
+            call_count: r.callCount,
+            error_count: r.errorCount,
+            avg_duration_ms: r.avgDurationMs.toFixed(2),
+            total_duration_ms: r.totalDurationMs,
+          })),
+        )
+        break
+      }
+      case "sessions": {
+        if (!sessionData) return
+        downloadCsv(
+          `oc-sessions-${ts}.csv`,
+          sessionData.byAgent.map((a) => ({
+            agent_id: a.agentId,
+            sessions: a.sessionCount,
+            messages: a.messageCount,
+            total_tokens: a.totalTokens,
+          })),
+        )
+        break
+      }
+      case "errors": {
+        if (!errorData) return
+        downloadCsv(
+          `oc-errors-${ts}.csv`,
+          errorData.byCategory.map((c) => ({
+            category: c.category,
+            count: c.count,
+          })),
+        )
+        break
+      }
+      case "insights": {
+        if (!insightsData) return
+        downloadCsv(
+          `oc-insights-topsessions-${ts}.csv`,
+          insightsData.topSessions.map((s) => ({
+            id: s.id,
+            title: s.title ?? "",
+            agent_id: s.agentId,
+            model_id: s.modelId ?? "",
+            message_count: s.messageCount,
+            total_tokens: s.totalTokens,
+            estimated_cost_usd: s.estimatedCostUsd.toFixed(6),
+            updated_at: s.updatedAt,
+          })),
+        )
+        break
+      }
+    }
+  }, [activeTab, tokenData, toolData, sessionData, errorData, insightsData])
+
+  const canExport =
+    (activeTab === "tokens" && !!tokenData) ||
+    (activeTab === "tools" && !!toolData) ||
+    (activeTab === "sessions" && !!sessionData) ||
+    (activeTab === "errors" && !!errorData) ||
+    (activeTab === "insights" && !!insightsData)
 
   const showGranularity =
     activeTab === "tokens" || activeTab === "sessions" || activeTab === "errors"
@@ -180,13 +377,54 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
           <ArrowLeft className="h-4 w-4" />
         </Button>
         <h1 className="text-lg font-semibold">{t("dashboard.title")}</h1>
+        {lastRefreshAt && (
+          <span className="text-[11px] text-muted-foreground hidden md:inline">
+            {t("dashboard.lastRefresh")}: {lastRefreshAt.toLocaleTimeString()}
+          </span>
+        )}
         <div className="flex-1" />
+
+        {/* Auto refresh selector */}
+        <Select
+          value={autoRefresh}
+          onValueChange={(v) => setAutoRefresh(v as AutoRefreshInterval)}
+        >
+          <SelectTrigger className="h-8 w-[120px] text-xs">
+            <div className="flex items-center gap-1.5">
+              {autoRefresh === "off" ? (
+                <Pause className="h-3 w-3" />
+              ) : (
+                <Play className="h-3 w-3 text-emerald-500" />
+              )}
+              <SelectValue />
+            </div>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="off">{t("dashboard.autoRefresh.off")}</SelectItem>
+            <SelectItem value="30s">{t("dashboard.autoRefresh.30s")}</SelectItem>
+            <SelectItem value="1m">{t("dashboard.autoRefresh.1m")}</SelectItem>
+            <SelectItem value="5m">{t("dashboard.autoRefresh.5m")}</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={handleExport}
+          disabled={!canExport}
+          title={t("dashboard.export") as string}
+        >
+          <Download className="h-4 w-4" />
+        </Button>
+
         <Button
           variant="ghost"
           size="icon"
           className="h-8 w-8"
           onClick={handleRefresh}
           disabled={loading}
+          title={t("dashboard.refresh") as string}
         >
           <RefreshCw className={cn("h-4 w-4", loading && "animate-spin")} />
         </Button>
@@ -197,8 +435,13 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
 
       {/* Scrollable content */}
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
-        {/* Overview cards */}
-        <OverviewCards data={overview} loading={loading} activeList={activeList} onCardClick={handleCardClick} />
+        {/* Overview cards with delta */}
+        <OverviewCards
+          data={overview}
+          loading={loading}
+          activeList={activeList}
+          onCardClick={handleCardClick}
+        />
 
         {/* Detail list panel (between cards and tabs) */}
         {activeList && (
@@ -214,6 +457,7 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
         <Tabs ref={tabsRef} value={activeTab} onValueChange={setActiveTab}>
           <div className="flex items-center gap-3 flex-wrap">
             <TabsList>
+              <TabsTrigger value="insights">{t("dashboard.tabs.insights")}</TabsTrigger>
               <TabsTrigger value="tokens">{t("dashboard.tabs.tokens")}</TabsTrigger>
               <TabsTrigger value="tools">{t("dashboard.tabs.tools")}</TabsTrigger>
               <TabsTrigger value="sessions">{t("dashboard.tabs.sessions")}</TabsTrigger>
@@ -238,6 +482,15 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
             )}
           </div>
 
+          <TabsContent value="insights">
+            <InsightsSection
+              data={insightsData}
+              loading={loading}
+              onDrillDownModel={(modelId) =>
+                setFilter((f) => ({ ...f, modelId }))
+              }
+            />
+          </TabsContent>
           <TabsContent value="tokens">
             <TokenUsageSection
               data={tokenData}
@@ -267,7 +520,11 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
             <TaskSection data={taskData} loading={loading} />
           </TabsContent>
           <TabsContent value="system">
-            <SystemMetricsSection data={systemMetrics} loading={loading} />
+            <SystemMetricsSection
+              data={systemMetrics}
+              history={systemHistory}
+              loading={loading}
+            />
           </TabsContent>
         </Tabs>
       </div>

--- a/src/components/dashboard/InsightsSection.tsx
+++ b/src/components/dashboard/InsightsSection.tsx
@@ -1,0 +1,527 @@
+import React, { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts"
+import {
+  Activity,
+  Flame,
+  Clock4,
+  TrendingUp,
+  Trophy,
+  Cpu,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { DashboardInsights } from "./types"
+import { formatNumber, formatCost, formatDuration } from "./types"
+
+interface InsightsSectionProps {
+  data: DashboardInsights | null
+  loading: boolean
+  onDrillDownSession?: (sessionId: string) => void
+  onDrillDownModel?: (modelId: string) => void
+}
+
+function SectionSkeleton({ height }: { height: number }) {
+  return (
+    <div
+      className="w-full bg-muted animate-pulse rounded-lg"
+      style={{ height }}
+    />
+  )
+}
+
+// ── Health Score Gauge ──────────────────────────────────────────
+
+function HealthGauge({ score, status }: { score: number; status: string }) {
+  const { t } = useTranslation()
+  const clamped = Math.max(0, Math.min(100, score))
+  // Ring: stroke-dasharray 251.2 circumference for r=40
+  const circumference = 2 * Math.PI * 40
+  const offset = circumference * (1 - clamped / 100)
+  const color =
+    status === "excellent"
+      ? "#10b981"
+      : status === "good"
+        ? "#3b82f6"
+        : status === "warning"
+          ? "#f59e0b"
+          : "#ef4444"
+  return (
+    <div className="flex flex-col items-center justify-center gap-2">
+      <div className="relative h-[120px] w-[120px]">
+        <svg className="h-full w-full -rotate-90" viewBox="0 0 100 100">
+          <circle
+            cx="50"
+            cy="50"
+            r="40"
+            fill="none"
+            className="stroke-muted"
+            strokeWidth="8"
+          />
+          <circle
+            cx="50"
+            cy="50"
+            r="40"
+            fill="none"
+            stroke={color}
+            strokeWidth="8"
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+            className="transition-[stroke-dashoffset] duration-700 ease-out"
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <div className="text-2xl font-bold" style={{ color }}>
+            {clamped}
+          </div>
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            {t(`dashboard.insights.status.${status}`)}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Activity Heatmap (7×24) ────────────────────────────────────
+
+function Heatmap({
+  cells,
+  max,
+}: {
+  cells: { weekday: number; hour: number; messageCount: number }[]
+  max: number
+}) {
+  const { t } = useTranslation()
+  // Build a 7×24 grid
+  const grid = useMemo(() => {
+    const g: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0))
+    for (const c of cells) {
+      if (c.weekday >= 0 && c.weekday <= 6 && c.hour >= 0 && c.hour <= 23) {
+        g[c.weekday][c.hour] = c.messageCount
+      }
+    }
+    return g
+  }, [cells])
+
+  const weekdayKeys = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
+  const safeMax = Math.max(max, 1)
+
+  function cellColor(v: number): string {
+    if (v === 0) return "var(--color-muted)"
+    const intensity = Math.min(1, v / safeMax)
+    // interpolate from light to strong purple
+    const alpha = 0.12 + 0.78 * intensity
+    return `rgba(139, 92, 246, ${alpha.toFixed(3)})`
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex gap-1 pl-8">
+        {Array.from({ length: 24 }).map((_, h) => (
+          <div
+            key={h}
+            className="flex-1 text-center text-[9px] text-muted-foreground"
+          >
+            {h % 3 === 0 ? h : ""}
+          </div>
+        ))}
+      </div>
+      {grid.map((row, wd) => (
+        <div key={wd} className="flex items-center gap-1">
+          <div className="w-7 shrink-0 text-right text-[10px] text-muted-foreground">
+            {t(`dashboard.insights.weekday.${weekdayKeys[wd]}`)}
+          </div>
+          <div className="flex flex-1 gap-1">
+            {row.map((v, h) => (
+              <div
+                key={h}
+                className="group relative flex-1 aspect-square rounded-sm border border-border/30 transition-transform hover:scale-110 hover:z-10"
+                style={{ backgroundColor: cellColor(v) }}
+              >
+                <div className="pointer-events-none absolute bottom-full left-1/2 mb-1 hidden -translate-x-1/2 whitespace-nowrap rounded-md bg-popover px-2 py-1 text-[10px] text-popover-foreground shadow-md group-hover:block z-20">
+                  {t(`dashboard.insights.weekday.${weekdayKeys[wd]}`)} {h.toString().padStart(2, "0")}:00 · {formatNumber(v)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+      <div className="flex items-center justify-end gap-2 pt-2 text-[10px] text-muted-foreground">
+        <span>{t("dashboard.insights.less")}</span>
+        {[0, 0.25, 0.5, 0.75, 1].map((i) => (
+          <div
+            key={i}
+            className="h-3 w-3 rounded-sm border border-border/30"
+            style={{ backgroundColor: cellColor(i * safeMax) }}
+          />
+        ))}
+        <span>{t("dashboard.insights.more")}</span>
+      </div>
+    </div>
+  )
+}
+
+// ── Main Section ────────────────────────────────────────────────
+
+const InsightsSection = React.memo(function InsightsSection({
+  data,
+  loading,
+  onDrillDownSession,
+  onDrillDownModel,
+}: InsightsSectionProps) {
+  const { t } = useTranslation()
+
+  if (loading && !data) {
+    return (
+      <div className="space-y-6 mt-4">
+        <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6">
+          <SectionSkeleton height={260} />
+          <SectionSkeleton height={260} />
+        </div>
+        <SectionSkeleton height={280} />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <SectionSkeleton height={280} />
+          <SectionSkeleton height={280} />
+        </div>
+      </div>
+    )
+  }
+
+  if (!data) return null
+
+  const costChartData = data.costTrend.points.map((p) => ({
+    date: p.date,
+    cost: Number(p.costUsd.toFixed(4)),
+  }))
+
+  const hourlyData = data.hourly.buckets.map((b) => ({
+    hour: `${b.hour.toString().padStart(2, "0")}:00`,
+    messageCount: b.messageCount,
+    sessionCount: b.sessionCount,
+  }))
+
+  return (
+    <div className="space-y-6 mt-4">
+      {/* Row 1: Health gauge + Key KPI stats */}
+      <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6">
+        <div className="bg-card border rounded-xl p-4 space-y-3">
+          <h3 className="text-sm font-medium flex items-center gap-2">
+            <Activity className="h-4 w-4 text-emerald-500" />
+            {t("dashboard.insights.healthScore")}
+          </h3>
+          <HealthGauge score={data.health.score} status={data.health.status} />
+          <div className="grid grid-cols-2 gap-2 text-[11px]">
+            <div className="rounded-md bg-muted/40 p-2">
+              <div className="text-muted-foreground">
+                {t("dashboard.insights.logErrorRate")}
+              </div>
+              <div className="font-semibold">
+                {data.health.logErrorRatePercent.toFixed(2)}%
+              </div>
+            </div>
+            <div className="rounded-md bg-muted/40 p-2">
+              <div className="text-muted-foreground">
+                {t("dashboard.insights.toolErrorRate")}
+              </div>
+              <div className="font-semibold">
+                {data.health.toolErrorRatePercent.toFixed(2)}%
+              </div>
+            </div>
+            <div className="rounded-md bg-muted/40 p-2">
+              <div className="text-muted-foreground">
+                {t("dashboard.insights.cronSuccessRate")}
+              </div>
+              <div className="font-semibold">
+                {data.health.cronSuccessRatePercent.toFixed(1)}%
+              </div>
+            </div>
+            <div className="rounded-md bg-muted/40 p-2">
+              <div className="text-muted-foreground">
+                {t("dashboard.insights.subagentSuccessRate")}
+              </div>
+              <div className="font-semibold">
+                {data.health.subagentSuccessRatePercent.toFixed(1)}%
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Cost trend chart */}
+        <div className="bg-card border rounded-xl p-4 space-y-3">
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <h3 className="text-sm font-medium flex items-center gap-2">
+              <TrendingUp className="h-4 w-4 text-amber-500" />
+              {t("dashboard.insights.costTrend")}
+            </h3>
+            <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+              <span>
+                {t("dashboard.insights.total")}:{" "}
+                <span className="font-semibold text-foreground">
+                  {formatCost(data.costTrend.totalCostUsd)}
+                </span>
+              </span>
+              <span>
+                {t("dashboard.insights.avgDaily")}:{" "}
+                <span className="font-semibold text-foreground">
+                  {formatCost(data.costTrend.avgDailyCostUsd)}
+                </span>
+              </span>
+              {data.costTrend.peakDay && (
+                <span>
+                  {t("dashboard.insights.peak")}:{" "}
+                  <span className="font-semibold text-foreground">
+                    {data.costTrend.peakDay} · {formatCost(data.costTrend.peakCostUsd)}
+                  </span>
+                </span>
+              )}
+            </div>
+          </div>
+          {costChartData.length === 0 ? (
+            <div className="flex items-center justify-center h-[220px] text-sm text-muted-foreground">
+              {t("dashboard.noData")}
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height={220}>
+              <LineChart data={costChartData} margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis
+                  dataKey="date"
+                  tick={{ fontSize: 11 }}
+                  className="fill-muted-foreground"
+                />
+                <YAxis
+                  tick={{ fontSize: 11 }}
+                  className="fill-muted-foreground"
+                  tickFormatter={(v: number) => `$${v.toFixed(2)}`}
+                />
+                <RechartsTooltip
+                  contentStyle={{
+                    backgroundColor: "var(--color-popover)",
+                    border: "1px solid var(--color-border)",
+                    borderRadius: "8px",
+                    fontSize: "12px",
+                    color: "var(--color-popover-foreground)",
+                  }}
+                  formatter={(value: number) => [formatCost(value), t("dashboard.insights.cost")]}
+                />
+                <ReferenceLine
+                  y={data.costTrend.avgDailyCostUsd}
+                  stroke="#94a3b8"
+                  strokeDasharray="4 4"
+                  strokeWidth={1}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="cost"
+                  stroke="#f59e0b"
+                  strokeWidth={2}
+                  dot={{ r: 3 }}
+                  activeDot={{ r: 5 }}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+      </div>
+
+      {/* Row 2: Heatmap */}
+      <div className="bg-card border rounded-xl p-4 space-y-3">
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <h3 className="text-sm font-medium flex items-center gap-2">
+            <Flame className="h-4 w-4 text-rose-500" />
+            {t("dashboard.insights.heatmap")}
+          </h3>
+          <span className="text-[11px] text-muted-foreground">
+            {t("dashboard.insights.totalMessages")}:{" "}
+            <span className="font-semibold text-foreground">{formatNumber(data.heatmap.total)}</span>
+          </span>
+        </div>
+        {data.heatmap.total === 0 ? (
+          <div className="flex items-center justify-center h-[220px] text-sm text-muted-foreground">
+            {t("dashboard.noData")}
+          </div>
+        ) : (
+          <Heatmap cells={data.heatmap.cells} max={data.heatmap.maxValue} />
+        )}
+      </div>
+
+      {/* Row 3: Hourly distribution + Top sessions */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="bg-card border rounded-xl p-4 space-y-3">
+          <div className="flex items-center justify-between flex-wrap gap-2">
+            <h3 className="text-sm font-medium flex items-center gap-2">
+              <Clock4 className="h-4 w-4 text-indigo-500" />
+              {t("dashboard.insights.hourly")}
+            </h3>
+            {data.hourly.peakHour != null && (
+              <span className="text-[11px] text-muted-foreground">
+                {t("dashboard.insights.peakHour")}:{" "}
+                <span className="font-semibold text-foreground">
+                  {data.hourly.peakHour.toString().padStart(2, "0")}:00
+                </span>
+              </span>
+            )}
+          </div>
+          <ResponsiveContainer width="100%" height={240}>
+            <BarChart data={hourlyData} margin={{ top: 10, right: 16, left: 0, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis
+                dataKey="hour"
+                tick={{ fontSize: 10 }}
+                interval={2}
+                className="fill-muted-foreground"
+              />
+              <YAxis
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v: number) => formatNumber(v)}
+                className="fill-muted-foreground"
+              />
+              <RechartsTooltip
+                contentStyle={{
+                  backgroundColor: "var(--color-popover)",
+                  border: "1px solid var(--color-border)",
+                  borderRadius: "8px",
+                  fontSize: "12px",
+                  color: "var(--color-popover-foreground)",
+                }}
+                formatter={(value: number, name: string) => [
+                  formatNumber(value),
+                  name === "messageCount"
+                    ? t("dashboard.insights.messages")
+                    : t("dashboard.insights.sessions"),
+                ]}
+              />
+              <Bar dataKey="messageCount" fill="#6366f1" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* Top sessions ranking */}
+        <div className="bg-card border rounded-xl p-4 space-y-3">
+          <h3 className="text-sm font-medium flex items-center gap-2">
+            <Trophy className="h-4 w-4 text-yellow-500" />
+            {t("dashboard.insights.topSessions")}
+          </h3>
+          <div className="overflow-auto max-h-[260px]">
+            {data.topSessions.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                {t("dashboard.noData")}
+              </div>
+            ) : (
+              <div className="space-y-1.5">
+                {data.topSessions.map((s, idx) => {
+                  const rankColor =
+                    idx === 0
+                      ? "bg-yellow-500 text-white"
+                      : idx === 1
+                        ? "bg-gray-400 text-white"
+                        : idx === 2
+                          ? "bg-orange-500 text-white"
+                          : "bg-muted text-muted-foreground"
+                  return (
+                    <div
+                      key={s.id}
+                      className={cn(
+                        "group flex items-center gap-2 rounded-md p-2 text-xs",
+                        onDrillDownSession ? "cursor-pointer hover:bg-muted/50" : "",
+                      )}
+                      onClick={() => onDrillDownSession?.(s.id)}
+                    >
+                      <div
+                        className={cn(
+                          "flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-bold",
+                          rankColor,
+                        )}
+                      >
+                        {idx + 1}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate font-medium">
+                          {s.title || s.id.slice(0, 8)}
+                        </div>
+                        <div className="truncate text-[10px] text-muted-foreground">
+                          {s.modelId ?? "unknown"} · {formatNumber(s.messageCount)}{" "}
+                          {t("dashboard.insights.msgs")}
+                        </div>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <div className="font-semibold">{formatNumber(s.totalTokens)}</div>
+                        <div className="text-[10px] text-muted-foreground">
+                          {formatCost(s.estimatedCostUsd)}
+                        </div>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Row 4: Model efficiency */}
+      <div className="bg-card border rounded-xl p-4 space-y-3">
+        <h3 className="text-sm font-medium flex items-center gap-2">
+          <Cpu className="h-4 w-4 text-cyan-500" />
+          {t("dashboard.insights.modelEfficiency")}
+        </h3>
+        {data.modelEfficiency.length === 0 ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            {t("dashboard.noData")}
+          </div>
+        ) : (
+          <div className="overflow-auto">
+            <div className="grid grid-cols-[1fr_100px_100px_110px_110px_90px] gap-2 border-b pb-2 text-xs font-medium text-muted-foreground">
+              <div>{t("dashboard.insights.model")}</div>
+              <div className="text-right">{t("dashboard.insights.messages")}</div>
+              <div className="text-right">{t("dashboard.insights.tokens")}</div>
+              <div className="text-right">{t("dashboard.insights.tokensPerMsg")}</div>
+              <div className="text-right">{t("dashboard.insights.costPer1k")}</div>
+              <div className="text-right">{t("dashboard.insights.ttft")}</div>
+            </div>
+            {data.modelEfficiency.map((m) => (
+              <div
+                key={`${m.modelId}-${m.providerName}`}
+                className={cn(
+                  "grid grid-cols-[1fr_100px_100px_110px_110px_90px] gap-2 py-2 text-xs border-b border-border/40",
+                  onDrillDownModel ? "cursor-pointer hover:bg-muted/40" : "",
+                )}
+                onClick={() => onDrillDownModel?.(m.modelId)}
+              >
+                <div className="min-w-0">
+                  <div className="truncate font-medium">{m.modelId}</div>
+                  <div className="truncate text-[10px] text-muted-foreground">
+                    {m.providerName}
+                  </div>
+                </div>
+                <div className="text-right">{formatNumber(m.messageCount)}</div>
+                <div className="text-right">{formatNumber(m.totalTokens)}</div>
+                <div className="text-right">{m.avgTokensPerMessage.toFixed(0)}</div>
+                <div className="text-right">
+                  ${m.avgCostPer1kTokens.toFixed(4)}
+                </div>
+                <div className="text-right">
+                  {m.avgTtftMs != null ? formatDuration(m.avgTtftMs) : "-"}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+})
+
+export default InsightsSection

--- a/src/components/dashboard/OverviewCards.tsx
+++ b/src/components/dashboard/OverviewCards.tsx
@@ -10,17 +10,20 @@ import {
   Bot,
   Clock,
   Zap,
+  TrendingUp,
+  TrendingDown,
+  Minus,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
-import type { OverviewStats, DetailListType } from "./types"
-import { formatNumber, formatCost, formatDuration } from "./types"
+import type { OverviewStats, OverviewStatsWithDelta, DetailListType } from "./types"
+import { formatNumber, formatCost, formatDuration, computeDelta, formatDelta } from "./types"
 
 export type CardAction =
   | { type: "tab"; tab: string }
   | { type: "list"; listType: DetailListType }
 
 interface OverviewCardsProps {
-  data: OverviewStats | null
+  data: OverviewStatsWithDelta | null
   loading: boolean
   activeList: DetailListType | null
   onCardClick?: (action: CardAction) => void
@@ -33,6 +36,10 @@ interface CardConfig {
   colorClass: string
   bgClass: string
   getValue: (data: OverviewStats) => string
+  /** Extract the numeric value used for delta comparison. */
+  getNumeric: (data: OverviewStats) => number
+  /** When true, higher values mean worse (e.g. errors). */
+  higherIsWorse?: boolean
 }
 
 const cards: CardConfig[] = [
@@ -43,6 +50,7 @@ const cards: CardConfig[] = [
     colorClass: "text-blue-500",
     bgClass: "bg-blue-500/10",
     getValue: (d) => formatNumber(d.totalSessions),
+    getNumeric: (d) => d.totalSessions,
   },
   {
     key: "totalMessages",
@@ -51,6 +59,7 @@ const cards: CardConfig[] = [
     colorClass: "text-green-500",
     bgClass: "bg-green-500/10",
     getValue: (d) => formatNumber(d.totalMessages),
+    getNumeric: (d) => d.totalMessages,
   },
   {
     key: "totalTokens",
@@ -59,6 +68,7 @@ const cards: CardConfig[] = [
     colorClass: "text-purple-500",
     bgClass: "bg-purple-500/10",
     getValue: (d) => formatNumber(d.totalInputTokens + d.totalOutputTokens),
+    getNumeric: (d) => d.totalInputTokens + d.totalOutputTokens,
   },
   {
     key: "estimatedCost",
@@ -67,6 +77,7 @@ const cards: CardConfig[] = [
     colorClass: "text-amber-500",
     bgClass: "bg-amber-500/10",
     getValue: (d) => formatCost(d.estimatedCostUsd),
+    getNumeric: (d) => d.estimatedCostUsd,
   },
   {
     key: "toolCalls",
@@ -75,6 +86,7 @@ const cards: CardConfig[] = [
     colorClass: "text-cyan-500",
     bgClass: "bg-cyan-500/10",
     getValue: (d) => formatNumber(d.totalToolCalls),
+    getNumeric: (d) => d.totalToolCalls,
   },
   {
     key: "errors",
@@ -83,6 +95,8 @@ const cards: CardConfig[] = [
     colorClass: "text-red-500",
     bgClass: "bg-red-500/10",
     getValue: (d) => formatNumber(d.totalErrors),
+    getNumeric: (d) => d.totalErrors,
+    higherIsWorse: true,
   },
   {
     key: "activeAgents",
@@ -91,6 +105,7 @@ const cards: CardConfig[] = [
     colorClass: "text-indigo-500",
     bgClass: "bg-indigo-500/10",
     getValue: (d) => formatNumber(d.activeAgents),
+    getNumeric: (d) => d.activeAgents,
   },
   {
     key: "cronJobs",
@@ -99,6 +114,7 @@ const cards: CardConfig[] = [
     colorClass: "text-orange-500",
     bgClass: "bg-orange-500/10",
     getValue: (d) => formatNumber(d.activeCronJobs),
+    getNumeric: (d) => d.activeCronJobs,
   },
   {
     key: "avgTtft",
@@ -107,6 +123,8 @@ const cards: CardConfig[] = [
     colorClass: "text-yellow-500",
     bgClass: "bg-yellow-500/10",
     getValue: (d) => (d.avgTtftMs != null ? formatDuration(d.avgTtftMs) : "-"),
+    getNumeric: (d) => d.avgTtftMs ?? 0,
+    higherIsWorse: true,
   },
 ]
 
@@ -124,24 +142,73 @@ function SkeletonCard() {
   )
 }
 
-const OverviewCards = React.memo(function OverviewCards({ data, loading, activeList, onCardClick }: OverviewCardsProps) {
+function DeltaBadge({
+  delta,
+  higherIsWorse,
+}: {
+  delta: number | null
+  higherIsWorse: boolean
+}) {
+  if (delta == null) return null
+  const isZero = delta === 0
+  const isUp = delta > 0
+  const good = isZero ? null : higherIsWorse ? !isUp : isUp
+  const Icon = isZero ? Minus : isUp ? TrendingUp : TrendingDown
+  const colorClass = isZero
+    ? "text-muted-foreground"
+    : good
+      ? "text-emerald-500"
+      : "text-red-500"
+  const bgClass = isZero
+    ? "bg-muted/40"
+    : good
+      ? "bg-emerald-500/10"
+      : "bg-red-500/10"
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-0.5 rounded-md px-1.5 py-0.5 text-[10px] font-medium",
+        bgClass,
+        colorClass,
+      )}
+    >
+      <Icon className="h-2.5 w-2.5" />
+      <span>{formatDelta(delta)}</span>
+    </div>
+  )
+}
+
+const OverviewCards = React.memo(function OverviewCards({
+  data,
+  loading,
+  activeList,
+  onCardClick,
+}: OverviewCardsProps) {
   const { t } = useTranslation()
 
   if (loading && !data) {
     return (
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        {Array.from({ length: 8 }).map((_, i) => (
+      <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4">
+        {Array.from({ length: 9 }).map((_, i) => (
           <SkeletonCard key={i} />
         ))}
       </div>
     )
   }
 
+  const current = data?.current ?? null
+  const previous = data?.previous ?? null
+  const hasPrev = previous != null
+
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4">
       {cards.map((card) => {
         const Icon = card.icon
-        const value = data ? card.getValue(data) : "-"
+        const value = current ? card.getValue(current) : "-"
+        const delta =
+          current && previous
+            ? computeDelta(card.getNumeric(current), card.getNumeric(previous))
+            : null
         const isActive = card.action.type === "list" && activeList === card.action.listType
         return (
           <div
@@ -153,11 +220,24 @@ const OverviewCards = React.memo(function OverviewCards({ data, loading, activeL
             onClick={() => onCardClick?.(card.action)}
           >
             <div className="flex items-center gap-3">
-              <div className={cn("h-9 w-9 rounded-full flex items-center justify-center", card.bgClass)}>
+              <div
+                className={cn(
+                  "h-9 w-9 rounded-full flex items-center justify-center shrink-0",
+                  card.bgClass,
+                )}
+              >
                 <Icon className={cn("h-4.5 w-4.5", card.colorClass)} />
               </div>
-              <div className="min-w-0">
-                <div className="text-xl font-bold truncate">{value}</div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <div className="text-xl font-bold truncate">{value}</div>
+                  {hasPrev && (
+                    <DeltaBadge
+                      delta={delta}
+                      higherIsWorse={card.higherIsWorse === true}
+                    />
+                  )}
+                </div>
                 <div className="text-xs text-muted-foreground truncate">
                   {t(`dashboard.overview.${card.key}`)}
                 </div>

--- a/src/components/dashboard/SystemMetricsSection.tsx
+++ b/src/components/dashboard/SystemMetricsSection.tsx
@@ -11,6 +11,8 @@ import {
   PieChart,
   Pie,
   Cell,
+  AreaChart,
+  Area,
 } from "recharts"
 import {
   Cpu,
@@ -27,9 +29,16 @@ import { cn } from "@/lib/utils"
 import type { SystemMetrics } from "./types"
 import { formatBytes, formatUptime } from "./types"
 
+export interface SystemHistoryPoint {
+  t: number
+  cpu: number
+  mem: number
+}
+
 interface SystemMetricsSectionProps {
   data: SystemMetrics | null
   loading: boolean
+  history?: SystemHistoryPoint[]
 }
 
 function SectionSkeleton({ height }: { height: number }) {
@@ -95,8 +104,18 @@ function getCpuColor(percent: number): string {
 const SystemMetricsSection = React.memo(function SystemMetricsSection({
   data,
   loading,
+  history,
 }: SystemMetricsSectionProps) {
   const { t } = useTranslation()
+
+  const historyData = useMemo(() => {
+    if (!history) return []
+    return history.map((h) => ({
+      t: h.t,
+      cpu: Number(h.cpu.toFixed(2)),
+      mem: Number(h.mem.toFixed(2)),
+    }))
+  }, [history])
 
   const memPieData = useMemo(() => {
     if (!data) return []
@@ -378,6 +397,91 @@ const SystemMetricsSection = React.memo(function SystemMetricsSection({
             </BarChart>
           </ResponsiveContainer>
         </div>
+
+        {/* Live resource history (client-side ring buffer, refreshed via auto-refresh) */}
+        {historyData.length > 1 && (
+          <div className="bg-card border rounded-xl p-4 space-y-3 lg:col-span-2">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-medium flex items-center gap-2">
+                <Cpu className="h-4 w-4 text-amber-500" />
+                {t("dashboard.system.liveHistory")}
+              </h3>
+              <span className="text-[11px] text-muted-foreground">
+                {historyData.length} {t("dashboard.system.samples")}
+              </span>
+            </div>
+            <ResponsiveContainer width="100%" height={180}>
+              <AreaChart
+                data={historyData}
+                margin={{ top: 5, right: 16, left: 0, bottom: 0 }}
+              >
+                <defs>
+                  <linearGradient id="cpuGrad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#f59e0b" stopOpacity={0.45} />
+                    <stop offset="100%" stopColor="#f59e0b" stopOpacity={0} />
+                  </linearGradient>
+                  <linearGradient id="memGrad" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#a855f7" stopOpacity={0.45} />
+                    <stop offset="100%" stopColor="#a855f7" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+                <XAxis
+                  dataKey="t"
+                  tick={{ fontSize: 10 }}
+                  className="fill-muted-foreground"
+                  tickFormatter={(v: number) =>
+                    new Date(v).toLocaleTimeString([], {
+                      hour: "2-digit",
+                      minute: "2-digit",
+                    })
+                  }
+                  minTickGap={24}
+                />
+                <YAxis
+                  tick={{ fontSize: 10 }}
+                  className="fill-muted-foreground"
+                  tickFormatter={(v: number) => `${v.toFixed(0)}%`}
+                />
+                <RechartsTooltip
+                  contentStyle={{
+                    backgroundColor: "var(--color-popover)",
+                    border: "1px solid var(--color-border)",
+                    borderRadius: "8px",
+                    fontSize: "12px",
+                    color: "var(--color-popover-foreground)",
+                  }}
+                  labelFormatter={(v: number) =>
+                    new Date(v).toLocaleTimeString()
+                  }
+                  formatter={(value: number, name: string) => [
+                    `${value.toFixed(2)}%`,
+                    name === "cpu"
+                      ? t("dashboard.system.cpuUsage")
+                      : t("dashboard.system.memRss"),
+                  ]}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="cpu"
+                  stroke="#f59e0b"
+                  strokeWidth={2}
+                  fill="url(#cpuGrad)"
+                />
+                <Area
+                  type="monotone"
+                  dataKey="mem"
+                  stroke="#a855f7"
+                  strokeWidth={2}
+                  fill="url(#memGrad)"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+            <p className="text-center text-[11px] text-muted-foreground">
+              {t("dashboard.system.liveHistoryHint")}
+            </p>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -19,6 +19,11 @@ export interface OverviewStats {
   avgTtftMs: number | null
 }
 
+export interface OverviewStatsWithDelta {
+  current: OverviewStats
+  previous: OverviewStats | null
+}
+
 export interface TokenUsageTrend {
   date: string
   inputTokens: number
@@ -209,6 +214,116 @@ export interface CronJob {
 }
 
 export type Granularity = "day" | "week" | "month"
+
+// ── Insights Types (Phase 2) ────────────────────────────────────
+
+export interface CostTrendPoint {
+  date: string
+  costUsd: number
+  inputTokens: number
+  outputTokens: number
+}
+
+export interface DashboardCostTrend {
+  points: CostTrendPoint[]
+  totalCostUsd: number
+  peakDay: string | null
+  peakCostUsd: number
+  avgDailyCostUsd: number
+}
+
+export interface HeatmapCell {
+  weekday: number // 0=Sun..6=Sat
+  hour: number // 0..23
+  messageCount: number
+}
+
+export interface DashboardHeatmap {
+  cells: HeatmapCell[]
+  maxValue: number
+  total: number
+}
+
+export interface HourlyBucket {
+  hour: number
+  messageCount: number
+  sessionCount: number
+}
+
+export interface DashboardHourlyDistribution {
+  buckets: HourlyBucket[]
+  peakHour: number | null
+  peakMessageCount: number
+}
+
+export interface TopSession {
+  id: string
+  title: string | null
+  agentId: string
+  modelId: string | null
+  totalTokens: number
+  messageCount: number
+  estimatedCostUsd: number
+  updatedAt: string
+}
+
+export interface ModelEfficiency {
+  modelId: string
+  providerName: string
+  totalTokens: number
+  totalCostUsd: number
+  avgTtftMs: number | null
+  messageCount: number
+  avgTokensPerMessage: number
+  avgCostPer1kTokens: number
+}
+
+export interface HealthBreakdown {
+  score: number
+  logErrorRatePercent: number
+  toolErrorRatePercent: number
+  cronSuccessRatePercent: number
+  subagentSuccessRatePercent: number
+  status: "excellent" | "good" | "warning" | "critical"
+}
+
+export interface DashboardInsights {
+  health: HealthBreakdown
+  costTrend: DashboardCostTrend
+  heatmap: DashboardHeatmap
+  hourly: DashboardHourlyDistribution
+  topSessions: TopSession[]
+  modelEfficiency: ModelEfficiency[]
+}
+
+export type AutoRefreshInterval = "off" | "30s" | "1m" | "5m"
+
+export function autoRefreshMs(interval: AutoRefreshInterval): number {
+  switch (interval) {
+    case "30s": return 30_000
+    case "1m": return 60_000
+    case "5m": return 300_000
+    default: return 0
+  }
+}
+
+/** Format percentage delta between current and previous. */
+export function computeDelta(current: number, previous: number): number | null {
+  if (!Number.isFinite(current) || !Number.isFinite(previous)) return null
+  if (previous === 0) {
+    if (current === 0) return 0
+    return null // infinite delta — don't display a number
+  }
+  return ((current - previous) / previous) * 100
+}
+
+/** Format a delta percent to a "+12.3%" or "-4.5%" string. */
+export function formatDelta(delta: number | null): string {
+  if (delta == null) return ""
+  const sign = delta > 0 ? "+" : ""
+  if (Math.abs(delta) >= 1000) return `${sign}${(delta / 1000).toFixed(1)}K%`
+  return `${sign}${delta.toFixed(1)}%`
+}
 
 /** Format large numbers as "1.2M", "45.6K", etc. */
 export function formatNumber(n: number): string {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1572,13 +1572,66 @@
   },
   "dashboard": {
     "title": "Dashboard",
+    "lastRefresh": "Last refresh",
+    "refresh": "Refresh now",
+    "export": "Export CSV",
+    "autoRefresh": {
+      "off": "Manual",
+      "30s": "30 sec",
+      "1m": "1 min",
+      "5m": "5 min"
+    },
     "tabs": {
+      "insights": "Insights",
       "tokens": "Token Usage",
       "tools": "Tool Usage",
       "sessions": "Sessions",
       "errors": "Errors",
       "tasks": "Tasks",
       "system": "System"
+    },
+    "insights": {
+      "healthScore": "Health Score",
+      "status": {
+        "excellent": "Excellent",
+        "good": "Good",
+        "warning": "Warning",
+        "critical": "Critical"
+      },
+      "logErrorRate": "Log Error Rate",
+      "toolErrorRate": "Tool Error Rate",
+      "cronSuccessRate": "Cron Success",
+      "subagentSuccessRate": "Subagent Success",
+      "costTrend": "Cost Trend",
+      "total": "Total",
+      "avgDaily": "Avg/day",
+      "peak": "Peak",
+      "cost": "Cost",
+      "heatmap": "Activity Heatmap",
+      "totalMessages": "Total Messages",
+      "less": "Less",
+      "more": "More",
+      "weekday": {
+        "sun": "Sun",
+        "mon": "Mon",
+        "tue": "Tue",
+        "wed": "Wed",
+        "thu": "Thu",
+        "fri": "Fri",
+        "sat": "Sat"
+      },
+      "hourly": "Hourly Distribution",
+      "peakHour": "Peak hour",
+      "messages": "Messages",
+      "sessions": "Sessions",
+      "msgs": "msgs",
+      "topSessions": "Top Sessions",
+      "modelEfficiency": "Model Efficiency",
+      "model": "Model",
+      "tokens": "Tokens",
+      "tokensPerMsg": "Tokens/msg",
+      "costPer1k": "Cost / 1k",
+      "ttft": "TTFT"
     },
     "granularity": {
       "day": "Day",
@@ -1697,7 +1750,10 @@
       "ofSystem": "of System",
       "diskIO": "Disk I/O",
       "diskRead": "Read",
-      "diskWrite": "Write"
+      "diskWrite": "Write",
+      "liveHistory": "Live Resource Usage",
+      "liveHistoryHint": "Enable auto-refresh to record CPU / memory samples over time",
+      "samples": "samples"
     },
     "noData": "No data available",
     "loading": "Loading...",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1572,13 +1572,66 @@
   },
   "dashboard": {
     "title": "数据大盘",
+    "lastRefresh": "最近刷新",
+    "refresh": "立即刷新",
+    "export": "导出 CSV",
+    "autoRefresh": {
+      "off": "手动刷新",
+      "30s": "30 秒",
+      "1m": "1 分钟",
+      "5m": "5 分钟"
+    },
     "tabs": {
+      "insights": "综合概览",
       "tokens": "Token 用量",
       "tools": "工具使用",
       "sessions": "会话分析",
       "errors": "异常监控",
       "tasks": "任务统计",
       "system": "系统监控"
+    },
+    "insights": {
+      "healthScore": "系统健康度",
+      "status": {
+        "excellent": "优秀",
+        "good": "良好",
+        "warning": "预警",
+        "critical": "告警"
+      },
+      "logErrorRate": "日志错误率",
+      "toolErrorRate": "工具错误率",
+      "cronSuccessRate": "定时任务成功率",
+      "subagentSuccessRate": "子 Agent 成功率",
+      "costTrend": "费用趋势",
+      "total": "累计",
+      "avgDaily": "日均",
+      "peak": "峰值",
+      "cost": "费用",
+      "heatmap": "活跃度热力图",
+      "totalMessages": "消息总数",
+      "less": "少",
+      "more": "多",
+      "weekday": {
+        "sun": "周日",
+        "mon": "周一",
+        "tue": "周二",
+        "wed": "周三",
+        "thu": "周四",
+        "fri": "周五",
+        "sat": "周六"
+      },
+      "hourly": "小时分布",
+      "peakHour": "峰值时段",
+      "messages": "消息数",
+      "sessions": "会话数",
+      "msgs": "条消息",
+      "topSessions": "Top 会话",
+      "modelEfficiency": "模型效率对比",
+      "model": "模型",
+      "tokens": "Token 数",
+      "tokensPerMsg": "平均/消息",
+      "costPer1k": "每千 Token",
+      "ttft": "首 Token"
     },
     "granularity": {
       "day": "按天",
@@ -1697,7 +1750,10 @@
       "ofSystem": "占系统",
       "diskIO": "磁盘 I/O",
       "diskRead": "读取",
-      "diskWrite": "写入"
+      "diskWrite": "写入",
+      "liveHistory": "实时资源曲线",
+      "liveHistoryHint": "开启自动刷新后，此处会实时记录 CPU / 内存占用",
+      "samples": "个采样"
     },
     "noData": "暂无数据",
     "loading": "加载中...",


### PR DESCRIPTION
让用户全方位了解系统运行情况：

- 新增 Insights 首屏 Tab：健康度环形仪表（四维加权：日志/工具/
  cron/subagent 成功率）、费用趋势折线 + 日均参考线、7×24 活跃度
  热力图、0–23 小时分布柱状图、Top 10 会话排行与模型效率对比表。
- OverviewCards 同比 Delta：后端 query_overview_with_delta 按相同
  时间跨度左移取 previous baseline，前端 DeltaBadge 用箭头 + 绿红
  语义展示涨跌，错误 / TTFT 翻转好坏方向。
- 大盘 Header 自动刷新选择器（关闭/30s/1m/5m）+ CSV 导出 +
  最近刷新时间戳。
- System Tab 客户端环形缓冲（≤60 采样）绘制 CPU / 内存实时面积图。
- 新增 oc-core dashboard/insights.rs、Tauri 命令 dashboard_insights
  与 dashboard_overview_delta、HTTP 路由 /dashboard/insights 与
  /dashboard/overview-delta。
- 更新 zh/en i18n、CHANGELOG、AGENTS 对应章节。

https://claude.ai/code/session_01XMLzjCrpUEqRKsC7mXTNcj