### PR TITLE
fix(audit): 2026-04-17 严重 Bug 修复 8 项 + 复核划掉 2 项

### DIFF
--- a/crates/oc-core/src/agent/providers/anthropic.rs
+++ b/crates/oc-core/src/agent/providers/anthropic.rs
@@ -155,6 +155,14 @@ impl AssistantAgent {
             }
             let system_with_cache = json!(system_blocks);
 
+            // On the final allowed round we must force a text response: if the
+            // model picks a tool here, the loop would execute it and append
+            // tool_results to history, then exit without sending those results
+            // back to the model — the user sees a generic "max rounds" notice
+            // instead of a synthesis of their tool output. Omitting `tools`
+            // removes the option entirely for this one call.
+            let is_final_round = round + 1 == max_rounds;
+
             // Add cache_control to the last tool definition (tools are static, worth caching)
             let mut tools_with_cache = tool_schemas.clone();
             if let Some(last_tool) = tools_with_cache.last_mut() {
@@ -168,10 +176,12 @@ impl AssistantAgent {
                 "model": model,
                 "max_tokens": max_tokens,
                 "system": system_with_cache,
-                "tools": tools_with_cache,
                 "messages": api_messages,
                 "stream": true,
             });
+            if !is_final_round {
+                body["tools"] = json!(tools_with_cache);
+            }
 
             // Add thinking parameter if enabled
             if let Some(ref think_config) = thinking {

--- a/crates/oc-core/src/agent/providers/codex.rs
+++ b/crates/oc-core/src/agent/providers/codex.rs
@@ -153,6 +153,12 @@ impl AssistantAgent {
                 }
             }
 
+            // On the final allowed round drop tools so the model is forced to
+            // synthesize a text response. Without this, a tool call on the
+            // last round would execute but the result would never reach the
+            // model (the loop exits immediately after), leaving the user
+            // with only a "max rounds" notice.
+            let is_final_round = round + 1 == max_rounds;
             let request = ResponsesRequest {
                 model: model.to_string(),
                 store: false,
@@ -168,7 +174,11 @@ impl AssistantAgent {
                 } else {
                     None
                 },
-                tools: Some(tool_schemas.clone()),
+                tools: if is_final_round {
+                    None
+                } else {
+                    Some(tool_schemas.clone())
+                },
                 temperature: self.temperature,
             };
 

--- a/crates/oc-core/src/agent/providers/openai_chat.rs
+++ b/crates/oc-core/src/agent/providers/openai_chat.rs
@@ -139,13 +139,21 @@ impl AssistantAgent {
                 .map(|t| json!({ "type": "function", "function": t }))
                 .collect();
 
+            // On the final allowed round omit `tools` so the model is forced to
+            // produce a text response. Without this, a tool call here would
+            // execute and append tool_results to history that the model never
+            // gets to see, leaving the user with only a "max rounds" notice.
+            let is_final_round = round + 1 == max_rounds;
+
             let mut body = json!({
                 "model": model,
                 "messages": api_messages,
-                "tools": tools_array,
                 "stream": true,
                 "stream_options": { "include_usage": true },
             });
+            if !is_final_round {
+                body["tools"] = json!(tools_array);
+            }
 
             // Apply thinking parameters based on provider's ThinkingStyle
             apply_thinking_to_chat_body(&mut body, &self.thinking_style, reasoning_effort, 16384);

--- a/crates/oc-core/src/agent/providers/openai_responses.rs
+++ b/crates/oc-core/src/agent/providers/openai_responses.rs
@@ -157,6 +157,12 @@ impl AssistantAgent {
                 }
             }
 
+            // On the final allowed round we drop tools so the model is forced
+            // to synthesize a text response. Without this, a tool call on the
+            // last round would execute but its result would never be sent back
+            // to the model (the loop exits), leaving the user with only a
+            // "max rounds" notice instead of an answer.
+            let is_final_round = round + 1 == max_rounds;
             let request = ResponsesRequest {
                 model: model.to_string(),
                 store: false,
@@ -172,7 +178,11 @@ impl AssistantAgent {
                 } else {
                     None
                 },
-                tools: Some(tool_schemas.clone()),
+                tools: if is_final_round {
+                    None
+                } else {
+                    Some(tool_schemas.clone())
+                },
                 temperature: self.temperature,
             };
 

--- a/crates/oc-core/src/async_jobs/injection.rs
+++ b/crates/oc-core/src/async_jobs/injection.rs
@@ -71,9 +71,7 @@ pub fn dispatch_injection(
                     push_message,
                     db_clone,
                 ));
-                if let Some(jdb) = crate::async_jobs::get_async_jobs_db() {
-                    let _ = jdb.mark_injected(&job_id_for_db);
-                }
+                mark_injected_with_retry(&job_id_for_db);
             }
             Err(e) => app_error!(
                 "async_jobs",
@@ -83,6 +81,61 @@ pub fn dispatch_injection(
             ),
         }
     });
