### PR TITLE
docs: 移除 mermaid 图表中的自定义背景色填充

### DIFF
--- a/docs/architecture/acp.md
+++ b/docs/architecture/acp.md
@@ -82,10 +82,6 @@ graph TB
     AGENT --> CONFIG
     AGENT --> AGENTS_DIR
 
-    style ZED fill:#4a9eff,color:#fff
-    style AGENT fill:#ff6b6b,color:#fff
-    style SESSION_DB fill:#51cf66,color:#fff
-    style ASSISTANT fill:#ffd43b,color:#333
 ```
 
 ---
@@ -184,8 +180,6 @@ graph LR
     MOD --> AGENT
     MOD --> SERVER
 
-    style AGENT fill:#ff6b6b,color:#fff
-    style TYPES fill:#4a9eff,color:#fff
 ```
 
 ### 各模块职责
@@ -321,9 +315,6 @@ flowchart TB
     NEXT_MODEL -- 是 --> TRY_MODEL
     NEXT_MODEL -- 否 --> ERROR
 
-    style START fill:#4a9eff,color:#fff
-    style SUCCESS fill:#51cf66,color:#fff
-    style ERROR fill:#ff6b6b,color:#fff
 ```
 
 ### 事件传递架构（异步到同步桥接）
@@ -348,8 +339,6 @@ graph LR
     RX --> FORMAT
     FORMAT --> WRITE
 
-    style CHAT fill:#ffd43b,color:#333
-    style WRITE fill:#4a9eff,color:#fff
 ```
 
 > **为什么用 `std::sync::mpsc` 而非 `tokio::sync::mpsc`？**
@@ -387,8 +376,6 @@ graph LR
     TR --> TCU
     US --> UU
 
-    style TD fill:#ffd43b,color:#333
-    style AMC fill:#4a9eff,color:#fff
 ```
 
 ### 映射详情表
@@ -458,9 +445,6 @@ flowchart TB
     NEXT -- "有下一模型" --> TRY["尝试下一模型"]
     NEXT -- "全部耗尽" --> FAIL["返回错误"]
 
-    style ERROR fill:#ff6b6b,color:#fff
-    style OK fill:#51cf66,color:#fff
-    style FAIL fill:#ff6b6b,color:#fff
 ```
 
 **退避参数**：
@@ -501,7 +485,6 @@ flowchart LR
     TC --> TCU
     EVT --> SKIP
 
-    style SKIP fill:#ccc,color:#666
 ```
 
 > **截断策略**：工具结果超过 8192 字节时，使用 `truncate_utf8()` 安全截断后追加 `...(truncated)` 标记。
@@ -536,7 +519,6 @@ graph TB
     CHAT_CMD --> AGENTS_FS
     ACP_SERVER --> AGENTS_FS
 
-    style SQLITE fill:#51cf66,color:#fff
 ```
 
 **WAL 模式**确保桌面端和 ACP 端可以同时读写 `sessions.db`，不会互相阻塞。

--- a/docs/architecture/backend-separation.md
+++ b/docs/architecture/backend-separation.md
@@ -24,9 +24,6 @@ graph TD
     OC_TAURI -->|"依赖"| OC_CORE
     OC_SERVER -->|"依赖"| OC_CORE
 
-    style OC_CORE fill:#2d5a27,stroke:#4a9e3f,color:#fff
-    style OC_SERVER fill:#1a3a5c,stroke:#3a7abd,color:#fff
-    style OC_TAURI fill:#5c3a1a,stroke:#bd7a3a,color:#fff
 ```
 
 **铁律**：`ha-core` 的 `Cargo.toml` 禁止出现 `tauri` 或 Tauri 插件依赖。

--- a/docs/architecture/chat-engine.md
+++ b/docs/architecture/chat-engine.md
@@ -230,8 +230,6 @@ flowchart TD
     B -->|Auth + Codex| J[emit codex_auth_expired]
     J --> I
 
-    style D fill:#f9f,stroke:#333
-    style E fill:#f66,stroke:#333
 ```
 
 **退避参数：**

--- a/docs/architecture/context-compact.md
+++ b/docs/architecture/context-compact.md
@@ -22,8 +22,6 @@ flowchart TD
     H --> I["后压缩文件恢复"]
     I --> Done
     J["ContextOverflow 错误"] --> K["Tier 4: 紧急<br/>清除所有 + 只保留最近 N 轮"]
