### PR TITLE
Use non-technical project instructions example

### DIFF
--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "ما الذي يدور حوله هذا المشروع؟",
     "projectInstructions": "تعليمات المشروع",
     "projectInstructionsHint": "تُضاف هذه التعليمات تلقائيًا إلى مطالبة النظام لكل جلسة ضمن هذا المشروع.",
-    "projectInstructionsPlaceholder": "مثال: الرد دائمًا بالإنجليزية؛ المكدس هو Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "مثال: الرد دائمًا بالعربية؛ اجعل النبرة واضحة ولطيفة؛ ابدأ بالخلاصة",
     "projectEmoji": "Emoji",
     "projectLogo": "الشعار",
     "projectLogoHint": "اختياري. عند التعيين يحل محل أيقونة الإيموجي في الشريط الجانبي. يتم تغيير حجم الصور تلقائيًا إلى 256×256.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "What is this project about?",
     "projectInstructions": "Project Instructions",
     "projectInstructionsHint": "These instructions are automatically added to the system prompt of every session in this project.",
-    "projectInstructionsPlaceholder": "e.g. Always reply in English; the stack is Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "e.g. Always reply in English; keep the tone clear and friendly; start with the conclusion",
     "projectEmoji": "Emoji",
     "projectLogo": "Logo",
     "projectLogoHint": "Optional. When set, replaces the emoji icon in the sidebar. Images are auto-resized to 256×256.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "¿De qué trata este proyecto?",
     "projectInstructions": "Instrucciones del proyecto",
     "projectInstructionsHint": "Estas instrucciones se añaden automáticamente al prompt de sistema de cada sesión de este proyecto.",
-    "projectInstructionsPlaceholder": "p. ej. Responde siempre en español; el stack es Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "p. ej. Responde siempre en español; usa un tono claro y amable; empieza por la conclusión",
     "projectEmoji": "Emoji",
     "projectLogo": "Logo",
     "projectLogoHint": "Opcional. Si se define, reemplaza el icono emoji en la barra lateral. Las imágenes se redimensionan automáticamente a 256×256.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "このプロジェクトの概要は？",
     "projectInstructions": "プロジェクト指示",
     "projectInstructionsHint": "この指示はこのプロジェクト内の全セッションのシステムプロンプトに自動的に追加されます。",
-    "projectInstructionsPlaceholder": "例：常に日本語で返答する。スタックは Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "例：常に日本語で返答する。明るく親しみやすい口調にし、最初に結論を述べる",
     "projectEmoji": "絵文字",
     "projectLogo": "ロゴ",
     "projectLogoHint": "任意。設定するとサイドバーの絵文字アイコンの代わりに表示。画像は 256×256 に自動リサイズされます。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "이 프로젝트는 무엇에 관한 것인가요?",
     "projectInstructions": "프로젝트 지침",
     "projectInstructionsHint": "이 지침은 이 프로젝트의 모든 세션 시스템 프롬프트에 자동으로 추가됩니다.",
-    "projectInstructionsPlaceholder": "예: 항상 한국어로 응답; 스택은 Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "예: 항상 한국어로 응답; 명확하고 친근한 톤 유지; 결론부터 말하기",
     "projectEmoji": "이모지",
     "projectLogo": "로고",
     "projectLogoHint": "선택. 설정 시 사이드바의 이모지 아이콘을 대체합니다. 이미지는 자동으로 256×256으로 조정됩니다.",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "Projek ini mengenai apa?",
     "projectInstructions": "Arahan projek",
     "projectInstructionsHint": "Arahan ini akan ditambah automatik ke prompt sistem setiap sesi projek ini.",
-    "projectInstructionsPlaceholder": "cth. Sentiasa balas dalam BM; stack ialah Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "cth. Sentiasa balas dalam BM; gunakan nada jelas dan mesra; mulakan dengan kesimpulan",
     "projectEmoji": "Emoji",
     "projectLogo": "Logo",
     "projectLogoHint": "Pilihan. Jika ditetapkan, ia menggantikan ikon emoji di bar sisi. Imej akan diubah saiz secara automatik kepada 256×256.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "Sobre o que é este projeto?",
     "projectInstructions": "Instruções do projeto",
     "projectInstructionsHint": "Essas instruções são adicionadas automaticamente ao prompt de sistema de cada sessão deste projeto.",
-    "projectInstructionsPlaceholder": "ex. Sempre responder em português; stack é Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "ex. Sempre responder em português; usar um tom claro e amigável; começar pela conclusão",
     "projectEmoji": "Emoji",
     "projectLogo": "Logo",
     "projectLogoHint": "Opcional. Quando definido, substitui o ícone emoji na barra lateral. Imagens são redimensionadas automaticamente para 256×256.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "О чём этот проект?",
     "projectInstructions": "Инструкции проекта",
     "projectInstructionsHint": "Эти инструкции автоматически добавляются в системный промпт каждой сессии этого проекта.",
-    "projectInstructionsPlaceholder": "напр. Всегда отвечай на русском; стек — Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "напр. Всегда отвечай на русском; сохраняй ясный и дружелюбный тон; начинай с вывода",
     "projectEmoji": "Эмодзи",
     "projectLogo": "Логотип",
     "projectLogoHint": "Необязательно. При установке заменяет эмодзи-иконку в боковой панели. Изображения автоматически масштабируются до 256×256.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "Bu proje ne hakkında?",
     "projectInstructions": "Proje talimatları",
     "projectInstructionsHint": "Bu talimatlar, bu projedeki her oturumun sistem istemine otomatik olarak eklenir.",
