### PR TITLE
Unify chat + searxng streaming under transport abstraction

### DIFF
--- a/crates/ha-core/src/docker/deploy.rs
+++ b/crates/ha-core/src/docker/deploy.rs
@@ -3,15 +3,21 @@ use std::sync::atomic::Ordering;
 use tokio::process::Command;
 
 use super::{
-    helpers::*, DeployProgress, CONTAINER_NAME, DEPLOYING, DEPLOY_PROGRESS, IMAGE, STATUS_LOCK,
+    helpers::*, DeployProgress, DeployProgressSnapshot, CONTAINER_NAME, DEPLOYING, DEPLOY_PROGRESS,
+    IMAGE, STATUS_LOCK,
 };
 
 /// Pull image, start container, inject config, health-check.
 /// Returns the accessible URL (e.g. "http://127.0.0.1:8080").
-/// `on_progress` is called with JSON messages: `{"step":"..."}` or `{"log":"..."}`.
+///
+/// `on_progress` is invoked with one [`DeployProgress`] frame per
+/// step/log line. Callers typically forward each frame to the shared
+/// `EventBus` under [`EVENT_SEARXNG_DEPLOY_PROGRESS`] — matches the
+/// `local_llm_install_ollama` pattern (see
+/// `local_llm/mod.rs::install_ollama_via_script`).
 pub async fn deploy<F>(on_progress: F) -> Result<String>
 where