-    style Done fill:#e8f5e9
-    style K fill:#ffcdd2
 ```
 
 ## 模块结构
@@ -103,8 +101,6 @@ flowchart TD
     Filter2 -- No --> Done
     Filter2 -- Yes --> Clear["内容替换为<br/>[Old tool result content cleared]"]
     Clear --> Done
-    style Done fill:#e8f5e9
-    style Skip fill:#fff9c4
 ```
 
 **优先级排序**：
@@ -216,8 +212,6 @@ flowchart TD
     Inject --> CheckMore
     FinalCheck{"有可恢复文件?"} -- Yes --> Return["注入 user 角色消息"]
     FinalCheck -- No --> None
-    style Return fill:#e8f5e9
-    style None fill:#fff9c4
 ```
 
 1. **扫描被摘要消息**：提取 `write`, `write_file`, `edit`, `patch_file`, `apply_patch` 工具调用中的文件路径

--- a/docs/architecture/image-generation.md
+++ b/docs/architecture/image-generation.md
@@ -23,9 +23,6 @@ graph TD
     TRAIT --> P6["ZhipuAI"]
     TRAIT --> P7["Tongyi"]
 
-    style LLM fill:#e0e7ff,stroke:#4f46e5
-    style ENTRY fill:#fef3c7,stroke:#d97706
-    style TRAIT fill:#d1fae5,stroke:#059669
 ```
 
 ---
@@ -199,12 +196,6 @@ flowchart TD
     CLASSIFY -- "否" --> LOG_ERR["记入 failover_log"]
     LOG_ERR --> NEXT_P
 
-    style START fill:#e0e7ff,stroke:#4f46e5
-    style LIST fill:#d1fae5,stroke:#059669
-    style SUCCESS fill:#d1fae5,stroke:#059669
-    style FAIL fill:#fee2e2,stroke:#dc2626
-    style RETURN_LIST fill:#d1fae5,stroke:#059669
-    style RETURN_OK fill:#d1fae5,stroke:#059669
 ```
 
 ### 参考图加载流程
@@ -220,8 +211,6 @@ flowchart LR
     DL --> IMG
     READ --> IMG
 
-    style INPUT fill:#e0e7ff,stroke:#4f46e5
-    style IMG fill:#d1fae5,stroke:#059669
 ```
 
 ### Resolution 自动推断
@@ -236,9 +225,6 @@ flowchart LR
     C2 -- "是" --> R2K["2K"]
     C2 -- "否" --> R1K["1K"]
 
-    style R4K fill:#fecaca,stroke:#dc2626
-    style R2K fill:#fef3c7,stroke:#d97706
-    style R1K fill:#d1fae5,stroke:#059669
 ```
 
 ---
@@ -270,8 +256,6 @@ flowchart LR
     DESC --> D5["resolution: 支持的 Provider"]
     DESC --> D6["n.maximum: 动态上限"]
 
-    style CONFIG fill:#e0e7ff,stroke:#4f46e5
-    style DESC fill:#fef3c7,stroke:#d97706
 ```
 
 新增或移除 Provider 时，工具描述自动更新，无需手动维护。
@@ -298,9 +282,6 @@ flowchart TD
     HAS -- "是" --> LOOP(["尝试下一个"])
     HAS -- "否" --> FAIL(["返回聚合错误<br/>failover_log 透明展示"])
 
-    style ERR fill:#fee2e2,stroke:#dc2626
-    style BACKOFF fill:#fef3c7,stroke:#d97706
-    style FAIL fill:#fee2e2,stroke:#dc2626
 ```
 
 ---
@@ -470,9 +451,6 @@ block-beta
         end
     end
 
-    style header fill:#e0e7ff,stroke:#4f46e5
-    style providers fill:#f0fdf4,stroke:#22c55e
-    style global fill:#fefce8,stroke:#ca8a04
 ```
 
 - **优先级排序**：上下箭头调整顺序，顺序即 failover 优先级
@@ -521,9 +499,6 @@ graph LR
     PANEL -.-> CFG
     PANEL -.-> PRO
 