-    "projectInstructionsPlaceholder": "örn. Her zaman Türkçe yanıtla; yığın Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "örn. Her zaman Türkçe yanıtla; tonu açık ve samimi tut; sonuca önce başla",
     "projectEmoji": "Emoji",
     "projectLogo": "Logo",
     "projectLogoHint": "İsteğe bağlı. Ayarlandığında kenar çubuğundaki emoji simgesinin yerine geçer. Görüntüler otomatik olarak 256×256 boyutuna getirilir.",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "Dự án này về việc gì?",
     "projectInstructions": "Chỉ dẫn dự án",
     "projectInstructionsHint": "Các chỉ dẫn này tự động được thêm vào system prompt của mọi phiên trong dự án này.",
-    "projectInstructionsPlaceholder": "vd. Luôn trả lời bằng tiếng Việt; stack là Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "vd. Luôn trả lời bằng tiếng Việt; giữ giọng rõ ràng và thân thiện; bắt đầu bằng kết luận",
     "projectEmoji": "Emoji",
     "projectLogo": "Logo",
     "projectLogoHint": "Tùy chọn. Khi đặt, sẽ thay thế biểu tượng emoji ở thanh bên. Ảnh tự động được thu về 256×256.",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "這個專案是做什麼的？",
     "projectInstructions": "專案指令",
     "projectInstructionsHint": "這些指令會自動加入此專案所有對話的系統提示詞",
-    "projectInstructionsPlaceholder": "例如：始終用繁體中文回覆；技術棧為 Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "例如：始終用繁體中文回覆；語氣清楚親切；先給結論再補充細節",
     "projectEmoji": "Emoji",
     "projectLogo": "Logo",
     "projectLogoHint": "可選。設定後會取代側邊欄的 Emoji 圖示。圖片會自動縮放為 256×256。",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -35,7 +35,7 @@
     "projectDescriptionPlaceholder": "这个项目是做什么的？",
     "projectInstructions": "项目指令",
     "projectInstructionsHint": "这些指令会自动加入该项目所有会话的系统提示词",
-    "projectInstructionsPlaceholder": "例如：始终用中文回复；技术栈是 Tauri 2 + React 19",
+    "projectInstructionsPlaceholder": "例如：始终用中文回复；语气清楚亲切；先给结论再补充细节",
     "projectEmoji": "Emoji",
     "projectLogo": "Logo",
     "projectLogoHint": "可选。设置后会替代侧边栏的 Emoji 图标显示。图片会自动压缩到 256×256。",

--- a/src/i18n/projectInstructionsPlaceholder.test.ts
+++ b/src/i18n/projectInstructionsPlaceholder.test.ts
@@ -1,0 +1,42 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict"
+import { readFileSync, readdirSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { test } from "node:test"
+import { fileURLToPath } from "node:url"
+
+const localesDir = join(dirname(fileURLToPath(import.meta.url)), "locales")
+
+const expectedPlaceholders: Record<string, string> = {
+  "ar.json": "مثال: الرد دائمًا بالعربية؛ اجعل النبرة واضحة ولطيفة؛ ابدأ بالخلاصة",
+  "en.json": "e.g. Always reply in English; keep the tone clear and friendly; start with the conclusion",
+  "es.json": "p. ej. Responde siempre en español; usa un tono claro y amable; empieza por la conclusión",
+  "ja.json": "例：常に日本語で返答する。明るく親しみやすい口調にし、最初に結論を述べる",
+  "ko.json": "예: 항상 한국어로 응답; 명확하고 친근한 톤 유지; 결론부터 말하기",
+  "ms.json": "cth. Sentiasa balas dalam BM; gunakan nada jelas dan mesra; mulakan dengan kesimpulan",
+  "pt.json": "ex. Sempre responder em português; usar um tom claro e amigável; começar pela conclusão",
+  "ru.json": "напр. Всегда отвечай на русском; сохраняй ясный и дружелюбный тон; начинай с вывода",
+  "tr.json": "örn. Her zaman Türkçe yanıtla; tonu açık ve samimi tut; sonuca önce başla",
+  "vi.json": "vd. Luôn trả lời bằng tiếng Việt; giữ giọng rõ ràng và thân thiện; bắt đầu bằng kết luận",
+  "zh-TW.json": "例如：始終用繁體中文回覆；語氣清楚親切；先給結論再補充細節",
+  "zh.json": "例如：始终用中文回复；语气清楚亲切；先给结论再补充细节",
+}
+
+test("project instruction placeholders use non-technical examples in every locale", () => {
+  const localeFiles = readdirSync(localesDir)
+    .filter((file) => file.endsWith(".json"))
+    .sort()
+
+  assert.deepEqual(Object.keys(expectedPlaceholders).sort(), localeFiles)
+
+  for (const file of localeFiles) {
+    const locale = JSON.parse(readFileSync(join(localesDir, file), "utf8")) as {
+      project?: { projectInstructionsPlaceholder?: string }
+    }
+    const placeholder = locale.project?.projectInstructionsPlaceholder
+
+    assert.equal(placeholder, expectedPlaceholders[file], file)
+    assert.doesNotMatch(placeholder ?? "", /Tauri|React|stack|技术栈|技術棧/i, file)
+  }
+})


### PR DESCRIPTION
## Summary
- Replace project instructions placeholders with non-technical examples across all locales.
- Add a regression test to keep the placeholder free of technical stack wording.

## Test Plan
- [x] cargo fmt --all --check
- [x] cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings
- [x] cargo test -p ha-core -p ha-server --locked
- [x] pnpm tsc --noEmit
- [x] pnpm lint
- [x] pnpm i18n:check
- [x] node --test --experimental-strip-types src/components/chat/cacheUsageDisplay.test.ts src/components/settings/openSettingsEvent.test.ts src/i18n/projectInstructionsPlaceholder.test.ts