### PR TITLE
feat(system-prompt): 在身份行后注入应用简介

### DIFF
--- a/crates/oc-core/src/system_prompt/build.rs
+++ b/crates/oc-core/src/system_prompt/build.rs
@@ -1,6 +1,6 @@
 use super::constants::{
-    build_tool_budget_guidance, HUMAN_IN_THE_LOOP_GUIDANCE, MAX_FILE_CHARS, MEMORY_GUIDELINES,
-    SOUL_EMBODIMENT_GUIDANCE, TOOL_CALL_NARRATION_GUIDANCE,
+    build_tool_budget_guidance, APP_INTRO, HUMAN_IN_THE_LOOP_GUIDANCE, MAX_FILE_CHARS,
+    MEMORY_GUIDELINES, SOUL_EMBODIMENT_GUIDANCE, TOOL_CALL_NARRATION_GUIDANCE,
 };
 use super::helpers::truncate;
 use super::sections::*;
@@ -61,6 +61,7 @@ pub fn build(
             "You are {}, running in OpenComputer on {} {}.",
             definition.config.name, os, arch
         ));
+        sections.push(APP_INTRO.to_string());
 
         // # Project Context — fixed 4-file order
         let mut project_ctx = String::from(
@@ -98,6 +99,7 @@ pub fn build(
             "You are {}, running in OpenComputer on {} {}.",
             definition.config.name, os, arch
         ));
+        sections.push(APP_INTRO.to_string());
 
         // agent.md — custom identity / instructions
         if let Some(md) = definition
@@ -142,6 +144,7 @@ pub fn build(
             "You are {}{}, running in OpenComputer on {} {}.",
             definition.config.name, role_suffix, os, arch
         ));
+        sections.push(APP_INTRO.to_string());
 
         // ② Personality — SoulMd mode injects soul.md verbatim + embodiment
         //    guidance; Structured mode (default) assembles from role/tone/values.

--- a/crates/oc-core/src/system_prompt/constants.rs
+++ b/crates/oc-core/src/system_prompt/constants.rs
@@ -27,6 +27,11 @@ pub(super) const MEMORY_GUIDELINES: &str =
      - You need to find what was said or decided in an earlier session\n\n\
      Do NOT save: ephemeral task details, code snippets, debugging steps, or anything derivable from the codebase.";
 
+/// Brief description of the host application, injected once right after the
+/// identity line so the model knows what "OpenComputer" actually is.
+pub(super) const APP_INTRO: &str =
+    "OpenComputer is a local, open-source AI assistant with configurable model providers, tools, skills, and persistent memory.";
+
 /// Embodiment guidance appended after injecting a SOUL.md block so the
 /// model commits to the persona rather than treating it as ambient text.
 /// Shared between openclaw 4-file mode and the SoulMd persona mode.


### PR DESCRIPTION
## Summary
- 新增 `APP_INTRO` 常量作为产品一句话简介，紧贴身份行注入（openclaw / custom / structured 三条装配路径各一处）
- 让模型不只靠 "running in OpenComputer" 这句话识别宿主应用，而是拿到一段 "OpenComputer 是什么" 的明确定义

## Test plan
- [ ] `cargo check -p oc-core` 通过
- [ ] 启动应用后发一条消息，检查返回的 system prompt 里能看到 `APP_INTRO` 那一段