-    style backend fill:#f0fdf4,stroke:#22c55e
-    style infra fill:#fef3c7,stroke:#d97706
-    style frontend fill:#e0e7ff,stroke:#4f46e5
 ```
 
 ---

--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -39,10 +39,6 @@ flowchart TD
     P --> Q
     Q --> I
 
-    style A fill:#e1f5fe
-    style G fill:#fff3e0
-    style M fill:#e8f5e9
-    style O fill:#e8f5e9
 ```
 
 ### 关键设计
@@ -148,8 +144,6 @@ flowchart TD
     I2 --> C
     L --> C
 
-    style A fill:#e1f5fe
-    style C fill:#e8f5e9
 ```
 
 ### 文件命名规则

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -143,9 +143,6 @@ flowchart TD
     Embed -- No --> FTS["更新 FTS5 索引"]
     GenVec --> FTS
     FTS --> Done["完成"]
-    style Skip fill:#ffcdd2
-    style Update fill:#fff9c4
-    style Insert fill:#e8f5e9
 ```
 
 ### 1. save_memory 工具 → `add_with_dedup()`
@@ -200,9 +197,6 @@ flowchart TD
 
     NewSession["用户新建会话"] --> Flush["flush_all_idle_extractions<br/>立即执行所有待提取"]
 
-    style Extract fill:#4CAF50,color:#fff
-    style IdleExtract fill:#FF9800,color:#fff
-    style Flush fill:#2196F3,color:#fff
 ```
 
 ### 3. 导入
@@ -235,8 +229,6 @@ flowchart TD
     Select -- Yes --> LLM["LLM 语义选择<br/>side_query 选 ≤5 条"]
     Select -- No --> Inject["注入系统提示<br/>Section 8: Memory"]
     LLM --> Inject
-    style Query fill:#e3f2fd
-    style Inject fill:#e8f5e9
 ```
 
 ### 双路并行检索
@@ -302,8 +294,6 @@ flowchart TD
     Google --> Use
     Voyage --> Use
     Mistral --> Use
-    style Local fill:#e8f5e9
-    style None fill:#ffcdd2
 ```
 
 ### 自动选择优先级
@@ -412,11 +402,6 @@ flowchart TD
 
     Replace --> Done
 
-    style Skip fill:#ffcdd2
-    style Done fill:#e8f5e9
-    style Section8 fill:#e3f2fd,stroke:#90caf9
-    style SQLite fill:#fff3e0,stroke:#ffb74d
-    style LLMSelect fill:#f3e5f5,stroke:#ce93d8
 ```
 
 ### 输出格式

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -71,10 +71,6 @@ graph TD
     EventBus -.->|"subscriber"| IPC
     EventBus -.->|"subscriber"| WSHandler
 
-    style Frontend fill:#e3f2fd
-    style OcCore fill:#e8f5e9
-    style OcServer fill:#e3f2fd
-    style TauriShell fill:#fff8e1
 ```
 
 ## 核心数据流
@@ -104,8 +100,6 @@ flowchart TD
     O --> P["6. 保存 context_json<br/>到 SessionDB (会话恢复)"]
     P --> Q["7. 自动记忆提取<br/>(inline, 复用 prompt cache)"]
 
-    style A fill:#e1f5fe
-    style Q fill:#e8f5e9
 ```
 
 ### Failover 降级链
@@ -126,8 +120,6 @@ flowchart TD
     J -- Yes --> A
     J -- "全部失败" --> K["返回错误"]
 
-    style C fill:#e8f5e9
-    style K fill:#ffcdd2
 ```
 
 ## 模块依赖关系
@@ -156,8 +148,6 @@ graph LR
     Dashboard --> CronDB["Cron DB"]
     Logging["Logging"] -.->|"非阻塞双写"| AllModules["全模块"]
 
-    style ChatEngine fill:#c8e6c9
-    style Logging fill:#fff9c4
 ```
 
 ## 存储架构

--- a/docs/architecture/prompt-system.md
+++ b/docs/architecture/prompt-system.md
@@ -53,7 +53,6 @@ graph TD
     S6 --> S7
     S8 --> S9
     S11 --> S12
