### PR TITLE
fix(chat): SubagentBlock 显示 Agent 友好名字 + emoji

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -555,6 +555,9 @@ export default function ChatScreen({
           planSubagentRunning={planMode.planSubagentRunning}
           onSwitchModel={(providerId, modelId) => handleModelChange(`${providerId}::${modelId}`)}
           onViewSystemPrompt={loadSystemPrompt}
+          onSwitchSession={(sid) => {
+            void session.handleSwitchSession(sid)
+          }}
         />
 
         {/* Memory extraction toast */}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -40,6 +40,8 @@ interface MessageListProps {
   planSubagentRunning?: boolean
   onSwitchModel?: (providerId: string, modelId: string) => void
   onViewSystemPrompt?: () => void
+  /** Jump to another session (e.g. a sub-agent's child session). */
+  onSwitchSession?: (sessionId: string) => void
 }
 
 export default function MessageList({
@@ -67,6 +69,7 @@ export default function MessageList({
   planSubagentRunning,
   onSwitchModel,
   onViewSystemPrompt,
+  onSwitchSession,
 }: MessageListProps) {
   const { t } = useTranslation()
   const [hoveredMsgIndex, setHoveredMsgIndex] = useState<number | null>(null)
@@ -188,6 +191,7 @@ export default function MessageList({
             onCopy={handleCopyMessage}
             sessionId={sessionId}
             onOpenPlanPanel={onOpenPlanPanel}
+            onSwitchSession={onSwitchSession}
             onSwitchModel={onSwitchModel}
             onViewSystemPrompt={onViewSystemPrompt}
           />

--- a/src/components/chat/SubagentBlock.tsx
+++ b/src/components/chat/SubagentBlock.tsx
@@ -90,8 +90,11 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
   return (
     <div className="my-1.5 rounded-lg border border-border bg-secondary/50 text-xs">
       <button
-        className="flex items-center gap-1.5 w-full px-2.5 py-1.5 text-left hover:bg-secondary/80 rounded-lg transition-colors"
+        type="button"
+        className="flex items-center gap-1.5 w-full px-2.5 py-1.5 text-left hover:bg-secondary/80 rounded-lg transition-colors disabled:hover:bg-transparent disabled:cursor-default"
         onClick={() => isTerminal && setExpanded(!expanded)}
+        disabled={!isTerminal}
+        aria-expanded={isTerminal ? expanded : undefined}
       >
         {!isTerminal ? (
           <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0" />
@@ -110,7 +113,10 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
         ) : (
           <Users className="h-3 w-3 shrink-0 text-muted-foreground" />
         )}
-        <span className="font-medium text-foreground shrink-0" title={nameTooltip}>
+        <span
+          className="font-medium text-foreground truncate max-w-[40%]"
+          title={nameTooltip || friendlyName}
+        >
           {friendlyName}
         </span>
         <span className="text-[10px] text-muted-foreground shrink-0 hidden sm:inline">
@@ -122,7 +128,7 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
             {attachmentCount}
           </span>
         )}
-        <span className="text-muted-foreground truncate flex-1">{task}</span>
+        <span className="text-muted-foreground truncate flex-1 min-w-0">{task}</span>
         <span
           className={cn("flex items-center gap-1 transition-colors duration-200", config.color)}
         >

--- a/src/components/chat/SubagentBlock.tsx
+++ b/src/components/chat/SubagentBlock.tsx
@@ -1,66 +1,17 @@
 import { useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
-import { ChevronRight, Users, CheckCircle, XCircle, Clock, Loader2, Skull, Paperclip } from "lucide-react"
+import { ChevronRight, Users, Paperclip } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getTransport } from "@/lib/transport-provider"
 import type { AgentSummaryForSidebar, SubagentEvent, SubagentRun } from "@/types/chat"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+import { loadAgents, statusConfig, TERMINAL_STATUSES } from "./subagentShared"
 
 interface SubagentBlockProps {
   runId: string
   agentId: string
   task: string
   initialStatus?: string
-}
-
-// ── Shared agent metadata cache (module-level, cross-instance) ─────────
-// One SubagentBlock may render many times in the same session; coalesce
-// list_agents calls via a single in-flight promise + 30s TTL.
-let agentCache: Map<string, AgentSummaryForSidebar> | null = null
-let agentCacheAt = 0
-let inflight: Promise<Map<string, AgentSummaryForSidebar>> | null = null
-const AGENT_CACHE_TTL_MS = 30_000
-
-function loadAgents(): Promise<Map<string, AgentSummaryForSidebar>> {
-  const now = Date.now()
-  if (agentCache && now - agentCacheAt < AGENT_CACHE_TTL_MS) {
-    return Promise.resolve(agentCache)
-  }
-  if (inflight) return inflight
-  inflight = getTransport()
-    .call<AgentSummaryForSidebar[]>("list_agents")
-    .then((list) => {
-      agentCache = new Map(list.map((a) => [a.id, a]))
-      agentCacheAt = Date.now()
-      inflight = null
-      return agentCache
-    })
-    .catch((e) => {
-      inflight = null
-      throw e
-    })
-  return inflight
-}
-
-const statusConfig: Record<string, { icon: React.ReactNode; label: string; color: string }> = {
-  spawning: {
-    icon: <Loader2 className="h-3 w-3 animate-spin" />,
-    label: "Spawning",
-    color: "text-blue-500",
-  },
-  running: {
-    icon: <Loader2 className="h-3 w-3 animate-spin" />,
-    label: "Running",
-    color: "text-blue-500",
-  },
-  completed: {
-    icon: <CheckCircle className="h-3 w-3" />,
-    label: "Completed",
-    color: "text-green-500",
-  },
-  error: { icon: <XCircle className="h-3 w-3" />, label: "Error", color: "text-red-500" },
-  timeout: { icon: <Clock className="h-3 w-3" />, label: "Timeout", color: "text-orange-500" },
-  killed: { icon: <Skull className="h-3 w-3" />, label: "Killed", color: "text-gray-500" },
 }
 
 export default function SubagentBlock({ runId, agentId, task, initialStatus }: SubagentBlockProps) {
@@ -129,7 +80,7 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
     })
   }, [runId])
 
-  const isTerminal = ["completed", "error", "timeout", "killed"].includes(status)
+  const isTerminal = TERMINAL_STATUSES.has(status)
   const config = statusConfig[status] || statusConfig.error
   const toolLabel = t("tools.subagent")
   const friendlyName = label || agentMeta?.name || agentId

--- a/src/components/chat/SubagentBlock.tsx
+++ b/src/components/chat/SubagentBlock.tsx
@@ -133,7 +133,7 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
           className={cn("flex items-center gap-1 transition-colors duration-200", config.color)}
         >
           {config.icon}
-          <span>{config.label}</span>
+          <span>{t(`subagent.status.${status}`, status)}</span>
         </span>
         {durationMs !== undefined && (
           <span className="text-muted-foreground">{(durationMs / 1000).toFixed(1)}s</span>

--- a/src/components/chat/SubagentBlock.tsx
+++ b/src/components/chat/SubagentBlock.tsx
@@ -98,10 +98,18 @@ export default function SubagentBlock({
   const nameTooltip = agentMissing ? t("subagent.deletedAgentTooltip") : undefined
 
   const canViewSession = !!(onSwitchSession && childSessionId)
+  const rowInteractive = isTerminal || canViewSession
 
   return (
     <div className="my-1.5 rounded-lg border border-border bg-secondary/50 text-xs">
-      <div className="flex items-center hover:bg-secondary/80 rounded-lg transition-colors">
+      <div
+        className={cn(
+          "flex items-center rounded-lg transition-colors",
+          // Only show row-hover tint when *something* in the row is actually
+          // interactable — otherwise disabled rows visually fake affordance.
+          rowInteractive && "hover:bg-secondary/80",
+        )}
+      >
         <button
           type="button"
           className="flex items-center gap-1.5 flex-1 min-w-0 px-2.5 py-1.5 text-left disabled:cursor-default"
@@ -162,7 +170,9 @@ export default function SubagentBlock({
               <button
                 type="button"
                 className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
-                onClick={() => onSwitchSession!(childSessionId!)}
+                onClick={() => {
+                  if (onSwitchSession && childSessionId) onSwitchSession(childSessionId)
+                }}
                 aria-label={t("subagent.viewChildSession")}
               >
                 <ArrowUpRight className="h-3 w-3" />

--- a/src/components/chat/SubagentBlock.tsx
+++ b/src/components/chat/SubagentBlock.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
-import { ChevronRight, Users, Paperclip } from "lucide-react"
+import { ChevronRight, Users, Paperclip, ArrowUpRight } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getTransport } from "@/lib/transport-provider"
 import type { AgentSummaryForSidebar, SubagentEvent, SubagentRun } from "@/types/chat"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+import { IconTip } from "@/components/ui/tooltip"
 import { loadAgents, statusConfig, TERMINAL_STATUSES } from "./subagentShared"
 
 interface SubagentBlockProps {
@@ -12,9 +13,16 @@ interface SubagentBlockProps {
   agentId: string
   task: string
   initialStatus?: string
+  onSwitchSession?: (sessionId: string) => void
 }
 
-export default function SubagentBlock({ runId, agentId, task, initialStatus }: SubagentBlockProps) {
+export default function SubagentBlock({
+  runId,
+  agentId,
+  task,
+  initialStatus,
+  onSwitchSession,
+}: SubagentBlockProps) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const [status, setStatus] = useState(initialStatus || "spawning")
@@ -26,6 +34,7 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
   const [inputTokens, setInputTokens] = useState<number | undefined>()
   const [outputTokens, setOutputTokens] = useState<number | undefined>()
   const [attachmentCount, setAttachmentCount] = useState(0)
+  const [childSessionId, setChildSessionId] = useState<string | undefined>()
   const [agentMeta, setAgentMeta] = useState<AgentSummaryForSidebar | undefined>()
   const [agentMissing, setAgentMissing] = useState(false)
 
@@ -61,6 +70,7 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
         if (run.inputTokens) setInputTokens(run.inputTokens)
         if (run.outputTokens) setOutputTokens(run.outputTokens)
         if (run.attachmentCount) setAttachmentCount(run.attachmentCount)
+        if (run.childSessionId) setChildSessionId(run.childSessionId)
       })
       .catch(() => {})
   }, [runId])
@@ -87,60 +97,84 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
   const emoji = agentMeta?.emoji?.trim() || null
   const nameTooltip = agentMissing ? t("subagent.deletedAgentTooltip") : undefined
 
+  const canViewSession = !!(onSwitchSession && childSessionId)
+
   return (
     <div className="my-1.5 rounded-lg border border-border bg-secondary/50 text-xs">
-      <button
-        type="button"
-        className="flex items-center gap-1.5 w-full px-2.5 py-1.5 text-left hover:bg-secondary/80 rounded-lg transition-colors disabled:hover:bg-transparent disabled:cursor-default"
-        onClick={() => isTerminal && setExpanded(!expanded)}
-        disabled={!isTerminal}
-        aria-expanded={isTerminal ? expanded : undefined}
-      >
-        {!isTerminal ? (
-          <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0" />
-        ) : (
-          <ChevronRight
-            className={cn(
-              "h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-200",
-              expanded && "rotate-90",
-            )}
-          />
-        )}
-        {emoji ? (
-          <span className="shrink-0 leading-none" aria-hidden>
-            {emoji}
-          </span>
-        ) : (
-          <Users className="h-3 w-3 shrink-0 text-muted-foreground" />
-        )}
-        <span
-          className="font-medium text-foreground truncate max-w-[40%]"
-          title={nameTooltip || friendlyName}
+      <div className="flex items-center hover:bg-secondary/80 rounded-lg transition-colors">
+        <button
+          type="button"
+          className="flex items-center gap-1.5 flex-1 min-w-0 px-2.5 py-1.5 text-left disabled:cursor-default"
+          onClick={() => isTerminal && setExpanded(!expanded)}
+          disabled={!isTerminal}
+          aria-expanded={isTerminal ? expanded : undefined}
         >
-          {friendlyName}
-        </span>
-        <span className="text-[10px] text-muted-foreground shrink-0 hidden sm:inline">
-          {toolLabel}
-        </span>
-        {attachmentCount > 0 && (
-          <span className="flex items-center gap-0.5 text-muted-foreground">
-            <Paperclip className="h-2.5 w-2.5" />
-            {attachmentCount}
+          {!isTerminal ? (
+            <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0" />
+          ) : (
+            <ChevronRight
+              className={cn(
+                "h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-200",
+                expanded && "rotate-90",
+              )}
+            />
+          )}
+          {emoji ? (
+            <span className="shrink-0 leading-none" aria-hidden>
+              {emoji}
+            </span>
+          ) : (
+            <Users className="h-3 w-3 shrink-0 text-muted-foreground" />
+          )}
+          <span
+            className="font-medium text-foreground truncate max-w-[40%]"
+            title={nameTooltip || friendlyName}
+          >
+            {friendlyName}
           </span>
-        )}
-        <span className="text-muted-foreground truncate flex-1 min-w-0">{task}</span>
-        <span
-          className={cn("flex items-center gap-1 transition-colors duration-200", config.color)}
-        >
-          {config.icon}
-          <span>{t(`subagent.status.${status}`, status)}</span>
-        </span>
-        {durationMs !== undefined && (
-          <span className="text-muted-foreground">{(durationMs / 1000).toFixed(1)}s</span>
-        )}
-      </button>
-      {/* Stats bar for terminal states */}
-      {isTerminal && (modelUsed || inputTokens !== undefined) && (
+          <span className="text-[10px] text-muted-foreground shrink-0 hidden sm:inline">
+            {toolLabel}
+          </span>
+          {attachmentCount > 0 && (
+            <span className="flex items-center gap-0.5 text-muted-foreground shrink-0">
+              <Paperclip className="h-2.5 w-2.5" />
+              {attachmentCount}
+            </span>
+          )}
+          <span className="text-muted-foreground truncate flex-1 min-w-0">{task}</span>
+        </button>
+        {/* Right action area — sibling of main button so the view-session
+            button is NOT nested inside another button. */}
+        <div className="flex items-center gap-1.5 pr-2 shrink-0">
+          <span
+            className={cn("flex items-center gap-1 transition-colors duration-200", config.color)}
+          >
+            {config.icon}
+            <span>{t(`subagent.status.${status}`, status)}</span>
+          </span>
+          {durationMs !== undefined && (
+            <span className="text-muted-foreground tabular-nums">
+              {(durationMs / 1000).toFixed(1)}s
+            </span>
+          )}
+          {canViewSession && (
+            <IconTip label={t("subagent.viewChildSession")}>
+              <button
+                type="button"
+                className="p-1 rounded hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+                onClick={() => onSwitchSession!(childSessionId!)}
+                aria-label={t("subagent.viewChildSession")}
+              >
+                <ArrowUpRight className="h-3 w-3" />
+              </button>
+            </IconTip>
+          )}
+        </div>
+      </div>
+      {/* Stats bar — show whenever we have something to display, not just
+          terminal. During running, tokens/model start appearing after the
+          first child tool round. */}
+      {(modelUsed || inputTokens !== undefined) && (
         <div className="flex items-center gap-2 px-2.5 pb-1 text-[10px] text-muted-foreground">
           {modelUsed && <span>{modelUsed}</span>}
           {inputTokens !== undefined && outputTokens !== undefined && (
@@ -151,10 +185,10 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
       <div
         className={cn(
           "overflow-hidden transition-all duration-200 ease-out",
-          expanded && (resultFull || error) ? "max-h-96 opacity-100" : "max-h-0 opacity-0",
+          expanded && (resultFull || error) ? "max-h-[600px] opacity-100" : "max-h-0 opacity-0",
         )}
       >
-        <div className="px-2.5 pb-2 pt-0.5 max-h-96 overflow-y-auto">
+        <div className="px-2.5 pb-2 pt-0.5 max-h-[600px] overflow-y-auto">
           {error && (
             <pre className="whitespace-pre-wrap text-red-400 bg-background rounded p-2 text-[11px] leading-relaxed">
               {error}

--- a/src/components/chat/SubagentBlock.tsx
+++ b/src/components/chat/SubagentBlock.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react"
+import { useTranslation } from "react-i18next"
 import { ChevronRight, Users, CheckCircle, XCircle, Clock, Loader2, Skull, Paperclip } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getTransport } from "@/lib/transport-provider"
-import type { SubagentEvent, SubagentRun } from "@/types/chat"
+import type { AgentSummaryForSidebar, SubagentEvent, SubagentRun } from "@/types/chat"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
 
 interface SubagentBlockProps {
@@ -10,6 +11,35 @@ interface SubagentBlockProps {
   agentId: string
   task: string
   initialStatus?: string
+}
+
+// ── Shared agent metadata cache (module-level, cross-instance) ─────────
+// One SubagentBlock may render many times in the same session; coalesce
+// list_agents calls via a single in-flight promise + 30s TTL.
+let agentCache: Map<string, AgentSummaryForSidebar> | null = null
+let agentCacheAt = 0
+let inflight: Promise<Map<string, AgentSummaryForSidebar>> | null = null
+const AGENT_CACHE_TTL_MS = 30_000
+
+function loadAgents(): Promise<Map<string, AgentSummaryForSidebar>> {
+  const now = Date.now()
+  if (agentCache && now - agentCacheAt < AGENT_CACHE_TTL_MS) {
+    return Promise.resolve(agentCache)
+  }
+  if (inflight) return inflight
+  inflight = getTransport()
+    .call<AgentSummaryForSidebar[]>("list_agents")
+    .then((list) => {
+      agentCache = new Map(list.map((a) => [a.id, a]))
+      agentCacheAt = Date.now()
+      inflight = null
+      return agentCache
+    })
+    .catch((e) => {
+      inflight = null
+      throw e
+    })
+  return inflight
 }
 
 const statusConfig: Record<string, { icon: React.ReactNode; label: string; color: string }> = {
@@ -34,6 +64,7 @@ const statusConfig: Record<string, { icon: React.ReactNode; label: string; color
 }
 
 export default function SubagentBlock({ runId, agentId, task, initialStatus }: SubagentBlockProps) {
+  const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const [status, setStatus] = useState(initialStatus || "spawning")
   const [resultFull, setResultFull] = useState<string | undefined>()
@@ -44,6 +75,26 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
   const [inputTokens, setInputTokens] = useState<number | undefined>()
   const [outputTokens, setOutputTokens] = useState<number | undefined>()
   const [attachmentCount, setAttachmentCount] = useState(0)
+  const [agentMeta, setAgentMeta] = useState<AgentSummaryForSidebar | undefined>()
+  const [agentMissing, setAgentMissing] = useState(false)
+
+  // Resolve agentId → friendly name + emoji via shared cache
+  useEffect(() => {
+    let cancelled = false
+    loadAgents()
+      .then((m) => {
+        if (cancelled) return
+        const meta = m.get(agentId)
+        setAgentMeta(meta)
+        setAgentMissing(!meta)
+      })
+      .catch(() => {
+        /* keep fallback to agentId */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [agentId])
 
   // Hydrate from DB on mount (handles re-mount after switching sessions)
   useEffect(() => {
@@ -80,7 +131,10 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
 
   const isTerminal = ["completed", "error", "timeout", "killed"].includes(status)
   const config = statusConfig[status] || statusConfig.error
-  const displayName = label || agentId
+  const toolLabel = t("tools.subagent")
+  const friendlyName = label || agentMeta?.name || agentId
+  const emoji = agentMeta?.emoji?.trim() || null
+  const nameTooltip = agentMissing ? t("subagent.deletedAgentTooltip") : undefined
 
   return (
     <div className="my-1.5 rounded-lg border border-border bg-secondary/50 text-xs">
@@ -98,17 +152,26 @@ export default function SubagentBlock({ runId, agentId, task, initialStatus }: S
             )}
           />
         )}
-        <Users className="h-3 w-3 shrink-0 text-muted-foreground" />
-        <span className="font-medium text-foreground">subagent</span>
+        {emoji ? (
+          <span className="shrink-0 leading-none" aria-hidden>
+            {emoji}
+          </span>
+        ) : (
+          <Users className="h-3 w-3 shrink-0 text-muted-foreground" />
+        )}
+        <span className="font-medium text-foreground shrink-0" title={nameTooltip}>
+          {friendlyName}
+        </span>
+        <span className="text-[10px] text-muted-foreground shrink-0 hidden sm:inline">
+          {toolLabel}
+        </span>
         {attachmentCount > 0 && (
           <span className="flex items-center gap-0.5 text-muted-foreground">
             <Paperclip className="h-2.5 w-2.5" />
             {attachmentCount}
           </span>
         )}
-        <span className="text-muted-foreground truncate flex-1">
-          {displayName}: {task}
-        </span>
+        <span className="text-muted-foreground truncate flex-1">{task}</span>
         <span
           className={cn("flex items-center gap-1 transition-colors duration-200", config.color)}
         >

--- a/src/components/chat/SubagentGroup.tsx
+++ b/src/components/chat/SubagentGroup.tsx
@@ -284,10 +284,16 @@ function SubagentRow({
   const canExpand = isTerminal && hasContent
   const childSessionId = state?.childSessionId
   const canViewSession = !!(onSwitchSession && childSessionId)
+  const rowInteractive = canExpand || canViewSession
 
   return (
     <div className="text-[11px]">
-      <div className="flex items-center hover:bg-secondary/60 transition-colors">
+      <div
+        className={cn(
+          "flex items-center transition-colors",
+          rowInteractive && "hover:bg-secondary/60",
+        )}
+      >
         <button
           type="button"
           className="flex items-center gap-1.5 flex-1 min-w-0 px-2.5 py-1 text-left disabled:cursor-default"
@@ -346,7 +352,9 @@ function SubagentRow({
               <button
                 type="button"
                 className="p-0.5 rounded hover:bg-secondary text-muted-foreground/50 hover:text-foreground transition-colors"
-                onClick={() => onSwitchSession!(childSessionId!)}
+                onClick={() => {
+                  if (onSwitchSession && childSessionId) onSwitchSession(childSessionId)
+                }}
                 aria-label={t("subagent.viewChildSession")}
               >
                 <ArrowUpRight className="h-3 w-3" />

--- a/src/components/chat/SubagentGroup.tsx
+++ b/src/components/chat/SubagentGroup.tsx
@@ -43,15 +43,22 @@ export default function SubagentGroup({ runs }: SubagentGroupProps) {
     return init
   })
   const [agentMetas, setAgentMetas] = useState<Map<string, AgentSummaryForSidebar>>(new Map())
+  const [metadataLoaded, setMetadataLoaded] = useState(false)
 
   // Hydrate agent metadata (shared cache across all SubagentBlock / SubagentGroup)
   useEffect(() => {
     let cancelled = false
     loadAgents()
       .then((m) => {
-        if (!cancelled) setAgentMetas(m)
+        if (cancelled) return
+        setAgentMetas(m)
+        setMetadataLoaded(true)
       })
-      .catch(() => {})
+      .catch(() => {
+        // Mark loaded so rows can fall back to agentId; failure means we
+        // have nothing better to show than the technical id anyway.
+        if (!cancelled) setMetadataLoaded(true)
+      })
     return () => {
       cancelled = true
     }
@@ -196,7 +203,10 @@ export default function SubagentGroup({ runs }: SubagentGroupProps) {
             {agg.totalInputTokens.toLocaleString()}↑ {agg.totalOutputTokens.toLocaleString()}↓
           </span>
         )}
-        {agg.totalDurationMs > 0 && (
+        {/* Only show aggregate duration once all runs are terminal, otherwise
+            the sum of completed-only durations is misleading (it's neither
+            wall-clock nor per-run elapsed). */}
+        {!anyRunning && agg.totalDurationMs > 0 && (
           <span className="text-muted-foreground shrink-0 tabular-nums">
             {(agg.totalDurationMs / 1000).toFixed(1)}s
           </span>
@@ -217,7 +227,7 @@ export default function SubagentGroup({ runs }: SubagentGroupProps) {
               run={run}
               state={states.get(run.runId)}
               agentMeta={agentMetas.get(run.agentId)}
-              agentMetasLoaded={agentMetas.size > 0}
+              agentMetasLoaded={metadataLoaded}
             />
           ))}
         </div>

--- a/src/components/chat/SubagentGroup.tsx
+++ b/src/components/chat/SubagentGroup.tsx
@@ -1,10 +1,19 @@
 import { useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
-import { ChevronRight, Users, CheckCircle, XCircle, Loader2 } from "lucide-react"
+import {
+  ChevronRight,
+  Users,
+  CheckCircle,
+  XCircle,
+  Loader2,
+  ArrowUpRight,
+  Paperclip,
+} from "lucide-react"
 import { cn } from "@/lib/utils"
 import { getTransport } from "@/lib/transport-provider"
 import type { AgentSummaryForSidebar, SubagentEvent, SubagentRun } from "@/types/chat"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+import { IconTip } from "@/components/ui/tooltip"
 import {
   loadAgents,
   statusConfig,
@@ -20,6 +29,7 @@ export interface SubagentGroupRun {
 
 interface SubagentGroupProps {
   runs: SubagentGroupRun[]
+  onSwitchSession?: (sessionId: string) => void
 }
 
 interface RunState {
@@ -32,9 +42,10 @@ interface RunState {
   inputTokens?: number
   outputTokens?: number
   attachmentCount?: number
+  childSessionId?: string
 }
 
-export default function SubagentGroup({ runs }: SubagentGroupProps) {
+export default function SubagentGroup({ runs, onSwitchSession }: SubagentGroupProps) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
   const [states, setStates] = useState<Map<string, RunState>>(() => {
@@ -86,6 +97,7 @@ export default function SubagentGroup({ runs }: SubagentGroupProps) {
               inputTokens: run.inputTokens,
               outputTokens: run.outputTokens,
               attachmentCount: run.attachmentCount,
+              childSessionId: run.childSessionId,
             })
             return next
           })
@@ -233,6 +245,7 @@ export default function SubagentGroup({ runs }: SubagentGroupProps) {
               state={states.get(run.runId)}
               agentMeta={agentMetas.get(run.agentId)}
               agentMetasLoaded={metadataLoaded}
+              onSwitchSession={onSwitchSession}
             />
           ))}
         </div>
@@ -246,9 +259,16 @@ interface SubagentRowProps {
   state: RunState | undefined
   agentMeta: AgentSummaryForSidebar | undefined
   agentMetasLoaded: boolean
+  onSwitchSession?: (sessionId: string) => void
 }
 
-function SubagentRow({ run, state, agentMeta, agentMetasLoaded }: SubagentRowProps) {
+function SubagentRow({
+  run,
+  state,
+  agentMeta,
+  agentMetasLoaded,
+  onSwitchSession,
+}: SubagentRowProps) {
   const { t } = useTranslation()
   const [expanded, setExpanded] = useState(false)
 
@@ -261,66 +281,88 @@ function SubagentRow({ run, state, agentMeta, agentMetasLoaded }: SubagentRowPro
   const agentMissing = agentMetasLoaded && !agentMeta
   const nameTooltip = agentMissing ? t("subagent.deletedAgentTooltip") : undefined
   const hasContent = !!(state?.resultFull || state?.error)
-
   const canExpand = isTerminal && hasContent
+  const childSessionId = state?.childSessionId
+  const canViewSession = !!(onSwitchSession && childSessionId)
 
   return (
     <div className="text-[11px]">
-      <button
-        type="button"
-        className="flex items-center gap-1.5 w-full px-2.5 py-1 text-left hover:bg-secondary/60 transition-colors disabled:hover:bg-transparent disabled:cursor-default"
-        onClick={() => canExpand && setExpanded(!expanded)}
-        disabled={!canExpand}
-        aria-expanded={canExpand ? expanded : undefined}
-      >
-        {!isTerminal ? (
-          <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0 text-muted-foreground/60" />
-        ) : hasContent ? (
-          <ChevronRight
-            className={cn(
-              "h-3 w-3 shrink-0 text-muted-foreground/40 transition-transform duration-150",
-              expanded && "rotate-90",
-            )}
-          />
-        ) : (
-          <span className="h-3 w-3 shrink-0" />
-        )}
-        {emoji ? (
-          <span className="shrink-0 leading-none" aria-hidden>
-            {emoji}
-          </span>
-        ) : (
-          <Users className="h-3 w-3 shrink-0 text-muted-foreground/50" />
-        )}
-        <span
-          className="font-medium text-foreground truncate max-w-[40%]"
-          title={nameTooltip || friendlyName}
+      <div className="flex items-center hover:bg-secondary/60 transition-colors">
+        <button
+          type="button"
+          className="flex items-center gap-1.5 flex-1 min-w-0 px-2.5 py-1 text-left disabled:cursor-default"
+          onClick={() => canExpand && setExpanded(!expanded)}
+          disabled={!canExpand}
+          aria-expanded={canExpand ? expanded : undefined}
         >
-          {friendlyName}
-        </span>
-        <span className="text-muted-foreground/70 truncate flex-1 min-w-0">{run.task}</span>
-        <span className={cn("flex items-center gap-0.5 shrink-0", config.color)}>
-          {config.icon}
-        </span>
-        {state?.durationMs !== undefined && (
-          <span className="text-muted-foreground/60 shrink-0 tabular-nums text-[10px]">
-            {(state.durationMs / 1000).toFixed(1)}s
+          {!isTerminal ? (
+            <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0 text-muted-foreground/60" />
+          ) : hasContent ? (
+            <ChevronRight
+              className={cn(
+                "h-3 w-3 shrink-0 text-muted-foreground/40 transition-transform duration-150",
+                expanded && "rotate-90",
+              )}
+            />
+          ) : (
+            <span className="h-3 w-3 shrink-0" />
+          )}
+          {emoji ? (
+            <span className="shrink-0 leading-none" aria-hidden>
+              {emoji}
+            </span>
+          ) : (
+            <Users className="h-3 w-3 shrink-0 text-muted-foreground/50" />
+          )}
+          <span
+            className="font-medium text-foreground truncate max-w-[40%]"
+            title={nameTooltip || friendlyName}
+          >
+            {friendlyName}
           </span>
-        )}
-        {state?.inputTokens !== undefined && state?.outputTokens !== undefined && (
-          <span className="text-muted-foreground/60 shrink-0 tabular-nums text-[10px]">
-            {state.inputTokens.toLocaleString()}↑ {state.outputTokens.toLocaleString()}↓
-          </span>
-        )}
-      </button>
+          {state?.attachmentCount !== undefined && state.attachmentCount > 0 && (
+            <span className="flex items-center gap-0.5 text-muted-foreground/70 shrink-0">
+              <Paperclip className="h-2.5 w-2.5" />
+              {state.attachmentCount}
+            </span>
+          )}
+          <span className="text-muted-foreground/70 truncate flex-1 min-w-0">{run.task}</span>
+        </button>
+        {/* Right action area — sibling of main button to avoid nested interactive elements. */}
+        <div className="flex items-center gap-1.5 pr-2 shrink-0">
+          <span className={cn("flex items-center gap-0.5", config.color)}>{config.icon}</span>
+          {state?.durationMs !== undefined && (
+            <span className="text-muted-foreground/60 tabular-nums text-[10px]">
+              {(state.durationMs / 1000).toFixed(1)}s
+            </span>
+          )}
+          {state?.inputTokens !== undefined && state?.outputTokens !== undefined && (
+            <span className="text-muted-foreground/60 tabular-nums text-[10px]">
+              {state.inputTokens.toLocaleString()}↑ {state.outputTokens.toLocaleString()}↓
+            </span>
+          )}
+          {canViewSession && (
+            <IconTip label={t("subagent.viewChildSession")}>
+              <button
+                type="button"
+                className="p-0.5 rounded hover:bg-secondary text-muted-foreground/50 hover:text-foreground transition-colors"
+                onClick={() => onSwitchSession!(childSessionId!)}
+                aria-label={t("subagent.viewChildSession")}
+              >
+                <ArrowUpRight className="h-3 w-3" />
+              </button>
+            </IconTip>
+          )}
+        </div>
+      </div>
 
       <div
         className={cn(
           "overflow-hidden transition-all duration-200 ease-out",
-          expanded && hasContent ? "max-h-96 opacity-100" : "max-h-0 opacity-0",
+          expanded && hasContent ? "max-h-[600px] opacity-100" : "max-h-0 opacity-0",
         )}
       >
-        <div className="px-2.5 pb-2 pt-0.5 max-h-96 overflow-y-auto">
+        <div className="px-2.5 pb-2 pt-0.5 max-h-[600px] overflow-y-auto">
           {state?.error && (
             <pre className="whitespace-pre-wrap text-red-400 bg-background rounded p-2 text-[11px] leading-relaxed">
               {state.error}

--- a/src/components/chat/SubagentGroup.tsx
+++ b/src/components/chat/SubagentGroup.tsx
@@ -1,0 +1,315 @@
+import { useState, useEffect, useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { ChevronRight, Users, CheckCircle, XCircle, Loader2 } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { getTransport } from "@/lib/transport-provider"
+import type { AgentSummaryForSidebar, SubagentEvent, SubagentRun } from "@/types/chat"
+import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+import {
+  loadAgents,
+  statusConfig,
+  TERMINAL_STATUSES,
+  FAILED_STATUSES,
+} from "./subagentShared"
+
+export interface SubagentGroupRun {
+  runId: string
+  agentId: string
+  task: string
+}
+
+interface SubagentGroupProps {
+  runs: SubagentGroupRun[]
+}
+
+interface RunState {
+  status: string
+  resultFull?: string
+  error?: string
+  durationMs?: number
+  label?: string
+  modelUsed?: string
+  inputTokens?: number
+  outputTokens?: number
+  attachmentCount?: number
+}
+
+export default function SubagentGroup({ runs }: SubagentGroupProps) {
+  const { t } = useTranslation()
+  const [expanded, setExpanded] = useState(false)
+  const [states, setStates] = useState<Map<string, RunState>>(() => {
+    const init = new Map<string, RunState>()
+    for (const r of runs) init.set(r.runId, { status: "spawning" })
+    return init
+  })
+  const [agentMetas, setAgentMetas] = useState<Map<string, AgentSummaryForSidebar>>(new Map())
+
+  // Hydrate agent metadata (shared cache across all SubagentBlock / SubagentGroup)
+  useEffect(() => {
+    let cancelled = false
+    loadAgents()
+      .then((m) => {
+        if (!cancelled) setAgentMetas(m)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Hydrate each run from DB on mount. Parent keys this component on the
+  // concatenated runIds, so a change in the run set remounts the group and
+  // runs this effect fresh — safe to use empty deps + closure `runs`.
+  useEffect(() => {
+    let cancelled = false
+    for (const { runId } of runs) {
+      getTransport()
+        .call<SubagentRun | null>("get_subagent_run", { runId })
+        .then((run) => {
+          if (cancelled || !run) return
+          setStates((prev) => {
+            const next = new Map(prev)
+            next.set(runId, {
+              status: run.status,
+              resultFull: run.result,
+              error: run.error,
+              durationMs: run.durationMs,
+              label: run.label,
+              modelUsed: run.modelUsed,
+              inputTokens: run.inputTokens,
+              outputTokens: run.outputTokens,
+              attachmentCount: run.attachmentCount,
+            })
+            return next
+          })
+        })
+        .catch(() => {})
+    }
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Single event listener for the whole group — filters by runId set.
+  // Same rationale as above: parent remounts on run-set change.
+  useEffect(() => {
+    const runIds = new Set(runs.map((r) => r.runId))
+    return getTransport().listen("subagent_event", (raw) => {
+      const payload = raw as SubagentEvent
+      if (!runIds.has(payload.runId)) return
+      setStates((prev) => {
+        const next = new Map(prev)
+        const cur = next.get(payload.runId) || { status: "spawning" }
+        next.set(payload.runId, {
+          ...cur,
+          status: payload.status,
+          resultFull: payload.resultFull ?? cur.resultFull,
+          error: payload.error ?? cur.error,
+          durationMs: payload.durationMs ?? cur.durationMs,
+          label: payload.label ?? cur.label,
+          inputTokens: payload.inputTokens ?? cur.inputTokens,
+          outputTokens: payload.outputTokens ?? cur.outputTokens,
+        })
+        return next
+      })
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Aggregate stats
+  const agg = useMemo(() => {
+    let running = 0
+    let completed = 0
+    let failed = 0
+    let totalDurationMs = 0
+    let totalInputTokens = 0
+    let totalOutputTokens = 0
+    for (const run of runs) {
+      const s = states.get(run.runId)
+      const status = s?.status ?? "spawning"
+      if (status === "completed") completed++
+      else if (FAILED_STATUSES.has(status)) failed++
+      else running++
+      if (s?.durationMs) totalDurationMs += s.durationMs
+      if (s?.inputTokens) totalInputTokens += s.inputTokens
+      if (s?.outputTokens) totalOutputTokens += s.outputTokens
+    }
+    return {
+      running,
+      completed,
+      failed,
+      totalDurationMs,
+      totalInputTokens,
+      totalOutputTokens,
+      total: runs.length,
+    }
+  }, [runs, states])
+
+  const anyRunning = agg.running > 0
+  const headerLabel = anyRunning
+    ? t("subagent.group.running", { count: agg.total })
+    : t("subagent.group.finished", { count: agg.total })
+
+  return (
+    <div className="my-1.5 rounded-lg border border-border bg-secondary/50 text-xs">
+      <button
+        className="flex items-center gap-1.5 w-full px-2.5 py-1.5 text-left hover:bg-secondary/80 rounded-lg transition-colors"
+        onClick={() => setExpanded(!expanded)}
+      >
+        {anyRunning ? (
+          <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0" />
+        ) : (
+          <ChevronRight
+            className={cn(
+              "h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-200",
+              expanded && "rotate-90",
+            )}
+          />
+        )}
+        <Users className="h-3 w-3 shrink-0 text-muted-foreground" />
+        <span className="font-medium text-foreground shrink-0">{headerLabel}</span>
+        {/* Status pills */}
+        <div className="flex items-center gap-1.5 shrink-0">
+          {agg.completed > 0 && (
+            <span className="flex items-center gap-0.5 text-green-500">
+              <CheckCircle className="h-3 w-3" />
+              {agg.completed}
+            </span>
+          )}
+          {agg.running > 0 && (
+            <span className="flex items-center gap-0.5 text-blue-500">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              {agg.running}
+            </span>
+          )}
+          {agg.failed > 0 && (
+            <span className="flex items-center gap-0.5 text-red-500">
+              <XCircle className="h-3 w-3" />
+              {agg.failed}
+            </span>
+          )}
+        </div>
+        <span className="flex-1" />
+        {(agg.totalInputTokens > 0 || agg.totalOutputTokens > 0) && (
+          <span className="text-[10px] text-muted-foreground shrink-0 tabular-nums">
+            {agg.totalInputTokens.toLocaleString()}↑ {agg.totalOutputTokens.toLocaleString()}↓
+          </span>
+        )}
+        {agg.totalDurationMs > 0 && (
+          <span className="text-muted-foreground shrink-0 tabular-nums">
+            {(agg.totalDurationMs / 1000).toFixed(1)}s
+          </span>
+        )}
+      </button>
+
+      {/* Expanded rows */}
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-200 ease-out",
+          expanded ? "max-h-[2000px] opacity-100" : "max-h-0 opacity-0",
+        )}
+      >
+        <div className="border-t border-border/60">
+          {runs.map((run) => (
+            <SubagentRow
+              key={run.runId}
+              run={run}
+              state={states.get(run.runId)}
+              agentMeta={agentMetas.get(run.agentId)}
+              agentMetasLoaded={agentMetas.size > 0}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface SubagentRowProps {
+  run: SubagentGroupRun
+  state: RunState | undefined
+  agentMeta: AgentSummaryForSidebar | undefined
+  agentMetasLoaded: boolean
+}
+
+function SubagentRow({ run, state, agentMeta, agentMetasLoaded }: SubagentRowProps) {
+  const { t } = useTranslation()
+  const [expanded, setExpanded] = useState(false)
+
+  const status = state?.status ?? "spawning"
+  const isTerminal = TERMINAL_STATUSES.has(status)
+  const config = statusConfig[status] || statusConfig.error
+  const friendlyName = state?.label || agentMeta?.name || run.agentId
+  const emoji = agentMeta?.emoji?.trim() || null
+  // Only mark as missing after the metadata load has resolved
+  const agentMissing = agentMetasLoaded && !agentMeta
+  const nameTooltip = agentMissing ? t("subagent.deletedAgentTooltip") : undefined
+  const hasContent = !!(state?.resultFull || state?.error)
+
+  return (
+    <div className="text-[11px]">
+      <button
+        className="flex items-center gap-1.5 w-full px-2.5 py-1 text-left hover:bg-secondary/60 transition-colors"
+        onClick={() => isTerminal && hasContent && setExpanded(!expanded)}
+      >
+        {!isTerminal ? (
+          <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0 text-muted-foreground/60" />
+        ) : hasContent ? (
+          <ChevronRight
+            className={cn(
+              "h-3 w-3 shrink-0 text-muted-foreground/40 transition-transform duration-150",
+              expanded && "rotate-90",
+            )}
+          />
+        ) : (
+          <span className="h-3 w-3 shrink-0" />
+        )}
+        {emoji ? (
+          <span className="shrink-0 leading-none" aria-hidden>
+            {emoji}
+          </span>
+        ) : (
+          <Users className="h-3 w-3 shrink-0 text-muted-foreground/50" />
+        )}
+        <span className="font-medium text-foreground shrink-0" title={nameTooltip}>
+          {friendlyName}
+        </span>
+        <span className="text-muted-foreground/70 truncate flex-1">{run.task}</span>
+        <span className={cn("flex items-center gap-0.5 shrink-0", config.color)}>
+          {config.icon}
+        </span>
+        {state?.durationMs !== undefined && (
+          <span className="text-muted-foreground/60 shrink-0 tabular-nums text-[10px]">
+            {(state.durationMs / 1000).toFixed(1)}s
+          </span>
+        )}
+        {state?.inputTokens !== undefined && state?.outputTokens !== undefined && (
+          <span className="text-muted-foreground/60 shrink-0 tabular-nums text-[10px]">
+            {state.inputTokens.toLocaleString()}↑ {state.outputTokens.toLocaleString()}↓
+          </span>
+        )}
+      </button>
+
+      <div
+        className={cn(
+          "overflow-hidden transition-all duration-200 ease-out",
+          expanded && hasContent ? "max-h-96 opacity-100" : "max-h-0 opacity-0",
+        )}
+      >
+        <div className="px-2.5 pb-2 pt-0.5 max-h-96 overflow-y-auto">
+          {state?.error && (
+            <pre className="whitespace-pre-wrap text-red-400 bg-background rounded p-2 text-[11px] leading-relaxed">
+              {state.error}
+            </pre>
+          )}
+          {state?.resultFull && (
+            <div className="bg-background rounded p-2 text-[11px] leading-relaxed">
+              <MarkdownRenderer content={state.resultFull} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/SubagentGroup.tsx
+++ b/src/components/chat/SubagentGroup.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react"
+import { useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { ChevronRight, Users, CheckCircle, XCircle, Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -124,8 +124,11 @@ export default function SubagentGroup({ runs }: SubagentGroupProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Aggregate stats
-  const agg = useMemo(() => {
+  // Aggregate stats — computed inline each render. useMemo would be wasted
+  // because the parent passes a new `runs` array reference on every render
+  // (although it's content-stable within this instance's lifetime). The loop
+  // is O(N) over N ≤ ~10 runs — negligible.
+  const agg = (() => {
     let running = 0
     let completed = 0
     let failed = 0
@@ -151,7 +154,7 @@ export default function SubagentGroup({ runs }: SubagentGroupProps) {
       totalOutputTokens,
       total: runs.length,
     }
-  }, [runs, states])
+  })()
 
   const anyRunning = agg.running > 0
   const headerLabel = anyRunning
@@ -161,8 +164,10 @@ export default function SubagentGroup({ runs }: SubagentGroupProps) {
   return (
     <div className="my-1.5 rounded-lg border border-border bg-secondary/50 text-xs">
       <button
+        type="button"
         className="flex items-center gap-1.5 w-full px-2.5 py-1.5 text-left hover:bg-secondary/80 rounded-lg transition-colors"
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
       >
         {anyRunning ? (
           <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0" />
@@ -257,11 +262,16 @@ function SubagentRow({ run, state, agentMeta, agentMetasLoaded }: SubagentRowPro
   const nameTooltip = agentMissing ? t("subagent.deletedAgentTooltip") : undefined
   const hasContent = !!(state?.resultFull || state?.error)
 
+  const canExpand = isTerminal && hasContent
+
   return (
     <div className="text-[11px]">
       <button
-        className="flex items-center gap-1.5 w-full px-2.5 py-1 text-left hover:bg-secondary/60 transition-colors"
-        onClick={() => isTerminal && hasContent && setExpanded(!expanded)}
+        type="button"
+        className="flex items-center gap-1.5 w-full px-2.5 py-1 text-left hover:bg-secondary/60 transition-colors disabled:hover:bg-transparent disabled:cursor-default"
+        onClick={() => canExpand && setExpanded(!expanded)}
+        disabled={!canExpand}
+        aria-expanded={canExpand ? expanded : undefined}
       >
         {!isTerminal ? (
           <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0 text-muted-foreground/60" />
@@ -282,10 +292,13 @@ function SubagentRow({ run, state, agentMeta, agentMetasLoaded }: SubagentRowPro
         ) : (
           <Users className="h-3 w-3 shrink-0 text-muted-foreground/50" />
         )}
-        <span className="font-medium text-foreground shrink-0" title={nameTooltip}>
+        <span
+          className="font-medium text-foreground truncate max-w-[40%]"
+          title={nameTooltip || friendlyName}
+        >
           {friendlyName}
         </span>
-        <span className="text-muted-foreground/70 truncate flex-1">{run.task}</span>
+        <span className="text-muted-foreground/70 truncate flex-1 min-w-0">{run.task}</span>
         <span className={cn("flex items-center gap-0.5 shrink-0", config.color)}>
           {config.icon}
         </span>

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -31,6 +31,8 @@ export interface MessageBubbleProps {
   // Plan mode
   sessionId?: string | null
   onOpenPlanPanel?: () => void
+  // Session switching (used by SubagentBlock's "jump to child session" button)
+  onSwitchSession?: (sessionId: string) => void
   // Model switching
   onSwitchModel?: (providerId: string, modelId: string) => void
   // View system prompt (triggered from context breakdown card)
@@ -88,6 +90,7 @@ function MessageBubbleInner({
   onCopy,
   sessionId,
   onOpenPlanPanel,
+  onSwitchSession,
   onSwitchModel,
   onViewSystemPrompt,
 }: MessageBubbleProps) {
@@ -218,6 +221,7 @@ function MessageBubbleInner({
               isLast={isLast}
               sessionId={sessionId}
               onOpenPlanPanel={onOpenPlanPanel}
+              onSwitchSession={onSwitchSession}
             />
           ) : msg.role === "assistant" ? (
             <AssistantLegacyContent msg={msg} loading={loading} isLast={isLast} />

--- a/src/components/chat/message/MessageContent.tsx
+++ b/src/components/chat/message/MessageContent.tsx
@@ -91,6 +91,7 @@ interface MessageContentProps {
   isLast: boolean
   sessionId?: string | null
   onOpenPlanPanel?: () => void
+  onSwitchSession?: (sessionId: string) => void
 }
 
 /** Renders assistant content blocks (thinking, text, tool calls) with grouping logic */
@@ -100,6 +101,7 @@ export function AssistantContentBlocks({
   isLast,
   sessionId,
   onOpenPlanPanel,
+  onSwitchSession,
 }: MessageContentProps) {
   const blocks = msg.contentBlocks!
   const elements: React.ReactNode[] = []
@@ -180,7 +182,9 @@ export function AssistantContentBlocks({
             // (instead of re-running effects) when the underlying run set
             // actually changes.
             const groupKey = `sgrp-${runs.map((r) => r.runId).join("|")}`
-            elements.push(<SubagentGroup key={groupKey} runs={runs} />)
+            elements.push(
+              <SubagentGroup key={groupKey} runs={runs} onSwitchSession={onSwitchSession} />,
+            )
           } else {
             // Single run (plain spawn, spawn_and_wait, or batch_spawn w/ 1 task)
             // → render SubagentBlock directly so batch_spawn's single case
@@ -193,6 +197,7 @@ export function AssistantContentBlocks({
                 runId={run.runId}
                 agentId={run.agentId}
                 task={run.task}
+                onSwitchSession={onSwitchSession}
               />,
             )
           }

--- a/src/components/chat/message/MessageContent.tsx
+++ b/src/components/chat/message/MessageContent.tsx
@@ -4,8 +4,9 @@ import ToolCallBlock from "./ToolCallBlock"
 import ToolCallGroup from "./ToolCallGroup"
 import ThinkingBlock from "./ThinkingBlock"
 import TaskBlock from "./TaskBlock"
+import SubagentGroup, { type SubagentGroupRun } from "@/components/chat/SubagentGroup"
 import { AskUserQuestionResult, SubmitPlanResult } from "./PlanResultBlocks"
-import type { ContentBlock } from "@/types/chat"
+import type { ContentBlock, ToolCall } from "@/types/chat"
 import type { Message } from "@/types/chat"
 
 const TASK_TOOL_NAMES = new Set(["task_create", "task_update", "task_list"])
@@ -15,7 +16,35 @@ const NO_GROUP_TOOLS = new Set([
   "task_create",
   "task_update",
   "task_list",
+  // subagent spawns are handled by a dedicated SubagentGroup path below;
+  // never let them fall into the generic tool-call group.
+  "subagent",
 ])
+
+/** Parse a tool_call block as a subagent spawn with a resolved run_id. */
+function parseSubagentSpawn(tool: ToolCall): SubagentGroupRun | null {
+  if (tool.name !== "subagent") return null
+  let args: { action?: string; agent_id?: string; task?: string } = {}
+  try {
+    args = JSON.parse(tool.arguments)
+  } catch {
+    return null
+  }
+  if (args.action !== "spawn") return null
+  if (!tool.result) return null
+  let runId: string | undefined
+  try {
+    runId = JSON.parse(tool.result).run_id
+  } catch {
+    return null
+  }
+  if (!runId) return null
+  return {
+    runId,
+    agentId: args.agent_id || "default",
+    task: args.task || "",
+  }
+}
 
 interface MessageContentProps {
   msg: Message
@@ -87,6 +116,42 @@ export function AssistantContentBlocks({
             <SubmitPlanResult key={block.tool.callId} title={title} sessionId={sessionId} onOpenPanel={onOpenPlanPanel} />,
           )
         }
+        i++
+        continue
+      }
+      // subagent spawn → collect consecutive spawns into a dedicated group
+      if (block.tool.name === "subagent") {
+        const parsed = parseSubagentSpawn(block.tool)
+        if (parsed) {
+          const runs: SubagentGroupRun[] = [parsed]
+          let j = i + 1
+          while (j < blocks.length) {
+            const nb = blocks[j]
+            if (nb.type !== "tool_call" || nb.tool.name !== "subagent") break
+            const nextParsed = parseSubagentSpawn(nb.tool)
+            if (!nextParsed) break
+            runs.push(nextParsed)
+            j++
+          }
+          if (runs.length >= 2) {
+            // Key on the concatenated runIds so React remounts the group
+            // (instead of re-running effects) when the underlying run set
+            // actually changes.
+            const groupKey = `sgrp-${runs.map((r) => r.runId).join("|")}`
+            elements.push(<SubagentGroup key={groupKey} runs={runs} />)
+            i = j
+            continue
+          }
+          // Single subagent spawn → fall through to the default ToolCallBlock
+          // path which already renders SubagentBlock.
+          elements.push(<ToolCallBlock key={block.tool.callId} tool={block.tool} />)
+          i++
+          continue
+        }
+        // Non-spawn subagent action (check / list / kill) or still in-flight
+        // → render individually. NO_GROUP_TOOLS prevents it from joining the
+        // generic tool-call group below.
+        elements.push(<ToolCallBlock key={block.tool.callId} tool={block.tool} />)
         i++
         continue
       }

--- a/src/components/chat/message/MessageContent.tsx
+++ b/src/components/chat/message/MessageContent.tsx
@@ -5,6 +5,7 @@ import ToolCallGroup from "./ToolCallGroup"
 import ThinkingBlock from "./ThinkingBlock"
 import TaskBlock from "./TaskBlock"
 import SubagentGroup, { type SubagentGroupRun } from "@/components/chat/SubagentGroup"
+import SubagentBlock from "@/components/chat/SubagentBlock"
 import { AskUserQuestionResult, SubmitPlanResult } from "./PlanResultBlocks"
 import type { ContentBlock, ToolCall } from "@/types/chat"
 import type { Message } from "@/types/chat"
@@ -21,29 +22,67 @@ const NO_GROUP_TOOLS = new Set([
   "subagent",
 ])
 
-/** Parse a tool_call block as a subagent spawn with a resolved run_id. */
-function parseSubagentSpawn(tool: ToolCall): SubagentGroupRun | null {
-  if (tool.name !== "subagent") return null
-  let args: { action?: string; agent_id?: string; task?: string } = {}
+/** Extract zero or more subagent runs from a tool_call block. Handles:
+ *   - action=spawn            → 1 run (if runId present)
+ *   - action=spawn_and_wait   → 1 run (foreground or backgrounded)
+ *   - action=batch_spawn      → N runs from result.runs[] (only "spawned" entries)
+ */
+function extractSubagentRuns(tool: ToolCall): SubagentGroupRun[] {
+  if (tool.name !== "subagent") return []
+  if (!tool.result) return []
+  let args: {
+    action?: string
+    agent_id?: string
+    task?: string
+    tasks?: Array<{ agent_id?: string; task?: string }>
+  } = {}
   try {
     args = JSON.parse(tool.arguments)
   } catch {
-    return null
+    return []
   }
-  if (args.action !== "spawn") return null
-  if (!tool.result) return null
-  let runId: string | undefined
+  let result: unknown
   try {
-    runId = JSON.parse(tool.result).run_id
+    result = JSON.parse(tool.result)
   } catch {
-    return null
+    return []
   }
-  if (!runId) return null
-  return {
-    runId,
-    agentId: args.agent_id || "default",
-    task: args.task || "",
+  if (!result || typeof result !== "object") return []
+
+  if (args.action === "spawn" || args.action === "spawn_and_wait") {
+    const runId = (result as { run_id?: unknown }).run_id
+    if (typeof runId !== "string" || !runId) return []
+    return [
+      {
+        runId,
+        agentId: args.agent_id || "default",
+        task: args.task || "",
+      },
+    ]
   }
+
+  if (args.action === "batch_spawn") {
+    const runs = (result as { runs?: unknown }).runs
+    if (!Array.isArray(runs)) return []
+    const taskDefs = Array.isArray(args.tasks) ? args.tasks : []
+    const out: SubagentGroupRun[] = []
+    for (let idx = 0; idx < runs.length; idx++) {
+      const r = runs[idx]
+      if (!r || typeof r !== "object") continue
+      const obj = r as { status?: unknown; run_id?: unknown }
+      if (obj.status !== "spawned") continue
+      if (typeof obj.run_id !== "string" || !obj.run_id) continue
+      const def = taskDefs[idx] || {}
+      out.push({
+        runId: obj.run_id,
+        agentId: def.agent_id || "default",
+        task: def.task || "",
+      })
+    }
+    return out
+  }
+
+  return []
 }
 
 interface MessageContentProps {
@@ -119,18 +158,21 @@ export function AssistantContentBlocks({
         i++
         continue
       }
-      // subagent spawn → collect consecutive spawns into a dedicated group
+      // subagent spawn / batch_spawn / spawn_and_wait → dedicated rendering
       if (block.tool.name === "subagent") {
-        const parsed = parseSubagentSpawn(block.tool)
-        if (parsed) {
-          const runs: SubagentGroupRun[] = [parsed]
+        const firstRuns = extractSubagentRuns(block.tool)
+        if (firstRuns.length > 0) {
+          // Collect additional consecutive subagent blocks that also expose
+          // one-or-more runs — covers "N parallel spawn calls" and "1 spawn
+          // followed by 1 batch_spawn" alike.
+          const runs: SubagentGroupRun[] = [...firstRuns]
           let j = i + 1
           while (j < blocks.length) {
             const nb = blocks[j]
             if (nb.type !== "tool_call" || nb.tool.name !== "subagent") break
-            const nextParsed = parseSubagentSpawn(nb.tool)
-            if (!nextParsed) break
-            runs.push(nextParsed)
+            const nextRuns = extractSubagentRuns(nb.tool)
+            if (nextRuns.length === 0) break
+            runs.push(...nextRuns)
             j++
           }
           if (runs.length >= 2) {
@@ -139,18 +181,28 @@ export function AssistantContentBlocks({
             // actually changes.
             const groupKey = `sgrp-${runs.map((r) => r.runId).join("|")}`
             elements.push(<SubagentGroup key={groupKey} runs={runs} />)
-            i = j
-            continue
+          } else {
+            // Single run (plain spawn, spawn_and_wait, or batch_spawn w/ 1 task)
+            // → render SubagentBlock directly so batch_spawn's single case
+            // also gets the rich UI (the legacy ToolCallBlock path only
+            // detects action="spawn").
+            const run = runs[0]
+            elements.push(
+              <SubagentBlock
+                key={run.runId}
+                runId={run.runId}
+                agentId={run.agentId}
+                task={run.task}
+              />,
+            )
           }
-          // Single subagent spawn → fall through to the default ToolCallBlock
-          // path which already renders SubagentBlock.
-          elements.push(<ToolCallBlock key={block.tool.callId} tool={block.tool} />)
-          i++
+          i = j
           continue
         }
-        // Non-spawn subagent action (check / list / kill) or still in-flight
-        // → render individually. NO_GROUP_TOOLS prevents it from joining the
-        // generic tool-call group below.
+        // Non-spawn-like subagent action (check / list / kill / steer / etc)
+        // or spawn still in-flight without a run_id yet → render individually.
+        // NO_GROUP_TOOLS prevents it from falling into the generic tool-call
+        // group below.
         elements.push(<ToolCallBlock key={block.tool.callId} tool={block.tool} />)
         i++
         continue

--- a/src/components/chat/subagentShared.tsx
+++ b/src/components/chat/subagentShared.tsx
@@ -38,27 +38,25 @@ export const FAILED_STATUSES = new Set(["error", "timeout", "killed"])
 
 export interface StatusDisplay {
   icon: React.ReactNode
-  label: string
   color: string
 }
 
+// Status label text lives in i18n (subagent.status.*), not here — call
+// t(`subagent.status.${status}`) at the use site.
 export const statusConfig: Record<string, StatusDisplay> = {
   spawning: {
     icon: <Loader2 className="h-3 w-3 animate-spin" />,
-    label: "Spawning",
     color: "text-blue-500",
   },
   running: {
     icon: <Loader2 className="h-3 w-3 animate-spin" />,
-    label: "Running",
     color: "text-blue-500",
   },
   completed: {
     icon: <CheckCircle className="h-3 w-3" />,
-    label: "Completed",
     color: "text-green-500",
   },
-  error: { icon: <XCircle className="h-3 w-3" />, label: "Error", color: "text-red-500" },
-  timeout: { icon: <Clock className="h-3 w-3" />, label: "Timeout", color: "text-orange-500" },
-  killed: { icon: <Skull className="h-3 w-3" />, label: "Killed", color: "text-gray-500" },
+  error: { icon: <XCircle className="h-3 w-3" />, color: "text-red-500" },
+  timeout: { icon: <Clock className="h-3 w-3" />, color: "text-orange-500" },
+  killed: { icon: <Skull className="h-3 w-3" />, color: "text-gray-500" },
 }

--- a/src/components/chat/subagentShared.tsx
+++ b/src/components/chat/subagentShared.tsx
@@ -1,0 +1,64 @@
+import type React from "react"
+import { CheckCircle, XCircle, Clock, Loader2, Skull } from "lucide-react"
+import { getTransport } from "@/lib/transport-provider"
+import type { AgentSummaryForSidebar } from "@/types/chat"
+
+// ── Shared agent metadata cache (module-level, cross-instance) ─────────
+// Coalesces list_agents calls across all SubagentBlock / SubagentGroup
+// instances via a single in-flight promise + 30s TTL.
+let agentCache: Map<string, AgentSummaryForSidebar> | null = null
+let agentCacheAt = 0
+let inflight: Promise<Map<string, AgentSummaryForSidebar>> | null = null
+const AGENT_CACHE_TTL_MS = 30_000
+
+export function loadAgents(): Promise<Map<string, AgentSummaryForSidebar>> {
+  const now = Date.now()
+  if (agentCache && now - agentCacheAt < AGENT_CACHE_TTL_MS) {
+    return Promise.resolve(agentCache)
+  }
+  if (inflight) return inflight
+  inflight = getTransport()
+    .call<AgentSummaryForSidebar[]>("list_agents")
+    .then((list) => {
+      agentCache = new Map(list.map((a) => [a.id, a]))
+      agentCacheAt = Date.now()
+      inflight = null
+      return agentCache
+    })
+    .catch((e) => {
+      inflight = null
+      throw e
+    })
+  return inflight
+}
+
+// ── Status classification ──────────────────────────────────────────────
+export const TERMINAL_STATUSES = new Set(["completed", "error", "timeout", "killed"])
+export const FAILED_STATUSES = new Set(["error", "timeout", "killed"])
+
+export interface StatusDisplay {
+  icon: React.ReactNode
+  label: string
+  color: string
+}
+
+export const statusConfig: Record<string, StatusDisplay> = {
+  spawning: {
+    icon: <Loader2 className="h-3 w-3 animate-spin" />,
+    label: "Spawning",
+    color: "text-blue-500",
+  },
+  running: {
+    icon: <Loader2 className="h-3 w-3 animate-spin" />,
+    label: "Running",
+    color: "text-blue-500",
+  },
+  completed: {
+    icon: <CheckCircle className="h-3 w-3" />,
+    label: "Completed",
+    color: "text-green-500",
+  },
+  error: { icon: <XCircle className="h-3 w-3" />, label: "Error", color: "text-red-500" },
+  timeout: { icon: <Clock className="h-3 w-3" />, label: "Timeout", color: "text-orange-500" },
+  killed: { icon: <Skull className="h-3 w-3" />, label: "Killed", color: "text-gray-500" },
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -252,7 +252,11 @@
     "skill": "Loaded {{count}} skills"
   },
   "subagent": {
-    "deletedAgentTooltip": "This agent has been deleted"
+    "deletedAgentTooltip": "This agent has been deleted",
+    "group": {
+      "running": "Running {{count}} agents",
+      "finished": "{{count}} agents finished"
+    }
   },
   "settings": {
     "title": "Settings",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -251,6 +251,9 @@
     "other": "Tool calls: {{count}}",
     "skill": "Loaded {{count}} skills"
   },
+  "subagent": {
+    "deletedAgentTooltip": "This agent has been deleted"
+  },
   "settings": {
     "title": "Settings",
     "general": "General",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -253,6 +253,7 @@
   },
   "subagent": {
     "deletedAgentTooltip": "This agent has been deleted",
+    "viewChildSession": "Open sub-agent session",
     "group": {
       "running": "Running {{count}} agents",
       "finished": "{{count}} agents finished"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -256,6 +256,14 @@
     "group": {
       "running": "Running {{count}} agents",
       "finished": "{{count}} agents finished"
+    },
+    "status": {
+      "spawning": "Spawning",
+      "running": "Running",
+      "completed": "Completed",
+      "error": "Error",
+      "timeout": "Timeout",
+      "killed": "Killed"
     }
   },
   "settings": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -256,6 +256,14 @@
     "group": {
       "running": "正在运行 {{count}} 个 Agent",
       "finished": "已完成 {{count}} 个 Agent"
+    },
+    "status": {
+      "spawning": "启动中",
+      "running": "运行中",
+      "completed": "已完成",
+      "error": "出错",
+      "timeout": "超时",
+      "killed": "已终止"
     }
   },
   "settings": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -251,6 +251,9 @@
     "other": "工具调用 {{count}} 次",
     "skill": "加载了 {{count}} 个技能"
   },
+  "subagent": {
+    "deletedAgentTooltip": "该 Agent 已被删除"
+  },
   "settings": {
     "title": "设置",
     "general": "通用",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -253,6 +253,7 @@
   },
   "subagent": {
     "deletedAgentTooltip": "该 Agent 已被删除",
+    "viewChildSession": "查看子 Agent 会话",
     "group": {
       "running": "正在运行 {{count}} 个 Agent",
       "finished": "已完成 {{count}} 个 Agent"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -252,7 +252,11 @@
     "skill": "加载了 {{count}} 个技能"
   },
   "subagent": {
-    "deletedAgentTooltip": "该 Agent 已被删除"
+    "deletedAgentTooltip": "该 Agent 已被删除",
+    "group": {
+      "running": "正在运行 {{count}} 个 Agent",
+      "finished": "已完成 {{count}} 个 Agent"
+    }
   },
   "settings": {
     "title": "设置",


### PR DESCRIPTION
- 标题行不再硬编码字面量 "subagent"，改用 t("tools.subagent") 显示语义化 tool label
- 解析 agentId → AgentConfig.name + emoji，通过模块级共享缓存 + in-flight dedupe
  调用 list_agents（30s TTL，跨实例复用一次 RPC）
- label 缺失时回退链：label > agent.name > agentId；Agent 被删除时 hover
  tooltip 提示「该 Agent 已被删除」
- 有 emoji 时替代 Users 图标，无 emoji 时保留 Users 占位

https://claude.ai/code/session_01T5GzmzS6JKYmYuAxsMwC5e