### PR TITLE
refactor(commands): unify Tauri command error type as CmdError (F-001)

### DIFF
--- a/docs/plans/review-followups.md
+++ b/docs/plans/review-followups.md
@@ -30,22 +30,6 @@
 
 ## Open
 
-### F-001 Tauri 命令错误类型未统一
-
-- **来源**：2026-04-26 本地小模型助手 `/simplify` review
-- **现象**：所有 Tauri 命令返回 `Result<T, String>`，每条命令尾巴都重复一行 `.map_err(|e| e.to_string())` 把 `anyhow::Error` 降成 `String`。`#[tauri::command]` 要求返回值实现 `Serialize`，`anyhow::Error` 不实现，所以不能直接 `?`。
-- **为什么留**：ha-server 那边已经有等价的 [`AppError`](../../crates/ha-server/src/error.rs) + `impl<E> From<E> for AppError where E: Into<anyhow::Error>` 让 `?` 直接 work；Tauri 这边没有，统一要动几百条命令的签名 + `invoke_handler!` 注册。属于独立"统一错误类型"重构 PR 的范畴，本期不在 scope。
-- **改的话要做什么**：
-  1. 在 [`src-tauri/src/commands/mod.rs`](../../src-tauri/src/commands/mod.rs) 引入 `pub struct CmdError(pub String);`
-  2. 给 `CmdError` 加 `impl<E> From<E> for CmdError where E: Into<anyhow::Error>`
-  3. 给 `CmdError` 加 `impl Serialize`（serialize 成纯字符串，与 `Result<T, String>` 在 IPC wire 上等价，前端零迁移）
-  4. 把 [`src-tauri/src/lib.rs`](../../src-tauri/src/lib.rs) 注册的所有命令的返回类型从 `Result<T, String>` 换成 `Result<T, CmdError>`
-  5. 删掉所有 `.map_err(|e| e.to_string())`、`.map_err(|e| format!("..."))`，改用 `?`
-- **影响面**：纯代码整洁度，无功能 bug、无性能影响。
-- **触发时机建议**："Tauri 命令错误类型统一" 独立 PR；或当某条命令需要返回结构化错误（带 code / category）时连带做。
-
----
-
 ### F-002 Provider 写入路径未单一化（add_provider 缺 upsert 语义）
 
 - **来源**：2026-04-26 本地小模型助手 `/simplify` review
@@ -118,4 +102,8 @@
 
 > 已修复条目移到此处，附 commit hash + 关闭日期。保留以便后续 grep。
 
-_(暂无)_
+### F-001 Tauri 命令错误类型未统一
+
+- **来源**：2026-04-26 本地小模型助手 `/simplify` review
+- **关闭**：2026-04-26 / branch `worktree-tauri-cmd-error-unify`
+- **修复方式**：新增 [`src-tauri/src/commands/error.rs`](../../src-tauri/src/commands/error.rs) 定义 `CmdError(pub String)`，挂 `impl<E: Into<anyhow::Error>> From<E>` + `impl Serialize`（输出纯字符串，IPC wire 与原 `Result<T, String>` 等价）；把 `src-tauri/src/commands/` 下 31 个文件的命令签名统一改成 `Result<T, CmdError>`，291 处 `.map_err(|e| e.to_string())?` 删成 `?`，剩余 `.map_err(|e| format!(...))` 改为 `CmdError::msg(format!(...))`，`Err("..".to_string())` / `.ok_or_else(|| "..".to_string())` 等串字面量误差类全部走 `CmdError::msg(..)`。`tauri_wrappers.rs` 不属于"命令尾巴 boilerplate"范畴，保持 `Result<T, String>` 不动。前端零变化。

--- a/src-tauri/src/commands/acp_control.rs
+++ b/src-tauri/src/commands/acp_control.rs
@@ -2,11 +2,12 @@
 
 use crate::acp_control::config::AcpControlConfig;
 use crate::acp_control::types::{AcpBackendInfo, AcpRun};
+use crate::commands::CmdError;
 
 /// List all registered ACP backends with their health status.
 #[tauri::command]