-    style SP fill:#f5f5f5
 ```
 
 **三种组装模式**：
@@ -68,9 +67,6 @@ graph LR
     OC --> REST["④~⑬ 共享段 (User/Tools/Skills/Memory/Runtime...)"]
     CP --> REST
     ST --> REST
-    style OC fill:#e3f2fd
-    style CP fill:#fff3cd
-    style ST fill:#d4edda
 ```
 
 **核心设计原则**：
@@ -112,10 +108,6 @@ graph LR
     AD --> S11["⑪ Sandbox (conditional)"]
     AD --> S13["⑬ ACP (conditional)"]
 
-    style S8 fill:#fff3cd
-    style S10 fill:#e3f2fd
-    style S11 fill:#e3f2fd
-    style S13 fill:#e3f2fd
 ```
 
 **代码位置**：`crates/ha-core/src/system_prompt/build.rs` — `pub fn build()`
@@ -394,11 +386,6 @@ flowchart TD
     C3 -- Yes --> T4["Tier 4: Emergency Compaction — 清空所有工具结果 + 只保留最近 N 轮对话"]
     C3 -- No --> Done
 
-    style T1 fill:#d4edda
-    style T2 fill:#fff3cd
-    style T3 fill:#fce4ec
-    style T4 fill:#f8d7da
-    style Done fill:#e8f5e9
 ```
 
 **代码位置**：`crates/ha-core/src/context_compact/mod.rs`

--- a/docs/architecture/sandbox.md
+++ b/docs/architecture/sandbox.md
@@ -56,9 +56,6 @@ flowchart TD
     G -->|通过| H["done<br/>返回 http://127.0.0.1:PORT"]
     G -->|超时| I["失败<br/>抓取容器日志<br/>docker logs --tail 50"]
 
-    style A fill:#e3f2fd
-    style H fill:#c8e6c9
-    style I fill:#ffcdd2
 ```
 
 部署通过 `AtomicBool::compare_exchange` 实现互斥，防止并发部署。部署进度通过 `DEPLOY_PROGRESS`（`LazyLock<Mutex<DeployProgress>>`）共享给 UI，保留最近 100 行日志。部署完成后自动清除进度并失效状态缓存。
@@ -112,9 +109,6 @@ flowchart LR
     J --> K["环境变量注入<br/>-e HTTP_PROXY=...<br/>-e HTTPS_PROXY=...<br/>（大小写各一份）"]
     J --> L["settings.yml 注入<br/>outgoing.proxies.all://:<br/>（SearXNG 不读环境变量）"]
 
-    style A fill:#fff3e0
-    style B fill:#e8f5e9
-    style C fill:#f3e5f5
 ```
 
 代理注入受 `web_search.searxng_docker_use_proxy` 配置项控制（默认开启）。SearXNG 使用自有网络模块，不读取标准 `HTTP_PROXY` 环境变量，因此必须通过 `settings.yml` 的 `outgoing.proxies` 配置。环境变量注入作为补充，覆盖其他可能的网络请求。

--- a/docs/architecture/session.md
+++ b/docs/architecture/session.md
@@ -375,9 +375,6 @@ flowchart TD
     E --> G["前端刷新 unread_count:<br/>messages.id > last_read_message_id"]
     F --> G
 
-    style A fill:#e3f2fd,stroke:#1976d2
-    style E fill:#fff3cd,stroke:#ffc107
-    style G fill:#d4edda,stroke:#28a745
 ```
 
 ### 消息顺序保持（TextBlock / ThinkingBlock）

--- a/docs/architecture/side-query.md
+++ b/docs/architecture/side-query.md
@@ -76,12 +76,6 @@ flowchart TD
     P --> Q["返回 OneShotResult { text, usage }"]
     Q --> R["side_query 包装为 SideQueryResult"]
 
-    style A fill:#e1f5fe
-    style G fill:#fff8e1
-    style I fill:#e8f5e9
-    style J fill:#fff3e0
-    style R fill:#e8f5e9
-    style N fill:#ffcdd2
 ```
 
 ### 关键约束

--- a/docs/architecture/skill-system.md
+++ b/docs/architecture/skill-system.md
@@ -181,10 +181,6 @@ block-beta
 
     lowest --> low --> mid --> high
 