-    F: Fn(&str),
+    F: Fn(&DeployProgress) + Send + Sync,
 {
     // Prevent concurrent deploy operations
     if DEPLOYING
@@ -24,7 +30,7 @@ where
     DEPLOYING.store(false, Ordering::SeqCst);
     // Clear shared progress after completion
     if let Ok(mut p) = DEPLOY_PROGRESS.lock() {
-        *p = DeployProgress::default();
+        *p = DeployProgressSnapshot::default();
     }
     // Invalidate status cache so next poll picks up new state
     if let Ok(mut guard) = STATUS_LOCK.try_lock() {
@@ -35,24 +41,25 @@ where
 
 async fn deploy_inner<F>(on_progress: &F) -> Result<String>
 where
-    F: Fn(&str),
+    F: Fn(&DeployProgress) + Send + Sync,
 {
     // Clear previous progress
     if let Ok(mut p) = DEPLOY_PROGRESS.lock() {
-        *p = DeployProgress::default();
+        *p = DeployProgressSnapshot::default();
     }
 
     let step = |s: &str| {
-        on_progress(&format!(r#"{{"step":"{}"}}"#, s));
+        on_progress(&DeployProgress::Step {
+            step: s.to_string(),
+        });
         if let Ok(mut p) = DEPLOY_PROGRESS.lock() {
             p.step = Some(s.to_string());
         }
     };
     let log = |msg: &str| {
-        on_progress(&format!(
-            r#"{{"log":"{}"}}"#,
-            msg.replace('\\', "\\\\").replace('"', "\\\"")
-        ));
+        on_progress(&DeployProgress::Log {
+            log: msg.to_string(),
+        });
         if let Ok(mut p) = DEPLOY_PROGRESS.lock() {
             p.logs.push(msg.to_string());
             // Keep last 100 lines

--- a/crates/ha-core/src/docker/mod.rs
+++ b/crates/ha-core/src/docker/mod.rs
@@ -8,6 +8,7 @@ pub use deploy::*;
 pub use lifecycle::*;
 pub use status::*;
 
+use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub(crate) const CONTAINER_NAME: &str = "hope-agent-searxng";
@@ -15,17 +16,33 @@ pub(crate) const IMAGE: &str = "searxng/searxng";
 pub(crate) const DEFAULT_HOST_PORT: u16 = 8080;
 const SEARXNG_DIR_NAME: &str = "searxng";
 
+/// EventBus channel name for deploy progress frames. Subscribed by both
+/// the Tauri webview and the HTTP `/ws/events` forwarder.
+pub const EVENT_SEARXNG_DEPLOY_PROGRESS: &str = "searxng:deploy_progress";
+
 /// Prevent concurrent deploy/start/stop/remove operations.
 pub(crate) static DEPLOYING: AtomicBool = AtomicBool::new(false);
 
-/// Shared deploy progress: (current_step, log_lines). Readable by any UI.
-pub(crate) static DEPLOY_PROGRESS: std::sync::LazyLock<std::sync::Mutex<DeployProgress>> =
-    std::sync::LazyLock::new(|| std::sync::Mutex::new(DeployProgress::default()));
+/// Shared deploy progress snapshot: (current_step, log_lines). Read by
+/// `status()` so a late-joining UI gets a snapshot without replaying
+/// EventBus history.
+pub(crate) static DEPLOY_PROGRESS: std::sync::LazyLock<std::sync::Mutex<DeployProgressSnapshot>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(DeployProgressSnapshot::default()));
 
 #[derive(Default, Clone)]
-pub(crate) struct DeployProgress {
+pub(crate) struct DeployProgressSnapshot {
     pub step: Option<String>,
     pub logs: Vec<String>,
+}
+
+/// One frame of deploy progress emitted via `on_progress` callback.
+/// Untagged so the wire form stays `{"step": "..."}` or `{"log": "..."}`,
+/// matching what the frontend `SearxngDocker` panel parses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DeployProgress {
+    Step { step: String },
+    Log { log: String },
 }
 
 /// Prevent concurrent status() calls; cache recent result to avoid redundant search tests.

--- a/crates/ha-server/src/routes/searxng.rs
+++ b/crates/ha-server/src/routes/searxng.rs
@@ -4,25 +4,34 @@
 //! deploy progress tracking, lifecycle) lives in ha-core so these handlers
 //! stay under ~15 lines each.
 
+use std::sync::Arc;
+
+use axum::extract::State;
 use axum::Json;
 use serde_json::{json, Value};
 
 use crate::error::AppError;
+use crate::AppContext;
 
 /// `GET /api/searxng/status` — combined Docker + SearXNG container status.
 pub async fn status() -> Result<Json<ha_core::docker::SearxngDockerStatus>, AppError> {
     Ok(Json(ha_core::docker::status().await))
 }
 
-/// `POST /api/searxng/deploy` — deploy the SearXNG container, blocking until
-/// the deploy completes. Progress messages are dropped on the floor in
-/// server mode (the desktop shell forwards them to a `Channel<String>`; the
-/// equivalent for HTTP would be a WebSocket which we can add later if the
-/// UI needs live deploy logs over the network).
-pub async fn deploy() -> Result<Json<Value>, AppError> {
-    let url = ha_core::docker::deploy(|_line| {})
-        .await
-        .map_err(|e| AppError::internal(e.to_string()))?;
+/// `POST /api/searxng/deploy` — deploy the SearXNG container, blocking
+/// until the deploy completes. Progress is emitted to the shared
+/// `EventBus` under [`ha_core::docker::EVENT_SEARXNG_DEPLOY_PROGRESS`];
+/// browsers receive the stream via `/ws/events`.
+pub async fn deploy(State(ctx): State<Arc<AppContext>>) -> Result<Json<Value>, AppError> {
+    let bus = ctx.event_bus.clone();
+    let url = ha_core::docker::deploy(move |progress| {
+        bus.emit(
+            ha_core::docker::EVENT_SEARXNG_DEPLOY_PROGRESS,
+            json!(progress),
+        );
+    })
+    .await
+    .map_err(|e| AppError::internal(e.to_string()))?;
     Ok(Json(json!({ "ok": true, "url": url })))
 }
 

--- a/docs/plans/review-followups.md
+++ b/docs/plans/review-followups.md
@@ -98,6 +98,93 @@
 
 ---
 
+### F-006 EventBus 桥接闭包样板在 4 处重复
+
+- **来源**：2026-04-26 `transport-streaming-unify` `/simplify` review
+- **现象**：把 ha-core 长任务的 progress callback 桥接到 EventBus 的样板（"取 bus → 闭包 emit"）目前在 4 处复制：
+  - [`crates/ha-server/src/routes/local_llm.rs::install_ollama`](../../crates/ha-server/src/routes/local_llm.rs) + `pull`
+  - [`crates/ha-server/src/routes/searxng.rs::deploy`](../../crates/ha-server/src/routes/searxng.rs)
+  - [`src-tauri/src/commands/local_llm.rs::local_llm_install_ollama`](../../src-tauri/src/commands/local_llm.rs) + `local_llm_pull_and_activate`
+  - [`src-tauri/src/commands/docker.rs::searxng_docker_deploy`](../../src-tauri/src/commands/docker.rs)
+- **为什么留**：跨 ha-server / src-tauri 两个 crate 抽 helper 涉及 trait 设计选择（free function vs `EventBus` trait method 默认实现）；本期 PR 的 scope 只是"消除前端裸 Channel"，再展开会扩大 diff。
+- **改的话要做什么**：在 [`crates/ha-core/src/event_bus.rs`](../../crates/ha-core/src/event_bus.rs) 给 `EventBus` trait 加默认方法 `fn emit_progress<T: Serialize>(&self, name: &str) -> impl Fn(&T) + Send + Sync` 返回桥接闭包；4 个调用点都改成 `bus.emit_progress(EVENT_*_PROGRESS)`，省掉 `move |p| bus.emit(NAME, json!(p))` 一行。
+- **影响面**：纯整洁度，0 行为变化。
+- **触发时机建议**：下次新增第 5 个 long-running command（例如 model fine-tune progress）时顺势抽；或独立 "EventBus helper" 小 PR。
+
+---
+
+### F-007 HTTP `startChat` 用合成 `session_created` 事件 vs 显式 return shape 的取舍
+
+- **来源**：2026-04-26 `transport-streaming-unify` `/simplify` review
+- **现象**：[`src/lib/transport-http.ts::startChat`](../../src/lib/transport-http.ts) 在 HTTP 模式下，POST `/api/chat` 返回后**手动合成**一个 `{type:"session_created", session_id:...}` 事件喂给 `onEvent` 回调，目的是让 [`useChatStream.ts`](../../src/components/chat/hooks/useChatStream.ts) 内部 `__pending__` cache key 替换逻辑统一走 onEvent 分支。语义上接口"看起来 generic"但 HTTP 实现行为隐式特化，签名留下"似 stream 实非 stream"的疑义。**还要顺便核实** [`crates/ha-server/src/ws/chat_stream.rs`](../../crates/ha-server/src/ws/chat_stream.rs) 的 `/ws/chat/{session_id}` 路由：前端 `openChatStream` 已删，server 端 `WsSink` 仍 broadcast 到这个路由，可能成为死路径——若 reattach `/ws/events` 能完整覆盖，可一并清理。
+- **为什么留**：换成"显式 return `{sessionId, response}` 让调用方自己改 cache"会把 transport 抽象的好处折损（hook 要自己 if (isHttp) 分支）；当前文档已显式说明 HTTP 模式仅合成 `session_created`，合约是诚实的。死路径核实涉及 axum router 注册顺序梳理，独立小工作。
+- **改的话要做什么**：(a) 评估是否换成"`startChat` 直接 return `ChatResponse`，cache rename 由 hook 自己做"。(b) 验证 `/ws/chat/{id}` 路由的所有消费者是否都已切到 `/ws/events`，无消费者则删 [`ws/chat_stream.rs`](../../crates/ha-server/src/ws/chat_stream.rs) + lib.rs 路由注册。
+- **影响面**：当前无 bug，无性能差异；属于架构清晰度问题。
+- **触发时机建议**：HTTP `startChat` 出现第二种"必须前置交付"的事件（例如 chat 命令同步阶段 error）时回头重设计；或独立 "chat stream 路径清理" PR。
+
+---
+
+### F-008 短期 EventBus 订阅 + `try/finally off()` 模式应抽 `withEventListener` helper
+
+- **来源**：2026-04-26 `transport-streaming-unify` `/simplify` review
+- **现象**：前端"调用一次长任务前订阅 EventBus、调用结束后取消订阅"的模式现在有 3 处：
+  - [`src/components/settings/web-search-panel/SearxngDocker.tsx::handleDeploy`](../../src/components/settings/web-search-panel/SearxngDocker.tsx)（本期新增）
+  - [`src/components/settings/local-llm/LocalLlmAssistantCard.tsx`](../../src/components/settings/local-llm/LocalLlmAssistantCard.tsx) install + pull 两处
+- **为什么留**：3 处刚好是抽 helper 的拐点（再多一处就该抽了），但 3 处之间订阅事件名 / handler 形态都不一样，抽完每个调用点节省也只有 2 行，性价比不高。本期不抽。
+- **改的话要做什么**：在 [`src/lib/transport.ts`](../../src/lib/transport.ts) 加：
+  ```ts
+  export async function withEventListener<T>(
+    eventName: string,
+    handler: (payload: unknown) => void,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const off = getTransport().listen(eventName, handler);
+    try { return await fn(); } finally { off(); }
+  }
+  ```
+  3 处调用点改成单层调用。
+- **影响面**：纯整洁度。
+- **触发时机建议**：再新增一处同模式时顺手抽；或与 F-006 一起做"event helpers" 小 PR。
+
+---
+
+### F-009 `useChatStream.ts::onEvent` 嵌套 try/catch + 多重 if 应 flatten
+
+- **来源**：2026-04-26 `transport-streaming-unify` `/simplify` review
+- **现象**：[`useChatStream.ts:307-359`](../../src/components/chat/hooks/useChatStream.ts) 的 `onEvent` 闭包内部 try/catch 包嵌套 `event.type === "session_created" && event.session_id` 早返回 + `streamId && endedStreamIdsRef.current.get(sid) === streamId` 早返回 + `_oc_seq` dedup + `handleStreamEvent(...)` dispatch + catch 兜底文本拼接，单函数 ~50 行。
+- **为什么留**：本期 PR 主题是"切换调用方 API"，没动 onEvent 内部逻辑；按 AGENTS.md "review 决定不改的清理登记到 followups"。
+- **改的话要做什么**：拆成几个 named handler：`handleSessionCreated`、`handleStreamDelta`、`fallbackTextAppend`，主 `onEvent` 退化为 `try { dispatch(JSON.parse(raw)) } catch { fallbackTextAppend(raw) }`。
+- **影响面**：纯可读性。
+- **触发时机建议**：下次有人为了别的事真要动这段逻辑时顺手收掉。
+
+---
+
+### F-010 EventBus 事件名常量散落，应有 events 常量模块
+
+- **来源**：2026-04-26 `transport-streaming-unify` `/simplify` review
+- **现象**：EventBus 事件名当前混合两种风格：
+  - **常量**：[`crates/ha-core/src/chat_engine/stream_broadcast.rs::EVENT_CHAT_STREAM_DELTA`](../../crates/ha-core/src/chat_engine/stream_broadcast.rs)、本期新增 [`crates/ha-core/src/docker/mod.rs::EVENT_SEARXNG_DEPLOY_PROGRESS`](../../crates/ha-core/src/docker/mod.rs)
+  - **字面量**：`local_llm:install_progress` / `local_llm:pull_progress`（在 4 处出现）；前端 [`useChatStreamReattach.ts:17`](../../src/components/chat/hooks/useChatStreamReattach.ts) 重新声明的 `EVENT_CHAT_STREAM_DELTA` 与 ha-core 常量值各自维护
+- **为什么留**：跨前端（TS）/ 后端（Rust）同步常量需要 codegen 或 wire-format 文档约定，引入新约束。本期把刚碰到的 searxng 升成常量已经是最低成本的"按碰到逐步收"。
+- **改的话要做什么**：候选方案：
+  - **A**：每个子系统在自己 mod 顶部定义 `pub const EVENT_*: &str = "..."`（已经 chat / searxng 在做）；前端继续维护独立常量但加注释指向 Rust 同名定义。Rust 端集中调用，前端只 listen 时用一次，漂移风险低
+  - **B**：用 `build.rs` 生成 TS const 文件，从 Rust 单一来源。需要新增 build pipeline 复杂度
+- **影响面**：纯整洁度。事件名漂移会被 watchdog 测试快速发现（事件不到达 → UI 不更新），是 "fail loud" 类型的 bug。
+- **触发时机建议**：等再积累 2-3 个新事件名（看 local_llm 之外）时一次性把所有 `local_llm:*` / 其它字面量升成常量；不必单独立 PR。
+
+---
+
+### F-011 `docs/architecture/` 缺中心化 transport mode 文档
+
+- **来源**：2026-04-26 `transport-streaming-unify` `/simplify` review
+- **现象**：[`useChatStreamReattach.ts:55-66`](../../src/components/chat/hooks/useChatStreamReattach.ts) 的 docstring 是仓库**首次**正式文字化"Tauri 模式 vs HTTP 模式行为差异"。其它地方对 transport 模式的判断散落在 [`isTauriMode()`](../../src/lib/transport.ts) 调用点 + 两个 transport adapter 实现 + `transport-provider.ts` 选 adapter 逻辑，没有架构级综述。新人接手或调试 transport 相关 bug 必须读多个源才能拼出全图。
+- **为什么留**：架构文档需要先把"打算保留的" vs "打算简化掉的"区分清楚（参见 F-007 关于 `/ws/chat/{id}` 死路径），再写权威文档；现在写容易立刻过时。
+- **改的话要做什么**：在 [`docs/architecture/`](../README.md) 新建 `transport-modes.md`，覆盖：(a) 三种运行模式的事件流向图；(b) 每个 Transport 方法在两种模式下的实现路径；(c) `chat:stream_delta` 双写架构 + reattach 角色（Tauri 兜底 vs HTTP 主路径）；(d) 列出所有 EventBus 事件名 + 用途；(e) 决策记录 "为什么 startChat 不是 streamCall 通用原语"。回填到 `docs/README.md` 索引。
+- **影响面**：纯文档债。无功能影响。
+- **触发时机建议**：F-007 决策落地（startChat 合约 / `/ws/chat/{id}` 死路径处置）后再写，避免文档与代码不同步。
+
+---
+
 ## Closed
 
 > 已修复条目移到此处，附 commit hash + 关闭日期。保留以便后续 grep。

--- a/src-tauri/src/commands/docker.rs
+++ b/src-tauri/src/commands/docker.rs
@@ -7,12 +7,20 @@ pub async fn searxng_docker_status() -> Result<docker::SearxngDockerStatus, CmdE
     Ok(docker::status().await)
 }
 
+/// Deploy the SearXNG container. Progress is emitted via the shared
+/// `EventBus` under [`ha_core::docker::EVENT_SEARXNG_DEPLOY_PROGRESS`];
+/// the frontend listens for those events instead of receiving a Tauri
+/// Channel (matches the `local_llm_install_ollama` pattern).
 #[tauri::command]
-pub async fn searxng_docker_deploy(
-    channel: tauri::ipc::Channel<String>,
-) -> Result<String, CmdError> {
-    let url = docker::deploy(|step| {
-        let _ = channel.send(step.to_string());
+pub async fn searxng_docker_deploy() -> Result<String, CmdError> {
+    let bus = ha_core::get_event_bus()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("EventBus not initialized"))?;
+    let url = docker::deploy(move |progress| {
+        bus.emit(
+            ha_core::docker::EVENT_SEARXNG_DEPLOY_PROGRESS,
+            serde_json::json!(progress),
+        );
     })
     .await?;
     // Auto-save the URL into the SearXNG provider entry and mark as docker-managed

--- a/src/components/chat/file-mention/expandMentions.ts
+++ b/src/components/chat/file-mention/expandMentions.ts
@@ -14,11 +14,13 @@
 import { parseMentions } from "./mentionTokens";
 import { joinAbs } from "./types";
 import { logger } from "@/lib/logger";
+import type { ChatAttachment } from "@/lib/transport";
 
-export interface MentionAttachment {
-  name: string;
-  mime_type: string;
-  /** Absolute file path on the server / desktop. */
+/**
+ * Mention-derived attachment. Always carries an absolute `file_path`
+ * (mentions never inline base64 the way pasted images do).
+ */
+export interface MentionAttachment extends ChatAttachment {
   file_path: string;
 }
 

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react"
 import { getTransport } from "@/lib/transport-provider"
-import { Channel } from "@tauri-apps/api/core"
+import type { ChatAttachment } from "@/lib/transport"
 import { useTranslation } from "react-i18next"
 import { logger } from "@/lib/logger"
 import { loadNotificationConfig, isAgentNotifyEnabled, notify } from "@/lib/notifications"
@@ -240,12 +240,7 @@ export function useChatStream({
     setLoading(true)
 
     // Process attached files: images → base64 data, non-images → save to disk via Rust
-    const attachments: {
-      name: string
-      mime_type: string
-      data?: string
-      file_path?: string
-    }[] = []
+    const attachments: ChatAttachment[] = []
 
     // Expand `@path` mentions into file_path attachments. Working dir resolves
     // from the current session (committed) or the draft picker (new chat).
@@ -305,8 +300,7 @@ export function useChatStream({
     let targetSessionId = currentSessionId
 
     try {
-      const onEvent = new Channel<string>()
-      onEvent.onmessage = (raw) => {
+      const onEvent = (raw: string) => {
         try {
           const event = JSON.parse(raw)
 
@@ -382,20 +376,22 @@ export function useChatStream({
       const modelOverride = activeModel
         ? `${activeModel.providerId}::${activeModel.modelId}`
         : undefined
-      await getTransport().call<string>("chat", {
-        message: text,
-        attachments,
-        sessionId: currentSessionId,
-        incognito: currentSessionId ? undefined : incognitoEnabled,
-        modelOverride,
-        agentId: currentAgentId,
-        toolPermissionMode: toolPermissionModeRef.current,
-        planMode: planMode && planMode !== "off" ? planMode : undefined,
-        temperatureOverride: temperatureOverride ?? undefined,
-        displayText: options?.displayText?.trim() || undefined,
-        workingDir: currentSessionId ? undefined : draftWorkingDir ?? undefined,
+      await getTransport().startChat(
+        {
+          message: text,
+          attachments,
+          sessionId: currentSessionId,
+          incognito: currentSessionId ? undefined : incognitoEnabled,
+          modelOverride,
+          agentId: currentAgentId,
+          toolPermissionMode: toolPermissionModeRef.current,
+          planMode: planMode && planMode !== "off" ? planMode : undefined,
+          temperatureOverride: temperatureOverride ?? undefined,
+          displayText: options?.displayText?.trim() || undefined,
+          workingDir: currentSessionId ? undefined : draftWorkingDir ?? undefined,
+        },
         onEvent,
-      })
+      )
     } catch (e) {
       const sid = targetSessionId || "__pending__"
       updateSessionMessages(sid, (prev) => {

--- a/src/components/chat/hooks/useChatStreamReattach.ts
+++ b/src/components/chat/hooks/useChatStreamReattach.ts
@@ -53,10 +53,17 @@ interface StreamEndPayload {
 }
 
 /**
- * EventBus reattach path for the main chat stream. Runs alongside the primary
- * `Channel` / WebSocket path in useChatStream; when the primary sink dies
- * (frontend reload), this path keeps the UI updating. Dedup by `_oc_seq`
- * against `lastSeqRef` — whichever path sees an event first bumps the cursor.
+ * EventBus path for the chat stream. Role differs per transport:
+ *  - Tauri mode: tertiary safety net for the in-flight `Channel` path inside
+ *    `useChatStream` — when the primary sink dies (frontend reload) this path
+ *    keeps the UI updating.
+ *  - HTTP mode: this path *is* the primary delivery for stream deltas.
+ *    `transport.startChat` over HTTP only synthesizes a `session_created`
+ *    event for cache-rename bookkeeping; everything else flows here via
+ *    `/ws/events` → `chat:stream_delta`.
+ *
+ * Dedup by `_oc_seq` against `lastSeqRef` — whichever path sees an event
+ * first bumps the cursor.
  */
 export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
   const {

--- a/src/components/settings/web-search-panel/SearxngDocker.tsx
+++ b/src/components/settings/web-search-panel/SearxngDocker.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react"
 import { getTransport } from "@/lib/transport-provider"
-import { Channel } from "@tauri-apps/api/core"
+import { parsePayload } from "@/lib/transport"
 import { useTranslation } from "react-i18next"
 import { logger } from "@/lib/logger"
 import { Button } from "@/components/ui/button"
@@ -112,28 +112,19 @@ export function SearxngDockerSection({
     setDeployStep(null)
     setDeployLogs([])
     setError(null)
+    const off = getTransport().listen("searxng:deploy_progress", (raw) => {
+      const parsed = parsePayload<{ step?: string; log?: string }>(raw)
+      if (parsed.step) setDeployStep(parsed.step)
+      if (parsed.log) setDeployLogs((prev) => [...prev.slice(-50), parsed.log!])
+    })
     try {
-      const channel = new Channel<string>()
-      channel.onmessage = (msg) => {
-        try {
-          const parsed = JSON.parse(msg)
-          if (parsed.step) {
-            setDeployStep(parsed.step)
-          }
-          if (parsed.log) {
-            setDeployLogs((prev) => [...prev.slice(-50), parsed.log])
-          }
-        } catch {
-          // Legacy: plain step string
-          setDeployStep(msg)
-        }
-      }
-      const url = await getTransport().call<string>("searxng_docker_deploy", { channel })
+      const url = await getTransport().call<string>("searxng_docker_deploy")
       onUrlSet(url)
       await refreshStatus()
     } catch (e) {
       setError(String(e))
     } finally {
+      off()
       setDeploying(false)
       setDeployStep(null)
     }

--- a/src/lib/transport-http.ts
+++ b/src/lib/transport-http.ts
@@ -8,7 +8,7 @@
 
 import type {
   Transport,
-  ChatStream,
+  ChatStartArgs,
   PickedImage,
   DirListing,
   FileSearchResponse,
@@ -595,6 +595,8 @@ function normalizeCommandResponse(command: string, value: unknown): unknown {
         return record.checkpoint;
       case "plan_rollback":
         return record.message;
+      case "searxng_docker_deploy":
+        return record.url;
     }
   }
   return value;
@@ -772,32 +774,29 @@ export class HttpTransport implements Transport {
     return (await response.json()) as T;
   }
 
-  // ----- openChatStream -----
+  // ----- startChat -----
 
-  openChatStream(
-    sessionId: string | null,
+  async startChat(
+    args: ChatStartArgs,
     onEvent: (event: string) => void,
-  ): ChatStream {
-    const path = sessionId
-      ? `/ws/chat/${encodeURIComponent(sessionId)}`
-      : "/ws/chat";
-    const ws = new WebSocket(this.wsUrl(path));
-
-    ws.onmessage = (ev) => {
-      if (typeof ev.data === "string") {
-        onEvent(ev.data);
-      }
-    };
-
-    ws.onerror = (err) => {
-      console.error("[HttpTransport] Chat WebSocket error", err);
-    };
-
-    return {
-      close() {
-        ws.close();
-      },
-    };
+  ): Promise<string> {
+    // Stream deltas arrive via /ws/events → useChatStreamReattach. We only
+    // bridge `session_created` so the in-hook __pending__ cache key gets
+    // renamed in place — POST /api/chat returns the real sessionId in its
+    // body, so synthesizing the event after the response is sufficient.
+    const resp = await this.call<{ sessionId: string; response: string }>(
+      "chat",
+      args,
+    );
+    if (!args.sessionId) {
+      onEvent(
+        JSON.stringify({
+          type: "session_created",
+          session_id: resp.sessionId,
+        }),
+      );
+    }
+    return resp.response;
   }
 
   // ----- media -----

--- a/src/lib/transport-tauri.ts
+++ b/src/lib/transport-tauri.ts
@@ -9,7 +9,7 @@ import { invoke, Channel, convertFileSrc } from "@tauri-apps/api/core";
 import { listen as tauriListen } from "@tauri-apps/api/event";
 import type {
   Transport,
-  ChatStream,
+  ChatStartArgs,
   PickedImage,
   DirListing,
   FileSearchResponse,
@@ -29,35 +29,21 @@ export class TauriTransport implements Transport {
     return Array.from(new Uint8Array(buffer));
   }
 
-  // ----- openChatStream -----
+  // ----- startChat -----
 
-  openChatStream(
-    _sessionId: string | null,
+  async startChat(
+    args: ChatStartArgs,
     onEvent: (event: string) => void,
-  ): ChatStream {
+  ): Promise<string> {
     const channel = new Channel<string>();
-    channel.onmessage = (raw: string) => {
-      onEvent(raw);
-    };
-
-    // The Tauri Channel is passed as an argument to the `chat` command.
-    // The actual `invoke("chat", { ..., onEvent: channel })` call is
-    // performed by the caller (e.g. useChatStream). Here we just expose
-    // the channel so callers can attach it.
-    //
-    // We store the channel reference on the returned handle so the caller
-    // can pass `handle.tauriChannel` to invoke().
-    const handle: TauriChatStream = {
-      tauriChannel: channel,
-      close() {
-        // Tauri Channels are closed when the invoke promise resolves or
-        // the caller drops the reference. Explicit close is a no-op but
-        // we null out the callback to prevent late deliveries.
-        channel.onmessage = () => {};
-      },
-    };
-
-    return handle;
+    channel.onmessage = onEvent;
+    try {
+      return await invoke<string>("chat", { ...args, onEvent: channel });
+    } finally {
+      // Drop the callback so any late-delivered Channel message after the
+      // invoke promise resolves does not re-enter caller state.
+      channel.onmessage = () => {};
+    }
   }
 
   // ----- media -----
@@ -166,19 +152,4 @@ export class TauriTransport implements Transport {
       unlisten?.();
     };
   }
-}
-
-/**
- * Extended ChatStream that exposes the underlying Tauri Channel.
- *
- * Callers that need to pass the channel to `invoke("chat", { onEvent })`
- * can narrow the type:
- *
- * ```ts
- * const stream = transport.openChatStream(sid, handler);
- * invoke("chat", { ..., onEvent: (stream as TauriChatStream).tauriChannel });
- * ```
- */
-export interface TauriChatStream extends ChatStream {
-  readonly tauriChannel: Channel<string>;
 }

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -6,19 +6,49 @@
  * standalone web app (HTTP / WebSocket).
  */
 
-import type { MediaItem } from "@/types/chat";
+import type { MediaItem, ToolPermissionMode } from "@/types/chat";
 
-/** A handle returned by `openChatStream` to control the stream lifetime. */
-export interface ChatStream {
-  /** Close the stream and release resources. */
-  close(): void;
+/**
+ * One entry in `ChatStartArgs.attachments`. Snake-case fields are the
+ * wire form — both Tauri IPC and `POST /api/chat` serialize this object
+ * as-is. `data` and `file_path` are mutually-exclusive: inline images
+ * carry base64 in `data`; everything else is persisted to disk and
+ * referenced by absolute `file_path`.
+ */
+export interface ChatAttachment {
+  name: string;
+  mime_type: string;
+  data?: string;
+  file_path?: string;
+}
+
+/**
+ * Args accepted by {@link Transport.startChat}. Mirrors the parameters of
+ * the Tauri `chat` command and the `POST /api/chat` body.
+ */
+export interface ChatStartArgs {
+  message: string;
+  attachments: ReadonlyArray<ChatAttachment>;
+  sessionId: string | null;
+  incognito?: boolean;
+  modelOverride?: string;
+  agentId?: string;
+  toolPermissionMode?: ToolPermissionMode;
+  planMode?: string;
+  temperatureOverride?: number;
+  displayText?: string;
+  workingDir?: string | null;
+  // Tauri's invoke serializes extra unknown fields without complaint, and
+  // HTTP's POST body is plain JSON — keep this open so HTTP impl can
+  // pass-through without an unsafe `as Record<string, unknown>` cast.
+  [key: string]: unknown;
 }
 
 /**
  * Transport defines the three communication primitives the app needs:
  *
  * 1. `call` – request/response (command invocation)
- * 2. `openChatStream` – streaming chat events for a session
+ * 2. `startChat` – run a chat turn and stream events for it
  * 3. `listen` – subscribe to backend-pushed events
  */
 export interface Transport {
@@ -40,16 +70,18 @@ export interface Transport {
   prepareFileData(buffer: ArrayBuffer, mimeType: string): Blob | number[];
 
   /**
-   * Open a streaming channel for chat events.
+   * Run a chat turn and stream its events. Resolves with the final
+   * assistant response text once the turn completes.
    *
-   * @param sessionId - The session to stream (may be `null` for new sessions).
-   * @param onEvent   - Called for every streamed event (raw JSON string).
-   * @returns A `ChatStream` handle; call `.close()` to terminate.
+   * - Tauri mode: opens a `Channel<string>` internally and forwards each
+   *   delta to `onEvent`.
+   * - HTTP mode: stream deltas arrive via the global EventBus path
+   *   (`/ws/events` → `chat:stream_delta`, consumed by
+   *   `useChatStreamReattach`). `onEvent` is invoked only for a
+   *   synthesized `session_created` event so callers' `__pending__` cache
+   *   gets renamed in place.
    */
-  openChatStream(
-    sessionId: string | null,
-    onEvent: (event: string) => void,
-  ): ChatStream;
+  startChat(args: ChatStartArgs, onEvent: (event: string) => void): Promise<string>;
 
   /**
    * Subscribe to a named backend event.


### PR DESCRIPTION
## Summary

- Eliminate the two remaining business-side `import { Channel } from "@tauri-apps/api/core"` call sites (`useChatStream.ts`, `SearxngDocker.tsx`) so HTTP-mode behavior matches Tauri.
- Introduce `Transport.startChat(args, onEvent)` that owns the Tauri Channel lifetime internally; HTTP mode synthesizes a `session_created` event so `useChatStream`'s `__pending__` cache rename keeps working, while stream deltas continue via `/ws/events` → reattach.
- ha-core `docker::deploy()` callback typed `Fn(&DeployProgress)` (untagged enum keeping wire form `{step}` / `{log}`); Tauri command + HTTP route bridge to EventBus under `EVENT_SEARXNG_DEPLOY_PROGRESS`. Server route now takes `State<Arc<AppContext>>` like `routes/local_llm.rs` instead of fetching the global bus. **Fixes silent dropping of deploy progress in HTTP mode.**
- Register 6 followups (F-006…F-011) for boilerplate / docs cleanup identified during `/simplify` but out of scope here.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- [x] `cargo test -p ha-core -p ha-server --locked`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] Tauri desktop manual: send chat → assistant tokens stream into UI; SearXNG deploy → progress bar advances through `pulling_image` / `starting_container` / `health_check` / `done`
- [ ] HTTP mode (`hope-agent server start` + browser): send chat → assistant tokens flow via reattach, new-session `__pending__` cache key gets renamed; SearXNG deploy → progress bar **finally moves** (was a no-op before)
- [ ] `grep -rn "@tauri-apps/api/core" src/ | grep -v transport-tauri.ts` returns empty