-pub async fn acp_list_backends() -> Result<Vec<AcpBackendInfo>, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn acp_list_backends() -> Result<Vec<AcpBackendInfo>, CmdError> {
+    let store = ha_core::config::load_config()?;
     if !store.acp_control.enabled {
         return Ok(Vec::new());
     }
@@ -48,16 +49,16 @@ pub async fn acp_list_backends() -> Result<Vec<AcpBackendInfo>, String> {
 
 /// Run health checks on all backends.
 #[tauri::command]
-pub async fn acp_health_check() -> Result<Vec<AcpBackendInfo>, String> {
+pub async fn acp_health_check() -> Result<Vec<AcpBackendInfo>, CmdError> {
     acp_list_backends().await
 }
 
 /// Refresh backend discovery (re-scan $PATH).
 #[tauri::command]
-pub async fn acp_refresh_backends() -> Result<(), String> {
+pub async fn acp_refresh_backends() -> Result<(), CmdError> {
     // Re-discovery happens via registry if manager is initialized
     if let Some(manager) = crate::get_acp_manager() {
-        let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+        let store = ha_core::config::load_config()?;
         let registry = std::sync::Arc::new(crate::acp_control::AcpRuntimeRegistry::new());
         crate::acp_control::registry::auto_discover_and_register(&registry, &store.acp_control)
             .await;
@@ -68,13 +69,13 @@ pub async fn acp_refresh_backends() -> Result<(), String> {
 
 /// List ACP runs for a parent session.
 #[tauri::command]
-pub async fn acp_list_runs(parent_session_id: Option<String>) -> Result<Vec<AcpRun>, String> {
+pub async fn acp_list_runs(parent_session_id: Option<String>) -> Result<Vec<AcpRun>, CmdError> {
     if let Some(manager) = crate::get_acp_manager() {
         Ok(manager.list_runs(parent_session_id.as_deref()).await)
     } else if let Some(db) = crate::get_session_db() {
         // Fallback to DB
         if let Some(pid) = parent_session_id {
-            db.list_acp_runs(&pid).map_err(|e| e.to_string())
+            db.list_acp_runs(&pid).map_err(Into::into)
         } else {
             Ok(Vec::new())
         }
@@ -85,31 +86,33 @@ pub async fn acp_list_runs(parent_session_id: Option<String>) -> Result<Vec<AcpR
 
 /// Kill a specific ACP run.
 #[tauri::command]
-pub async fn acp_kill_run(run_id: String) -> Result<(), String> {
-    let manager = crate::get_acp_manager().ok_or("ACP control plane not initialized")?;
-    manager.kill_run(&run_id).await.map_err(|e| e.to_string())
+pub async fn acp_kill_run(run_id: String) -> Result<(), CmdError> {
+    let manager = crate::get_acp_manager()
+        .ok_or_else(|| CmdError::msg("ACP control plane not initialized"))?;
+    manager.kill_run(&run_id).await.map_err(Into::into)
 }
 
 /// Get the full result of an ACP run.
 #[tauri::command]
-pub async fn acp_get_run_result(run_id: String) -> Result<String, String> {
-    let manager = crate::get_acp_manager().ok_or("ACP control plane not initialized")?;
-    manager.get_result(&run_id).await.map_err(|e| e.to_string())
+pub async fn acp_get_run_result(run_id: String) -> Result<String, CmdError> {
+    let manager = crate::get_acp_manager()
+        .ok_or_else(|| CmdError::msg("ACP control plane not initialized"))?;
+    manager.get_result(&run_id).await.map_err(Into::into)
 }
 
 /// Get ACP control config.
 #[tauri::command]
-pub async fn acp_get_config() -> Result<AcpControlConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn acp_get_config() -> Result<AcpControlConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.acp_control)
 }
 
 /// Save ACP control config.
 #[tauri::command]
-pub async fn acp_set_config(config: AcpControlConfig) -> Result<(), String> {
+pub async fn acp_set_config(config: AcpControlConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("acp_control", "settings-ui"), |store| {
         store.acp_control = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }

--- a/src-tauri/src/commands/agent_mgmt.rs
+++ b/src-tauri/src/commands/agent_mgmt.rs
@@ -1,30 +1,31 @@
 use crate::agent_config;
 use crate::agent_loader;
+use crate::commands::CmdError;
 use ha_core::openclaw_import;
 use serde_json::json;
 
 #[tauri::command]
-pub async fn list_agents() -> Result<Vec<agent_config::AgentSummary>, String> {
-    agent_loader::list_agents().map_err(|e| e.to_string())
+pub async fn list_agents() -> Result<Vec<agent_config::AgentSummary>, CmdError> {
+    agent_loader::list_agents().map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_agent_config(id: String) -> Result<agent_config::AgentConfig, String> {
-    let def = agent_loader::load_agent(&id).map_err(|e| e.to_string())?;
+pub async fn get_agent_config(id: String) -> Result<agent_config::AgentConfig, CmdError> {
+    let def = agent_loader::load_agent(&id)?;
     Ok(def.config)
 }
 
 #[tauri::command]
-pub async fn get_agent_markdown(id: String, file: String) -> Result<Option<String>, String> {
-    agent_loader::get_agent_markdown(&id, &file).map_err(|e| e.to_string())
+pub async fn get_agent_markdown(id: String, file: String) -> Result<Option<String>, CmdError> {
+    agent_loader::get_agent_markdown(&id, &file).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn save_agent_config_cmd(
     id: String,
     config: agent_config::AgentConfig,
-) -> Result<(), String> {
-    agent_loader::save_agent_config(&id, &config).map_err(|e| e.to_string())?;
+) -> Result<(), CmdError> {
+    agent_loader::save_agent_config(&id, &config)?;
     if let Some(bus) = ha_core::get_event_bus() {
         bus.emit("agents:changed", json!({ "id": id, "kind": "saved" }));
     }
@@ -32,13 +33,17 @@ pub async fn save_agent_config_cmd(
 }
 
 #[tauri::command]
-pub async fn save_agent_markdown(id: String, file: String, content: String) -> Result<(), String> {
-    agent_loader::save_agent_markdown(&id, &file, &content).map_err(|e| e.to_string())
+pub async fn save_agent_markdown(
+    id: String,
+    file: String,
+    content: String,
+) -> Result<(), CmdError> {
+    agent_loader::save_agent_markdown(&id, &file, &content).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn delete_agent(id: String) -> Result<(), String> {
-    agent_loader::delete_agent(&id).map_err(|e| e.to_string())?;
+pub async fn delete_agent(id: String) -> Result<(), CmdError> {
+    agent_loader::delete_agent(&id)?;
     if let Some(bus) = ha_core::get_event_bus() {
         bus.emit("agents:changed", json!({ "id": id, "kind": "deleted" }));
     }
@@ -46,38 +51,39 @@ pub async fn delete_agent(id: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub async fn render_persona_to_soul_md(id: String) -> Result<String, String> {
-    agent_loader::render_persona_to_soul_md(&id).map_err(|e| e.to_string())
+pub async fn render_persona_to_soul_md(id: String) -> Result<String, CmdError> {
+    agent_loader::render_persona_to_soul_md(&id).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_agent_template(name: String, locale: String) -> Result<String, String> {
+pub async fn get_agent_template(name: String, locale: String) -> Result<String, CmdError> {
     agent_loader::get_template(&name, &locale)
-        .ok_or_else(|| format!("Template not found: {}", name))
+        .ok_or_else(|| CmdError::msg(format!("Template not found: {}", name)))
 }
 
 #[tauri::command]
-pub async fn scan_openclaw_agents() -> Result<Vec<openclaw_import::OpenClawAgentPreview>, String> {
-    openclaw_import::scan_openclaw_agents().map_err(|e| e.to_string())
+pub async fn scan_openclaw_agents() -> Result<Vec<openclaw_import::OpenClawAgentPreview>, CmdError>
+{
+    openclaw_import::scan_openclaw_agents().map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn import_openclaw_agents(
     requests: Vec<openclaw_import::ImportAgentRequest>,
-) -> Result<Vec<openclaw_import::ImportResult>, String> {
-    openclaw_import::import_openclaw_agents(&requests).map_err(|e| e.to_string())
+) -> Result<Vec<openclaw_import::ImportResult>, CmdError> {
+    openclaw_import::import_openclaw_agents(&requests).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn scan_openclaw_full() -> Result<openclaw_import::OpenClawImportPreview, String> {
-    openclaw_import::scan_openclaw_full().map_err(|e| e.to_string())
+pub async fn scan_openclaw_full() -> Result<openclaw_import::OpenClawImportPreview, CmdError> {
+    openclaw_import::scan_openclaw_full().map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn import_openclaw_full(
     request: openclaw_import::OpenClawImportRequest,
-) -> Result<openclaw_import::OpenClawImportSummary, String> {
-    let summary = openclaw_import::import_openclaw_full(&request).map_err(|e| e.to_string())?;
+) -> Result<openclaw_import::OpenClawImportSummary, CmdError> {
+    let summary = openclaw_import::import_openclaw_full(&request)?;
     if let Some(bus) = ha_core::get_event_bus() {
         let imported_count = summary.agents.iter().filter(|r| r.success).count();
         if imported_count > 0 {

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1,4 +1,5 @@
 use crate::agent::{self, AssistantAgent};
+use crate::commands::CmdError;
 use crate::oauth;
 use crate::provider::{self, ActiveModel, ApiType, ProviderConfig};
 use crate::AppState;
@@ -7,7 +8,7 @@ use serde::Serialize;
 use tauri::State;
 
 #[tauri::command]
-pub async fn initialize_agent(api_key: String, state: State<'_, AppState>) -> Result<(), String> {
+pub async fn initialize_agent(api_key: String, state: State<'_, AppState>) -> Result<(), CmdError> {
     let provider = ProviderConfig::new_default_anthropic(api_key);
     let provider_id = provider.id.clone();
     let model_id = provider.models[0].id.clone();
@@ -20,8 +21,7 @@ pub async fn initialize_agent(api_key: String, state: State<'_, AppState>) -> Re
             model_id,
         });
         Ok(())
-    })
-    .map_err(|e| e.to_string())?;
+    })?;
     *state.agent.lock().await = Some(agent);
     Ok(())
 }
@@ -29,7 +29,7 @@ pub async fn initialize_agent(api_key: String, state: State<'_, AppState>) -> Re
 // ── Codex OAuth Auth ──────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn start_codex_auth(state: State<'_, AppState>) -> Result<(), String> {
+pub async fn start_codex_auth(state: State<'_, AppState>) -> Result<(), CmdError> {
     {
         let mut lock = state.auth_result.lock().await;
         *lock = None;
@@ -37,11 +37,11 @@ pub async fn start_codex_auth(state: State<'_, AppState>) -> Result<(), String> 
     let auth_result = state.auth_result.clone();
     oauth::start_oauth_flow(auth_result)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn check_auth_status(state: State<'_, AppState>) -> Result<oauth::AuthStatus, String> {
+pub async fn check_auth_status(state: State<'_, AppState>) -> Result<oauth::AuthStatus, CmdError> {
     let lock = state.auth_result.lock().await;
     match lock.as_ref() {
         None => Ok(oauth::AuthStatus {
@@ -60,13 +60,13 @@ pub async fn check_auth_status(state: State<'_, AppState>) -> Result<oauth::Auth
 }
 
 #[tauri::command]
-pub async fn finalize_codex_auth(state: State<'_, AppState>) -> Result<(), String> {
+pub async fn finalize_codex_auth(state: State<'_, AppState>) -> Result<(), CmdError> {
     let token = {
         let mut lock = state.auth_result.lock().await;
         match lock.take() {
             Some(Ok(token)) => token,
-            Some(Err(e)) => return Err(e.to_string()),
-            None => return Err("Auth not complete yet".to_string()),
+            Some(Err(e)) => return Err(e.into()),
+            None => return Err(CmdError::msg("Auth not complete yet")),
         }
     };
 
@@ -74,7 +74,7 @@ pub async fn finalize_codex_auth(state: State<'_, AppState>) -> Result<(), Strin
         .account_id
         .clone()
         .or_else(|| oauth::extract_account_id(&token.access_token))
-        .ok_or_else(|| "Failed to extract account ID from token".to_string())?;
+        .ok_or_else(|| CmdError::msg("Failed to extract account ID from token"))?;
 
     // Ensure Codex provider exists in store
     let default_model_id = "gpt-5.4".to_string();
@@ -86,8 +86,7 @@ pub async fn finalize_codex_auth(state: State<'_, AppState>) -> Result<(), Strin
             model_id: model_for_agent.clone(),
         });
         Ok(())
-    })
-    .map_err(|e| e.to_string())?;
+    })?;
 
     let agent = AssistantAgent::new_openai(&token.access_token, &account_id, &default_model_id);
     *state.agent.lock().await = Some(agent);
@@ -96,7 +95,7 @@ pub async fn finalize_codex_auth(state: State<'_, AppState>) -> Result<(), Strin
 }
 
 #[tauri::command]
-pub async fn try_restore_session(state: State<'_, AppState>) -> Result<bool, String> {
+pub async fn try_restore_session(state: State<'_, AppState>) -> Result<bool, CmdError> {
     // Try to restore Codex OAuth session
     match oauth::load_token() {
         Ok(Some(mut token)) => {
@@ -153,8 +152,7 @@ pub async fn try_restore_session(state: State<'_, AppState>) -> Result<bool, Str
                             });
                         }
                         Ok(())
-                    })
-                    .map_err(|e| e.to_string())?;
+                    })?;
 
                     // Create agent based on the active model's provider type
                     {
@@ -225,7 +223,7 @@ pub(crate) async fn try_restore_non_codex_session(state: &State<'_, AppState>) -
 }
 
 #[tauri::command]
-pub async fn logout_codex(state: State<'_, AppState>) -> Result<(), String> {
+pub async fn logout_codex(state: State<'_, AppState>) -> Result<(), CmdError> {
     *state.agent.lock().await = None;
     *state.codex_token.lock().await = None;
 
@@ -239,10 +237,9 @@ pub async fn logout_codex(state: State<'_, AppState>) -> Result<(), String> {
             }
         }
         Ok(())
-    })
-    .map_err(|e| e.to_string())?;
+    })?;
 
-    oauth::clear_token().map_err(|e| e.to_string())?;
+    oauth::clear_token()?;
     Ok(())
 }
 
@@ -255,12 +252,12 @@ pub struct CurrentSettings {
 }
 
 #[tauri::command]
-pub async fn get_codex_models() -> Result<Vec<agent::CodexModel>, String> {
+pub async fn get_codex_models() -> Result<Vec<agent::CodexModel>, CmdError> {
     Ok(agent::get_codex_models())
 }
 
 #[tauri::command]
-pub async fn get_current_settings(state: State<'_, AppState>) -> Result<CurrentSettings, String> {
+pub async fn get_current_settings(state: State<'_, AppState>) -> Result<CurrentSettings, CmdError> {
     let model = ha_core::config::cached_config()
         .active_model
         .as_ref()
@@ -274,9 +271,9 @@ pub async fn get_current_settings(state: State<'_, AppState>) -> Result<CurrentS
 }
 
 #[tauri::command]
-pub async fn set_codex_model(model: String, state: State<'_, AppState>) -> Result<(), String> {
+pub async fn set_codex_model(model: String, state: State<'_, AppState>) -> Result<(), CmdError> {
     if !agent::is_valid_codex_model(&model) {
-        return Err(format!("Unknown model: {}", model));
+        return Err(CmdError::msg(format!("Unknown model: {}", model)));
     }
 
     // Update active model in store
@@ -286,8 +283,7 @@ pub async fn set_codex_model(model: String, state: State<'_, AppState>) -> Resul
             active.model_id = model_for_mut;
         }
         Ok(())
-    })
-    .map_err(|e| e.to_string())?;
+    })?;
 
     // Rebuild agent with new model if authenticated
     let token_info = state.codex_token.lock().await.clone();
@@ -304,13 +300,13 @@ pub async fn set_codex_model(model: String, state: State<'_, AppState>) -> Resul
 pub(crate) async fn set_reasoning_effort_core(
     effort: &str,
     state: &AppState,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     let valid = ["none", "low", "medium", "high", "xhigh"];
     if !valid.contains(&effort) {
-        return Err(format!(
+        return Err(CmdError::msg(format!(
             "Invalid reasoning effort: {}. Valid: {:?}",
             effort, valid
-        ));
+        )));
     }
     *state.reasoning_effort.lock().await = effort.to_string();
     Ok(())
@@ -320,6 +316,6 @@ pub(crate) async fn set_reasoning_effort_core(
 pub async fn set_reasoning_effort(
     effort: String,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     set_reasoning_effort_core(&effort, &state).await
 }

--- a/src-tauri/src/commands/browser.rs
+++ b/src-tauri/src/commands/browser.rs
@@ -1,44 +1,41 @@
 use crate::browser_ui;
+use crate::commands::CmdError;
 
 #[tauri::command]
-pub async fn browser_get_status() -> Result<browser_ui::BrowserStatus, String> {
-    browser_ui::get_status().await.map_err(|e| e.to_string())
+pub async fn browser_get_status() -> Result<browser_ui::BrowserStatus, CmdError> {
+    browser_ui::get_status().await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn browser_list_profiles() -> Result<Vec<browser_ui::BrowserProfileInfo>, String> {
-    browser_ui::list_profiles().await.map_err(|e| e.to_string())
+pub async fn browser_list_profiles() -> Result<Vec<browser_ui::BrowserProfileInfo>, CmdError> {
+    browser_ui::list_profiles().await.map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn browser_create_profile(
     name: String,
-) -> Result<browser_ui::BrowserProfileInfo, String> {
-    browser_ui::create_profile(&name)
-        .await
-        .map_err(|e| e.to_string())
+) -> Result<browser_ui::BrowserProfileInfo, CmdError> {
+    browser_ui::create_profile(&name).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn browser_delete_profile(name: String) -> Result<(), String> {
-    browser_ui::delete_profile(&name)
-        .await
-        .map_err(|e| e.to_string())
+pub async fn browser_delete_profile(name: String) -> Result<(), CmdError> {
+    browser_ui::delete_profile(&name).await.map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn browser_launch(
     options: browser_ui::LaunchOptions,
-) -> Result<browser_ui::BrowserStatus, String> {
-    browser_ui::launch(options).await.map_err(|e| e.to_string())
+) -> Result<browser_ui::BrowserStatus, CmdError> {
+    browser_ui::launch(options).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn browser_connect(url: String) -> Result<browser_ui::BrowserStatus, String> {
-    browser_ui::connect(&url).await.map_err(|e| e.to_string())
+pub async fn browser_connect(url: String) -> Result<browser_ui::BrowserStatus, CmdError> {
+    browser_ui::connect(&url).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn browser_disconnect() -> Result<browser_ui::BrowserStatus, String> {
-    browser_ui::disconnect().await.map_err(|e| e.to_string())
+pub async fn browser_disconnect() -> Result<browser_ui::BrowserStatus, CmdError> {
+    browser_ui::disconnect().await.map_err(Into::into)
 }

--- a/src-tauri/src/commands/channel.rs
+++ b/src-tauri/src/commands/channel.rs
@@ -1,12 +1,14 @@
 use crate::channel::accounts::{self, UpdateAccountParams};
 use crate::channel::types::*;
+use crate::commands::CmdError;
+use anyhow::Context;
 
 // ── List Plugins ─────────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn channel_list_plugins() -> Result<Vec<serde_json::Value>, String> {
+pub async fn channel_list_plugins() -> Result<Vec<serde_json::Value>, CmdError> {
     let registry = crate::get_channel_registry()
-        .ok_or_else(|| "Channel registry not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("Channel registry not initialized"))?;
 
     let plugins = registry.list_plugins();
     let result: Vec<serde_json::Value> = plugins
@@ -25,7 +27,7 @@ pub async fn channel_list_plugins() -> Result<Vec<serde_json::Value>, String> {
 // ── Account Management ───────────────────────────────────────────
 
 #[tauri::command]
-pub async fn channel_list_accounts() -> Result<Vec<ChannelAccountConfig>, String> {
+pub async fn channel_list_accounts() -> Result<Vec<ChannelAccountConfig>, CmdError> {
     Ok(ha_core::config::cached_config().channels.accounts.clone())
 }
 
@@ -37,10 +39,10 @@ pub async fn channel_add_account(
     credentials: serde_json::Value,
     settings: serde_json::Value,
     security: SecurityConfig,
-) -> Result<String, String> {
+) -> Result<String, CmdError> {
     accounts::add_account(channel_id, label, agent_id, credentials, settings, security)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -53,7 +55,7 @@ pub async fn channel_update_account(
     credentials: Option<serde_json::Value>,
     settings: Option<serde_json::Value>,
     security: Option<SecurityConfig>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     accounts::update_account(
         &account_id,
         UpdateAccountParams {
@@ -67,52 +69,46 @@ pub async fn channel_update_account(
         },
     )
     .await
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn channel_remove_account(account_id: String) -> Result<(), String> {
+pub async fn channel_remove_account(account_id: String) -> Result<(), CmdError> {
     accounts::remove_account(&account_id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 // ── Lifecycle ────────────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn channel_start_account(account_id: String) -> Result<(), String> {
+pub async fn channel_start_account(account_id: String) -> Result<(), CmdError> {
     let account = ha_core::config::cached_config()
         .channels
         .find_account(&account_id)
-        .ok_or_else(|| format!("Account '{}' not found", account_id))?
+        .ok_or_else(|| CmdError::msg(format!("Account '{}' not found", account_id)))?
         .clone();
 
     let registry = crate::get_channel_registry()
-        .ok_or_else(|| "Channel registry not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("Channel registry not initialized"))?;
 
-    registry
-        .start_account(&account)
-        .await
-        .map_err(|e| e.to_string())
+    registry.start_account(&account).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn channel_stop_account(account_id: String) -> Result<(), String> {
+pub async fn channel_stop_account(account_id: String) -> Result<(), CmdError> {
     let registry = crate::get_channel_registry()
-        .ok_or_else(|| "Channel registry not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("Channel registry not initialized"))?;
 
-    registry
-        .stop_account(&account_id)
-        .await
-        .map_err(|e| e.to_string())
+    registry.stop_account(&account_id).await.map_err(Into::into)
 }
 
 // ── Health ───────────────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn channel_health(account_id: String) -> Result<ChannelHealth, String> {
+pub async fn channel_health(account_id: String) -> Result<ChannelHealth, CmdError> {
     let registry = crate::get_channel_registry()
-        .ok_or_else(|| "Channel registry not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("Channel registry not initialized"))?;
 
     // Get running status
     let mut health = registry.health(&account_id).await;
@@ -136,9 +132,9 @@ pub async fn channel_health(account_id: String) -> Result<ChannelHealth, String>
 }
 
 #[tauri::command]
-pub async fn channel_health_all() -> Result<Vec<(String, ChannelHealth)>, String> {
+pub async fn channel_health_all() -> Result<Vec<(String, ChannelHealth)>, CmdError> {
     let registry = crate::get_channel_registry()
-        .ok_or_else(|| "Channel registry not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("Channel registry not initialized"))?;
 
     Ok(registry.list_running().await)
 }
@@ -149,22 +145,22 @@ pub async fn channel_health_all() -> Result<Vec<(String, ChannelHealth)>, String
 pub async fn channel_validate_credentials(
     channel_id: String,
     credentials: serde_json::Value,
-) -> Result<String, String> {
+) -> Result<String, CmdError> {
     let parsed_channel_id: ChannelId =
         serde_json::from_value(serde_json::Value::String(channel_id.clone()))
-            .map_err(|e| format!("Invalid channel_id '{}': {}", channel_id, e))?;
+            .with_context(|| format!("Invalid channel_id '{}'", channel_id))?;
 
     let registry = crate::get_channel_registry()
-        .ok_or_else(|| "Channel registry not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("Channel registry not initialized"))?;
 
     let plugin = registry
         .get_plugin(&parsed_channel_id)
-        .ok_or_else(|| format!("No plugin for channel: {}", channel_id))?;
+        .ok_or_else(|| CmdError::msg(format!("No plugin for channel: {}", channel_id)))?;
 
     plugin
         .validate_credentials(&credentials)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 // ── Test Message ─────────────────────────────────────────────────
@@ -174,21 +170,21 @@ pub async fn channel_send_test_message(
     account_id: String,
     chat_id: String,
     text: String,
-) -> Result<DeliveryResult, String> {
+) -> Result<DeliveryResult, CmdError> {
     let store = ha_core::config::cached_config();
     let account = store
         .channels
         .find_account(&account_id)
-        .ok_or_else(|| format!("Account '{}' not found", account_id))?;
+        .ok_or_else(|| CmdError::msg(format!("Account '{}' not found", account_id)))?;
 
     let registry = crate::get_channel_registry()
-        .ok_or_else(|| "Channel registry not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("Channel registry not initialized"))?;
 
     let payload = ReplyPayload::text(text);
     registry
         .send_reply(account, &chat_id, &payload)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 // ── Sessions ─────────────────────────────────────────────────────
@@ -197,13 +193,11 @@ pub async fn channel_send_test_message(
 pub async fn channel_list_sessions(
     channel_id: String,
     account_id: String,
-) -> Result<Vec<serde_json::Value>, String> {
+) -> Result<Vec<serde_json::Value>, CmdError> {
     let channel_db =
-        crate::get_channel_db().ok_or_else(|| "Channel DB not initialized".to_string())?;
+        crate::get_channel_db().ok_or_else(|| CmdError::msg("Channel DB not initialized"))?;
 
-    let conversations = channel_db
-        .list_conversations(&channel_id, &account_id)
-        .map_err(|e| e.to_string())?;
+    let conversations = channel_db.list_conversations(&channel_id, &account_id)?;
 
     let result: Vec<serde_json::Value> = conversations
         .into_iter()
@@ -232,18 +226,18 @@ pub async fn channel_list_sessions(
 #[tauri::command]
 pub async fn channel_wechat_start_login(
     account_id: Option<String>,
-) -> Result<crate::channel::wechat::login::WeChatLoginStart, String> {
+) -> Result<crate::channel::wechat::login::WeChatLoginStart, CmdError> {
     crate::channel::wechat::login::start_login(account_id.as_deref())
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn channel_wechat_wait_login(
     session_key: String,
     timeout_ms: Option<u64>,
-) -> Result<crate::channel::wechat::login::WeChatLoginWait, String> {
+) -> Result<crate::channel::wechat::login::WeChatLoginWait, CmdError> {
     crate::channel::wechat::login::wait_login(&session_key, timeout_ms)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1,11 +1,13 @@
 use crate::agent::Attachment;
 use crate::agent_loader;
 use crate::chat_engine::EventSink;
+use crate::commands::CmdError;
 use crate::provider::{self, ActiveModel};
 use crate::session::{self, SessionDB};
 use crate::tools;
 use crate::truncate_utf8;
 use crate::AppState;
+use anyhow::Context;
 use ha_core::{app_error, app_info, app_warn};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -30,9 +32,9 @@ pub async fn save_attachment(
     file_name: String,
     _mime_type: String,
     data: Vec<u8>,
-) -> Result<String, String> {
+) -> Result<String, CmdError> {
     ha_core::attachments::save_attachment_bytes(session_id.as_deref(), &file_name, &data)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -55,7 +57,7 @@ pub async fn chat(
     working_dir: Option<String>,
     on_event: tauri::ipc::Channel<String>,
     state: State<'_, AppState>,
-) -> Result<String, String> {
+) -> Result<String, CmdError> {
     if let Some(mode) = tool_permission_mode {
         crate::tools::set_tool_permission_mode(mode).await;
     }
@@ -82,9 +84,7 @@ pub async fn chat(
         Some(id) if !id.is_empty() => id,
         _ => {
             // Auto-create a new session; emit session_created after auto_title is set
-            let meta = db
-                .create_session_with_project(&current_agent_id, None, incognito)
-                .map_err(|e| e.to_string())?;
+            let meta = db.create_session_with_project(&current_agent_id, None, incognito)?;
             new_session_created = Some(meta.id.clone());
             meta.id
         }
@@ -96,8 +96,7 @@ pub async fn chat(
     // an invalid path doesn't silently get dropped.
     if new_session_created.is_some() {
         if let Some(wd) = working_dir.as_ref().filter(|s| !s.trim().is_empty()) {
-            db.update_session_working_dir(&sid, Some(wd.clone()))
-                .map_err(|e| e.to_string())?;
+            db.update_session_working_dir(&sid, Some(wd.clone()))?;
             app_info!(
                 "session",
                 "chat",
@@ -114,9 +113,8 @@ pub async fn chat(
     // Build attachments metadata from file paths (files already saved by save_attachment)
     let attachments_meta = if !attachments.is_empty() {
         // Ensure session attachments directory exists and move temp files if needed
-        let att_dir = crate::paths::attachments_dir(&sid).map_err(|e| e.to_string())?;
-        std::fs::create_dir_all(&att_dir)
-            .map_err(|e| format!("Failed to create attachments dir: {}", e))?;
+        let att_dir = crate::paths::attachments_dir(&sid)?;
+        std::fs::create_dir_all(&att_dir).context("Failed to create attachments dir")?;
 
         let temp_dir = crate::paths::root_dir()
             .map(|r| r.join("attachments").join("_temp"))
@@ -317,7 +315,7 @@ pub async fn chat(
             let recent_summary = build_recent_context_summary(&db, &sid).await;
             let cancel_registry = crate::get_subagent_cancels()
                 .cloned()
-                .ok_or_else(|| "Sub-agent cancel registry not initialized".to_string())?;
+                .ok_or_else(|| CmdError::msg("Sub-agent cancel registry not initialized"))?;
             match crate::plan::spawn_plan_subagent(
                 &sid,
                 &current_agent_id,
@@ -439,7 +437,7 @@ pub async fn chat(
                     Err(e) => {
                         let err = e.to_string();
                         let _ = db.append_message(&sid, &session::NewMessage::event(&err));
-                        return Err(err);
+                        return Err(CmdError::msg(err));
                     }
                 };
                 let duration_ms = chat_start.elapsed().as_millis() as u64;
@@ -466,7 +464,7 @@ pub async fn chat(
             None => {
                 let err = "Agent not initialized. Please sign in first.".to_string();
                 let _ = db.append_message(&sid, &session::NewMessage::event(&err));
-                Err(err)
+                Err(CmdError::msg(err))
             }
         };
     }
@@ -628,13 +626,13 @@ pub async fn chat(
             if let Some(ref agent) = *state.agent.lock().await {
                 crate::chat_engine::save_agent_context(&db, &sid, agent);
             }
-            Err(e)
+            Err(CmdError::msg(e))
         }
     }
 }
 
 #[tauri::command]
-pub async fn stop_chat(state: State<'_, AppState>) -> Result<(), String> {
+pub async fn stop_chat(state: State<'_, AppState>) -> Result<(), CmdError> {
     state.chat_cancel.store(true, Ordering::SeqCst);
     Ok(())
 }
@@ -649,13 +647,12 @@ pub async fn set_tool_permission_mode(
     session_id: Option<String>,
     mode: tools::ToolPermissionMode,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     tools::set_tool_permission_mode(mode).await;
     if let Some(sid) = session_id.as_deref() {
         state
             .session_db
-            .update_session_tool_permission_mode(sid, mode.as_str())
-            .map_err(|e| e.to_string())?;
+            .update_session_tool_permission_mode(sid, mode.as_str())?;
     }
     Ok(())
 }
@@ -698,16 +695,21 @@ async fn build_recent_context_summary(db: &Arc<SessionDB>, session_id: &str) -> 
 // ── Command Approval ──────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn respond_to_approval(request_id: String, response: String) -> Result<(), String> {
+pub async fn respond_to_approval(request_id: String, response: String) -> Result<(), CmdError> {
     let approval_response = match response.as_str() {
         "allow_once" => tools::ApprovalResponse::AllowOnce,
         "allow_always" => tools::ApprovalResponse::AllowAlways,
         "deny" => tools::ApprovalResponse::Deny,
-        _ => return Err(format!("Invalid approval response: {}", response)),
+        _ => {
+            return Err(CmdError::msg(format!(
+                "Invalid approval response: {}",
+                response
+            )))
+        }
     };
     tools::submit_approval_response(&request_id, approval_response)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 // ── System Prompt ────────────────────────────────────────────────
@@ -723,7 +725,7 @@ pub async fn get_system_prompt(
     agent_id: Option<String>,
     session_id: Option<String>,
     state: State<'_, AppState>,
-) -> Result<String, String> {
+) -> Result<String, CmdError> {
     let aid = match agent_id {
         Some(id) => id,
         None => state.current_agent_id.lock().await.clone(),
@@ -755,7 +757,7 @@ pub async fn get_system_prompt(
 // ── Tools Info Commands ───────────────────────────────────────────
 
 #[tauri::command]
-pub async fn list_builtin_tools() -> Result<Vec<serde_json::Value>, String> {
+pub async fn list_builtin_tools() -> Result<Vec<serde_json::Value>, CmdError> {
     let mut all = tools::get_available_tools();
     // Include conditionally-injected tools so they appear in settings
     all.push(tools::get_notification_tool());

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1,14 +1,16 @@
 use crate::chat_engine::save_agent_context;
+use crate::commands::CmdError;
 use crate::context_compact;
 use crate::paths;
 use crate::provider;
 use crate::tools;
 use crate::user_config;
 use crate::AppState;
+use anyhow::Context;
 
 #[tauri::command]
-pub async fn get_web_search_config() -> Result<tools::web_search::WebSearchConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_web_search_config() -> Result<tools::web_search::WebSearchConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     let mut config = store.web_search;
     tools::web_search::backfill_providers(&mut config);
     Ok(config)
@@ -17,96 +19,99 @@ pub async fn get_web_search_config() -> Result<tools::web_search::WebSearchConfi
 #[tauri::command]
 pub async fn save_web_search_config(
     config: tools::web_search::WebSearchConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("web_search", "settings-ui"), |store| {
         store.web_search = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_web_fetch_config() -> Result<tools::web_fetch::WebFetchConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_web_fetch_config() -> Result<tools::web_fetch::WebFetchConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.web_fetch)
 }
 
 #[tauri::command]
-pub async fn save_web_fetch_config(config: tools::web_fetch::WebFetchConfig) -> Result<(), String> {
+pub async fn save_web_fetch_config(
+    config: tools::web_fetch::WebFetchConfig,
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("web_fetch", "settings-ui"), |store| {
         store.web_fetch = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_ssrf_config() -> Result<ha_core::security::ssrf::SsrfConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_ssrf_config() -> Result<ha_core::security::ssrf::SsrfConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.ssrf)
 }
 
 #[tauri::command]
-pub async fn save_ssrf_config(config: ha_core::security::ssrf::SsrfConfig) -> Result<(), String> {
+pub async fn save_ssrf_config(config: ha_core::security::ssrf::SsrfConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("security.ssrf", "settings-ui"), |store| {
         store.ssrf = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_compact_config() -> Result<context_compact::CompactConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_compact_config() -> Result<context_compact::CompactConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.compact)
 }
 
 #[tauri::command]
-pub async fn save_compact_config(config: context_compact::CompactConfig) -> Result<(), String> {
+pub async fn save_compact_config(config: context_compact::CompactConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("compact", "settings-ui"), |store| {
         store.compact = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_session_title_config() -> Result<ha_core::session_title::SessionTitleConfig, String>
-{
+pub async fn get_session_title_config(
+) -> Result<ha_core::session_title::SessionTitleConfig, CmdError> {
     Ok(ha_core::config::cached_config().session_title.clone())
 }
 
 #[tauri::command]
 pub async fn save_session_title_config(
     config: ha_core::session_title::SessionTitleConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("session_title", "settings-ui"), |store| {
         store.session_title = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_notification_config() -> Result<ha_core::config::NotificationConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_notification_config() -> Result<ha_core::config::NotificationConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.notification)
 }
 
 #[tauri::command]
 pub async fn save_notification_config(
     config: ha_core::config::NotificationConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("notification", "settings-ui"), |store| {
         store.notification = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_image_generate_config() -> Result<tools::image_generate::ImageGenConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_image_generate_config() -> Result<tools::image_generate::ImageGenConfig, CmdError>
+{
+    let store = ha_core::config::load_config()?;
     let mut config = store.image_generate;
     tools::image_generate::backfill_providers(&mut config);
     Ok(config)
@@ -115,12 +120,12 @@ pub async fn get_image_generate_config() -> Result<tools::image_generate::ImageG
 #[tauri::command]
 pub async fn save_image_generate_config(
     config: tools::image_generate::ImageGenConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("image_generate", "settings-ui"), |store| {
         store.image_generate = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 /// Core logic for manual context compaction. Usable from both Tauri commands
@@ -128,9 +133,11 @@ pub async fn save_image_generate_config(
 pub(crate) async fn compact_context_now_core(
     session_id: &str,
     state: &AppState,
-) -> Result<context_compact::CompactResult, String> {
+) -> Result<context_compact::CompactResult, CmdError> {
     let agent = state.agent.lock().await;
-    let agent = agent.as_ref().ok_or("No active agent")?;
+    let agent = agent
+        .as_ref()
+        .ok_or_else(|| CmdError::msg("No active agent"))?;
 
     let mut history = agent.get_conversation_history();
     if history.is_empty() {
@@ -144,7 +151,7 @@ pub(crate) async fn compact_context_now_core(
         });
     }
 
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+    let store = ha_core::config::load_config()?;
     let compact_config = store.compact;
 
     let system_prompt_estimate = "system";
@@ -227,7 +234,7 @@ pub(crate) async fn compact_context_now_core(
 pub async fn compact_context_now(
     session_id: String,
     state: tauri::State<'_, AppState>,
-) -> Result<context_compact::CompactResult, String> {
+) -> Result<context_compact::CompactResult, CmdError> {
     compact_context_now_core(&session_id, &state).await
 }
 
@@ -236,7 +243,7 @@ pub async fn compact_context_now(
 /// Temporarily unregister all global shortcuts (for recording mode)
 /// or re-register them from config.
 #[tauri::command]
-pub async fn set_shortcuts_paused(app: tauri::AppHandle, paused: bool) -> Result<(), String> {
+pub async fn set_shortcuts_paused(app: tauri::AppHandle, paused: bool) -> Result<(), CmdError> {
     use tauri_plugin_global_shortcut::GlobalShortcutExt;
     let manager = app.global_shortcut();
 
@@ -246,7 +253,7 @@ pub async fn set_shortcuts_paused(app: tauri::AppHandle, paused: bool) -> Result
         let _ = manager.unregister_all();
     } else {
         // Re-register from saved config
-        let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+        let store = ha_core::config::load_config()?;
         let _ = manager.unregister_all();
         for binding in &store.shortcuts.bindings {
             if !binding.enabled || binding.keys.is_empty() {
@@ -267,8 +274,8 @@ pub async fn set_shortcuts_paused(app: tauri::AppHandle, paused: bool) -> Result
 }
 
 #[tauri::command]
-pub async fn get_shortcut_config() -> Result<ha_core::config::ShortcutConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_shortcut_config() -> Result<ha_core::config::ShortcutConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.shortcuts)
 }
 
@@ -276,7 +283,7 @@ pub async fn get_shortcut_config() -> Result<ha_core::config::ShortcutConfig, St
 pub async fn save_shortcut_config(
     app: tauri::AppHandle,
     config: ha_core::config::ShortcutConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     // Validate all key combinations first
     for binding in &config.bindings {
         if binding.keys.is_empty() {
@@ -287,7 +294,10 @@ pub async fn save_shortcut_config(
                 .parse::<tauri_plugin_global_shortcut::Shortcut>()
                 .is_err()
             {
-                return Err(format!("Invalid shortcut key combination: {}", part));
+                return Err(CmdError::msg(format!(
+                    "Invalid shortcut key combination: {}",
+                    part
+                )));
             }
         }
     }
@@ -295,8 +305,7 @@ pub async fn save_shortcut_config(
     ha_core::config::mutate_config(("shortcuts", "settings-ui"), |store| {
         store.shortcuts = config.clone();
         Ok(())
-    })
-    .map_err(|e| e.to_string())?;
+    })?;
 
     // Clear any pending chord state
     crate::shortcuts::clear_chord_state();
@@ -343,8 +352,8 @@ pub async fn save_shortcut_config(
 // ── Server Config ───────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_server_config() -> Result<serde_json::Value, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_server_config() -> Result<serde_json::Value, CmdError> {
+    let store = ha_core::config::load_config()?;
     let server = &store.server;
     // Mask api_key for security
     let masked_key = server.api_key.as_ref().map(|k| {
@@ -364,137 +373,139 @@ pub async fn get_server_config() -> Result<serde_json::Value, String> {
 #[tauri::command]
 pub async fn save_server_config(
     config: ha_core::config::EmbeddedServerConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("server", "settings-ui"), |store| {
         store.server = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 /// Runtime status of the embedded HTTP/WS server. Shape mirrors
 /// `GET /api/server/status` so frontend Transport calls route identically
 /// in either mode.
 #[tauri::command]
-pub async fn get_server_runtime_status() -> Result<serde_json::Value, String> {
+pub async fn get_server_runtime_status() -> Result<serde_json::Value, CmdError> {
     Ok(ha_core::server_status::runtime_status_json(true))
 }
 
 // ── Proxy ────────────────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_proxy_config() -> Result<provider::ProxyConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_proxy_config() -> Result<provider::ProxyConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.proxy)
 }
 
 #[tauri::command]
-pub async fn save_proxy_config(config: provider::ProxyConfig) -> Result<(), String> {
+pub async fn save_proxy_config(config: provider::ProxyConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("proxy", "settings-ui"), |store| {
         store.proxy = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 /// Outbound proxy probe used by Settings → Proxy → "Test". Body lives in
 /// [`ha_core::provider::test::test_proxy`] so the Tauri shell and HTTP route
 /// share one source of truth.
 #[tauri::command]
-pub async fn test_proxy(config: provider::ProxyConfig) -> Result<String, String> {
-    ha_core::provider::test::test_proxy(config).await
+pub async fn test_proxy(config: provider::ProxyConfig) -> Result<String, CmdError> {
+    ha_core::provider::test::test_proxy(config)
+        .await
+        .map_err(CmdError::msg)
 }
 
 // ── Theme & Language ─────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_theme() -> Result<String, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_theme() -> Result<String, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.theme)
 }
 
 #[tauri::command]
-pub async fn set_theme(theme: String) -> Result<(), String> {
+pub async fn set_theme(theme: String) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("theme", "settings-ui"), |store| {
         store.theme = theme;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_language() -> Result<String, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_language() -> Result<String, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.language)
 }
 
 #[tauri::command]
-pub async fn set_language(language: String) -> Result<(), String> {
+pub async fn set_language(language: String) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("language", "settings-ui"), |store| {
         store.language = language;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_ui_effects_enabled() -> Result<bool, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_ui_effects_enabled() -> Result<bool, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.ui_effects_enabled)
 }
 
 #[tauri::command]
-pub async fn set_ui_effects_enabled(enabled: bool) -> Result<(), String> {
+pub async fn set_ui_effects_enabled(enabled: bool) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("ui_effects", "settings-ui"), |store| {
         store.ui_effects_enabled = enabled;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_tool_call_narration_enabled() -> Result<bool, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_tool_call_narration_enabled() -> Result<bool, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.tool_call_narration_enabled)
 }
 
 #[tauri::command]
-pub async fn set_tool_call_narration_enabled(enabled: bool) -> Result<(), String> {
+pub async fn set_tool_call_narration_enabled(enabled: bool) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("tool_call_narration", "settings-ui"), |store| {
         store.tool_call_narration_enabled = enabled;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 // ── User Config Commands ─────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_user_config() -> Result<user_config::UserConfig, String> {
-    user_config::load_user_config().map_err(|e| e.to_string())
+pub async fn get_user_config() -> Result<user_config::UserConfig, CmdError> {
+    user_config::load_user_config().map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn save_user_config(config: user_config::UserConfig) -> Result<(), String> {
-    user_config::save_user_config_to_disk(&config).map_err(|e| e.to_string())
+pub async fn save_user_config(config: user_config::UserConfig) -> Result<(), CmdError> {
+    user_config::save_user_config_to_disk(&config).map_err(Into::into)
 }
 
 // ── Autostart ────────────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_autostart_enabled(app: tauri::AppHandle) -> Result<bool, String> {
+pub async fn get_autostart_enabled(app: tauri::AppHandle) -> Result<bool, CmdError> {
     use tauri_plugin_autostart::ManagerExt;
-    app.autolaunch().is_enabled().map_err(|e| e.to_string())
+    app.autolaunch().is_enabled().map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn set_autostart_enabled(app: tauri::AppHandle, enabled: bool) -> Result<(), String> {
+pub async fn set_autostart_enabled(app: tauri::AppHandle, enabled: bool) -> Result<(), CmdError> {
     use tauri_plugin_autostart::ManagerExt;
     let manager = app.autolaunch();
     if enabled {
-        manager.enable().map_err(|e| e.to_string())
+        manager.enable().map_err(Into::into)
     } else {
-        manager.disable().map_err(|e| e.to_string())
+        manager.disable().map_err(Into::into)
     }
 }
 
@@ -503,19 +514,19 @@ pub async fn set_autostart_enabled(app: tauri::AppHandle, enabled: bool) -> Resu
 /// (serialized as `number[]` in the Tauri IPC path, the `data` field of a
 /// multipart form in the HTTP path — see `ha-server/routes/avatars::upload`).
 #[tauri::command]
-pub async fn save_avatar(data: Vec<u8>, file_name: String) -> Result<String, String> {
-    let dir = paths::avatars_dir().map_err(|e| e.to_string())?;
-    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+pub async fn save_avatar(data: Vec<u8>, file_name: String) -> Result<String, CmdError> {
+    let dir = paths::avatars_dir()?;
+    std::fs::create_dir_all(&dir)?;
 
     let path = dir.join(&file_name);
-    std::fs::write(&path, &data).map_err(|e| format!("Failed to write avatar: {}", e))?;
+    std::fs::write(&path, &data).context("Failed to write avatar")?;
 
     Ok(path.to_string_lossy().to_string())
 }
 
 /// Get the system's IANA timezone name
 #[tauri::command]
-pub async fn get_system_timezone() -> Result<String, String> {
+pub async fn get_system_timezone() -> Result<String, CmdError> {
     // Try reading /etc/localtime symlink (macOS/Linux)
     if let Ok(link) = std::fs::read_link("/etc/localtime") {
         let path_str = link.to_string_lossy().to_string();
@@ -534,66 +545,66 @@ pub async fn get_system_timezone() -> Result<String, String> {
 }
 
 #[tauri::command]
-pub async fn get_tool_timeout() -> Result<u64, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_tool_timeout() -> Result<u64, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.tool_timeout)
 }
 
 #[tauri::command]
-pub async fn set_tool_timeout(seconds: u64) -> Result<(), String> {
+pub async fn set_tool_timeout(seconds: u64) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("tool_timeout", "settings-ui"), |store| {
         store.tool_timeout = seconds;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_approval_timeout() -> Result<u64, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_approval_timeout() -> Result<u64, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.approval_timeout_secs)
 }
 
 #[tauri::command]
-pub async fn set_approval_timeout(seconds: u64) -> Result<(), String> {
+pub async fn set_approval_timeout(seconds: u64) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("approval_timeout", "settings-ui"), |store| {
         store.approval_timeout_secs = seconds;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_approval_timeout_action() -> Result<ha_core::config::ApprovalTimeoutAction, String>
-{
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_approval_timeout_action(
+) -> Result<ha_core::config::ApprovalTimeoutAction, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.approval_timeout_action)
 }
 
 #[tauri::command]
 pub async fn set_approval_timeout_action(
     action: ha_core::config::ApprovalTimeoutAction,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("approval_timeout_action", "settings-ui"), |store| {
         store.approval_timeout_action = action;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_tool_result_disk_threshold() -> Result<usize, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_tool_result_disk_threshold() -> Result<usize, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.tool_result_disk_threshold.unwrap_or(50_000))
 }
 
 #[tauri::command]
-pub async fn set_tool_result_disk_threshold(bytes: usize) -> Result<(), String> {
+pub async fn set_tool_result_disk_threshold(bytes: usize) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("tool_result_disk_threshold", "settings-ui"), |store| {
         store.tool_result_disk_threshold = if bytes == 0 { Some(0) } else { Some(bytes) };
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 // ── Tool Limits ────────────────────────────────────────────────
@@ -607,8 +618,8 @@ pub struct ToolLimitsConfig {
 }
 
 #[tauri::command]
-pub async fn get_tool_limits() -> Result<ToolLimitsConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_tool_limits() -> Result<ToolLimitsConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(ToolLimitsConfig {
         max_images: store.image.max_images,
         max_pdfs: store.pdf.max_pdfs,
@@ -617,83 +628,83 @@ pub async fn get_tool_limits() -> Result<ToolLimitsConfig, String> {
 }
 
 #[tauri::command]
-pub async fn set_tool_limits(config: ToolLimitsConfig) -> Result<(), String> {
+pub async fn set_tool_limits(config: ToolLimitsConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("tool_limits", "settings-ui"), |store| {
         store.image.max_images = config.max_images;
         store.pdf.max_pdfs = config.max_pdfs;
         store.pdf.max_vision_pages = config.max_vision_pages;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 // ── Temperature ─────────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_global_temperature() -> Result<Option<f64>, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_global_temperature() -> Result<Option<f64>, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.temperature)
 }
 
 #[tauri::command]
-pub async fn set_global_temperature(temperature: Option<f64>) -> Result<(), String> {
+pub async fn set_global_temperature(temperature: Option<f64>) -> Result<(), CmdError> {
     if let Some(t) = temperature {
         if !(0.0..=2.0).contains(&t) {
-            return Err("Temperature must be between 0.0 and 2.0".to_string());
+            return Err(CmdError::msg("Temperature must be between 0.0 and 2.0"));
         }
     }
     ha_core::config::mutate_config(("temperature", "settings-ui"), |store| {
         store.temperature = temperature;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_plan_subagent() -> Result<bool, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_plan_subagent() -> Result<bool, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.plan_subagent)
 }
 
 #[tauri::command]
-pub async fn set_plan_subagent(enabled: bool) -> Result<(), String> {
+pub async fn set_plan_subagent(enabled: bool) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("plan_subagent", "settings-ui"), |store| {
         store.plan_subagent = enabled;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_ask_user_question_timeout() -> Result<u64, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_ask_user_question_timeout() -> Result<u64, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.ask_user_question_timeout_secs)
 }
 
 #[tauri::command]
-pub async fn set_ask_user_question_timeout(secs: u64) -> Result<(), String> {
+pub async fn set_ask_user_question_timeout(secs: u64) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("ask_user_question_timeout", "settings-ui"), |store| {
         store.ask_user_question_timeout_secs = secs;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 // ── Recap Config ────────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_recap_config() -> Result<ha_core::config::RecapConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_recap_config() -> Result<ha_core::config::RecapConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.recap)
 }
 
 #[tauri::command]
-pub async fn save_recap_config(config: ha_core::config::RecapConfig) -> Result<(), String> {
+pub async fn save_recap_config(config: ha_core::config::RecapConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("recap", "settings-ui"), |store| {
         store.recap = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 // ── Weather ─────────────────────────────────────────────────────
@@ -703,11 +714,11 @@ pub async fn save_recap_config(config: ha_core::config::RecapConfig) -> Result<(
 pub async fn geocode_search(
     query: String,
     language: Option<String>,
-) -> Result<Vec<crate::weather::GeoResult>, String> {
+) -> Result<Vec<crate::weather::GeoResult>, CmdError> {
     let lang = language.as_deref().unwrap_or("zh");
     crate::weather::geocode_search(&query, lang)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Fetch real-time weather preview explicitly for the provided settings, bypassing config layout.
@@ -716,113 +727,115 @@ pub async fn preview_weather(
     lat: f64,
     lon: f64,
     city: String,
-) -> Result<crate::weather::WeatherData, String> {
+) -> Result<crate::weather::WeatherData, CmdError> {
     crate::weather::fetch_weather(lat, lon, &city, 1)
         .await
         .map(|w| w.current)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Get the currently cached weather data for frontend preview.
 #[tauri::command]
-pub async fn get_current_weather() -> Result<Option<crate::weather::WeatherData>, String> {
+pub async fn get_current_weather() -> Result<Option<crate::weather::WeatherData>, CmdError> {
     Ok(crate::weather::get_cached_weather().await)
 }
 
 /// Force refresh weather cache and return fresh data.
 #[tauri::command]
-pub async fn refresh_weather() -> Result<Option<crate::weather::WeatherData>, String> {
+pub async fn refresh_weather() -> Result<Option<crate::weather::WeatherData>, CmdError> {
     crate::weather::force_refresh_weather()
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 // ── Async Tools ───────────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_async_tools_config() -> Result<ha_core::config::AsyncToolsConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_async_tools_config() -> Result<ha_core::config::AsyncToolsConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.async_tools)
 }
 
 #[tauri::command]
 pub async fn save_async_tools_config(
     config: ha_core::config::AsyncToolsConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("async_tools", "settings-ui"), |store| {
         store.async_tools = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 // ── Deferred Tool Loading ─────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_deferred_tools_config() -> Result<ha_core::config::DeferredToolsConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_deferred_tools_config() -> Result<ha_core::config::DeferredToolsConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.deferred_tools)
 }
 
 #[tauri::command]
 pub async fn save_deferred_tools_config(
     config: ha_core::config::DeferredToolsConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("deferred_tools", "settings-ui"), |store| {
         store.deferred_tools = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 /// Detect user location automatically (CoreLocation → IP fallback).
 #[tauri::command]
-pub async fn detect_location() -> Result<crate::weather::DetectedLocation, String> {
-    crate::weather::detect_location()
-        .await
-        .map_err(|e| e.to_string())
+pub async fn detect_location() -> Result<crate::weather::DetectedLocation, CmdError> {
+    crate::weather::detect_location().await.map_err(Into::into)
 }
 
 // ── Behavior Awareness ────────────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_awareness_config() -> Result<ha_core::awareness::AwarenessConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_awareness_config() -> Result<ha_core::awareness::AwarenessConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.awareness)
 }
 
 #[tauri::command]
 pub async fn save_awareness_config(
     config: ha_core::awareness::AwarenessConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("awareness", "settings-ui"), |store| {
         store.awareness = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_session_awareness_override(session_id: String) -> Result<Option<String>, String> {
-    let db = ha_core::get_session_db().ok_or("Session DB not initialized")?;
+pub async fn get_session_awareness_override(
+    session_id: String,
+) -> Result<Option<String>, CmdError> {
+    let db =
+        ha_core::get_session_db().ok_or_else(|| CmdError::msg("Session DB not initialized"))?;
     db.get_session_awareness_config_json(&session_id)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn set_session_awareness_override(
     session_id: String,
     json: Option<String>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     // Validate before persisting.
     if let Some(ref j) = json {
         if !j.trim().is_empty() {
             let base = ha_core::awareness::AwarenessConfig::default();
             ha_core::awareness::config::validate_override(&base, j)
-                .map_err(|e| format!("invalid override JSON: {}", e))?;
+                .context("invalid override JSON")?;
         }
     }
-    let db = ha_core::get_session_db().ok_or("Session DB not initialized")?;
+    let db =
+        ha_core::get_session_db().ok_or_else(|| CmdError::msg("Session DB not initialized"))?;
     db.set_session_awareness_config_json(&session_id, json.as_deref())
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }

--- a/src-tauri/src/commands/crash.rs
+++ b/src-tauri/src/commands/crash.rs
@@ -1,9 +1,10 @@
 use crate::backup;
+use crate::commands::CmdError;
 use crate::crash_journal;
 use crate::paths;
 
 #[tauri::command]
-pub async fn get_crash_recovery_info() -> Result<serde_json::Value, String> {
+pub async fn get_crash_recovery_info() -> Result<serde_json::Value, CmdError> {
     let recovered = std::env::var("HOPE_AGENT_RECOVERED").is_ok();
     let crash_count: u32 = std::env::var("HOPE_AGENT_CRASH_COUNT")
         .ok()
@@ -31,57 +32,58 @@ pub async fn get_crash_recovery_info() -> Result<serde_json::Value, String> {
 }
 
 #[tauri::command]
-pub async fn get_crash_history() -> Result<serde_json::Value, String> {
-    let path = paths::crash_journal_path().map_err(|e| e.to_string())?;
+pub async fn get_crash_history() -> Result<serde_json::Value, CmdError> {
+    let path = paths::crash_journal_path()?;
     let journal = crash_journal::CrashJournal::load(&path);
-    serde_json::to_value(&journal).map_err(|e| e.to_string())
+    Ok(serde_json::to_value(&journal)?)
 }
 
 #[tauri::command]
-pub async fn clear_crash_history() -> Result<(), String> {
-    let path = paths::crash_journal_path().map_err(|e| e.to_string())?;
+pub async fn clear_crash_history() -> Result<(), CmdError> {
+    let path = paths::crash_journal_path()?;
     let mut journal = crash_journal::CrashJournal::load(&path);
     journal.clear();
-    journal.save(&path)
+    journal.save(&path).map_err(CmdError::msg)
 }
 
 #[tauri::command]
-pub async fn request_app_restart(app: tauri::AppHandle) -> Result<(), String> {
+pub async fn request_app_restart(app: tauri::AppHandle) -> Result<(), CmdError> {
     app.exit(42);
     Ok(())
 }
 
 #[tauri::command]
-pub async fn list_backups_cmd() -> Result<Vec<backup::BackupInfo>, String> {
-    backup::list_backups()
+pub async fn list_backups_cmd() -> Result<Vec<backup::BackupInfo>, CmdError> {
+    backup::list_backups().map_err(CmdError::msg)
 }
 
 #[tauri::command]
-pub async fn restore_backup_cmd(name: String) -> Result<(), String> {
-    backup::restore_backup(&name)
+pub async fn restore_backup_cmd(name: String) -> Result<(), CmdError> {
+    backup::restore_backup(&name).map_err(CmdError::msg)
 }
 
 #[tauri::command]
-pub async fn create_backup_cmd() -> Result<String, String> {
-    backup::create_backup()
+pub async fn create_backup_cmd() -> Result<String, CmdError> {
+    backup::create_backup().map_err(CmdError::msg)
 }
 
 #[tauri::command]
-pub async fn list_settings_backups_cmd() -> Result<Vec<backup::AutosaveEntry>, String> {
-    backup::list_autosaves()
+pub async fn list_settings_backups_cmd() -> Result<Vec<backup::AutosaveEntry>, CmdError> {
+    backup::list_autosaves().map_err(CmdError::msg)
 }
 
 #[tauri::command]
-pub async fn restore_settings_backup_cmd(id: String) -> Result<backup::AutosaveEntry, String> {
-    backup::restore_autosave(&id)
+pub async fn restore_settings_backup_cmd(id: String) -> Result<backup::AutosaveEntry, CmdError> {
+    backup::restore_autosave(&id).map_err(CmdError::msg)
 }
 
 #[tauri::command]
-pub async fn get_guardian_enabled() -> Result<bool, String> {
-    crate::guardian::get_enabled_from_config().map_err(|e| e.to_string())
+pub async fn get_guardian_enabled() -> Result<bool, CmdError> {
+    Ok(crate::guardian::get_enabled_from_config()?)
 }
 
 #[tauri::command]
-pub async fn set_guardian_enabled(enabled: bool) -> Result<(), String> {
-    crate::guardian::set_enabled_in_config(enabled).map_err(|e| e.to_string())
+pub async fn set_guardian_enabled(enabled: bool) -> Result<(), CmdError> {
+    crate::guardian::set_enabled_in_config(enabled)?;
+    Ok(())
 }

--- a/src-tauri/src/commands/cron.rs
+++ b/src-tauri/src/commands/cron.rs
@@ -1,36 +1,41 @@
+use crate::commands::CmdError;
 use crate::cron;
 use crate::AppState;
+use anyhow::Context;
 use tauri::State;
 
 #[tauri::command]
-pub async fn cron_list_jobs(state: State<'_, AppState>) -> Result<Vec<cron::CronJob>, String> {
-    state.cron_db.list_jobs().map_err(|e| e.to_string())
+pub async fn cron_list_jobs(state: State<'_, AppState>) -> Result<Vec<cron::CronJob>, CmdError> {
+    state.cron_db.list_jobs().map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn cron_get_job(
     id: String,
     state: State<'_, AppState>,
-) -> Result<Option<cron::CronJob>, String> {
-    state.cron_db.get_job(&id).map_err(|e| e.to_string())
+) -> Result<Option<cron::CronJob>, CmdError> {
+    state.cron_db.get_job(&id).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn cron_create_job(
     job: cron::NewCronJob,
     state: State<'_, AppState>,
-) -> Result<cron::CronJob, String> {
-    state.cron_db.add_job(&job).map_err(|e| e.to_string())
+) -> Result<cron::CronJob, CmdError> {
+    state.cron_db.add_job(&job).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn cron_update_job(job: cron::CronJob, state: State<'_, AppState>) -> Result<(), String> {
-    state.cron_db.update_job(&job).map_err(|e| e.to_string())
+pub async fn cron_update_job(
+    job: cron::CronJob,
+    state: State<'_, AppState>,
+) -> Result<(), CmdError> {
+    state.cron_db.update_job(&job).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn cron_delete_job(id: String, state: State<'_, AppState>) -> Result<(), String> {
-    state.cron_db.delete_job(&id).map_err(|e| e.to_string())
+pub async fn cron_delete_job(id: String, state: State<'_, AppState>) -> Result<(), CmdError> {
+    state.cron_db.delete_job(&id).map_err(Into::into)
 }
 
 #[tauri::command]
@@ -38,20 +43,16 @@ pub async fn cron_toggle_job(
     id: String,
     enabled: bool,
     state: State<'_, AppState>,
-) -> Result<(), String> {
-    state
-        .cron_db
-        .toggle_job(&id, enabled)
-        .map_err(|e| e.to_string())
+) -> Result<(), CmdError> {
+    state.cron_db.toggle_job(&id, enabled).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn cron_run_now(id: String, state: State<'_, AppState>) -> Result<(), String> {
+pub async fn cron_run_now(id: String, state: State<'_, AppState>) -> Result<(), CmdError> {
     let job = state
         .cron_db
-        .get_job(&id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| "Job not found".to_string())?;
+        .get_job(&id)?
+        .ok_or_else(|| CmdError::msg("Job not found"))?;
 
     let db = state.cron_db.clone();
     let sdb = state.session_db.clone();
@@ -66,12 +67,12 @@ pub async fn cron_get_run_logs(
     job_id: String,
     limit: Option<usize>,
     state: State<'_, AppState>,
-) -> Result<Vec<cron::CronRunLog>, String> {
+) -> Result<Vec<cron::CronRunLog>, CmdError> {
     let limit = limit.unwrap_or(50);
     state
         .cron_db
         .get_run_logs(&job_id, limit)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -79,15 +80,15 @@ pub async fn cron_get_calendar_events(
     start: String,
     end: String,
     state: State<'_, AppState>,
-) -> Result<Vec<cron::CalendarEvent>, String> {
+) -> Result<Vec<cron::CalendarEvent>, CmdError> {
     let start_dt = chrono::DateTime::parse_from_rfc3339(&start)
-        .map_err(|e| format!("Invalid start date: {}", e))?
+        .context("Invalid start date")?
         .with_timezone(&chrono::Utc);
     let end_dt = chrono::DateTime::parse_from_rfc3339(&end)
-        .map_err(|e| format!("Invalid end date: {}", e))?
+        .context("Invalid end date")?
         .with_timezone(&chrono::Utc);
     state
         .cron_db
         .get_calendar_events(&start_dt, &end_dt)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }

--- a/src-tauri/src/commands/dashboard.rs
+++ b/src-tauri/src/commands/dashboard.rs
@@ -1,3 +1,4 @@
+use crate::commands::CmdError;
 use crate::dashboard::{self, *};
 use crate::AppState;
 use tauri::State;
@@ -6,116 +7,114 @@ use tauri::State;
 pub async fn dashboard_overview(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<OverviewStats, String> {
-    query_overview(&state.session_db, &state.log_db, &state.cron_db, &filter)
-        .map_err(|e| e.to_string())
+) -> Result<OverviewStats, CmdError> {
+    query_overview(&state.session_db, &state.log_db, &state.cron_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_token_usage(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<DashboardTokenData, String> {
-    query_token_usage(&state.session_db, &filter).map_err(|e| e.to_string())
+) -> Result<DashboardTokenData, CmdError> {
+    query_token_usage(&state.session_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_tool_usage(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<Vec<ToolUsageStats>, String> {
-    query_tool_usage(&state.session_db, &filter).map_err(|e| e.to_string())
+) -> Result<Vec<ToolUsageStats>, CmdError> {
+    query_tool_usage(&state.session_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_sessions(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<DashboardSessionData, String> {
-    query_sessions(&state.session_db, &filter).map_err(|e| e.to_string())
+) -> Result<DashboardSessionData, CmdError> {
+    query_sessions(&state.session_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_errors(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<DashboardErrorData, String> {
-    query_errors(&state.log_db, &filter).map_err(|e| e.to_string())
+) -> Result<DashboardErrorData, CmdError> {
+    query_errors(&state.log_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_tasks(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<DashboardTaskData, String> {
-    query_tasks(&state.session_db, &state.cron_db, &filter).map_err(|e| e.to_string())
+) -> Result<DashboardTaskData, CmdError> {
+    query_tasks(&state.session_db, &state.cron_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn dashboard_system_metrics() -> Result<dashboard::SystemMetrics, String> {
+pub async fn dashboard_system_metrics() -> Result<dashboard::SystemMetrics, CmdError> {
     // Run on blocking thread since sysinfo does a brief sleep for CPU measurement
     tokio::task::spawn_blocking(|| dashboard::query_system_metrics())
-        .await
-        .map_err(|e| e.to_string())?
-        .map_err(|e| e.to_string())
+        .await?
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_session_list(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<Vec<dashboard::DashboardSessionItem>, String> {
-    dashboard::query_session_list(&state.session_db, &filter).map_err(|e| e.to_string())
+) -> Result<Vec<dashboard::DashboardSessionItem>, CmdError> {
+    dashboard::query_session_list(&state.session_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_message_list(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<Vec<dashboard::DashboardMessageItem>, String> {
-    dashboard::query_message_list(&state.session_db, &filter).map_err(|e| e.to_string())
+) -> Result<Vec<dashboard::DashboardMessageItem>, CmdError> {
+    dashboard::query_message_list(&state.session_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_tool_call_list(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<Vec<dashboard::DashboardToolCallItem>, String> {
-    dashboard::query_tool_call_list(&state.session_db, &filter).map_err(|e| e.to_string())
+) -> Result<Vec<dashboard::DashboardToolCallItem>, CmdError> {
+    dashboard::query_tool_call_list(&state.session_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_error_list(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<Vec<dashboard::DashboardErrorItem>, String> {
-    dashboard::query_error_list(&state.log_db, &filter).map_err(|e| e.to_string())
+) -> Result<Vec<dashboard::DashboardErrorItem>, CmdError> {
+    dashboard::query_error_list(&state.log_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_agent_list(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<Vec<dashboard::DashboardAgentItem>, String> {
-    dashboard::query_agent_list(&state.session_db, &filter).map_err(|e| e.to_string())
+) -> Result<Vec<dashboard::DashboardAgentItem>, CmdError> {
+    dashboard::query_agent_list(&state.session_db, &filter).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_overview_delta(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<dashboard::OverviewStatsWithDelta, String> {
+) -> Result<dashboard::OverviewStatsWithDelta, CmdError> {
     dashboard::query_overview_with_delta(&state.session_db, &state.log_db, &state.cron_db, &filter)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_insights(
     filter: DashboardFilter,
     state: State<'_, AppState>,
-) -> Result<dashboard::DashboardInsights, String> {
+) -> Result<dashboard::DashboardInsights, CmdError> {
     dashboard::query_insights(&state.session_db, &state.log_db, &state.cron_db, &filter)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 // ── Phase B'4: Learning Dashboard ──────────────────────────────
@@ -124,16 +123,16 @@ pub async fn dashboard_insights(
 pub async fn dashboard_learning_overview(
     window_days: u32,
     state: State<'_, AppState>,
-) -> Result<dashboard::LearningOverview, String> {
-    dashboard::query_learning_overview(&state.session_db, window_days).map_err(|e| e.to_string())
+) -> Result<dashboard::LearningOverview, CmdError> {
+    dashboard::query_learning_overview(&state.session_db, window_days).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_learning_timeline(
     window_days: u32,
     state: State<'_, AppState>,
-) -> Result<Vec<dashboard::TimelinePoint>, String> {
-    dashboard::query_skill_timeline(&state.session_db, window_days).map_err(|e| e.to_string())
+) -> Result<Vec<dashboard::TimelinePoint>, CmdError> {
+    dashboard::query_skill_timeline(&state.session_db, window_days).map_err(Into::into)
 }
 
 #[tauri::command]
@@ -141,14 +140,14 @@ pub async fn dashboard_top_skills(
     window_days: u32,
     limit: usize,
     state: State<'_, AppState>,
-) -> Result<Vec<dashboard::SkillUsage>, String> {
-    dashboard::query_top_skills(&state.session_db, window_days, limit).map_err(|e| e.to_string())
+) -> Result<Vec<dashboard::SkillUsage>, CmdError> {
+    dashboard::query_top_skills(&state.session_db, window_days, limit).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn dashboard_recall_stats(
     window_days: u32,
     state: State<'_, AppState>,
-) -> Result<dashboard::RecallStats, String> {
-    dashboard::query_recall_stats(&state.session_db, window_days).map_err(|e| e.to_string())
+) -> Result<dashboard::RecallStats, CmdError> {
+    dashboard::query_recall_stats(&state.session_db, window_days).map_err(Into::into)
 }

--- a/src-tauri/src/commands/docker.rs
+++ b/src-tauri/src/commands/docker.rs
@@ -1,18 +1,20 @@
+use crate::commands::CmdError;
 use crate::docker;
 use crate::tools;
 
 #[tauri::command]
-pub async fn searxng_docker_status() -> Result<docker::SearxngDockerStatus, String> {
+pub async fn searxng_docker_status() -> Result<docker::SearxngDockerStatus, CmdError> {
     Ok(docker::status().await)
 }
 
 #[tauri::command]
-pub async fn searxng_docker_deploy(channel: tauri::ipc::Channel<String>) -> Result<String, String> {
+pub async fn searxng_docker_deploy(
+    channel: tauri::ipc::Channel<String>,
+) -> Result<String, CmdError> {
     let url = docker::deploy(|step| {
         let _ = channel.send(step.to_string());
     })
-    .await
-    .map_err(|e| e.to_string())?;
+    .await?;
     // Auto-save the URL into the SearXNG provider entry and mark as docker-managed
     let url_for_mut = url.clone();
     let _ = ha_core::config::mutate_config(("web_search", "searxng-docker-deploy"), |store| {
@@ -32,18 +34,18 @@ pub async fn searxng_docker_deploy(channel: tauri::ipc::Channel<String>) -> Resu
 }
 
 #[tauri::command]
-pub async fn searxng_docker_start() -> Result<(), String> {
-    docker::start().await.map_err(|e| e.to_string())
+pub async fn searxng_docker_start() -> Result<(), CmdError> {
+    docker::start().await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn searxng_docker_stop() -> Result<(), String> {
-    docker::stop().await.map_err(|e| e.to_string())
+pub async fn searxng_docker_stop() -> Result<(), CmdError> {
+    docker::stop().await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn searxng_docker_remove() -> Result<(), String> {
-    docker::remove().await.map_err(|e| e.to_string())?;
+pub async fn searxng_docker_remove() -> Result<(), CmdError> {
+    docker::remove().await?;
     // Clear docker-managed flag
     let _ = ha_core::config::mutate_config(("web_search", "searxng-docker-remove"), |store| {
         store.web_search.searxng_docker_managed = None;

--- a/src-tauri/src/commands/dreaming.rs
+++ b/src-tauri/src/commands/dreaming.rs
@@ -2,12 +2,13 @@
 //! frontend. All heavy work happens inside ha-core; these commands are
 //! thin error-translating shells.
 
+use crate::commands::CmdError;
 use ha_core::memory::dreaming;
 
 /// Run an offline consolidation cycle synchronously and return the report.
 /// Maps to `POST /api/dreaming/run` on the HTTP side.
 #[tauri::command]
-pub async fn dreaming_run_now() -> Result<dreaming::DreamReport, String> {
+pub async fn dreaming_run_now() -> Result<dreaming::DreamReport, CmdError> {
     Ok(dreaming::manual_run(dreaming::DreamTrigger::Manual).await)
 }
 
@@ -17,19 +18,19 @@ pub async fn dreaming_run_now() -> Result<dreaming::DreamReport, String> {
 #[tauri::command]
 pub async fn dreaming_list_diaries(
     limit: Option<usize>,
-) -> Result<Vec<dreaming::DiaryEntry>, String> {
-    dreaming::list_diaries(limit).map_err(|e| e.to_string())
+) -> Result<Vec<dreaming::DiaryEntry>, CmdError> {
+    dreaming::list_diaries(limit).map_err(Into::into)
 }
 
 /// Read the markdown for a single diary file.
 #[tauri::command]
-pub async fn dreaming_read_diary(filename: String) -> Result<String, String> {
-    dreaming::read_diary(&filename).map_err(|e| e.to_string())
+pub async fn dreaming_read_diary(filename: String) -> Result<String, CmdError> {
+    dreaming::read_diary(&filename).map_err(Into::into)
 }
 
 /// Lightweight status probe so the Dashboard can grey out the "Run now"
 /// button while a cycle is already in progress.
 #[tauri::command]
-pub async fn dreaming_is_running() -> Result<bool, String> {
+pub async fn dreaming_is_running() -> Result<bool, CmdError> {
     Ok(dreaming::dreaming_running())
 }

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -1,0 +1,33 @@
+use serde::{Serialize, Serializer};
+
+/// 统一的 Tauri 命令错误类型。
+///
+/// `#[tauri::command]` 要求返回值实现 `Serialize`，但 `anyhow::Error` 不实现，
+/// 历史上每条命令都用 `.map_err(|e| e.to_string())?` 把错误降成 `String`。
+/// `CmdError` 在 IPC wire 上等价于一个普通字符串（前端零迁移），同时通过
+/// `impl<E: Into<anyhow::Error>> From<E>` 让命令体内部直接用 `?` 透传 `anyhow::Error`、
+/// `std::io::Error`、`serde_json::Error` 等任何实现了 `std::error::Error` 的错误。
+pub struct CmdError(String);
+
+impl CmdError {
+    /// 构造一个纯文本错误（取代散落在各处的 `Err("msg".to_string())` 模式）。
+    pub fn msg(m: impl Into<String>) -> Self {
+        Self(m.into())
+    }
+}
+
+impl<E> From<E> for CmdError
+where
+    E: Into<anyhow::Error>,
+{
+    fn from(err: E) -> Self {
+        // 用 alternate Display 输出 cause chain，让 `.context("...")?` 加的上下文不丢。
+        Self(format!("{:#}", err.into()))
+    }
+}
+
+impl Serialize for CmdError {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.0)
+    }
+}

--- a/src-tauri/src/commands/filesystem.rs
+++ b/src-tauri/src/commands/filesystem.rs
@@ -8,14 +8,17 @@
 //! Errors are flattened into `String` at the Tauri boundary; the front-end
 //! shows the message directly.
 
+use crate::commands::CmdError;
+use anyhow::Context;
 use ha_core::filesystem::{self, DirListing, FileSearchResponse};
 
 #[tauri::command]
-pub async fn fs_list_dir(path: Option<String>) -> Result<DirListing, String> {
-    tokio::task::spawn_blocking(move || filesystem::list_dir(path.as_deref()))
-        .await
-        .map_err(|e| format!("fs_list_dir task failed: {}", e))?
-        .map_err(|e| e.to_string())
+pub async fn fs_list_dir(path: Option<String>) -> Result<DirListing, CmdError> {
+    Ok(
+        tokio::task::spawn_blocking(move || filesystem::list_dir(path.as_deref()))
+            .await
+            .context("fs_list_dir task failed")??,
+    )
 }
 
 #[tauri::command]
@@ -23,9 +26,10 @@ pub async fn fs_search_files(
     root: String,
     q: String,
     limit: Option<usize>,
-) -> Result<FileSearchResponse, String> {
-    tokio::task::spawn_blocking(move || filesystem::search_files(&root, &q, limit))
-        .await
-        .map_err(|e| format!("fs_search_files task failed: {}", e))?
-        .map_err(|e| e.to_string())
+) -> Result<FileSearchResponse, CmdError> {
+    Ok(
+        tokio::task::spawn_blocking(move || filesystem::search_files(&root, &q, limit))
+            .await
+            .context("fs_search_files task failed")??,
+    )
 }

--- a/src-tauri/src/commands/local_llm.rs
+++ b/src-tauri/src/commands/local_llm.rs
@@ -1,3 +1,4 @@
+use crate::commands::CmdError;
 use crate::AppState;
 use ha_core::agent::AssistantAgent;
 use ha_core::local_llm::{
@@ -8,18 +9,18 @@ use serde_json::json;
 use tauri::State;
 
 #[tauri::command]
-pub async fn local_llm_detect_hardware() -> Result<HardwareInfo, String> {
+pub async fn local_llm_detect_hardware() -> Result<HardwareInfo, CmdError> {
     Ok(detect_hardware())
 }
 
 #[tauri::command]
-pub async fn local_llm_recommend_model() -> Result<ModelRecommendation, String> {
+pub async fn local_llm_recommend_model() -> Result<ModelRecommendation, CmdError> {
     let hw = detect_hardware();
     Ok(recommend_model(&hw))
 }
 
 #[tauri::command]
-pub async fn local_llm_detect_ollama() -> Result<OllamaStatus, String> {
+pub async fn local_llm_detect_ollama() -> Result<OllamaStatus, CmdError> {
     Ok(detect_ollama().await)
 }
 
@@ -27,20 +28,20 @@ pub async fn local_llm_detect_ollama() -> Result<OllamaStatus, String> {
 /// shared event bus on `local_llm:install_progress`; the frontend listens
 /// for those events instead of receiving a Tauri Channel.
 #[tauri::command]
-pub async fn local_llm_install_ollama() -> Result<(), String> {
+pub async fn local_llm_install_ollama() -> Result<(), CmdError> {
     let bus = ha_core::get_event_bus()
         .cloned()
-        .ok_or_else(|| "EventBus not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("EventBus not initialized"))?;
     install_ollama_via_script(move |p| {
         bus.emit("local_llm:install_progress", json!(p));
     })
     .await
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn local_llm_start_ollama() -> Result<(), String> {
-    start_ollama().await.map_err(|e| e.to_string())
+pub async fn local_llm_start_ollama() -> Result<(), CmdError> {
+    start_ollama().await.map_err(Into::into)
 }
 
 /// Pull the requested model, register the local-Ollama provider, and switch
@@ -50,15 +51,14 @@ pub async fn local_llm_start_ollama() -> Result<(), String> {
 pub async fn local_llm_pull_and_activate(
     model: ModelCandidate,
     state: State<'_, AppState>,
-) -> Result<serde_json::Value, String> {
+) -> Result<serde_json::Value, CmdError> {
     let bus = ha_core::get_event_bus()
         .cloned()
-        .ok_or_else(|| "EventBus not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("EventBus not initialized"))?;
     let (provider_id, model_id) = pull_and_activate(model, move |p| {
         bus.emit("local_llm:pull_progress", json!(p));
     })
-    .await
-    .map_err(|e| e.to_string())?;
+    .await?;
 
     // Rebuild the cached agent so the next chat call uses the new local
     // provider without requiring a frontend reload.
@@ -67,7 +67,9 @@ pub async fn local_llm_pull_and_activate(
         .iter()
         .find(|p| p.id == provider_id)
         .cloned()
-        .ok_or_else(|| format!("Provider not found after register: {provider_id}"))?;
+        .ok_or_else(|| {
+            CmdError::msg(format!("Provider not found after register: {provider_id}"))
+        })?;
     let agent = AssistantAgent::new_from_provider(&provider, &model_id);
     *state.agent.lock().await = Some(agent);
     Ok(json!({ "providerId": provider_id, "modelId": model_id }))

--- a/src-tauri/src/commands/logging.rs
+++ b/src-tauri/src/commands/logging.rs
@@ -1,3 +1,4 @@
+use crate::commands::CmdError;
 use crate::logging;
 use crate::AppState;
 use tauri::State;
@@ -8,37 +9,36 @@ pub async fn query_logs_cmd(
     page: u32,
     page_size: u32,
     state: State<'_, AppState>,
-) -> Result<logging::LogQueryResult, String> {
+) -> Result<logging::LogQueryResult, CmdError> {
     let ps = if page_size == 0 {
         50
     } else {
         page_size.min(500)
     };
     let pg = if page == 0 { 1 } else { page };
-    state
-        .log_db
-        .query(&filter, pg, ps)
-        .map_err(|e| e.to_string())
+    state.log_db.query(&filter, pg, ps).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_log_stats_cmd(state: State<'_, AppState>) -> Result<logging::LogStats, String> {
-    state.log_db.get_stats().map_err(|e| e.to_string())
+pub async fn get_log_stats_cmd(state: State<'_, AppState>) -> Result<logging::LogStats, CmdError> {
+    state.log_db.get_stats().map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn clear_logs_cmd(
     before_date: Option<String>,
     state: State<'_, AppState>,
-) -> Result<u64, String> {
+) -> Result<u64, CmdError> {
     state
         .log_db
         .clear(before_date.as_deref())
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_log_config_cmd(state: State<'_, AppState>) -> Result<logging::LogConfig, String> {
+pub async fn get_log_config_cmd(
+    state: State<'_, AppState>,
+) -> Result<logging::LogConfig, CmdError> {
     Ok(state.logger.get_config())
 }
 
@@ -46,28 +46,28 @@ pub async fn get_log_config_cmd(state: State<'_, AppState>) -> Result<logging::L
 pub async fn save_log_config_cmd(
     config: logging::LogConfig,
     state: State<'_, AppState>,
-) -> Result<(), String> {
-    logging::save_log_config(&config).map_err(|e| e.to_string())?;
+) -> Result<(), CmdError> {
+    logging::save_log_config(&config)?;
     state.logger.update_config(config);
     Ok(())
 }
 
 #[tauri::command]
-pub async fn list_log_files_cmd() -> Result<Vec<logging::LogFileInfo>, String> {
-    logging::list_log_files().map_err(|e| e.to_string())
+pub async fn list_log_files_cmd() -> Result<Vec<logging::LogFileInfo>, CmdError> {
+    logging::list_log_files().map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn read_log_file_cmd(
     filename: String,
     tail_lines: Option<u32>,
-) -> Result<String, String> {
-    logging::read_log_file(&filename, tail_lines).map_err(|e| e.to_string())
+) -> Result<String, CmdError> {
+    logging::read_log_file(&filename, tail_lines).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_log_file_path_cmd() -> Result<String, String> {
-    logging::current_log_file_path().map_err(|e| e.to_string())
+pub async fn get_log_file_path_cmd() -> Result<String, CmdError> {
+    logging::current_log_file_path().map_err(Into::into)
 }
 
 /// Receive log entries from the frontend and write them to the unified logging system.
@@ -80,7 +80,7 @@ pub async fn frontend_log(
     details: Option<String>,
     session_id: Option<String>,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     // Validate level
     let valid_levels = ["error", "warn", "info", "debug"];
     let level = if valid_levels.contains(&level.as_str()) {
@@ -100,7 +100,7 @@ pub async fn frontend_log(
 pub async fn frontend_log_batch(
     entries: Vec<serde_json::Value>,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     let valid_levels = ["error", "warn", "info", "debug"];
     for entry in entries {
         let level = entry
@@ -142,8 +142,8 @@ pub async fn export_logs_cmd(
     filter: logging::LogFilter,
     format: String,
     state: State<'_, AppState>,
-) -> Result<String, String> {
-    let logs = state.log_db.export(&filter).map_err(|e| e.to_string())?;
+) -> Result<String, CmdError> {
+    let logs = state.log_db.export(&filter)?;
     match format.as_str() {
         "csv" => {
             let mut csv =
@@ -163,6 +163,6 @@ pub async fn export_logs_cmd(
             }
             Ok(csv)
         }
-        _ => serde_json::to_string_pretty(&logs).map_err(|e| e.to_string()),
+        _ => serde_json::to_string_pretty(&logs).map_err(Into::into),
     }
 }

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1,15 +1,16 @@
 //! Tauri IPC commands for the MCP subsystem.
 //!
 //! Thin shells over the business logic in
-//! [`ha_core::mcp::api`]. Every command returns `Result<T, String>` —
-//! Tauri serializes `T` to JS via serde and surfaces the `Err(String)` to
-//! `invoke()` callers as a rejected promise.
+//! [`ha_core::mcp::api`]. Every command returns `Result<T, CmdError>` —
+//! Tauri serializes `T` to JS via serde and surfaces the `Err` (rendered as
+//! a string) to `invoke()` callers as a rejected promise.
 //!
 //! Both the Tauri invoke handler in `src-tauri/src/lib.rs` and the
 //! matching axum routes in `crates/ha-server/src/routes/mcp.rs` dispatch
 //! to the SAME `ha_core::mcp::api::*` functions — behavior parity is
 //! enforced by the single source of truth, not by copy-paste.
 
+use crate::commands::CmdError;
 use ha_core::mcp::api::{
     self, ImportSummary, McpLogLine, McpServerDraft, McpServerSummary, McpToolSummary,
 };
@@ -19,16 +20,12 @@ use ha_core::mcp::registry::ServerStatusSnapshot;
 use crate::AppState;
 use tauri::State;
 
-fn map_err<E: std::fmt::Display>(e: E) -> String {
-    e.to_string()
-}
-
 // ── CRUD ─────────────────────────────────────────────────────────
 
 #[tauri::command]
 pub async fn mcp_list_servers(
     _state: State<'_, AppState>,
-) -> Result<Vec<McpServerSummary>, String> {
+) -> Result<Vec<McpServerSummary>, CmdError> {
     Ok(api::list_servers().await)
 }
 
@@ -36,18 +33,18 @@ pub async fn mcp_list_servers(
 pub async fn mcp_get_server_status(
     id: String,
     _state: State<'_, AppState>,
-) -> Result<ServerStatusSnapshot, String> {
+) -> Result<ServerStatusSnapshot, CmdError> {
     api::get_server_status(&id)
         .await
-        .ok_or_else(|| format!("MCP server '{id}' not found"))
+        .ok_or_else(|| CmdError::msg(format!("MCP server '{id}' not found")))
 }
 
 #[tauri::command]
 pub async fn mcp_add_server(
     draft: McpServerDraft,
     _state: State<'_, AppState>,
-) -> Result<McpServerSummary, String> {
-    api::add_server(draft).await.map_err(map_err)
+) -> Result<McpServerSummary, CmdError> {
+    api::add_server(draft).await.map_err(Into::into)
 }
 
 #[tauri::command]
@@ -55,21 +52,21 @@ pub async fn mcp_update_server(
     id: String,
     draft: McpServerDraft,
     _state: State<'_, AppState>,
-) -> Result<McpServerSummary, String> {
-    api::update_server(&id, draft).await.map_err(map_err)
+) -> Result<McpServerSummary, CmdError> {
+    api::update_server(&id, draft).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn mcp_remove_server(id: String, _state: State<'_, AppState>) -> Result<(), String> {
-    api::remove_server(&id).await.map_err(map_err)
+pub async fn mcp_remove_server(id: String, _state: State<'_, AppState>) -> Result<(), CmdError> {
+    api::remove_server(&id).await.map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn mcp_reorder_servers(
     order: Vec<String>,
     _state: State<'_, AppState>,
-) -> Result<(), String> {
-    api::reorder_servers(order).await.map_err(map_err)
+) -> Result<(), CmdError> {
+    api::reorder_servers(order).await.map_err(Into::into)
 }
 
 // ── Connection + diagnostics ─────────────────────────────────────
@@ -78,34 +75,34 @@ pub async fn mcp_reorder_servers(
 pub async fn mcp_test_connection(
     id: String,
     _state: State<'_, AppState>,
-) -> Result<ServerStatusSnapshot, String> {
-    api::test_connection(&id).await.map_err(map_err)
+) -> Result<ServerStatusSnapshot, CmdError> {
+    api::test_connection(&id).await.map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn mcp_reconnect_server(
     id: String,
     _state: State<'_, AppState>,
-) -> Result<ServerStatusSnapshot, String> {
-    api::reconnect_server(&id).await.map_err(map_err)
+) -> Result<ServerStatusSnapshot, CmdError> {
+    api::reconnect_server(&id).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn mcp_start_oauth(id: String, _state: State<'_, AppState>) -> Result<(), String> {
-    api::start_oauth(&id).await.map_err(map_err)
+pub async fn mcp_start_oauth(id: String, _state: State<'_, AppState>) -> Result<(), CmdError> {
+    api::start_oauth(&id).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn mcp_sign_out(id: String, _state: State<'_, AppState>) -> Result<(), String> {
-    api::sign_out(&id).await.map_err(map_err)
+pub async fn mcp_sign_out(id: String, _state: State<'_, AppState>) -> Result<(), CmdError> {
+    api::sign_out(&id).await.map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn mcp_list_tools(
     id: String,
     _state: State<'_, AppState>,
-) -> Result<Vec<McpToolSummary>, String> {
-    api::list_server_tools(&id).await.map_err(map_err)
+) -> Result<Vec<McpToolSummary>, CmdError> {
+    api::list_server_tools(&id).await.map_err(Into::into)
 }
 
 #[tauri::command]
@@ -113,20 +110,20 @@ pub async fn mcp_get_recent_logs(
     id: String,
     limit: Option<usize>,
     _state: State<'_, AppState>,
-) -> Result<Vec<McpLogLine>, String> {
+) -> Result<Vec<McpLogLine>, CmdError> {
     api::get_recent_logs(&id, limit.unwrap_or(200))
         .await
-        .map_err(map_err)
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn mcp_import_claude_desktop_config(
     json: String,
     _state: State<'_, AppState>,
-) -> Result<ImportSummary, String> {
+) -> Result<ImportSummary, CmdError> {
     api::import_claude_desktop_config(&json)
         .await
-        .map_err(map_err)
+        .map_err(Into::into)
 }
 
 // ── Global settings ──────────────────────────────────────────────
@@ -134,7 +131,7 @@ pub async fn mcp_import_claude_desktop_config(
 #[tauri::command]
 pub async fn mcp_get_global_settings(
     _state: State<'_, AppState>,
-) -> Result<McpGlobalSettings, String> {
+) -> Result<McpGlobalSettings, CmdError> {
     Ok(api::get_global_settings())
 }
 
@@ -142,6 +139,8 @@ pub async fn mcp_get_global_settings(
 pub async fn mcp_update_global_settings(
     settings: McpGlobalSettings,
     _state: State<'_, AppState>,
-) -> Result<(), String> {
-    api::update_global_settings(settings).await.map_err(map_err)
+) -> Result<(), CmdError> {
+    api::update_global_settings(settings)
+        .await
+        .map_err(Into::into)
 }

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -1,37 +1,41 @@
+use crate::commands::CmdError;
 use crate::get_memory_backend;
 use crate::memory;
 use ha_core::{app_info, app_warn};
 
 #[tauri::command]
-pub async fn memory_add(entry: memory::NewMemory) -> Result<i64, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend.add(entry).map_err(|e| e.to_string())
+pub async fn memory_add(entry: memory::NewMemory) -> Result<i64, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.add(entry).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn memory_update(id: i64, content: String, tags: Vec<String>) -> Result<(), String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend
-        .update(id, &content, &tags)
-        .map_err(|e| e.to_string())
+pub async fn memory_update(id: i64, content: String, tags: Vec<String>) -> Result<(), CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.update(id, &content, &tags).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn memory_toggle_pin(id: i64, pinned: bool) -> Result<(), String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend.toggle_pin(id, pinned).map_err(|e| e.to_string())
+pub async fn memory_toggle_pin(id: i64, pinned: bool) -> Result<(), CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.toggle_pin(id, pinned).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn memory_delete(id: i64) -> Result<(), String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend.delete(id).map_err(|e| e.to_string())
+pub async fn memory_delete(id: i64) -> Result<(), CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.delete(id).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn memory_get(id: i64) -> Result<Option<memory::MemoryEntry>, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend.get(id).map_err(|e| e.to_string())
+pub async fn memory_get(id: i64) -> Result<Option<memory::MemoryEntry>, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.get(id).map_err(Into::into)
 }
 
 #[tauri::command]
@@ -40,8 +44,9 @@ pub async fn memory_list(
     types: Option<Vec<memory::MemoryType>>,
     limit: Option<usize>,
     offset: Option<usize>,
-) -> Result<Vec<memory::MemoryEntry>, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
+) -> Result<Vec<memory::MemoryEntry>, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
     backend
         .list(
             scope.as_ref(),
@@ -49,29 +54,30 @@ pub async fn memory_list(
             limit.unwrap_or(50),
             offset.unwrap_or(0),
         )
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn memory_search(
     query: memory::MemorySearchQuery,
-) -> Result<Vec<memory::MemoryEntry>, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend.search(&query).map_err(|e| e.to_string())
+) -> Result<Vec<memory::MemoryEntry>, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.search(&query).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn memory_count(scope: Option<memory::MemoryScope>) -> Result<usize, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend.count(scope.as_ref()).map_err(|e| e.to_string())
+pub async fn memory_count(scope: Option<memory::MemoryScope>) -> Result<usize, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.count(scope.as_ref()).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn memory_export(scope: Option<memory::MemoryScope>) -> Result<String, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend
-        .export_markdown(scope.as_ref())
-        .map_err(|e| e.to_string())
+pub async fn memory_export(scope: Option<memory::MemoryScope>) -> Result<String, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.export_markdown(scope.as_ref()).map_err(Into::into)
 }
 
 #[tauri::command]
@@ -79,24 +85,26 @@ pub async fn memory_find_similar(
     content: String,
     threshold: Option<f32>,
     limit: Option<usize>,
-) -> Result<Vec<memory::MemoryEntry>, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
+) -> Result<Vec<memory::MemoryEntry>, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
     let dedup_cfg = memory::load_dedup_config();
     let threshold = threshold.unwrap_or(dedup_cfg.threshold_merge);
     let limit = limit.unwrap_or(5);
     backend
         .find_similar(&content, None, None, threshold, limit)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn memory_delete_batch(ids: Vec<i64>) -> Result<usize, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend.delete_batch(&ids).map_err(|e| e.to_string())
+pub async fn memory_delete_batch(ids: Vec<i64>) -> Result<usize, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.delete_batch(&ids).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn memory_get_import_from_ai_prompt(locale: Option<String>) -> Result<String, String> {
+pub async fn memory_get_import_from_ai_prompt(locale: Option<String>) -> Result<String, CmdError> {
     let locale = locale.as_deref().unwrap_or("en");
     Ok(memory::import_prompt::import_from_ai_prompt(locale).to_string())
 }
@@ -106,186 +114,188 @@ pub async fn memory_import(
     content: String,
     format: String,
     dedup: bool,
-) -> Result<memory::ImportResult, String> {
-    let entries = memory::parse_import(&content, &format).map_err(|e| e.to_string())?;
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend
-        .import_entries(entries, dedup)
-        .map_err(|e| e.to_string())
+) -> Result<memory::ImportResult, CmdError> {
+    let entries = memory::parse_import(&content, &format)?;
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.import_entries(entries, dedup).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn memory_reembed(ids: Option<Vec<i64>>) -> Result<usize, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
+pub async fn memory_reembed(ids: Option<Vec<i64>>) -> Result<usize, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
     match ids {
-        Some(ids) => backend.reembed_batch(&ids).map_err(|e| e.to_string()),
-        None => backend.reembed_all().map_err(|e| e.to_string()),
+        Some(ids) => backend.reembed_batch(&ids).map_err(Into::into),
+        None => backend.reembed_all().map_err(Into::into),
     }
 }
 
 #[tauri::command]
 pub async fn memory_stats(
     scope: Option<memory::MemoryScope>,
-) -> Result<memory::MemoryStats, String> {
-    let backend = get_memory_backend().ok_or("Memory backend not initialized")?;
-    backend.stats(scope.as_ref()).map_err(|e| e.to_string())
+) -> Result<memory::MemoryStats, CmdError> {
+    let backend =
+        get_memory_backend().ok_or_else(|| CmdError::msg("Memory backend not initialized"))?;
+    backend.stats(scope.as_ref()).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_extract_config() -> Result<memory::MemoryExtractConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_extract_config() -> Result<memory::MemoryExtractConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.memory_extract)
 }
 
 #[tauri::command]
-pub async fn save_extract_config(config: memory::MemoryExtractConfig) -> Result<(), String> {
+pub async fn save_extract_config(config: memory::MemoryExtractConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("memory_extract", "settings-ui"), |store| {
         store.memory_extract = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_memory_selection_config() -> Result<memory::MemorySelectionConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_memory_selection_config() -> Result<memory::MemorySelectionConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.memory_selection)
 }
 
 #[tauri::command]
 pub async fn save_memory_selection_config(
     config: memory::MemorySelectionConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("memory_selection", "settings-ui"), |store| {
         store.memory_selection = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_memory_budget_config() -> Result<memory::MemoryBudgetConfig, String> {
+pub async fn get_memory_budget_config() -> Result<memory::MemoryBudgetConfig, CmdError> {
     Ok(ha_core::config::cached_config().memory_budget.clone())
 }
 
 #[tauri::command]
-pub async fn save_memory_budget_config(config: memory::MemoryBudgetConfig) -> Result<(), String> {
+pub async fn save_memory_budget_config(config: memory::MemoryBudgetConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("memory_budget", "settings-ui"), |store| {
         store.memory_budget = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_dedup_config() -> Result<memory::DedupConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_dedup_config() -> Result<memory::DedupConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.dedup)
 }
 
 #[tauri::command]
-pub async fn save_dedup_config(config: memory::DedupConfig) -> Result<(), String> {
+pub async fn save_dedup_config(config: memory::DedupConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("memory_dedup", "settings-ui"), |store| {
         store.dedup = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 // ── Search Tuning Configs ──────────────────────────────────────
 
 #[tauri::command]
-pub async fn get_hybrid_search_config() -> Result<memory::HybridSearchConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_hybrid_search_config() -> Result<memory::HybridSearchConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.hybrid_search)
 }
 
 #[tauri::command]
-pub async fn save_hybrid_search_config(config: memory::HybridSearchConfig) -> Result<(), String> {
+pub async fn save_hybrid_search_config(config: memory::HybridSearchConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("hybrid_search", "settings-ui"), |store| {
         store.hybrid_search = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_temporal_decay_config() -> Result<memory::TemporalDecayConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_temporal_decay_config() -> Result<memory::TemporalDecayConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.temporal_decay)
 }
 
 #[tauri::command]
-pub async fn save_temporal_decay_config(config: memory::TemporalDecayConfig) -> Result<(), String> {
+pub async fn save_temporal_decay_config(
+    config: memory::TemporalDecayConfig,
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("temporal_decay", "settings-ui"), |store| {
         store.temporal_decay = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_mmr_config() -> Result<memory::MmrConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_mmr_config() -> Result<memory::MmrConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.mmr)
 }
 
 #[tauri::command]
-pub async fn save_mmr_config(config: memory::MmrConfig) -> Result<(), String> {
+pub async fn save_mmr_config(config: memory::MmrConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("memory_mmr", "settings-ui"), |store| {
         store.mmr = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_embedding_cache_config() -> Result<memory::EmbeddingCacheConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_embedding_cache_config() -> Result<memory::EmbeddingCacheConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.embedding_cache)
 }
 
 #[tauri::command]
 pub async fn save_embedding_cache_config(
     config: memory::EmbeddingCacheConfig,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("embedding_cache", "settings-ui"), |store| {
         store.embedding_cache = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_multimodal_config() -> Result<memory::MultimodalConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_multimodal_config() -> Result<memory::MultimodalConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.multimodal)
 }
 
 #[tauri::command]
-pub async fn save_multimodal_config(config: memory::MultimodalConfig) -> Result<(), String> {
+pub async fn save_multimodal_config(config: memory::MultimodalConfig) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("multimodal", "settings-ui"), |store| {
         store.multimodal = config;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_embedding_config() -> Result<memory::EmbeddingConfig, String> {
-    let store = ha_core::config::load_config().map_err(|e| e.to_string())?;
+pub async fn get_embedding_config() -> Result<memory::EmbeddingConfig, CmdError> {
+    let store = ha_core::config::load_config()?;
     Ok(store.embedding)
 }
 
 #[tauri::command]
-pub async fn save_embedding_config(config: memory::EmbeddingConfig) -> Result<(), String> {
+pub async fn save_embedding_config(config: memory::EmbeddingConfig) -> Result<(), CmdError> {
     let should_enable = config.enabled;
     let applied = config.clone();
     ha_core::config::mutate_config(("embedding", "settings-ui"), |store| {
         store.embedding = applied;
         Ok(())
-    })
-    .map_err(|e| e.to_string())?;
+    })?;
 
     // Apply embedder in background to avoid blocking the command response
     tokio::task::spawn_blocking(move || {
@@ -323,56 +333,46 @@ pub async fn save_embedding_config(config: memory::EmbeddingConfig) -> Result<()
 }
 
 #[tauri::command]
-pub async fn get_embedding_presets() -> Result<Vec<memory::EmbeddingPreset>, String> {
+pub async fn get_embedding_presets() -> Result<Vec<memory::EmbeddingPreset>, CmdError> {
     Ok(memory::embedding_presets())
 }
 
 #[tauri::command]
-pub async fn list_local_embedding_models() -> Result<Vec<memory::LocalEmbeddingModel>, String> {
+pub async fn list_local_embedding_models() -> Result<Vec<memory::LocalEmbeddingModel>, CmdError> {
     Ok(memory::list_local_models_with_status())
 }
 
 // ── Core Memory (memory.md) commands ────────────────────────────
 
 #[tauri::command]
-pub async fn get_global_memory_md() -> Result<Option<String>, String> {
-    let path = crate::paths::root_dir()
-        .map_err(|e| e.to_string())?
-        .join("memory.md");
+pub async fn get_global_memory_md() -> Result<Option<String>, CmdError> {
+    let path = crate::paths::root_dir()?.join("memory.md");
     if path.exists() {
-        std::fs::read_to_string(&path)
-            .map(Some)
-            .map_err(|e| e.to_string())
+        std::fs::read_to_string(&path).map(Some).map_err(Into::into)
     } else {
         Ok(None)
     }
 }
 
 #[tauri::command]
-pub async fn save_global_memory_md(content: String) -> Result<(), String> {
-    let path = crate::paths::root_dir()
-        .map_err(|e| e.to_string())?
-        .join("memory.md");
-    std::fs::write(&path, content).map_err(|e| e.to_string())
+pub async fn save_global_memory_md(content: String) -> Result<(), CmdError> {
+    let path = crate::paths::root_dir()?.join("memory.md");
+    std::fs::write(&path, content).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_agent_memory_md(id: String) -> Result<Option<String>, String> {
-    let path = crate::paths::agent_dir(&id)
-        .map_err(|e| e.to_string())?
-        .join("memory.md");
+pub async fn get_agent_memory_md(id: String) -> Result<Option<String>, CmdError> {
+    let path = crate::paths::agent_dir(&id)?.join("memory.md");
     if path.exists() {
-        std::fs::read_to_string(&path)
-            .map(Some)
-            .map_err(|e| e.to_string())
+        std::fs::read_to_string(&path).map(Some).map_err(Into::into)
     } else {
         Ok(None)
     }
 }
 
 #[tauri::command]
-pub async fn save_agent_memory_md(id: String, content: String) -> Result<(), String> {
-    let dir = crate::paths::agent_dir(&id).map_err(|e| e.to_string())?;
+pub async fn save_agent_memory_md(id: String, content: String) -> Result<(), CmdError> {
+    let dir = crate::paths::agent_dir(&id)?;
     let _ = std::fs::create_dir_all(&dir);
-    std::fs::write(dir.join("memory.md"), content).map_err(|e| e.to_string())
+    std::fs::write(dir.join("memory.md"), content).map_err(Into::into)
 }

--- a/src-tauri/src/commands/misc.rs
+++ b/src-tauri/src/commands/misc.rs
@@ -1,7 +1,9 @@
+use crate::commands::CmdError;
+use anyhow::Context;
 use tauri;
 
 #[tauri::command]
-pub async fn open_directory(path: String) -> Result<(), String> {
+pub async fn open_directory(path: String) -> Result<(), CmdError> {
     // Resolve ~ to home directory
     let resolved = if path.starts_with("~/") {
         if let Some(home) = dirs::home_dir() {
@@ -12,11 +14,12 @@ pub async fn open_directory(path: String) -> Result<(), String> {
     } else {
         path
     };
-    open::that(&resolved).map_err(|e| format!("Failed to open directory: {}", e))
+    open::that(&resolved).context("Failed to open directory")?;
+    Ok(())
 }
 
 #[tauri::command]
-pub async fn reveal_in_folder(path: String) -> Result<(), String> {
+pub async fn reveal_in_folder(path: String) -> Result<(), CmdError> {
     let resolved = if path.starts_with("~/") {
         if let Some(home) = dirs::home_dir() {
             home.join(&path[2..]).to_string_lossy().to_string()
@@ -32,14 +35,14 @@ pub async fn reveal_in_folder(path: String) -> Result<(), String> {
             .arg("-R")
             .arg(&resolved)
             .spawn()
-            .map_err(|e| format!("Failed to reveal in Finder: {}", e))?;
+            .context("Failed to reveal in Finder")?;
     }
     #[cfg(target_os = "windows")]
     {
         std::process::Command::new("explorer")
             .arg(format!("/select,{}", &resolved))
             .spawn()
-            .map_err(|e| format!("Failed to reveal in Explorer: {}", e))?;
+            .context("Failed to reveal in Explorer")?;
     }
     #[cfg(target_os = "linux")]
     {
@@ -48,20 +51,22 @@ pub async fn reveal_in_folder(path: String) -> Result<(), String> {
             .parent()
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or(resolved);
-        open::that(&parent).map_err(|e| format!("Failed to open folder: {}", e))?;
+        open::that(&parent).context("Failed to open folder")?;
     }
     Ok(())
 }
 
 #[tauri::command]
-pub async fn open_url(url: String) -> Result<(), String> {
-    open::that(&url).map_err(|e| format!("Failed to open URL: {}", e))
+pub async fn open_url(url: String) -> Result<(), CmdError> {
+    open::that(&url).context("Failed to open URL")?;
+    Ok(())
 }
 
 /// Write exported content to a file (used by slash command /export).
 #[tauri::command]
-pub async fn write_export_file(path: String, content: String) -> Result<(), String> {
-    std::fs::write(&path, content).map_err(|e| format!("Failed to write export file: {}", e))
+pub async fn write_export_file(path: String, content: String) -> Result<(), CmdError> {
+    std::fs::write(&path, content).context("Failed to write export file")?;
+    Ok(())
 }
 
 /// Query whether Dangerous Mode (skip ALL tool approvals) is active, and the
@@ -80,16 +85,16 @@ pub fn get_dangerous_mode_status() -> ha_core::security::dangerous::DangerousMod
 /// Follows the same autosave-backup path as other config writes and emits
 /// `config:changed` so subscribed UIs refresh immediately.
 #[tauri::command]
-pub fn set_dangerous_skip_all_approvals(enabled: bool) -> Result<(), String> {
+pub fn set_dangerous_skip_all_approvals(enabled: bool) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("security.dangerous", "settings-ui"), |store| {
         store.dangerous_skip_all_approvals = enabled;
         Ok(())
-    })
-    .map_err(|e| e.to_string())
+    })?;
+    Ok(())
 }
 
 #[tauri::command]
-pub async fn set_window_theme(is_dark: bool, app_handle: tauri::AppHandle) -> Result<(), String> {
+pub async fn set_window_theme(is_dark: bool, app_handle: tauri::AppHandle) -> Result<(), CmdError> {
     #[cfg(target_os = "macos")]
     {
         use tauri::Manager;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,6 @@
+pub mod error;
+pub use error::CmdError;
+
 pub mod acp_control;
 pub mod agent_mgmt;
 pub mod auth;

--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -5,6 +5,7 @@
 //! exposed over HTTP in `ha-server::routes::onboarding` so the web GUI
 //! (browser-mode wizard) shares the exact same semantics.
 
+use crate::commands::CmdError;
 use ha_core::onboarding::{
     apply::{self, ProfileStepInput, SafetyStepInput, ServerStepInput},
     personality_preset_by_id, state, OnboardingState,
@@ -12,33 +13,33 @@ use ha_core::onboarding::{
 use serde_json::Value;
 
 #[tauri::command]
-pub async fn get_onboarding_state() -> Result<OnboardingState, String> {
-    state::get_state().map_err(|e| e.to_string())
+pub async fn get_onboarding_state() -> Result<OnboardingState, CmdError> {
+    state::get_state().map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn save_onboarding_draft(step: u32, draft: Value) -> Result<(), String> {
-    state::save_draft(step, draft).map_err(|e| e.to_string())
+pub async fn save_onboarding_draft(step: u32, draft: Value) -> Result<(), CmdError> {
+    state::save_draft(step, draft).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn mark_onboarding_completed() -> Result<(), String> {
-    state::mark_completed().map_err(|e| e.to_string())
+pub async fn mark_onboarding_completed() -> Result<(), CmdError> {
+    state::mark_completed().map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn mark_onboarding_skipped(step_key: String) -> Result<(), String> {
-    state::mark_skipped(&step_key).map_err(|e| e.to_string())
+pub async fn mark_onboarding_skipped(step_key: String) -> Result<(), CmdError> {
+    state::mark_skipped(&step_key).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn reset_onboarding() -> Result<(), String> {
-    state::reset().map_err(|e| e.to_string())
+pub async fn reset_onboarding() -> Result<(), CmdError> {
+    state::reset().map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn apply_onboarding_language(language: String) -> Result<(), String> {
-    apply::apply_language(&language).map_err(|e| e.to_string())
+pub async fn apply_onboarding_language(language: String) -> Result<(), CmdError> {
+    apply::apply_language(&language).map_err(Into::into)
 }
 
 #[tauri::command]
@@ -47,43 +48,43 @@ pub async fn apply_onboarding_profile(
     timezone: Option<String>,
     ai_experience: Option<String>,
     response_style: Option<String>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     apply::apply_profile(ProfileStepInput {
         name,
         timezone,
         ai_experience,
         response_style,
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn apply_personality_preset_cmd(preset_id: String) -> Result<(), String> {
+pub async fn apply_personality_preset_cmd(preset_id: String) -> Result<(), CmdError> {
     let preset = personality_preset_by_id(&preset_id)
-        .ok_or_else(|| format!("unknown personality preset: {}", preset_id))?;
-    apply::apply_personality_preset(preset).map_err(|e| e.to_string())
+        .ok_or_else(|| CmdError::msg(format!("unknown personality preset: {}", preset_id)))?;
+    apply::apply_personality_preset(preset).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn apply_onboarding_safety(approvals_enabled: bool) -> Result<(), String> {
-    apply::apply_safety(SafetyStepInput { approvals_enabled }).map_err(|e| e.to_string())
+pub async fn apply_onboarding_safety(approvals_enabled: bool) -> Result<(), CmdError> {
+    apply::apply_safety(SafetyStepInput { approvals_enabled }).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn apply_onboarding_skills(disabled: Vec<String>) -> Result<(), String> {
-    apply::apply_skills(disabled).map_err(|e| e.to_string())
+pub async fn apply_onboarding_skills(disabled: Vec<String>) -> Result<(), CmdError> {
+    apply::apply_skills(disabled).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn apply_onboarding_server(
     bind_addr: Option<String>,
     api_key: Option<String>,
-) -> Result<(), String> {
-    apply::apply_server(ServerStepInput { bind_addr, api_key }).map_err(|e| e.to_string())
+) -> Result<(), CmdError> {
+    apply::apply_server(ServerStepInput { bind_addr, api_key }).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn generate_api_key() -> Result<String, String> {
+pub async fn generate_api_key() -> Result<String, CmdError> {
     Ok(apply::generate_api_key())
 }
 
@@ -91,6 +92,6 @@ pub async fn generate_api_key() -> Result<String, String> {
 /// Summary page / Launch Banner can show a "same-LAN" URL. Returns an
 /// empty vec if interface enumeration fails.
 #[tauri::command]
-pub async fn list_local_ips() -> Result<Vec<String>, String> {
+pub async fn list_local_ips() -> Result<Vec<String>, CmdError> {
     Ok(crate::cli_onboarding::banner::local_ipv4_addresses())
 }

--- a/src-tauri/src/commands/plan.rs
+++ b/src-tauri/src/commands/plan.rs
@@ -1,3 +1,4 @@
+use crate::commands::CmdError;
 use crate::plan::{self, PlanModeState, PlanStep, PlanStepStatus, PlanVersionInfo};
 use ha_core::app_info;
 use ha_core::ask_user::AskUserQuestionAnswer;
@@ -6,7 +7,7 @@ use ha_core::ask_user::AskUserQuestionAnswer;
 pub async fn get_plan_mode(
     session_id: String,
     app_state: tauri::State<'_, crate::AppState>,
-) -> Result<String, String> {
+) -> Result<String, CmdError> {
     if let Ok(Some(meta)) = app_state.session_db.get_session(&session_id) {
         if meta.plan_mode == "off" {
             plan::set_plan_state(&session_id, PlanModeState::Off).await;
@@ -30,7 +31,7 @@ pub async fn set_plan_mode(
     session_id: String,
     state: String,
     app_state: tauri::State<'_, crate::AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     let plan_state = PlanModeState::from_str(&state);
     let is_executing = plan_state == PlanModeState::Executing;
 
@@ -64,20 +65,19 @@ pub async fn set_plan_mode(
     }
     // Persist to DB
     let db = &app_state.session_db;
-    db.update_session_plan_mode(&session_id, &state)
-        .map_err(|e| e.to_string())?;
+    db.update_session_plan_mode(&session_id, &state)?;
     Ok(())
 }
 
 #[tauri::command]
-pub async fn get_plan_content(session_id: String) -> Result<Option<String>, String> {
-    plan::load_plan_file(&session_id).map_err(|e| e.to_string())
+pub async fn get_plan_content(session_id: String) -> Result<Option<String>, CmdError> {
+    plan::load_plan_file(&session_id).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn save_plan_content(session_id: String, content: String) -> Result<(), String> {
+pub async fn save_plan_content(session_id: String, content: String) -> Result<(), CmdError> {
     // Save file
-    plan::save_plan_file(&session_id, &content).map_err(|e| e.to_string())?;
+    plan::save_plan_file(&session_id, &content)?;
     // Parse steps and update in-memory state
     let steps = plan::parse_plan_steps(&content);
     plan::update_plan_steps(&session_id, steps).await;
@@ -88,7 +88,7 @@ pub async fn save_plan_content(session_id: String, content: String) -> Result<()
 pub async fn get_plan_steps(
     session_id: String,
     app_state: tauri::State<'_, crate::AppState>,
-) -> Result<Vec<PlanStep>, String> {
+) -> Result<Vec<PlanStep>, CmdError> {
     if let Ok(Some(session_meta)) = app_state.session_db.get_session(&session_id) {
         if session_meta.plan_mode == "off" {
             plan::set_plan_state(&session_id, PlanModeState::Off).await;
@@ -114,7 +114,7 @@ pub async fn update_plan_step_status(
     session_id: String,
     step_index: usize,
     status: String,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     let step_status = PlanStepStatus::from_str(&status);
     plan::update_step_status(&session_id, step_index, step_status, None).await;
 
@@ -163,10 +163,10 @@ pub async fn update_plan_step_status(
 #[tauri::command]
 pub async fn get_pending_ask_user_group(
     session_id: String,
-) -> Result<Option<ha_core::ask_user::AskUserQuestionGroup>, String> {
+) -> Result<Option<ha_core::ask_user::AskUserQuestionGroup>, CmdError> {
     ha_core::ask_user::find_live_pending_group_for_session(&session_id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Submit the user's answers to an `ask_user_question` tool call.
@@ -174,38 +174,38 @@ pub async fn get_pending_ask_user_group(
 pub async fn respond_ask_user_question(
     request_id: String,
     answers: Vec<AskUserQuestionAnswer>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::ask_user::submit_ask_user_question_response(&request_id, answers)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_plan_versions(session_id: String) -> Result<Vec<PlanVersionInfo>, String> {
-    plan::list_plan_versions(&session_id).map_err(|e| e.to_string())
+pub async fn get_plan_versions(session_id: String) -> Result<Vec<PlanVersionInfo>, CmdError> {
+    plan::list_plan_versions(&session_id).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn load_plan_version_content(file_path: String) -> Result<String, String> {
-    plan::load_plan_version(&file_path).map_err(|e| e.to_string())
+pub async fn load_plan_version_content(file_path: String) -> Result<String, CmdError> {
+    plan::load_plan_version(&file_path).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn restore_plan_version(session_id: String, file_path: String) -> Result<(), String> {
-    let content = plan::load_plan_version(&file_path).map_err(|e| e.to_string())?;
-    plan::save_plan_file(&session_id, &content).map_err(|e| e.to_string())?;
+pub async fn restore_plan_version(session_id: String, file_path: String) -> Result<(), CmdError> {
+    let content = plan::load_plan_version(&file_path)?;
+    plan::save_plan_file(&session_id, &content)?;
     let steps = plan::parse_plan_steps(&content);
     plan::update_plan_steps(&session_id, steps).await;
     Ok(())
 }
 
 #[tauri::command]
-pub async fn plan_rollback(session_id: String) -> Result<String, String> {
+pub async fn plan_rollback(session_id: String) -> Result<String, CmdError> {
     let checkpoint = plan::get_checkpoint_ref(&session_id)
         .await
-        .ok_or_else(|| "No git checkpoint found for this plan execution".to_string())?;
+        .ok_or_else(|| CmdError::msg("No git checkpoint found for this plan execution"))?;
 
-    let msg = plan::rollback_to_checkpoint(&checkpoint).map_err(|e| e.to_string())?;
+    let msg = plan::rollback_to_checkpoint(&checkpoint)?;
 
     // Clear checkpoint ref after rollback
     let mut map = plan::store().write().await;
@@ -217,12 +217,12 @@ pub async fn plan_rollback(session_id: String) -> Result<String, String> {
 }
 
 #[tauri::command]
-pub async fn get_plan_checkpoint(session_id: String) -> Result<Option<String>, String> {
+pub async fn get_plan_checkpoint(session_id: String) -> Result<Option<String>, CmdError> {
     Ok(plan::get_checkpoint_ref(&session_id).await)
 }
 
 #[tauri::command]
-pub async fn get_plan_file_path(session_id: String) -> Result<Option<String>, String> {
+pub async fn get_plan_file_path(session_id: String) -> Result<Option<String>, CmdError> {
     if let Some(meta) = plan::get_plan_meta(&session_id).await {
         if !meta.file_path.is_empty() {
             return Ok(Some(meta.file_path));
@@ -232,7 +232,7 @@ pub async fn get_plan_file_path(session_id: String) -> Result<Option<String>, St
 }
 
 #[tauri::command]
-pub async fn cancel_plan_subagent(session_id: String) -> Result<(), String> {
+pub async fn cancel_plan_subagent(session_id: String) -> Result<(), CmdError> {
     if let Some(run_id) = plan::get_active_plan_run_id(&session_id).await {
         if let Some(cancels) = crate::get_subagent_cancels() {
             cancels.cancel(&run_id);
@@ -244,7 +244,7 @@ pub async fn cancel_plan_subagent(session_id: String) -> Result<(), String> {
             );
             Ok(())
         } else {
-            Err("Cancel registry not initialized".to_string())
+            Err(CmdError::msg("Cancel registry not initialized"))
         }
     } else {
         Ok(()) // No active plan sub-agent — nothing to cancel

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -1,9 +1,11 @@
 //! Tauri commands for the Project feature.
 //!
 //! Thin wrappers around [`ha_core::project`] — all business logic lives in
-//! ha-core; this file only handles `Result<T, E>` → `Result<T, String>`
+//! ha-core; this file only handles `Result<T, E>` → `Result<T, CmdError>`
 //! conversion and holds the `AppState` bridge.
 
+use crate::commands::CmdError;
+use anyhow::Context;
 use ha_core::project::{
     delete_project_cascade, delete_project_file as delete_file_pipeline, upload_project_file,
     CreateProjectInput, Project, ProjectFile, ProjectMeta, UpdateProjectInput, UploadInput,
@@ -13,19 +15,15 @@ use tauri::State;
 
 use crate::AppState;
 
-fn map_err<E: std::fmt::Display>(e: E) -> String {
-    e.to_string()
-}
-
 // ── Project CRUD ────────────────────────────────────────────────
 
 #[tauri::command]
 pub async fn list_projects_cmd(
     include_archived: Option<bool>,
     state: State<'_, AppState>,
-) -> Result<Vec<ProjectMeta>, String> {
+) -> Result<Vec<ProjectMeta>, CmdError> {
     let include_archived = include_archived.unwrap_or(false);
-    let mut projects = state.project_db.list(include_archived).map_err(map_err)?;
+    let mut projects = state.project_db.list(include_archived)?;
 
     // Cross-DB enrichment: fetch project-scoped memory counts.
     if let Some(backend) = ha_core::get_memory_backend() {
@@ -43,16 +41,16 @@ pub async fn list_projects_cmd(
 pub async fn get_project_cmd(
     id: String,
     state: State<'_, AppState>,
-) -> Result<Option<Project>, String> {
-    state.project_db.get(&id).map_err(map_err)
+) -> Result<Option<Project>, CmdError> {
+    state.project_db.get(&id).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn create_project_cmd(
     input: CreateProjectInput,
     state: State<'_, AppState>,
-) -> Result<Project, String> {
-    let project = state.project_db.create(input).map_err(map_err)?;
+) -> Result<Project, CmdError> {
+    let project = state.project_db.create(input)?;
 
     if let Some(bus) = ha_core::get_event_bus() {
         let _ = bus.emit(
@@ -68,8 +66,8 @@ pub async fn update_project_cmd(
     id: String,
     patch: UpdateProjectInput,
     state: State<'_, AppState>,
-) -> Result<Project, String> {
-    let project = state.project_db.update(&id, patch).map_err(map_err)?;
+) -> Result<Project, CmdError> {
+    let project = state.project_db.update(&id, patch)?;
 
     if let Some(bus) = ha_core::get_event_bus() {
         let _ = bus.emit(
@@ -81,8 +79,8 @@ pub async fn update_project_cmd(
 }
 
 #[tauri::command]
-pub async fn delete_project_cmd(id: String, state: State<'_, AppState>) -> Result<bool, String> {
-    let deleted = delete_project_cascade(&id, &state.project_db).map_err(map_err)?;
+pub async fn delete_project_cmd(id: String, state: State<'_, AppState>) -> Result<bool, CmdError> {
+    let deleted = delete_project_cascade(&id, &state.project_db)?;
 
     if deleted {
         if let Some(bus) = ha_core::get_event_bus() {
@@ -97,12 +95,12 @@ pub async fn archive_project_cmd(
     id: String,
     archived: bool,
     state: State<'_, AppState>,
-) -> Result<Project, String> {
+) -> Result<Project, CmdError> {
     let patch = UpdateProjectInput {
         archived: Some(archived),
         ..Default::default()
     };
-    let project = state.project_db.update(&id, patch).map_err(map_err)?;
+    let project = state.project_db.update(&id, patch)?;
 
     if let Some(bus) = ha_core::get_event_bus() {
         let _ = bus.emit(
@@ -122,21 +120,16 @@ pub async fn list_project_sessions_cmd(
     offset: Option<u32>,
     active_session_id: Option<String>,
     state: State<'_, AppState>,
-) -> Result<(Vec<SessionMeta>, u32), String> {
+) -> Result<(Vec<SessionMeta>, u32), CmdError> {
     use ha_core::session::ProjectFilter;
-    let (mut sessions, total) = state
-        .session_db
-        .list_sessions_paged(
-            None,
-            ProjectFilter::InProject(&id),
-            limit,
-            offset,
-            active_session_id.as_deref(),
-        )
-        .map_err(map_err)?;
-    ha_core::session::enrich_pending_interactions(&mut sessions, &state.session_db)
-        .await
-        .map_err(map_err)?;
+    let (mut sessions, total) = state.session_db.list_sessions_paged(
+        None,
+        ProjectFilter::InProject(&id),
+        limit,
+        offset,
+        active_session_id.as_deref(),
+    )?;
+    ha_core::session::enrich_pending_interactions(&mut sessions, &state.session_db).await?;
     Ok((sessions, total))
 }
 
@@ -145,11 +138,11 @@ pub async fn move_session_to_project_cmd(
     session_id: String,
     project_id: Option<String>,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     state
         .session_db
         .set_session_project(&session_id, project_id.as_deref())
-        .map_err(map_err)
+        .map_err(Into::into)
 }
 
 // ── Project Files ───────────────────────────────────────────────
@@ -158,8 +151,8 @@ pub async fn move_session_to_project_cmd(
 pub async fn list_project_files_cmd(
     id: String,
     state: State<'_, AppState>,
-) -> Result<Vec<ProjectFile>, String> {
-    state.project_db.list_files(&id).map_err(map_err)
+) -> Result<Vec<ProjectFile>, CmdError> {
+    state.project_db.list_files(&id).map_err(Into::into)
 }
 
 #[tauri::command]
@@ -169,7 +162,7 @@ pub async fn upload_project_file_cmd(
     mime_type: Option<String>,
     data: Vec<u8>,
     state: State<'_, AppState>,
-) -> Result<ProjectFile, String> {
+) -> Result<ProjectFile, CmdError> {
     // Run the blocking upload pipeline (file IO + text extraction) off the
     // tokio runtime so the main thread stays responsive on large files.
     let project_db = state.project_db.clone();
@@ -184,9 +177,7 @@ pub async fn upload_project_file_cmd(
             &project_db,
         )
     })
-    .await
-    .map_err(|e| e.to_string())?
-    .map_err(map_err)?;
+    .await??;
 
     if let Some(bus) = ha_core::get_event_bus() {
         let _ = bus.emit(
@@ -205,14 +196,12 @@ pub async fn delete_project_file_cmd(
     project_id: String,
     file_id: String,
     state: State<'_, AppState>,
-) -> Result<bool, String> {
+) -> Result<bool, CmdError> {
     let project_db = state.project_db.clone();
     let file_id_for_pipe = file_id.clone();
     let deleted =
         tokio::task::spawn_blocking(move || delete_file_pipeline(&file_id_for_pipe, &project_db))
-            .await
-            .map_err(|e| e.to_string())?
-            .map_err(map_err)?;
+            .await??;
 
     if deleted {
         if let Some(bus) = ha_core::get_event_bus() {
@@ -234,11 +223,11 @@ pub async fn rename_project_file_cmd(
     file_id: String,
     name: String,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     state
         .project_db
         .rename_file(&file_id, &name)
-        .map_err(map_err)
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -248,23 +237,27 @@ pub async fn read_project_file_content_cmd(
     offset: Option<u32>,
     limit: Option<u32>,
     state: State<'_, AppState>,
-) -> Result<serde_json::Value, String> {
+) -> Result<serde_json::Value, CmdError> {
     let file = state
         .project_db
-        .get_file(&project_id, &file_id)
-        .map_err(map_err)?
-        .ok_or_else(|| format!("file {} not found in project {}", file_id, project_id))?;
+        .get_file(&project_id, &file_id)?
+        .ok_or_else(|| {
+            CmdError::msg(format!(
+                "file {} not found in project {}",
+                file_id, project_id
+            ))
+        })?;
 
     let ext_rel = file
         .extracted_path
         .as_ref()
-        .ok_or_else(|| "file has no extracted text (binary)".to_string())?;
+        .ok_or_else(|| CmdError::msg("file has no extracted text (binary)"))?;
 
-    let base = ha_core::paths::projects_dir().map_err(map_err)?;
+    let base = ha_core::paths::projects_dir()?;
     let full = base.join(ext_rel);
     let content = tokio::fs::read_to_string(&full)
         .await
-        .map_err(|e| format!("read {}: {}", full.display(), e))?;
+        .with_context(|| format!("read {}", full.display()))?;
 
     let lines: Vec<&str> = content.lines().collect();
     let total = lines.len();
@@ -293,9 +286,9 @@ pub async fn list_project_memories_cmd(
     id: String,
     limit: Option<u32>,
     offset: Option<u32>,
-) -> Result<Vec<ha_core::memory::MemoryEntry>, String> {
+) -> Result<Vec<ha_core::memory::MemoryEntry>, CmdError> {
     let backend = ha_core::get_memory_backend()
-        .ok_or_else(|| "memory backend not initialized".to_string())?;
+        .ok_or_else(|| CmdError::msg("memory backend not initialized"))?;
     let scope = ha_core::memory::MemoryScope::Project { id };
     backend
         .list(
@@ -304,5 +297,5 @@ pub async fn list_project_memories_cmd(
             limit.unwrap_or(200) as usize,
             offset.unwrap_or(0) as usize,
         )
-        .map_err(map_err)
+        .map_err(Into::into)
 }

--- a/src-tauri/src/commands/provider/crud.rs
+++ b/src-tauri/src/commands/provider/crud.rs
@@ -1,3 +1,4 @@
+use crate::commands::CmdError;
 use crate::provider::{self, ProviderConfig};
 use crate::AppState;
 use tauri::State;
@@ -5,7 +6,7 @@ use tauri::State;
 // ── Provider Management Commands ──────────────────────────────────
 
 #[tauri::command]
-pub async fn get_providers(_state: State<'_, AppState>) -> Result<Vec<ProviderConfig>, String> {
+pub async fn get_providers(_state: State<'_, AppState>) -> Result<Vec<ProviderConfig>, CmdError> {
     Ok(ha_core::config::cached_config().providers.clone())
 }
 
@@ -13,7 +14,7 @@ pub async fn get_providers(_state: State<'_, AppState>) -> Result<Vec<ProviderCo
 pub async fn add_provider(
     config: ProviderConfig,
     _state: State<'_, AppState>,
-) -> Result<ProviderConfig, String> {
+) -> Result<ProviderConfig, CmdError> {
     let new_provider = ProviderConfig::new(
         config.name,
         config.api_type,
@@ -31,8 +32,7 @@ pub async fn add_provider(
     ha_core::config::mutate_config(("providers.add", "ui"), |store| {
         store.providers.push(provider_with_models);
         Ok(())
-    })
-    .map_err(|e| e.to_string())?;
+    })?;
     Ok(masked)
 }
 
@@ -40,7 +40,7 @@ pub async fn add_provider(
 pub async fn update_provider(
     config: ProviderConfig,
     _state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("providers.update", "ui"), |store| {
         let Some(existing) = store.providers.iter_mut().find(|p| p.id == config.id) else {
             return Err(anyhow::anyhow!("Provider not found: {}", config.id));
@@ -62,14 +62,14 @@ pub async fn update_provider(
         existing.allow_private_network = config.allow_private_network;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn reorder_providers(
     provider_ids: Vec<String>,
     _state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("providers.reorder", "ui"), |store| {
         let mut reordered = Vec::with_capacity(provider_ids.len());
         for id in &provider_ids {
@@ -86,14 +86,14 @@ pub async fn reorder_providers(
         store.providers = reordered;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn delete_provider(
     provider_id: String,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     // Capture whether the active agent needs to be torn down, then persist.
     let active_was_removed = ha_core::config::mutate_config(("providers.delete", "ui"), |store| {
         let len_before = store.providers.len();
@@ -110,8 +110,7 @@ pub async fn delete_provider(
             store.active_model = None;
         }
         Ok(removed_active)
-    })
-    .map_err(|e| e.to_string())?;
+    })?;
 
     if active_was_removed {
         *state.agent.lock().await = None;
@@ -120,6 +119,6 @@ pub async fn delete_provider(
 }
 
 #[tauri::command]
-pub async fn has_providers(_state: State<'_, AppState>) -> Result<bool, String> {
+pub async fn has_providers(_state: State<'_, AppState>) -> Result<bool, CmdError> {
     Ok(!ha_core::config::cached_config().providers.is_empty())
 }

--- a/src-tauri/src/commands/provider/models.rs
+++ b/src-tauri/src/commands/provider/models.rs
@@ -1,4 +1,5 @@
 use crate::agent::AssistantAgent;
+use crate::commands::CmdError;
 use crate::provider::{self, ActiveModel, ApiType, AvailableModel};
 use crate::AppState;
 use tauri::State;
@@ -6,14 +7,16 @@ use tauri::State;
 #[tauri::command]
 pub async fn get_available_models(
     _state: State<'_, AppState>,
-) -> Result<Vec<AvailableModel>, String> {
+) -> Result<Vec<AvailableModel>, CmdError> {
     Ok(provider::build_available_models(
         &ha_core::config::cached_config().providers,
     ))
 }
 
 #[tauri::command]
-pub async fn get_active_model(_state: State<'_, AppState>) -> Result<Option<ActiveModel>, String> {
+pub async fn get_active_model(
+    _state: State<'_, AppState>,
+) -> Result<Option<ActiveModel>, CmdError> {
     Ok(ha_core::config::cached_config().active_model.clone())
 }
 
@@ -23,7 +26,7 @@ pub(crate) async fn set_active_model_core(
     provider_id: &str,
     model_id: &str,
     state: &AppState,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     // Clone the provider snapshot before mutating — holding the Arc from
     // `cached_config()` across the later `.await` points would deadlock.
     let provider = {
@@ -33,9 +36,9 @@ pub(crate) async fn set_active_model_core(
             .iter()
             .find(|p| p.id == provider_id)
             .cloned()
-            .ok_or_else(|| format!("Provider not found: {}", provider_id))?;
+            .ok_or_else(|| CmdError::msg(format!("Provider not found: {}", provider_id)))?;
         if !found.models.iter().any(|m| m.id == model_id) {
-            return Err(format!("Model not found: {}", model_id));
+            return Err(CmdError::msg(format!("Model not found: {}", model_id)));
         }
         found
     };
@@ -61,7 +64,7 @@ pub(crate) async fn set_active_model_core(
         });
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -69,12 +72,14 @@ pub async fn set_active_model(
     provider_id: String,
     model_id: String,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     set_active_model_core(&provider_id, &model_id, &state).await
 }
 
 #[tauri::command]
-pub async fn get_fallback_models(_state: State<'_, AppState>) -> Result<Vec<ActiveModel>, String> {
+pub async fn get_fallback_models(
+    _state: State<'_, AppState>,
+) -> Result<Vec<ActiveModel>, CmdError> {
     Ok(ha_core::config::cached_config().fallback_models.clone())
 }
 
@@ -82,12 +87,12 @@ pub async fn get_fallback_models(_state: State<'_, AppState>) -> Result<Vec<Acti
 pub async fn set_fallback_models(
     models: Vec<ActiveModel>,
     _state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     ha_core::config::mutate_config(("fallback_models", "ui"), |store| {
         store.fallback_models = models;
         Ok(())
     })
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 // has_providers is in crud.rs

--- a/src-tauri/src/commands/provider/test_embedding.rs
+++ b/src-tauri/src/commands/provider/test_embedding.rs
@@ -1,6 +1,9 @@
+use crate::commands::CmdError;
 use crate::memory;
 
 #[tauri::command]
-pub async fn test_embedding(config: memory::EmbeddingConfig) -> Result<String, String> {
-    ha_core::provider::test::test_embedding(config).await
+pub async fn test_embedding(config: memory::EmbeddingConfig) -> Result<String, CmdError> {
+    ha_core::provider::test::test_embedding(config)
+        .await
+        .map_err(CmdError::msg)
 }

--- a/src-tauri/src/commands/provider/test_image.rs
+++ b/src-tauri/src/commands/provider/test_image.rs
@@ -1,8 +1,12 @@
+use crate::commands::CmdError;
+
 #[tauri::command]
 pub async fn test_image_generate(
     provider_id: String,
     api_key: String,
     base_url: Option<String>,
-) -> Result<String, String> {
-    ha_core::provider::test::test_image_generate(provider_id, api_key, base_url).await
+) -> Result<String, CmdError> {
+    ha_core::provider::test::test_image_generate(provider_id, api_key, base_url)
+        .await
+        .map_err(CmdError::msg)
 }

--- a/src-tauri/src/commands/provider/test_provider.rs
+++ b/src-tauri/src/commands/provider/test_provider.rs
@@ -1,14 +1,19 @@
+use crate::commands::CmdError;
 use crate::provider::ProviderConfig;
 
 #[tauri::command]
-pub async fn test_provider(config: ProviderConfig) -> Result<String, String> {
-    ha_core::provider::test::test_provider(config).await
+pub async fn test_provider(config: ProviderConfig) -> Result<String, CmdError> {
+    ha_core::provider::test::test_provider(config)
+        .await
+        .map_err(CmdError::msg)
 }
 
 /// Single-turn chat probe used by the Settings panel's "Test model" button.
 /// Full implementation lives in [`ha_core::provider::test::test_model`] so
 /// both the Tauri shell and the HTTP route share the same body.
 #[tauri::command]
-pub async fn test_model(config: ProviderConfig, model_id: String) -> Result<String, String> {
-    ha_core::provider::test::test_model(config, model_id).await
+pub async fn test_model(config: ProviderConfig, model_id: String) -> Result<String, CmdError> {
+    ha_core::provider::test::test_model(config, model_id)
+        .await
+        .map_err(CmdError::msg)
 }

--- a/src-tauri/src/commands/recap.rs
+++ b/src-tauri/src/commands/recap.rs
@@ -1,27 +1,31 @@
+use crate::commands::CmdError;
 use ha_core::recap::api;
 use ha_core::recap::types::{GenerateMode, RecapReport, RecapReportSummary};
 
 #[tauri::command]
-pub async fn recap_generate(mode: GenerateMode) -> Result<RecapReport, String> {
-    api::generate(mode).await.map_err(|e| e.to_string())
+pub async fn recap_generate(mode: GenerateMode) -> Result<RecapReport, CmdError> {
+    api::generate(mode).await.map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn recap_list_reports(limit: Option<u32>) -> Result<Vec<RecapReportSummary>, String> {
-    api::list_reports(limit.unwrap_or(50)).map_err(|e| e.to_string())
+pub async fn recap_list_reports(limit: Option<u32>) -> Result<Vec<RecapReportSummary>, CmdError> {
+    api::list_reports(limit.unwrap_or(50)).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn recap_get_report(id: String) -> Result<Option<RecapReport>, String> {
-    api::get_report(&id).map_err(|e| e.to_string())
+pub async fn recap_get_report(id: String) -> Result<Option<RecapReport>, CmdError> {
+    api::get_report(&id).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn recap_delete_report(id: String) -> Result<(), String> {
-    api::delete_report(&id).map_err(|e| e.to_string())
+pub async fn recap_delete_report(id: String) -> Result<(), CmdError> {
+    api::delete_report(&id).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn recap_export_html(id: String, output_path: Option<String>) -> Result<String, String> {
-    api::export_html(&id, output_path).map_err(|e| e.to_string())
+pub async fn recap_export_html(
+    id: String,
+    output_path: Option<String>,
+) -> Result<String, CmdError> {
+    api::export_html(&id, output_path).map_err(Into::into)
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,3 +1,4 @@
+use crate::commands::CmdError;
 use crate::session;
 use crate::session::ProjectFilter;
 use crate::AppState;
@@ -9,12 +10,12 @@ pub async fn create_session_cmd(
     project_id: Option<String>,
     incognito: Option<bool>,
     state: State<'_, AppState>,
-) -> Result<session::SessionMeta, String> {
+) -> Result<session::SessionMeta, CmdError> {
     let agent_id = agent_id.unwrap_or_else(|| "default".to_string());
     state
         .session_db
         .create_session_with_project(&agent_id, project_id.as_deref(), incognito)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -26,7 +27,7 @@ pub async fn list_sessions_cmd(
     offset: Option<u32>,
     active_session_id: Option<String>,
     state: State<'_, AppState>,
-) -> Result<(Vec<session::SessionMeta>, u32), String> {
+) -> Result<(Vec<session::SessionMeta>, u32), CmdError> {
     // Precedence: explicit `unassigned=true` wins; then `project_id`; else All.
     let project_filter = if unassigned.unwrap_or(false) {
         ProjectFilter::Unassigned
@@ -36,20 +37,15 @@ pub async fn list_sessions_cmd(
         ProjectFilter::All
     };
 
-    let (mut sessions, total) = state
-        .session_db
-        .list_sessions_paged(
-            agent_id.as_deref(),
-            project_filter,
-            limit,
-            offset,
-            active_session_id.as_deref(),
-        )
-        .map_err(|e| e.to_string())?;
+    let (mut sessions, total) = state.session_db.list_sessions_paged(
+        agent_id.as_deref(),
+        project_filter,
+        limit,
+        offset,
+        active_session_id.as_deref(),
+    )?;
 
-    session::enrich_pending_interactions(&mut sessions, &state.session_db)
-        .await
-        .map_err(|e| e.to_string())?;
+    session::enrich_pending_interactions(&mut sessions, &state.session_db).await?;
 
     Ok((sessions, total))
 }
@@ -59,11 +55,11 @@ pub async fn load_session_messages_latest_cmd(
     session_id: String,
     limit: u32,
     state: State<'_, AppState>,
-) -> Result<(Vec<session::SessionMessage>, u32, bool), String> {
+) -> Result<(Vec<session::SessionMessage>, u32, bool), CmdError> {
     state
         .session_db
         .load_session_messages_latest(&session_id, limit)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -72,22 +68,22 @@ pub async fn load_session_messages_before_cmd(
     before_id: i64,
     limit: u32,
     state: State<'_, AppState>,
-) -> Result<(Vec<session::SessionMessage>, bool), String> {
+) -> Result<(Vec<session::SessionMessage>, bool), CmdError> {
     state
         .session_db
         .load_session_messages_before(&session_id, before_id, limit)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn get_session_cmd(
     session_id: String,
     state: State<'_, AppState>,
-) -> Result<Option<session::SessionMeta>, String> {
+) -> Result<Option<session::SessionMeta>, CmdError> {
     state
         .session_db
         .get_session(&session_id)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -95,11 +91,11 @@ pub async fn set_session_incognito(
     session_id: String,
     enabled: bool,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     state
         .session_db
         .update_session_incognito(&session_id, enabled)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Persist the user-selected working directory for a chat session. The core
@@ -110,34 +106,34 @@ pub async fn set_session_working_dir(
     session_id: String,
     working_dir: Option<String>,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     state
         .session_db
         .update_session_working_dir(&session_id, working_dir)
         .map(|_| ())
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn delete_session_cmd(
     session_id: String,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     state
         .session_db
         .delete_session(&session_id)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn purge_session_if_incognito(
     session_id: String,
     state: State<'_, AppState>,
-) -> Result<bool, String> {
+) -> Result<bool, CmdError> {
     state
         .session_db
         .purge_session_if_incognito(&session_id)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -145,11 +141,11 @@ pub async fn rename_session_cmd(
     session_id: String,
     title: String,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     state
         .session_db
         .update_session_title(&session_id, &title)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Mark all messages in a session as read.
@@ -157,11 +153,11 @@ pub async fn rename_session_cmd(
 pub async fn mark_session_read_cmd(
     session_id: String,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     state
         .session_db
         .mark_session_read(&session_id)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Mark all messages in multiple sessions as read.
@@ -169,19 +165,19 @@ pub async fn mark_session_read_cmd(
 pub async fn mark_session_read_batch_cmd(
     session_ids: Vec<String>,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     state
         .session_db
         .mark_session_read_batch(&session_ids)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn mark_all_sessions_read_cmd(state: State<'_, AppState>) -> Result<(), String> {
+pub async fn mark_all_sessions_read_cmd(state: State<'_, AppState>) -> Result<(), CmdError> {
     state
         .session_db
         .mark_all_sessions_read()
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Search message history (FTS5) across sessions.
@@ -196,7 +192,7 @@ pub async fn search_sessions_cmd(
     types: Option<Vec<String>>,
     limit: Option<u32>,
     state: State<'_, AppState>,
-) -> Result<Vec<session::SessionSearchResult>, String> {
+) -> Result<Vec<session::SessionSearchResult>, CmdError> {
     let limit = limit.unwrap_or(80) as usize;
 
     let parsed_types: Option<Vec<session::SessionTypeFilter>> = types.map(|list| {
@@ -209,7 +205,7 @@ pub async fn search_sessions_cmd(
     state
         .session_db
         .search_messages(&query, agent_id.as_deref(), None, type_slice, limit)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Search message history within a single session (FTS5). Used by the
@@ -220,12 +216,12 @@ pub async fn search_session_messages_cmd(
     query: String,
     limit: Option<u32>,
     state: State<'_, AppState>,
-) -> Result<Vec<session::SessionSearchResult>, String> {
+) -> Result<Vec<session::SessionSearchResult>, CmdError> {
     let limit = limit.unwrap_or(200) as usize;
     state
         .session_db
         .search_messages(&query, None, Some(&session_id), None, limit)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Load a window of messages centred on a target message id (used by search
@@ -237,11 +233,11 @@ pub async fn load_session_messages_around_cmd(
     before: u32,
     after: u32,
     state: State<'_, AppState>,
-) -> Result<(Vec<session::SessionMessage>, u32, bool, bool), String> {
+) -> Result<(Vec<session::SessionMessage>, u32, bool, bool), CmdError> {
     state
         .session_db
         .load_session_messages_around(&session_id, target_message_id, before, after)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 /// Report whether a session currently has an active chat stream running in
@@ -251,6 +247,6 @@ pub async fn load_session_messages_around_cmd(
 #[tauri::command]
 pub async fn get_session_stream_state(
     session_id: String,
-) -> Result<ha_core::chat_engine::SessionStreamState, String> {
+) -> Result<ha_core::chat_engine::SessionStreamState, CmdError> {
     Ok(ha_core::chat_engine::session_stream_state(&session_id))
 }

--- a/src-tauri/src/commands/skills.rs
+++ b/src-tauri/src/commands/skills.rs
@@ -1,3 +1,4 @@
+use crate::commands::CmdError;
 use crate::skills;
 use crate::AppState;
 use tauri::State;
@@ -7,7 +8,9 @@ use ha_core::skills::commands as core;
 const SOURCE: &str = "settings-ui";
 
 #[tauri::command]
-pub async fn get_skills(_state: State<'_, AppState>) -> Result<Vec<skills::SkillSummary>, String> {
+pub async fn get_skills(
+    _state: State<'_, AppState>,
+) -> Result<Vec<skills::SkillSummary>, CmdError> {
     Ok(core::list_skills())
 }
 
@@ -15,32 +18,35 @@ pub async fn get_skills(_state: State<'_, AppState>) -> Result<Vec<skills::Skill
 pub async fn get_skill_detail(
     name: String,
     _state: State<'_, AppState>,
-) -> Result<skills::SkillDetail, String> {
-    core::get_skill_detail(&name).ok_or_else(|| format!("Skill not found: {}", name))
+) -> Result<skills::SkillDetail, CmdError> {
+    core::get_skill_detail(&name).ok_or_else(|| CmdError::msg(format!("Skill not found: {}", name)))
 }
 
 #[tauri::command]
-pub async fn get_extra_skills_dirs(_state: State<'_, AppState>) -> Result<Vec<String>, String> {
+pub async fn get_extra_skills_dirs(_state: State<'_, AppState>) -> Result<Vec<String>, CmdError> {
     Ok(core::get_extra_skills_dirs())
 }
 
 #[tauri::command]
-pub async fn add_extra_skills_dir(dir: String, _state: State<'_, AppState>) -> Result<(), String> {
-    core::add_extra_skills_dir(dir, SOURCE).map_err(|e| e.to_string())
+pub async fn add_extra_skills_dir(
+    dir: String,
+    _state: State<'_, AppState>,
+) -> Result<(), CmdError> {
+    core::add_extra_skills_dir(dir, SOURCE).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn remove_extra_skills_dir(
     dir: String,
     _state: State<'_, AppState>,
-) -> Result<(), String> {
-    core::remove_extra_skills_dir(&dir, SOURCE).map_err(|e| e.to_string())
+) -> Result<(), CmdError> {
+    core::remove_extra_skills_dir(&dir, SOURCE).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn discover_preset_skill_sources(
     _state: State<'_, AppState>,
-) -> Result<Vec<core::PresetSkillSource>, String> {
+) -> Result<Vec<core::PresetSkillSource>, CmdError> {
     Ok(core::discover_preset_skill_sources())
 }
 
@@ -49,18 +55,21 @@ pub async fn toggle_skill(
     name: String,
     enabled: bool,
     _state: State<'_, AppState>,
-) -> Result<(), String> {
-    core::toggle_skill(name, enabled, SOURCE).map_err(|e| e.to_string())
+) -> Result<(), CmdError> {
+    core::toggle_skill(name, enabled, SOURCE).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn get_skill_env_check(_state: State<'_, AppState>) -> Result<bool, String> {
+pub async fn get_skill_env_check(_state: State<'_, AppState>) -> Result<bool, CmdError> {
     Ok(core::get_skill_env_check())
 }
 
 #[tauri::command]
-pub async fn set_skill_env_check(enabled: bool, _state: State<'_, AppState>) -> Result<(), String> {
-    core::set_skill_env_check(enabled, SOURCE).map_err(|e| e.to_string())
+pub async fn set_skill_env_check(
+    enabled: bool,
+    _state: State<'_, AppState>,
+) -> Result<(), CmdError> {
+    core::set_skill_env_check(enabled, SOURCE).map_err(Into::into)
 }
 
 /// Get the configured env vars for a specific skill (values masked).
@@ -68,7 +77,7 @@ pub async fn set_skill_env_check(enabled: bool, _state: State<'_, AppState>) -> 
 pub async fn get_skill_env(
     name: String,
     _state: State<'_, AppState>,
-) -> Result<std::collections::HashMap<String, String>, String> {
+) -> Result<std::collections::HashMap<String, String>, CmdError> {
     Ok(core::get_skill_env_masked(&name))
 }
 
@@ -79,8 +88,8 @@ pub async fn set_skill_env_var(
     key: String,
     value: String,
     _state: State<'_, AppState>,
-) -> Result<(), String> {
-    core::set_skill_env_var(skill, key, value, SOURCE).map_err(|e| e.to_string())
+) -> Result<(), CmdError> {
+    core::set_skill_env_var(skill, key, value, SOURCE).map_err(Into::into)
 }
 
 /// Remove a configured env var for a skill.
@@ -89,8 +98,8 @@ pub async fn remove_skill_env_var(
     skill: String,
     key: String,
     _state: State<'_, AppState>,
-) -> Result<(), String> {
-    core::remove_skill_env_var(&skill, &key, SOURCE).map_err(|e| e.to_string())
+) -> Result<(), CmdError> {
+    core::remove_skill_env_var(&skill, &key, SOURCE).map_err(Into::into)
 }
 
 /// Batch-return env configuration status for all skills.
@@ -98,7 +107,7 @@ pub async fn remove_skill_env_var(
 #[tauri::command]
 pub async fn get_skills_env_status(
     _state: State<'_, AppState>,
-) -> Result<std::collections::HashMap<String, std::collections::HashMap<String, bool>>, String> {
+) -> Result<std::collections::HashMap<String, std::collections::HashMap<String, bool>>, CmdError> {
     Ok(core::get_skills_env_status())
 }
 
@@ -106,7 +115,7 @@ pub async fn get_skills_env_status(
 #[tauri::command]
 pub async fn get_skills_status(
     _state: State<'_, AppState>,
-) -> Result<Vec<skills::SkillStatusEntry>, String> {
+) -> Result<Vec<skills::SkillStatusEntry>, CmdError> {
     Ok(core::get_skills_status())
 }
 
@@ -120,10 +129,10 @@ pub async fn install_skill_dependency(
     skill_name: String,
     spec_index: usize,
     _state: State<'_, AppState>,
-) -> Result<String, String> {
+) -> Result<String, CmdError> {
     core::install_skill_dependency(&skill_name, spec_index)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 // ── Phase B' Auto-Review ────────────────────────────────────────
@@ -131,23 +140,23 @@ pub async fn install_skill_dependency(
 #[tauri::command]
 pub async fn list_draft_skills(
     _state: State<'_, AppState>,
-) -> Result<Vec<skills::SkillSummary>, String> {
+) -> Result<Vec<skills::SkillSummary>, CmdError> {
     Ok(core::list_draft_skills())
 }
 
 #[tauri::command]
-pub async fn activate_draft_skill(name: String) -> Result<(), String> {
-    core::activate_draft_skill(&name).map_err(|e| e.to_string())
+pub async fn activate_draft_skill(name: String) -> Result<(), CmdError> {
+    core::activate_draft_skill(&name).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn discard_draft_skill(name: String) -> Result<(), String> {
-    core::discard_draft_skill(&name).map_err(|e| e.to_string())
+pub async fn discard_draft_skill(name: String) -> Result<(), CmdError> {
+    core::discard_draft_skill(&name).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn trigger_skill_review_now(session_id: String) -> Result<serde_json::Value, String> {
+pub async fn trigger_skill_review_now(session_id: String) -> Result<serde_json::Value, CmdError> {
     core::trigger_skill_review_now(&session_id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }

--- a/src-tauri/src/commands/subagent.rs
+++ b/src-tauri/src/commands/subagent.rs
@@ -1,3 +1,4 @@
+use crate::commands::CmdError;
 use crate::subagent;
 use crate::AppState;
 use tauri::State;
@@ -6,43 +7,42 @@ use tauri::State;
 pub async fn list_subagent_runs(
     session_id: String,
     state: State<'_, AppState>,
-) -> Result<Vec<subagent::SubagentRun>, String> {
+) -> Result<Vec<subagent::SubagentRun>, CmdError> {
     state
         .session_db
         .list_subagent_runs(&session_id)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn get_subagent_run(
     run_id: String,
     state: State<'_, AppState>,
-) -> Result<Option<subagent::SubagentRun>, String> {
+) -> Result<Option<subagent::SubagentRun>, CmdError> {
     state
         .session_db
         .get_subagent_run(&run_id)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn get_subagent_runs_batch(
     run_ids: Vec<String>,
     state: State<'_, AppState>,
-) -> Result<std::collections::HashMap<String, subagent::SubagentRun>, String> {
+) -> Result<std::collections::HashMap<String, subagent::SubagentRun>, CmdError> {
     state
         .session_db
         .get_subagent_runs_batch(&run_ids)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn kill_subagent(run_id: String, state: State<'_, AppState>) -> Result<String, String> {
+pub async fn kill_subagent(run_id: String, state: State<'_, AppState>) -> Result<String, CmdError> {
     // Verify run exists
     let run = state
         .session_db
-        .get_subagent_run(&run_id)
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("Sub-agent run '{}' not found", run_id))?;
+        .get_subagent_run(&run_id)?
+        .ok_or_else(|| CmdError::msg(format!("Sub-agent run '{}' not found", run_id)))?;
 
     if run.status.is_terminal() {
         return Ok(format!(

--- a/src-tauri/src/commands/team.rs
+++ b/src-tauri/src/commands/team.rs
@@ -1,3 +1,4 @@
+use crate::commands::CmdError;
 use crate::AppState;
 use ha_core::team;
 use tauri::State;
@@ -6,17 +7,14 @@ use tauri::State;
 pub async fn list_teams(
     session_id: Option<String>,
     state: State<'_, AppState>,
-) -> Result<Vec<team::Team>, String> {
+) -> Result<Vec<team::Team>, CmdError> {
     if let Some(sid) = session_id {
         state
             .session_db
             .list_teams_by_session(&sid)
-            .map_err(|e| e.to_string())
+            .map_err(Into::into)
     } else {
-        state
-            .session_db
-            .list_active_teams()
-            .map_err(|e| e.to_string())
+        state.session_db.list_active_teams().map_err(Into::into)
     }
 }
 
@@ -24,22 +22,19 @@ pub async fn list_teams(
 pub async fn get_team(
     team_id: String,
     state: State<'_, AppState>,
-) -> Result<Option<team::Team>, String> {
-    state
-        .session_db
-        .get_team(&team_id)
-        .map_err(|e| e.to_string())
+) -> Result<Option<team::Team>, CmdError> {
+    state.session_db.get_team(&team_id).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn get_team_members(
     team_id: String,
     state: State<'_, AppState>,
-) -> Result<Vec<team::TeamMember>, String> {
+) -> Result<Vec<team::TeamMember>, CmdError> {
     state
         .session_db
         .list_team_members(&team_id)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -47,11 +42,11 @@ pub async fn get_team_messages(
     team_id: String,
     limit: Option<u32>,
     state: State<'_, AppState>,
-) -> Result<(Vec<team::TeamMessage>, bool), String> {
+) -> Result<(Vec<team::TeamMessage>, bool), CmdError> {
     state
         .session_db
         .list_team_messages_latest(&team_id, limit.unwrap_or(50))
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -61,7 +56,7 @@ pub async fn get_team_messages_before(
     before_message_id: String,
     limit: Option<u32>,
     state: State<'_, AppState>,
-) -> Result<(Vec<team::TeamMessage>, bool), String> {
+) -> Result<(Vec<team::TeamMessage>, bool), CmdError> {
     state
         .session_db
         .list_team_messages_before(
@@ -70,18 +65,18 @@ pub async fn get_team_messages_before(
             &before_message_id,
             limit.unwrap_or(50),
         )
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn get_team_tasks(
     team_id: String,
     state: State<'_, AppState>,
-) -> Result<Vec<team::TeamTask>, String> {
+) -> Result<Vec<team::TeamTask>, CmdError> {
     state
         .session_db
         .list_team_tasks(&team_id)
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
@@ -90,7 +85,7 @@ pub async fn send_user_team_message(
     to: Option<String>,
     content: String,
     state: State<'_, AppState>,
-) -> Result<(), String> {
+) -> Result<(), CmdError> {
     team::messaging::send_message(
         &state.session_db,
         &team_id,
@@ -98,15 +93,14 @@ pub async fn send_user_team_message(
         to.as_deref(),
         &content,
         team::TeamMessageType::Chat,
-    )
-    .map_err(|e| e.to_string())?;
+    )?;
     Ok(())
 }
 
 #[tauri::command]
 pub async fn list_team_templates(
     state: State<'_, AppState>,
-) -> Result<Vec<team::TeamTemplate>, String> {
+) -> Result<Vec<team::TeamTemplate>, CmdError> {
     Ok(team::templates::all_templates(&state.session_db))
 }
 
@@ -119,7 +113,7 @@ pub async fn create_team(
     members: Vec<team::CreateTeamMemberSpec>,
     template: Option<String>,
     state: State<'_, AppState>,
-) -> Result<team::Team, String> {
+) -> Result<team::Team, CmdError> {
     let (member_specs, resolved_template_id) = if !members.is_empty() {
         (members, template.clone())
     } else if let Some(ref tpl_name) = template {
@@ -127,7 +121,7 @@ pub async fn create_team(
         let tpl = templates
             .iter()
             .find(|t| t.template_id == *tpl_name || t.name.eq_ignore_ascii_case(tpl_name))
-            .ok_or_else(|| format!("Template '{}' not found", tpl_name))?;
+            .ok_or_else(|| CmdError::msg(format!("Template '{}' not found", tpl_name)))?;
         let specs = tpl
             .members
             .iter()
@@ -148,7 +142,7 @@ pub async fn create_team(
             .collect();
         (specs, Some(tpl.template_id.clone()))
     } else {
-        return Err("Either 'members' or 'template' is required".to_string());
+        return Err(CmdError::msg("Either 'members' or 'template' is required"));
     };
 
     team::coordinator::create_team(
@@ -162,38 +156,38 @@ pub async fn create_team(
         None,
     )
     .await
-    .map_err(|e| e.to_string())
+    .map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn save_team_template(
     template: team::TeamTemplate,
     state: State<'_, AppState>,
-) -> Result<team::TeamTemplate, String> {
-    team::templates::save_template(&state.session_db, template).map_err(|e| e.to_string())
+) -> Result<team::TeamTemplate, CmdError> {
+    team::templates::save_template(&state.session_db, template).map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn delete_team_template(
     template_id: String,
     state: State<'_, AppState>,
-) -> Result<(), String> {
-    team::templates::delete_template(&state.session_db, &template_id).map_err(|e| e.to_string())
+) -> Result<(), CmdError> {
+    team::templates::delete_template(&state.session_db, &template_id).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn pause_team(team_id: String, state: State<'_, AppState>) -> Result<(), String> {
-    team::coordinator::pause_team(&state.session_db, &team_id).map_err(|e| e.to_string())
+pub async fn pause_team(team_id: String, state: State<'_, AppState>) -> Result<(), CmdError> {
+    team::coordinator::pause_team(&state.session_db, &team_id).map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn resume_team(team_id: String, state: State<'_, AppState>) -> Result<(), String> {
+pub async fn resume_team(team_id: String, state: State<'_, AppState>) -> Result<(), CmdError> {
     team::coordinator::resume_team(&state.session_db, &team_id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(Into::into)
 }
 
 #[tauri::command]
-pub async fn dissolve_team(team_id: String, state: State<'_, AppState>) -> Result<(), String> {
-    team::coordinator::dissolve_team(&state.session_db, &team_id).map_err(|e| e.to_string())
+pub async fn dissolve_team(team_id: String, state: State<'_, AppState>) -> Result<(), CmdError> {
+    team::coordinator::dissolve_team(&state.session_db, &team_id).map_err(Into::into)
 }

--- a/src-tauri/src/commands/url_preview.rs
+++ b/src-tauri/src/commands/url_preview.rs
@@ -1,16 +1,15 @@
+use crate::commands::CmdError;
 use crate::url_preview;
 
 #[tauri::command]
-pub async fn fetch_url_preview(url: String) -> Result<url_preview::UrlPreviewMeta, String> {
-    url_preview::fetch_preview(&url)
-        .await
-        .map_err(|e| e.to_string())
+pub async fn fetch_url_preview(url: String) -> Result<url_preview::UrlPreviewMeta, CmdError> {
+    url_preview::fetch_preview(&url).await.map_err(Into::into)
 }
 
 #[tauri::command]
 pub async fn fetch_url_previews(
     urls: Vec<String>,
-) -> Result<Vec<url_preview::UrlPreviewMeta>, String> {
+) -> Result<Vec<url_preview::UrlPreviewMeta>, CmdError> {
     let handles: Vec<_> = urls
         .into_iter()
         .map(|url| tokio::spawn(async move { url_preview::fetch_preview(&url).await }))


### PR DESCRIPTION
## Summary

- 关闭 [F-001](docs/plans/review-followups.md)：统一 `src-tauri/src/commands/` 下所有 Tauri 命令的错误类型，去掉每条命令尾巴重复的 `.map_err(|e| e.to_string())` boilerplate
- 新建 `src-tauri/src/commands/error.rs::CmdError`：`Serialize` 输出纯字符串（**IPC wire 与原 `Result<T, String>` 等价，前端零迁移**），`impl<E: Into<anyhow::Error>> From<E>` 让命令体内部直接用 `?` 透传 `anyhow`/`io`/`serde_json` 等错误，并通过 `format!(\"{:#}\", ..)` 保留 `anyhow::Context` 加的 cause chain
- 命令体里 9 处 `.map_err(|e| CmdError::msg(format!(\"...: {}\", e)))?` 改成 idiomatic `.context(\"...\")?` / `.with_context(|| ..)?`

## Scope

- ✅ `src-tauri/src/commands/` 31 个文件 + `mod.rs` 注册：命令签名 `Result<T, String>` → `Result<T, CmdError>`，invoke_handler! 注册名/前端 invoke 名一律不变
- ✅ 291 处 `.map_err(|e| e.to_string())?` 删成 `?`
- ✅ `Err(\"..\".to_string())` / `.ok_or_else(|| \"..\".to_string())` 等串字面量入口走 `CmdError::msg(..)`（因 `From<String>` 与 blanket `From<anyhow::Error>` 在 Rust coherence 上不能共存）
- ✅ ha-core 的 `Result<_, String>` upstream（`backup::*`、`provider::test::*`、`run_chat_engine` 等）在 wrapper 层显式 `.map_err(CmdError::msg)` 包一层
- ❎ `src-tauri/src/tauri_wrappers.rs` 不属于\"命令尾巴 boilerplate\"范畴（直接 forward 到 ha-core，不是逐条 `.map_err`），**保留 `Result<T, String>` 不动**

## Wire compatibility

`CmdError(String)` 的 `Serialize` 用 `serialize_str(&self.0)` 输出纯 string，与原 `Err(String)` 在 IPC wire 上完全一致 → 前端 `invoke()` 仍以 string reject，零变化。

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test -p ha-core -p ha-server --locked`
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test`
- [x] `/simplify` 三 agent review，4 条有效项已修
- [x] `/codex:review` —— No discrete correctness issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)