-    style B fill:#f3e8ff,stroke:#a855f7
-    style E fill:#fef3c7,stroke:#f59e0b
-    style M fill:#dbeafe,stroke:#3b82f6
-    style P fill:#dcfce7,stroke:#22c55e
 ```
 
 ### 技能标识（Skill Key）
@@ -335,10 +331,6 @@ flowchart TD
     DEDUP --> SORT["按 name 字母排序"]
     SORT --> RESULT(["返回 Vec SkillEntry"])
 
-    style B fill:#f3e8ff,stroke:#a855f7
-    style E fill:#fef3c7,stroke:#f59e0b
-    style M fill:#dbeafe,stroke:#3b82f6
-    style P fill:#dcfce7,stroke:#22c55e
 ```
 
 **优先级覆盖规则**：Project > Managed > Extra dirs > Bundled，高优先级的同名技能覆盖低优先级的。
@@ -402,8 +394,6 @@ flowchart TD
 
     ENV -.-> ENV_CHECK
 
-    style PASS fill:#dcfce7,stroke:#22c55e
-    style FAIL fill:#fee2e2,stroke:#ef4444
 ```
 
 ### `primaryEnv` 机制
@@ -493,10 +483,6 @@ flowchart TD
     INLINE --> OUT_IN(["主对话收到 SKILL.md 正文 + $ARGUMENTS 替换"])
     FORK --> OUT_FK(["主对话只看到一条摘要 tool_result"])
 
-    style INLINE fill:#fef3c7,stroke:#f59e0b
-    style FORK fill:#dcfce7,stroke:#22c55e
-    style ERR fill:#fee2e2,stroke:#ef4444
-    style ERR2 fill:#fee2e2,stroke:#ef4444
 ```
 
 ### 两条入口共享 helper
@@ -672,8 +658,6 @@ flowchart LR
         B3 --> B4[后续轮次模型只看到摘要]
     end
 
-    style A3 fill:#fee2e2,stroke:#ef4444
-    style B3 fill:#dcfce7,stroke:#22c55e
 ```
 
 这是 Phase 1 改造的**核心价值**：把 fork skill 从"隔离执行但结果回灌主对话"升级为"隔离执行 + 隔离结果"，让主对话 context 真正只长 1 条 tool_use + 1 条摘要 tool_result。
@@ -753,8 +737,6 @@ flowchart TD
     LOG --> DISPATCH(["继续工具 dispatch"])
     SKIP --> DISPATCH
 
-    style SKIP fill:#f3f4f6,stroke:#9ca3af
-    style BUMP fill:#dcfce7,stroke:#22c55e
 ```
 
 **关键点：**
@@ -888,9 +870,6 @@ flowchart TD
     CHECK2 -->|是| BSEARCH["二分搜索最大前缀<br/>找到最多 N 条 compact<br/>使总字符 ≤ max_chars"]
     BSEARCH --> OUT_TRUNC(["输出前 N 条 Compact<br/>+ ⚠️ truncated: N of M 提示"])
 
-    style OUT_FULL fill:#dcfce7,stroke:#22c55e
-    style OUT_COMPACT fill:#fef3c7,stroke:#f59e0b
-    style OUT_TRUNC fill:#fee2e2,stroke:#ef4444
 ```
 
 **路径不再注入：**`compact_path()` 辅助函数仍保留（日志 / 调试 / 测试用，标记 `#[allow(dead_code)]`），但 catalog 条目已改为 `- name: description`（full）或 `- name`（compact），不含 `(read: path)` 后缀。
@@ -911,10 +890,6 @@ flowchart LR
     F55 --> F6["8. max_count<br/>数量上限"]
     F6 --> OUT(["注入 Prompt"])
 
-    style ALL fill:#e0e7ff,stroke:#6366f1
-    style F0 fill:#fef3c7,stroke:#f59e0b
-    style F55 fill:#dcfce7,stroke:#22c55e
-    style OUT fill:#dcfce7,stroke:#22c55e
 ```
 
 **每层语义：**
@@ -1331,9 +1306,6 @@ graph TD
     DETAIL --> D5["文件列表"]
     DETAIL --> D6["SKILL.md 预览"]
 
-    style SP fill:#e0e7ff,stroke:#6366f1
-    style LIST fill:#dbeafe,stroke:#3b82f6
-    style DETAIL fill:#fef3c7,stroke:#f59e0b
 ```
 
 ### InstallSpecRow 组件

