### PR TITLE
Add ExecToolResultCard and special-case UI for exec tool outputs

### DIFF
--- a/src/components/chat/message/ExecToolResultCard.tsx
+++ b/src/components/chat/message/ExecToolResultCard.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useMemo, useRef } from "react"
+import { useTranslation } from "react-i18next"
+import type { ToolCall } from "@/types/chat"
+
+function parseExecCommand(tool: ToolCall): string {
+  try {
+    const parsed = JSON.parse(tool.arguments) as { command?: string }
+    return parsed.command?.trim() || ""
+  } catch {
+    return ""
+  }
+}
+
+function getDisplayOutput(result: string | undefined): string | null {
+  if (!result) return null
+  const trimmed = result.trim()
+  if (trimmed === "Command completed with exit code 0") return null
+  return result
+}
+
+export default function ExecToolResultCard({ tool, isRunning }: { tool: ToolCall; isRunning: boolean }) {
+  const { t } = useTranslation()
+  const command = useMemo(() => parseExecCommand(tool), [tool])
+  const output = useMemo(() => getDisplayOutput(tool.result), [tool.result])
+  const outputRef = useRef<HTMLPreElement>(null)
+
+  useEffect(() => {
+    const el = outputRef.current
+    if (!el) return
+    el.scrollTop = el.scrollHeight
+  }, [output, isRunning])
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-secondary/40 px-3 py-2.5">
+      <div className="mb-2 text-[11px] font-semibold text-muted-foreground/80">
+        {t("tools.execPanel.title", "Shell")}
+      </div>
+      <pre className="whitespace-pre-wrap break-all text-foreground font-mono text-xs leading-relaxed">
+        $ {command}
+      </pre>
+      <div className="mt-2.5 border-t border-border/40 pt-2.5">
+        {output ? (
+          <pre
+            ref={outputRef}
+            className="whitespace-pre-wrap break-words text-muted-foreground/85 font-mono text-[11px] leading-relaxed max-h-64 overflow-y-auto"
+          >
+            {output}
+          </pre>
+        ) : isRunning ? (
+          <div className="text-[11px] text-muted-foreground/60">{t("tools.execPanel.running", "运行中...")}</div>
+        ) : (
+          <div className="text-[11px] text-muted-foreground/60">{t("tools.execPanel.noOutput", "无输出")}</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/message/ToolCallBlock.tsx
+++ b/src/components/chat/message/ToolCallBlock.tsx
@@ -41,6 +41,7 @@ import type { ToolCall } from "@/types/chat"
 import { IconTip } from "@/components/ui/tooltip"
 import SubagentBlock from "@/components/chat/SubagentBlock"
 import ToolMediaPreview from "@/components/chat/message/ToolMediaPreview"
+import ExecToolResultCard from "@/components/chat/message/ExecToolResultCard"
 import { getExecutionToolLabel, getToolExecutionState } from "./executionStatus"
 
 /** Map tool name → Lucide icon component */
@@ -337,7 +338,7 @@ export default function ToolCallBlock({ tool, shimmer }: { tool: ToolCall; shimm
     <div className="my-1 text-xs">
       <button
         className="flex items-center gap-1.5 w-full px-1 py-1 text-left hover:bg-secondary/60 rounded-md transition-colors group"
-        onClick={() => !isRunning && setExpanded(!expanded)}
+        onClick={() => (tool.name === "exec" || !isRunning) && setExpanded(!expanded)}
       >
         {isRunning ? (
           <span className="animate-spin h-3.5 w-3.5 border-[1.5px] border-current border-t-transparent rounded-full shrink-0 text-muted-foreground" />
@@ -467,13 +468,17 @@ export default function ToolCallBlock({ tool, shimmer }: { tool: ToolCall; shimm
       <div
         className={cn(
           "overflow-hidden transition-all duration-200 ease-out",
-          expanded && tool.result ? "max-h-[400px] opacity-100" : "max-h-0 opacity-0",
+          expanded && (tool.name === "exec" || tool.result) ? "max-h-[420px] opacity-100" : "max-h-0 opacity-0",
         )}
       >
         <div className="ml-5 mt-0.5 mb-1">
-          <pre className="whitespace-pre-wrap text-muted-foreground/80 bg-secondary/40 rounded-md p-2.5 max-h-64 overflow-y-auto text-[11px] leading-relaxed border border-border/50">
-            {tool.result}
-          </pre>
+          {tool.name === "exec" ? (
+            <ExecToolResultCard tool={tool} isRunning={isRunning} />
+          ) : (
+            <pre className="whitespace-pre-wrap text-muted-foreground/80 bg-secondary/40 rounded-md p-2.5 max-h-64 overflow-y-auto text-[11px] leading-relaxed border border-border/50">
+              {tool.result}
+            </pre>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/chat/message/ToolCallGroup.tsx
+++ b/src/components/chat/message/ToolCallGroup.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils"
 import type { ToolCall } from "@/types/chat"
 import { IconTip } from "@/components/ui/tooltip"
 import ToolMediaPreview from "@/components/chat/message/ToolMediaPreview"
+import ExecToolResultCard from "@/components/chat/message/ExecToolResultCard"
 import {
   getExecutionToolGroupLabel,
   getExecutionToolLabel,
@@ -137,7 +138,7 @@ function GroupItem({ tool }: { tool: ToolCall }) {
     <div className="text-[11px]">
       <button
         className="flex items-center gap-1.5 w-full px-1.5 py-0.5 text-left hover:bg-secondary/60 rounded transition-colors group/item"
-        onClick={() => !isRunning && tool.result && setShowResult(!showResult)}
+        onClick={() => (tool.name === "exec" || (!isRunning && tool.result)) && setShowResult(!showResult)}
       >
         {isRunning ? (
           <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0 text-muted-foreground/60" />
@@ -201,13 +202,17 @@ function GroupItem({ tool }: { tool: ToolCall }) {
       <div
         className={cn(
           "overflow-hidden transition-all duration-200 ease-out",
-          showResult && tool.result ? "max-h-[400px] opacity-100" : "max-h-0 opacity-0",
+          showResult && (tool.name === "exec" || tool.result) ? "max-h-[420px] opacity-100" : "max-h-0 opacity-0",
         )}
       >
         <div className="ml-4 mt-0.5 mb-1">
-          <pre className="whitespace-pre-wrap text-muted-foreground/70 bg-secondary/40 rounded-md p-2 max-h-56 overflow-y-auto text-[11px] leading-relaxed border border-border/40">
-            {tool.result}
-          </pre>
+          {tool.name === "exec" ? (
+            <ExecToolResultCard tool={tool} isRunning={isRunning} />
+          ) : (
+            <pre className="whitespace-pre-wrap text-muted-foreground/70 bg-secondary/40 rounded-md p-2 max-h-56 overflow-y-auto text-[11px] leading-relaxed border border-border/40">
+              {tool.result}
+            </pre>
+          )}
         </div>
       </div>
     </div>

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "عرض الاستدعاء الخام",
     "loadingSkill": "تحميل skill: {{name}}",
-    "elapsed": "المدة {{time}}"
+    "elapsed": "المدة {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "تم تصفح {{count}} ملفاً",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "View raw call",
     "loadingSkill": "Loading skill: {{name}}",
-    "elapsed": "Elapsed {{time}}"
+    "elapsed": "Elapsed {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "No output",
+      "running": "Running..."
+    }
   },
   "toolGroup": {
     "browse": "Browsed {{count}} files",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "Ver llamada en bruto",
     "loadingSkill": "Cargando skill: {{name}}",
-    "elapsed": "Transcurrido {{time}}"
+    "elapsed": "Transcurrido {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "{{count}} archivos explorados",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "生の呼び出しを表示",
     "loadingSkill": "スキルを読み込み中: {{name}}",
-    "elapsed": "経過時間 {{time}}"
+    "elapsed": "経過時間 {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "{{count}} 件のファイルを閲覧しました",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "원시 호출 보기",
     "loadingSkill": "스킬 로드 중: {{name}}",
-    "elapsed": "경과 {{time}}"
+    "elapsed": "경과 {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "{{count}} 개 파일 탐색",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "Lihat panggilan mentah",
     "loadingSkill": "Memuatkan skill: {{name}}",
-    "elapsed": "Berlalu {{time}}"
+    "elapsed": "Berlalu {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "Melayari {{count}} fail",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "Ver chamada bruta",
     "loadingSkill": "Carregando skill: {{name}}",
-    "elapsed": "Decorrido {{time}}"
+    "elapsed": "Decorrido {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "{{count}} arquivos navegados",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "Просмотреть исходный вызов",
     "loadingSkill": "Загрузка skill: {{name}}",
-    "elapsed": "Прошло {{time}}"
+    "elapsed": "Прошло {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "Просмотрено {{count}} файлов",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "Ham çağrıyı görüntüle",
     "loadingSkill": "Skill yükleniyor: {{name}}",
-    "elapsed": "Geçen süre {{time}}"
+    "elapsed": "Geçen süre {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "{{count}} dosya tarandı",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "Xem lệnh gọi gốc",
     "loadingSkill": "Đang tải skill: {{name}}",
-    "elapsed": "Đã trôi qua {{time}}"
+    "elapsed": "Đã trôi qua {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "Đã duyệt {{count}} tệp",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "查看原始調用",
     "loadingSkill": "加載技能: {{name}}",
-    "elapsed": "耗時 {{time}}"
+    "elapsed": "耗時 {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "已瀏覽 {{count}} 個文件",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -345,7 +345,12 @@
     },
     "rawCall": "查看原始调用",
     "loadingSkill": "加载技能: {{name}}",
-    "elapsed": "耗时 {{time}}"
+    "elapsed": "耗时 {{time}}",
+    "execPanel": {
+      "title": "Shell",
+      "noOutput": "无输出",
+      "running": "运行中..."
+    }
   },
   "toolGroup": {
     "browse": "已浏览 {{count}} 个文件",


### PR DESCRIPTION
### Motivation
- Provide a clearer UI for shell/exec tool calls by showing the executed command and formatted output while suppressing trivial success messages.

### Description
- Add `ExecToolResultCard.tsx` which parses `tool.arguments` for a `command`, displays the command and output, excludes the "Command completed with exit code 0" message, and auto-scrolls output; localized running/no-output strings are used via `useTranslation`.
- Update `ToolCallBlock.tsx` and `ToolCallGroup.tsx` to allow expanding `exec` tools while running, render `ExecToolResultCard` for `tool.name === "exec"`, and increase the result panel max height to accommodate the card.
- Add `execPanel` translation keys (`title`, `noOutput`, `running`) to multiple locale files to support the new UI strings.

### Testing
- Run TypeScript type check (`tsc`) and project build (`yarn build`) — succeeded.
- No automated unit tests were added for the new component in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab58f9b5c832192bf836652facd86)