+}
+
+/// Retry `mark_injected` with exponential backoff. If all retries fail,
+/// log an error and emit an EventBus alarm — the row will be replayed on
+/// the next `replay_pending_jobs()` sweep, creating a duplicate
+/// `<tool-job-result>` injection, so surfacing the failure matters.
+fn mark_injected_with_retry(job_id: &str) {
+    const BACKOFFS_MS: &[u64] = &[0, 100, 500, 2_000];
+    let Some(jdb) = crate::async_jobs::get_async_jobs_db() else {
+        app_error!(
+            "async_jobs",
+            "injection",
+            "Cannot mark job {} injected: async_jobs DB is not initialized",
+            job_id
+        );
+        return;
+    };
+    let mut last_err: Option<String> = None;
+    for (attempt, delay_ms) in BACKOFFS_MS.iter().enumerate() {
+        if *delay_ms > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(*delay_ms));
+        }
+        match jdb.mark_injected(job_id) {
+            Ok(()) => return,
+            Err(e) => {
+                last_err = Some(e.to_string());
+                app_warn!(
+                    "async_jobs",
+                    "injection",
+                    "mark_injected({}) attempt {} failed: {}",
+                    job_id,
+                    attempt + 1,
+                    e
+                );
+            }
+        }
+    }
+    let err = last_err.unwrap_or_else(|| "unknown".to_string());
+    app_error!(
+        "async_jobs",
+        "injection",
+        "mark_injected({}) failed after {} attempts: {} — job may be re-injected on restart",
+        job_id,
+        BACKOFFS_MS.len(),
+        &err
+    );
+    if let Some(bus) = crate::globals::get_event_bus() {
+        bus.emit(
+            "async_tool_job:mark_injected_failed",
+            serde_json::json!({
+                "job_id": job_id,
+                "error": err,
+            }),
+        );
+    }
 }
 
 /// Format the user-visible message that gets injected back into the parent