--- a/docs/architecture/tool-system.md
+++ b/docs/architecture/tool-system.md
@@ -318,12 +318,6 @@ flowchart TD
 
     FD --> Done([最终 tool_schemas → API 请求])
 
-    style Start fill:#cfe2ff,stroke:#0d6efd
-    style Branch fill:#fff3cd,stroke:#ffc107
-    style CondGroup fill:#fff3cd,stroke:#ffc107
-    style Filter fill:#fce4ec,stroke:#e91e63
-    style FD fill:#fce4ec,stroke:#e91e63
-    style Done fill:#d4edda,stroke:#28a745
 ```
 
 ### 三个易混淆的"开关"对比
@@ -406,13 +400,6 @@ flowchart TD
     Race -- 是 --> InlineResult[把真实结果作为 tool_result 返回]
     Race -- 否 --> AutoBgDetach[原地 detach 成 job<br/>返回 synthetic auto_backgrounded]
 
-    style Tier1 fill:#fff3cd,stroke:#ffc107
-    style Tier2 fill:#fff3cd,stroke:#ffc107
-    style Tier3 fill:#d4edda,stroke:#28a745
-    style ExplicitSpawn fill:#cfe2ff,stroke:#0d6efd
-    style AutoBgDetach fill:#cfe2ff,stroke:#0d6efd
-    style InlineResult fill:#d4edda,stroke:#28a745
-    style SyncPath fill:#e2e3e5,stroke:#6c757d
 ```
 
 | Tier | 触发 | 行为 |
@@ -602,11 +589,6 @@ flowchart LR
     T2 --> T3["Tier 3<br/>LLM 摘要<br/>调用模型压缩旧消息"]
     T3 --> T4["Tier 4<br/>紧急<br/>清除所有工具结果 + 只保留最近 N 轮"]
 
-    style T0 fill:#d4edda,stroke:#28a745
-    style T1 fill:#d4edda,stroke:#28a745
-    style T2 fill:#fff3cd,stroke:#ffc107
-    style T3 fill:#fce4ec,stroke:#e91e63
-    style T4 fill:#f8d7da,stroke:#dc3545
 ```
 
 ---
@@ -765,12 +747,6 @@ flowchart TD
     PathAllowed -- 是 --> Execute
     PathAllowed -- 否 --> PlanDenied[❌ Plan Mode restriction<br/>cannot modify file]
 
-    style DirectExec fill:#d4edda,stroke:#28a745
-    style Execute fill:#d4edda,stroke:#28a745
-    style Blocked fill:#e2e3e5,stroke:#6c757d
-    style Denied fill:#f8d7da,stroke:#dc3545
-    style PlanDenied fill:#f8d7da,stroke:#dc3545
-    style ShowApproval fill:#fff3cd,stroke:#ffc107
 ```
 
 ### 审批对话框交互
@@ -825,10 +801,6 @@ flowchart TD
     ExecChoice2 -- 始终允许 --> WriteExecAllowlist[写入 exec-approvals.json<br/><small>下次同命令自动放行</small>] --> ExecRun
     ExecChoice2 -- 拒绝 --> ExecDenied
 
-    style ExecRun fill:#d4edda,stroke:#28a745
-    style ExecDenied fill:#f8d7da,stroke:#dc3545
-    style ExecAsk fill:#fff3cd,stroke:#ffc107
-    style ExecAskAuto fill:#fff3cd,stroke:#ffc107
 ```
 
 **Allowlist 持久化文件**：`~/.hope-agent/exec-approvals.json`
@@ -981,10 +953,6 @@ block-beta
     L2 --> L3
     L3 --> L4
 
-    style L1 fill:#dc3545,color:#fff
-    style L2 fill:#fd7e14,color:#fff
-    style L3 fill:#ffc107,color:#000
-    style L4 fill:#28a745,color:#fff
 ```
 
 > **关键理解**：输入框的盾牌（ToolPermissionMode）是全局最高优先级开关，它能完全覆盖 Agent 设置中的 `require_approval` 配置。Agent 设置中的审批配置只在盾牌为 Auto（默认）时才参与决策。


### PR DESCRIPTION
去掉 docs/architecture/ 下 14 个文档中共 173 行 `style ... fill:` 声明， 让 mermaid 图表使用默认主题配色，提升可维护性和主题适配能力。