### PR TITLE
ci: disable pretty tsc build output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ pnpm dev               # 仅前端 Vite 开发服务器
 pnpm tauri build       # 构建生产包
 pnpm sync:version      # 以 package.json 为单一来源，同步 src-tauri 版本号
 pnpm release:verify    # 校验 package.json / src-tauri 版本一致；可附 -- --tag vX.Y.Z
-pnpm typecheck         # 前端类型检查（tsc -b）
+pnpm typecheck         # 前端类型检查（tsc -b --pretty false）
 pnpm lint              # Lint
 node scripts/sync-i18n.mjs --check   # 检查各语言翻译缺失
 node scripts/sync-i18n.mjs --apply   # 从翻译文件补齐缺失翻译
@@ -31,7 +31,7 @@ hope-agent server stop               # 停止服务
 cargo fmt --all --check                                                    # 对应 CI: rust.yml fmt job
 cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings # 对应 CI: rust.yml clippy job
 cargo test  -p ha-core -p ha-server --locked                               # 对应 CI: rust.yml test job
-pnpm typecheck                                                              # 对应 CI: lint.yml 前端类型（tsc -b）
+pnpm typecheck                                                              # 对应 CI: lint.yml 前端类型（tsc -b --pretty false）
 pnpm lint                                                                    # 对应 CI: lint.yml ESLint
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -104,7 +104,7 @@ pnpm install
 pnpm tauri dev         # desktop dev (frontend + Rust hot reload)
 
 # Other useful commands
-pnpm typecheck         # frontend typecheck (tsc -b)
+pnpm typecheck         # frontend typecheck (tsc -b --pretty false)
 pnpm lint              # lint
 pnpm tauri build       # production build
 ```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ pnpm install
 pnpm tauri dev         # 桌面开发模式（前端 + Rust 热重载）
 
 # 其他常用命令
-pnpm typecheck         # 前端类型检查（tsc -b）
+pnpm typecheck         # 前端类型检查（tsc -b --pretty false）
 pnpm lint              # Lint
 pnpm tauri build       # 打生产包
 ```

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "packageManager": "pnpm@10.33.1+sha512.05ba3c1d5d1c18f68df06470d74055e62d41fc110a0c660db1b2dfb2785327f04cf0f68345d4609bc52089e7fa0343c31593b2f9594e2c5d5da426230acc9820",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
-    "typecheck": "tsc -b",
+    "build": "tsc -b --pretty false && vite build",
+    "typecheck": "tsc -b --pretty false",
     "lint": "eslint .",
     "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx,json,css}'",
     "i18n:check": "node scripts/sync-i18n.mjs --check",


### PR DESCRIPTION
## Summary
- Add `--pretty false` to the TypeScript build gate used by `pnpm build`.
- Add `--pretty false` to `pnpm typecheck` so CI/local compiler output is non-ANSI and easier to parse.
- Update project docs to reflect the exact typecheck command.

## Stack
- Stacked on PR #70 (`ci/use-tsc-build-gate`) because this adjusts the `tsc -b` command introduced there.

## Test Plan
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `.husky/pre-push`
- [x] Push pre-push hook completed successfully