--- a/crates/oc-core/src/context_compact/summarization.rs
+++ b/crates/oc-core/src/context_compact/summarization.rs
@@ -243,10 +243,10 @@ pub fn apply_summary(
     // Cap summary length (configurable, clamped to 4000–64000)
     let max_summary_chars = config.max_compaction_summary_chars.clamp(4_000, 64_000);
     let capped_summary = if summary.len() > max_summary_chars {
-        let budget = max_summary_chars - SUMMARY_TRUNCATED_MARKER.len();
+        let budget = max_summary_chars.saturating_sub(SUMMARY_TRUNCATED_MARKER.len());
         format!(
             "{}{}",
-            &summary[..budget.min(summary.len())],
+            crate::truncate_utf8(summary, budget),
             SUMMARY_TRUNCATED_MARKER
         )
     } else {

--- a/crates/oc-core/src/context_compact/truncation.rs
+++ b/crates/oc-core/src/context_compact/truncation.rs
@@ -11,8 +11,7 @@ use serde_json::Value;
 /// Detect if text tail contains important content (errors, JSON closing, results).
 /// Reference: openclaw hasImportantTail()
 fn has_important_tail(text: &str) -> bool {
-    let tail_start = text.len().saturating_sub(2000);
-    let tail = &text[tail_start..];
+    let tail = crate::truncate_utf8_tail(text, 2000);
     let lower = tail.to_lowercase();
 
     // Error patterns
@@ -41,13 +40,33 @@ fn has_important_tail(text: &str) -> bool {
     result_patterns.iter().any(|p| lower.contains(p))
 }
 
+/// Snap `pos` down to the nearest valid UTF-8 char boundary (≤ pos).
+fn floor_char_boundary(text: &str, pos: usize) -> usize {
+    let mut p = pos.min(text.len());
+    while p > 0 && !text.is_char_boundary(p) {
+        p -= 1;
+    }
+    p
+}
+
+/// Snap `pos` up to the nearest valid UTF-8 char boundary (≥ pos).
+fn ceil_char_boundary(text: &str, pos: usize) -> usize {
+    let mut p = pos.min(text.len());
+    while p < text.len() && !text.is_char_boundary(p) {
+        p += 1;
+    }
+    p
+}
+
 /// Find a clean cut point near target_pos, preferring structure boundaries.
 /// Improvement over openclaw: recognizes JSON, code blocks, and paragraph boundaries.
+/// Guaranteed to return a valid UTF-8 char boundary.
 pub(super) fn find_structure_boundary(text: &str, target_pos: usize, search_range: f64) -> usize {
-    let search_start = (target_pos as f64 * (1.0 - search_range)) as usize;
-    let search_end = target_pos.min(text.len());
+    let raw_start = (target_pos as f64 * (1.0 - search_range)) as usize;
+    let search_start = floor_char_boundary(text, raw_start);
+    let search_end = floor_char_boundary(text, target_pos.min(text.len()));
     if search_start >= search_end {
-        return target_pos.min(text.len());
+        return search_end;
     }
     let search_slice = &text[search_start..search_end];
 
@@ -70,15 +89,16 @@ pub(super) fn find_structure_boundary(text: &str, target_pos: usize, search_rang
     if let Some(pos) = search_slice.rfind('\n') {
         return search_start + pos + 1;
     }
-    // Fallback: raw position
-    target_pos.min(text.len())
+    // Fallback: snap down to char boundary to avoid slicing mid-codepoint.
+    floor_char_boundary(text, target_pos)
 }
 
 /// Find a forward-looking clean cut point near target_pos.
+/// Guaranteed to return a valid UTF-8 char boundary.
 fn find_structure_boundary_forward(text: &str, target_pos: usize, search_range: f64) -> usize {
-    let search_start = target_pos.min(text.len());
+    let search_start = ceil_char_boundary(text, target_pos.min(text.len()));
     let max_search = (text.len() as f64 * search_range) as usize;
-    let search_end = (search_start + max_search).min(text.len());
+    let search_end = ceil_char_boundary(text, (search_start + max_search).min(text.len()));
     if search_start >= search_end {
         return search_start;
     }

--- a/crates/oc-core/src/failover.rs
+++ b/crates/oc-core/src/failover.rs
@@ -317,10 +317,41 @@ pub static PROFILE_COOLDOWNS: LazyLock<ProfileCooldownTracker> =
 //  Maps (provider_id, session_id) → last-successful profile_id.
 //  Ensures cache-friendly behavior by preferring the same key across turns.
 
-/// Nested HashMap: provider_id → (session_id → profile_id).
-/// Avoids tuple key allocation on every lookup.
+/// Per-provider LRU of (session_id → profile_id). We need insertion-order
+/// tracking for O(1) "evict oldest" semantics without pulling a full LRU
+/// crate, so sessions live in a side `VecDeque` alongside the map: `get`
+/// looks up in the map, `set` promotes the key to the back, eviction drops
+/// the front. Keeps the whole map bounded without the old "blow away
+/// everything at 500" behavior that destroyed session stickiness for
+/// every long-running process.
+#[derive(Default)]
+struct StickyShard {
+    map: HashMap<String, String>,
+    order: std::collections::VecDeque<String>,
+}
+
+impl StickyShard {
+    fn promote(&mut self, session_id: &str) {
+        if let Some(pos) = self.order.iter().position(|s| s == session_id) {
+            self.order.remove(pos);
+        }
+        self.order.push_back(session_id.to_string());
+    }
+
+    fn insert(&mut self, session_id: &str, profile_id: &str, max: usize) {
+        self.map
+            .insert(session_id.to_string(), profile_id.to_string());
+        self.promote(session_id);
+        while self.order.len() > max {
+            if let Some(evicted) = self.order.pop_front() {
+                self.map.remove(&evicted);
+            }
+        }
+    }
+}
+
 pub struct ProfileStickyMap {
-    map: Mutex<HashMap<String, HashMap<String, String>>>,
+    map: Mutex<HashMap<String, StickyShard>>,
 }
 
 /// Cap per-provider session entries to prevent unbounded growth.
@@ -335,23 +366,22 @@ impl ProfileStickyMap {
 
     /// Get the sticky profile ID for a provider+session pair.
     pub fn get(&self, provider_id: &str, session_id: &str) -> Option<String> {
-        self.map
-            .lock()
-            .ok()?
-            .get(provider_id)?
-            .get(session_id)
-            .cloned()
+        let mut guard = self.map.lock().ok()?;
+        let shard = guard.get_mut(provider_id)?;
+        let profile = shard.map.get(session_id).cloned();
+        if profile.is_some() {
+            shard.promote(session_id);
+        }
+        profile
     }
 
     /// Set the sticky profile ID after a successful request.
+    /// Uses LRU semantics so hitting the cap evicts the single oldest
+    /// session entry instead of wiping every existing stickiness.
     pub fn set(&self, provider_id: &str, session_id: &str, profile_id: &str) {
         if let Ok(mut map) = self.map.lock() {
-            let sessions = map.entry(provider_id.to_string()).or_default();
-            // Prune oldest entries if over cap
-            if sessions.len() >= STICKY_MAX_SESSIONS_PER_PROVIDER {
-                sessions.clear();
-            }
-            sessions.insert(session_id.to_string(), profile_id.to_string());
+            let shard = map.entry(provider_id.to_string()).or_default();
+            shard.insert(session_id, profile_id, STICKY_MAX_SESSIONS_PER_PROVIDER);
         }
     }
 }
@@ -587,6 +617,65 @@ mod tests {
         sticky.set("prov1", "sess1", "profile-a");
         assert_eq!(sticky.get("prov1", "sess1").as_deref(), Some("profile-a"));
         assert!(sticky.get("prov1", "sess2").is_none());
+    }
+
+    #[test]
+    fn test_sticky_map_lru_eviction_preserves_recent() {
+        // Hit the cap + 1 with distinct sessions; oldest is evicted but
+        // newer ones must survive (old `clear()` wiped everything).
+        let sticky = ProfileStickyMap::new();
+        for i in 0..STICKY_MAX_SESSIONS_PER_PROVIDER {
+            sticky.set("prov1", &format!("sess{}", i), "profile-a");
+        }
+        // One past the cap triggers eviction of sess0.
+        sticky.set(
+            "prov1",
+            &format!("sess{}", STICKY_MAX_SESSIONS_PER_PROVIDER),
+            "profile-a",
+        );
+        assert!(
+            sticky.get("prov1", "sess0").is_none(),
+            "oldest entry should have been evicted"
+        );
+        // Recently used entries must still be present.
+        assert_eq!(
+            sticky.get("prov1", "sess1").as_deref(),
+            Some("profile-a"),
+            "recent entries must not be wiped by cap enforcement"
+        );
+        assert_eq!(
+            sticky
+                .get("prov1", &format!("sess{}", STICKY_MAX_SESSIONS_PER_PROVIDER))
+                .as_deref(),
+            Some("profile-a"),
+            "newest entry must be present"
+        );
+    }
+
+    #[test]
+    fn test_sticky_map_lru_promotes_on_get() {
+        let sticky = ProfileStickyMap::new();
+        // Fill up to the cap so the next insert triggers exactly one
+        // eviction. Seed the two oldest entries first so we can observe
+        // the promotion effect before fillers arrive.
+        sticky.set("prov1", "sess-a", "profile-a");
+        sticky.set("prov1", "sess-b", "profile-b");
+        for i in 0..(STICKY_MAX_SESSIONS_PER_PROVIDER - 2) {
+            sticky.set("prov1", &format!("filler{}", i), "profile-a");
+        }
+        // Promote sess-a so sess-b is now the oldest.
+        assert_eq!(sticky.get("prov1", "sess-a").as_deref(), Some("profile-a"));
+        // Next insert overflows the cap by one → pop_front evicts sess-b.
+        sticky.set("prov1", "trigger", "profile-a");
+        assert_eq!(
+            sticky.get("prov1", "sess-a").as_deref(),
+            Some("profile-a"),
+            "promoted entry must survive eviction"
+        );
+        assert!(
+            sticky.get("prov1", "sess-b").is_none(),
+            "untouched older entry should have been evicted"
+        );
     }
 
     #[test]

--- a/crates/oc-core/src/project/files.rs
+++ b/crates/oc-core/src/project/files.rs
@@ -168,9 +168,49 @@ pub fn delete_project_file(file_id: &str, db: &ProjectDB) -> Result<bool> {
 /// Remove every file belonging to a project, both the rows and the on-disk
 /// directory tree. Called when the parent project itself is being deleted.
 pub fn purge_project_files_dir(project_id: &str) {
-    if let Ok(dir) = crate::paths::project_dir(project_id) {
-        let _ = std::fs::remove_dir_all(dir);
+    let Ok(dir) = crate::paths::project_dir(project_id) else {
+        return;
+    };
+    if !dir.exists() {
+        return;
     }
+    // Defense-in-depth: refuse to delete if `dir` canonicalizes outside
+    // the projects root. Project IDs come from `Uuid::new_v4()` today so
+    // this should never trigger, but a traversal-style id (or a symlink
+    // that escaped the root) must not cause `remove_dir_all` to walk
+    // outside `~/.opencomputer/projects/`.
+    let Ok(projects_root) = crate::paths::projects_dir() else {
+        return;
+    };
+    let canonical = match dir.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            app_warn!(
+                "project",
+                "files",
+                "Refusing to purge project {}: canonicalize failed: {}",
+                project_id,
+                e
+            );
+            return;
+        }
+    };
+    let canonical_root = match projects_root.canonicalize() {
+        Ok(p) => p,
+        Err(_) => projects_root.clone(),
+    };
+    if !canonical.starts_with(&canonical_root) {
+        app_error!(
+            "project",
+            "files",
+            "Refusing to purge project {}: resolved path {:?} escapes projects root {:?}",
+            project_id,
+            canonical,
+            canonical_root
+        );
+        return;
+    }
+    let _ = std::fs::remove_dir_all(canonical);
 }
 
 /// Delete a project and every resource attached to it:

--- a/crates/oc-core/src/service_install.rs
+++ b/crates/oc-core/src/service_install.rs
@@ -3,6 +3,49 @@ use std::path::PathBuf;
 
 const SERVICE_LABEL: &str = "com.opencomputer.server";
 
+/// Minimal XML-text escape for plist `<string>` bodies. launchd parses
+/// the plist as XML, so any user-controlled value (home path, api key)
+/// MUST be escaped or `<`/`>`/`&`/quotes in the input will be interpreted
+/// as XML markup — in the worst case injecting extra `<string>` elements
+/// that become additional argv entries to the launched process.
+#[cfg(target_os = "macos")]
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '&' => out.push_str("&amp;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Escape a value for a systemd unit `ExecStart=` line so that whitespace,
+/// quotes and backslashes can't split the command into multiple args or
+/// inject extra tokens. systemd supports double-quoted strings with
+/// backslash escapes — see systemd.exec(5) "Command lines".
+#[cfg(target_os = "linux")]
+fn systemd_escape_arg(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
 // ── Public API ────────────────────────────────────────────────────
 
 /// Install OpenComputer as a system service (launchd on macOS, systemd on Linux).
@@ -109,19 +152,23 @@ fn install_launchd(
 ) -> Result<String> {
     let plist = plist_path()?;
 
-    // Build ProgramArguments entries
+    // Build ProgramArguments entries. Every user-controlled value
+    // (exe path, bind addr, api key, log path) is XML-escaped so that
+    // characters like `<`, `>`, `"` or `&` cannot break out of the
+    // surrounding `<string>` element and inject additional argv entries.
     let mut args_xml = format!(
         "        <string>{}</string>\n\
          \x20       <string>server</string>\n\
          \x20       <string>--bind</string>\n\
          \x20       <string>{}</string>",
-        exe_path, bind_addr
+        xml_escape(exe_path),
+        xml_escape(bind_addr)
     );
     if let Some(key) = api_key {
         args_xml.push_str(&format!(
             "\n        <string>--api-key</string>\n\
              \x20       <string>{}</string>",
-            key
+            xml_escape(key)
         ));
     }
 
@@ -149,7 +196,7 @@ fn install_launchd(
 "#,
         label = SERVICE_LABEL,
         args = args_xml,
-        log = log_path,
+        log = xml_escape(log_path),
     );
 
     // Unload the existing service if present (ignore errors)
@@ -267,9 +314,17 @@ fn install_systemd(
 ) -> Result<String> {
     let unit = unit_path()?;
 
-    let mut exec_start = format!("{} server --bind {}", exe_path, bind_addr);
+    // Quote every argv token individually so whitespace / quotes in any
+    // user-controlled value (exe path, bind addr, api key) cannot split
+    // the line into extra tokens or inject shell metacharacters into
+    // `ExecStart`.
+    let mut exec_start = format!(
+        "{} server --bind {}",
+        systemd_escape_arg(exe_path),
+        systemd_escape_arg(bind_addr)
+    );
     if let Some(key) = api_key {
-        exec_start.push_str(&format!(" --api-key {}", key));
+        exec_start.push_str(&format!(" --api-key {}", systemd_escape_arg(key)));
     }
 
     let stdout_log = format!("{}/server.stdout.log", log_path);

--- a/crates/oc-core/src/service_install.rs
+++ b/crates/oc-core/src/service_install.rs
@@ -27,7 +27,9 @@ fn xml_escape(s: &str) -> String {
 /// Escape a value for a systemd unit `ExecStart=` line so that whitespace,
 /// quotes and backslashes can't split the command into multiple args or
 /// inject extra tokens. systemd supports double-quoted strings with
-/// backslash escapes — see systemd.exec(5) "Command lines".
+/// backslash escapes — see systemd.exec(5) "Command lines". `$` is doubled
+/// to `$$` so systemd's `$VAR` / `${VAR}` expansion can't substitute an
+/// environment value into the command.
 #[cfg(target_os = "linux")]
 fn systemd_escape_arg(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
@@ -36,6 +38,7 @@ fn systemd_escape_arg(s: &str) -> String {
         match c {
             '\\' => out.push_str("\\\\"),
             '"' => out.push_str("\\\""),
+            '$' => out.push_str("$$"),
             '\n' => out.push_str("\\n"),
             '\r' => out.push_str("\\r"),
             '\t' => out.push_str("\\t"),

--- a/crates/oc-server/src/middleware.rs
+++ b/crates/oc-server/src/middleware.rs
@@ -13,12 +13,66 @@ pub struct ApiKeyState {
     pub api_key: Option<String>,
 }
 
+/// Constant-time byte comparison. Guards against timing side-channels when
+/// comparing API keys — never use `==` for secret comparisons. A length
+/// mismatch short-circuits to `false`; equal-length inputs XOR-fold into a
+/// single byte to produce a branch-free answer.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// `application/x-www-form-urlencoded` value decoder: treats `+` as space
+/// and `%XX` as a byte; anything else passes through. Returns the raw
+/// decoded bytes so comparison stays byte-for-byte.
+fn percent_decode_form_value(s: &str) -> Vec<u8> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let h = (bytes[i + 1] as char).to_digit(16);
+                let l = (bytes[i + 2] as char).to_digit(16);
+                match (h, l) {
+                    (Some(h), Some(l)) => {
+                        out.push((h as u8) * 16 + l as u8);
+                        i += 3;
+                    }
+                    _ => {
+                        out.push(bytes[i]);
+                        i += 1;
+                    }
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
 /// Middleware that validates requests against an optional API key.
 ///
 /// - If `api_key` is `None`, all requests pass through (no-auth mode).
 /// - If `api_key` is `Some`, checks in order:
 ///   1. `Authorization: Bearer <token>` header (for HTTP requests)
-///   2. `?token=<token>` query parameter (for browser WebSocket connections)
+///   2. `?token=<token>` query parameter (for browser WebSocket connections).
+///      Values are percent-decoded so keys containing reserved characters
+///      match correctly when the client URL-encodes them.
+/// - All comparisons are constant-time to avoid timing side-channels.
 /// - Returns 401 on failure.
 pub async fn require_api_key(
     State(state): State<ApiKeyState>,
@@ -29,12 +83,13 @@ pub async fn require_api_key(
         Some(key) => key,
         None => return next.run(request).await,
     };
+    let expected_bytes = expected.as_bytes();
 
     // Check Authorization header first
     if let Some(auth_header) = request.headers().get("authorization") {
         if let Ok(value) = auth_header.to_str() {
             if let Some(token) = value.strip_prefix("Bearer ") {
-                if token == expected {
+                if constant_time_eq(token.as_bytes(), expected_bytes) {
                     return next.run(request).await;
                 }
             }
@@ -45,7 +100,8 @@ pub async fn require_api_key(
     if let Some(query) = request.uri().query() {
         for pair in query.split('&') {
             if let Some(token) = pair.strip_prefix("token=") {
-                if token == expected {
+                let decoded = percent_decode_form_value(token);
+                if constant_time_eq(&decoded, expected_bytes) {
                     return next.run(request).await;
                 }
             }
@@ -57,4 +113,43 @@ pub async fn require_api_key(
         Json(json!({ "error": "Unauthorized: invalid or missing API key" })),
     )
         .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constant_time_eq_matches_equal_inputs() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(constant_time_eq(b"", b""));
+    }
+
+    #[test]
+    fn constant_time_eq_rejects_unequal_length() {
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+        assert!(!constant_time_eq(b"abc", b""));
+    }
+
+    #[test]
+    fn constant_time_eq_rejects_different_content() {
+        assert!(!constant_time_eq(b"abc", b"abd"));
+    }
+
+    #[test]
+    fn percent_decode_handles_encoded_symbols() {
+        assert_eq!(percent_decode_form_value("hello%20world"), b"hello world");
+        assert_eq!(percent_decode_form_value("a%2Bb%3Dc"), b"a+b=c");
+        assert_eq!(percent_decode_form_value("plain"), b"plain");
+        // `+` decodes to space per application/x-www-form-urlencoded.
+        assert_eq!(percent_decode_form_value("a+b"), b"a b");
+    }
+
+    #[test]
+    fn percent_decode_tolerates_bad_sequences() {
+        // Malformed `%Q1` must not crash; passes through as literal.
+        assert_eq!(percent_decode_form_value("%Q1"), b"%Q1");
+        // Trailing `%` with no digits passes through.
+        assert_eq!(percent_decode_form_value("abc%"), b"abc%");
+    }
 }

--- a/docs/audit/2026-04-17-codebase-audit.md
+++ b/docs/audit/2026-04-17-codebase-audit.md
@@ -6,10 +6,12 @@
 
 优先级排序：🔴 严重 Bug → 🟠 中等 Bug → 🟡 性能/稳定 → ℹ️ 设计与功能改进。
 
-- 严重 Bug：10 项
+- 严重 Bug：10 项（已处理 9 项 / 1 项维持原状）
 - 中等 Bug：11 项
 - 性能/稳定：10 项
 - 轻微/设计：5 项
+
+> **2026-04-17 复核（分支 `claude/fix-audit-bugs-Ip6Bl`）**：按本文件列出的严重 Bug 逐条 Read 源文件复核。B1 / B3 / B4 / B5 / B6 / B7 / B8 / B9 均已在本轮修复；B10 经复核发现 `job_status` 早就改用 `async_jobs::wait::Notify` 注册表，不再依赖 EventBus 事件，原描述已失效；B2 经复核与原描述偏差较大（`find_round_safe_boundary` 已按 round 边界对齐，不会把 tool_use / tool_result 切开），保留观察。
 
 ---
 
@@ -22,70 +24,68 @@
   - `crates/oc-core/src/context_compact/truncation.rs:74, 116, 118`
 - **因果**：`&summary[..budget.min(summary.len())]` 把字符预算当字节用；`find_structure_boundary` 的 fallback `target_pos` 由浮点运算转换得到，可能落在 UTF-8 多字节字符中间。中文 / emoji 摘要接近阈值时直接 panic。
 - **修复**：统一改 `crate::truncate_utf8(s, max_bytes)`，红线已经明确禁用字节切片。
-- **状态**：待修复。
+- **状态**：✅ 已修复（summarization 的 cap 切片改走 `truncate_utf8`；`find_structure_boundary` / `_forward` 的搜索边界、fallback 回退点、`has_important_tail` 的 2KB 尾部切片全部用新增的 `floor_char_boundary` / `ceil_char_boundary` helper 或 `truncate_utf8_tail` 对齐到字符边界）。
 
-### B2. Tier 3 摘要可能拆散 tool_use / tool_result 对
+### ~~B2. Tier 3 摘要可能拆散 tool_use / tool_result 对~~（原描述失效）
 
 - **位置**：`crates/oc-core/src/context_compact/summarization.rs:57-91`
-- **因果**：`find_round_safe_boundary` 在所有剩余消息同属一个 round 时返回 0，导致整轮被跳过摘要或 tool_use 被保留而对应 tool_result 被摘走。模型看到"没有结果的工具调用"，Anthropic 会直接 400 拒绝请求。
-- **修复**：round 调整失败时向前搜索下一个 round 边界，而不是静默返回 0。
-- **状态**：待修复。
+- **复核结论**：`find_round_safe_boundary` 实现是"从 `target_index` 向后回退到一个 round 变更点"，返回的 boundary_index 处满足 `messages[i-1].round != messages[i].round`，即 tool_use / tool_result 不会被切开；若所有可摘要消息同属一个 round 则返回 0，`split_for_summarization` 直接返回 `None` 跳过摘要，**不会** 把 tool_use 留下、tool_result 摘走——不会产生 Anthropic 400。审计描述的"拆散"场景在当前实现下不存在，至多是"整块跳过本次摘要"。该退化行为更接近性能/稳定性问题，本次不动。
+- **状态**：⛔ 划掉（原因描述与现状不符）。
 
 ### B3. Tool loop 最后一轮的 tool_results 被静默丢弃
 
-- **位置**：`crates/oc-core/src/agent/providers/anthropic.rs:318-320, 473-477`（其他 3 个 provider 很可能存在对称问题）
+- **位置**：`crates/oc-core/src/agent/providers/{anthropic,openai_chat,openai_responses,codex}.rs`
 - **因果**：循环在最后一轮执行完工具、把 tool_result 压进 history，但此时已到 `max_rounds` 上限，下一轮 API 不再调用，结果永远不会进入模型。用户侧表现为"工具跑了但模型没收到"。
 - **修复**：在 round 起始检测 `round >= max_rounds - 1` 时禁止接受新的 tool_use；或至少额外跑一次"只发消息不要工具"的收尾请求把结果送回模型。
-- **状态**：待修复。
+- **状态**：✅ 已修复（4 个 provider 统一：进入最后一轮 `round + 1 == max_rounds` 时请求不再携带 `tools`，模型只能产出文本应答；natural_exit 自然成立，避免静默丢结果 + 省掉"max rounds"占位文本）。
 
 ### B4. Async job 注入的 `mark_injected` 错误被吞
 
-- **位置**：`crates/oc-core/src/async_jobs/spawn.rs:75`；`async_jobs/injection.rs:13-31`
+- **位置**：`crates/oc-core/src/async_jobs/spawn.rs:444`（无 parent session 的兜底）；`async_jobs/injection.rs` 注入主路径
 - **因果**：`let _ = mark_injected(...)` 忽略失败。DB 写失败后，下次 `replay_pending_jobs()` 会把同一 job 再注入一遍，对话里出现重复 `<tool-job-result>` 块。
 - **修复**：失败时带 backoff 重试，彻底失败再通过 EventBus 报警；不要吞错误。
-- **状态**：待修复。
+- **状态**：✅ 已修复（`injection.rs` 新增 `mark_injected_with_retry`：`[0, 100ms, 500ms, 2000ms]` 4 次退避；彻底失败 emit `async_tool_job:mark_injected_failed` 事件 + `app_error!` 日志，保留"下次 replay 会重新注入"的语义但不再静默）。spawn.rs:444 的"无 parent session"分支只剩 orphan 清理意图，不涉及回放路径，保持 `let _ =`。
 
 ### B5. Query string token 未 URL 解码 → 鉴权绕过 / 误拒
 
 - **位置**：`crates/oc-server/src/middleware.rs:47`
 - **因果**：`strip_prefix("token=")` 直接拿原始 query，不做 `percent_decode`。带百分号编码的合法 token 会被拒；若 expected 自身含特殊字符（或双端编码不一致），可构造绕过分支。
 - **修复**：改用 `url::form_urlencoded::parse` 或 `percent_encoding::percent_decode_str` 先解码再比对。
-- **状态**：待修复。
+- **状态**：✅ 已修复（middleware 新增轻量 `percent_decode_form_value` + 配合 `+` → space 语义，query token 解码后再比较；配套单测覆盖正常/畸形编码）。
 
 ### B6. API Key 比较非常量时间
 
 - **位置**：`crates/oc-server/src/middleware.rs:37, 48`
 - **因果**：普通 `==` 比较 token，存在 timing side-channel，尤其在 HTTP 暴露到 `0.0.0.0:8420` 的公网/内网场景。
 - **修复**：使用 `subtle::ConstantTimeEq` 或等长 HMAC 比较。
-- **状态**：待修复。
+- **状态**：✅ 已修复（新增内联 `constant_time_eq` 做 XOR-fold 常量时间比较；Header / Query 两条分支都走同一实现；长度不等短路的 timing leak 对固定长度 API key 可接受；附 3 条单测）。
 
 ### B7. Service install 脚本命令注入
 
 - **位置**：`crates/oc-core/src/service_install.rs:121-125, 270`
 - **因果**：`exe_path` / `bind_addr` / `api_key` 未转义直接拼进 systemd `ExecStart` / launchd `ProgramArguments`。用户 home 含空格、`api_key` 含引号就能把参数拆破；恶意配置可注入额外命令到开机自启。
 - **修复**：systemd 用 `shlex::try_quote`；launchd plist 用多个独立 `<string>` 元素保持数组结构，不要拼成单串。
-- **状态**：待修复。
+- **状态**：✅ 已修复（新增 `xml_escape`：launchd plist 里 exe / bind / api_key / log 全部先转义 `<`, `>`, `&`, `"`, `'`，杜绝通过用户字符串打破 `<string>` 元素追加 argv；新增 `systemd_escape_arg`：systemd `ExecStart` 每个 argv 独立加 `"..."` 并转义 `\`, `"`, 控制字符，避免空格/引号拆分）。
 
 ### B8. ProfileStickyMap 内存泄漏 + 粗暴 clear
 
 - **位置**：`crates/oc-core/src/failover.rs:338-348`
 - **因果**：到达 `STICKY_MAX_SESSIONS_PER_PROVIDER=500` 上限时 `sessions.clear()` 清空全部，破坏 session 粘性；长期运行下 session 只增不减（无死 session 清理路径）。
 - **修复**：改 LRU（`lru` crate，或 `IndexMap` + 手动 evict 最旧），粘性不受清空冲击。
-- **状态**：待修复。
+- **状态**：✅ 已修复（新增 `StickyShard { map, order: VecDeque }` 本地 LRU 结构，`get` 访问时 promote，`set` 到上限时 `pop_front` 仅 evict 最旧一条，不再破坏全局粘性；补 2 条单测验证"填满+1"只淘汰最旧、"get 后 promote 的条目不会被当作最旧"）。
 
 ### B9. Project 删除非事务：DB 成功 / FS 残留 / symlink 风险
 
 - **位置**：`crates/oc-core/src/project/db.rs:283-294` + `project/files.rs:184-213`
 - **因果**：先 `DELETE projects`（事务内），再 `rm -rf projects/{id}/`（事务外）。commit 后崩溃 → 目录残留成孤儿；更糟：若 `{id}` 被篡改为 symlink，可删到预期外路径。
 - **修复**：`canonicalize()` 校验目标必须位于 `~/.opencomputer/projects/` 下；或改为先改名到 `.trash/`、commit 后异步清理。
-- **状态**：待修复。
+- **状态**：✅ symlink / 路径逃逸分支已修复（`purge_project_files_dir` 现在 `canonicalize()` 目标并强制 `starts_with(projects_root)` 检查，失败只记日志不删）。DB commit 后 `rm -rf` 仍是非事务的"先改 DB 后清盘"顺序——现有 project_id 全部来自 `Uuid::new_v4()`，路径逃逸风险已被 canonicalize 兜底，孤儿目录仅限崩溃窗口，不再升级为安全问题，后续清理可由 D2 方向的 reconciler 统一解决。
 
-### B10. EventBus broadcast 容量溢出 → 异步 job 完成通知丢失
+### ~~B10. EventBus broadcast 容量溢出 → 异步 job 完成通知丢失~~（原描述失效）
 
 - **位置**：`crates/oc-core/src/event_bus.rs:27` + `async_jobs` 消费路径
-- **因果**：`tokio::broadcast` 滞后消费者会收到 `RecvError::Lagged` 并丢事件。`job_status(block=true)` 只靠 `async_tool_job:completed` + 200ms 兜底轮询；事件丢失时模型必须等到兜底轮询才醒，而且只覆盖 600s 上限，极端场景直接 timeout。
-- **修复**：订阅端显式 match `Lagged`，丢失时立即做一次 DB 状态查询；或核心事件改走 mpsc / watch。
-- **状态**：待修复。
+- **复核结论**：`job_status` 早已改走 `async_jobs::wait::Notify` 注册表（`crates/oc-core/src/async_jobs/wait.rs` + `tools/job_status.rs`），producer 在 `finalize_job` 里通过 `notify_waiters()` 唤醒，*不再依赖* EventBus `async_tool_job:completed` 事件——broadcast lag 已不能导致 waiter 丢醒。`job_status` 循环还保留 100ms→2s 退避 select 做防御兜底，退避上限是单次等待窗口（默认 min(max_job_secs, 1800)），不是 600s。当前真实行为与审计描述偏差较大，原计划的"订阅端处理 Lagged"改进点归入 P4 继续跟踪。
+- **状态**：⛔ 划掉（实现早于本次审计就已迁移到 Notify 注册表，原风险不存在）。
 
 ---
 
@@ -285,19 +285,33 @@
 
 ## 📊 总计
 
-| 档次 | 数量 | 集中区域 |
-|---|---|---|
-| 🔴 严重 | 10 | `context_compact` UTF-8 切片、tool loop 终止、async_jobs 注入、server 鉴权、service install 命令注入 |
-| 🟠 中等 | 11 | cache-TTL 逻辑、memory_extract 竞态、plan 状态机、cron 重放、前端 stale closure |
-| 🟡 性能/稳定 | 10 | XSS、CSP、broadcast lag、SSRF、日志 token |
-| ℹ️ 轻微/设计 | 5 | SQL 拼接习惯、孤儿清理、排序字段、CI 校验、工具上下文共享 |
+| 档次 | 数量 | 本轮处理 | 集中区域 |
+|---|---|---|---|
+| 🔴 严重 | 10 | 8 ✅ / 2 ⛔ | `context_compact` UTF-8 切片、tool loop 终止、async_jobs 注入、server 鉴权、service install 命令注入 |
+| 🟠 中等 | 11 | – | cache-TTL 逻辑、memory_extract 竞态、plan 状态机、cron 重放、前端 stale closure |
+| 🟡 性能/稳定 | 10 | – | XSS、CSP、broadcast lag、SSRF、日志 token |
+| ℹ️ 轻微/设计 | 5 | – | SQL 拼接习惯、孤儿清理、排序字段、CI 校验、工具上下文共享 |
 
-**修复顺序建议**
+**2026-04-17 修复批次（分支 `claude/fix-audit-bugs-Ip6Bl`）**
 
-1. 第一批（用户可触发即时故障）：B1、B3、B5 + B6、B7
-2. 第二批（长尾数据/稳定性）：B2、B4、B9、B10、M4、M7、M8
-3. 第三批（安全加固批）：P1、P3、P7、P8
-4. 其余按迭代节奏推进。
+| ID | 处理结果 |
+|---|---|
+| B1 UTF-8 切片 | ✅ 切换到 `truncate_utf8` / `truncate_utf8_tail` + 新增 `floor_char_boundary` / `ceil_char_boundary` helper |
+| ~~B2 Tier 3 切分~~ | ⛔ 复核后确认 round 边界逻辑已保证 tool_use/tool_result 不分离，原描述失效 |
+| B3 Tool loop 末轮 | ✅ 4 个 provider 最后一轮移除 `tools`，模型被迫出文本 |
+| B4 mark_injected | ✅ 注入路径改走 4 次退避 + EventBus 报警 |
+| B5 Query 解码 | ✅ 新增 `percent_decode_form_value` + 单测 |
+| B6 常量时间 | ✅ 新增 `constant_time_eq` + 单测 |
+| B7 Service install | ✅ launchd XML 转义 + systemd ExecStart 单 arg 引号 |
+| B8 ProfileSticky LRU | ✅ `StickyShard` 本地 LRU，上限只驱逐最旧 + 2 条单测 |
+| B9 Project 删除 | ✅ `purge_project_files_dir` canonicalize 校验前缀 |
+| ~~B10 broadcast 丢事件~~ | ⛔ `job_status` 已改用 `Notify` 注册表，不再依赖 broadcast |
+
+**修复顺序建议（剩余批次）**
+
+1. 第二批（长尾数据/稳定性）：M4、M7、M8
+2. 第三批（安全加固批）：P1、P3、P7、P8
+3. 其余按迭代节奏推进。
 
 ## 复核建议
 


### PR DESCRIPTION
按 docs/audit/2026-04-17-codebase-audit.md 逐条 Read 复核：

- B1 UTF-8 切片 panic：summarization 的 cap 切片 + truncation 的
  find_structure_boundary / find_structure_boundary_forward /
  has_important_tail 全部改走 truncate_utf8 + 新增的
  floor_char_boundary / ceil_char_boundary helper。
- B3 Tool loop 末轮丢 tool_result：4 个 provider 在
  round + 1 == max_rounds 时不再发送 tools，模型被迫产出文本应答。
- B4 mark_injected 吞错：注入路径改走 mark_injected_with_retry，
  4 次退避后失败走 EventBus async_tool_job:mark_injected_failed 报警。
- B5 Query token URL 解码：新增 percent_decode_form_value + 单测。
- B6 API Key 常量时间比较：新增 constant_time_eq + 单测。
- B7 Service install 命令注入：launchd plist XML 转义 + systemd
  ExecStart 每个 argv 独立加引号并转义。
- B8 ProfileStickyMap 粗暴 clear：StickyShard { map, order: VecDeque }
  本地 LRU，上限只驱逐最旧一条，get 自动 promote + 2 条单测。
- B9 Project 删除 symlink 风险：purge_project_files_dir canonicalize
  校验前缀必须在 projects_root 下。
- B2 / B10 经复核发现原描述与当前实现不符（round 边界已保证不切分
  tool_use/tool_result；job_status 已迁移到 Notify 注册表不再依赖
  broadcast），在审计文档里划掉。

docs/audit/2026-04-17-codebase-audit.md 同步更新每条状态 + 修复批次总表。

https://claude.ai/code/session_01CcKMvYodQmcK2P2PnJ35YV