### PR TITLE
[codex] Add Ollama local embedding assistant

### DIFF
--- a/crates/ha-core/src/lib.rs
+++ b/crates/ha-core/src/lib.rs
@@ -40,6 +40,7 @@ pub mod failover;
 pub mod file_extract;
 pub mod filesystem;
 pub mod guardian;
+pub mod local_embedding;
 pub mod local_llm;
 
 pub mod mcp;

--- a/crates/ha-core/src/local_embedding.rs
+++ b/crates/ha-core/src/local_embedding.rs
@@ -1,0 +1,237 @@
+//! Local embedding helper for Ollama-backed vector search.
+//!
+//! This intentionally writes the existing `EmbeddingConfig` shape instead of
+//! adding a new provider type: Ollama exposes `/v1/embeddings`, so memory
+//! search can keep using the OpenAI-compatible embedding provider.
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::local_llm::{
+    detect_ollama_version, list_ollama_model_names, pull_model, PullProgress, OLLAMA_BASE_URL,
+};
+use crate::memory::{EmbeddingConfig, EmbeddingProviderType};
+
+pub const EVENT_LOCAL_EMBEDDING_PULL_PROGRESS: &str = "local_embedding:pull_progress";
+const PROVIDER_SOURCE: &str = "local-embedding-wizard";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OllamaEmbeddingModel {
+    pub id: String,
+    pub display_name: String,
+    pub dimensions: u32,
+    pub size_mb: u64,
+    pub context_window: u32,
+    pub languages: Vec<String>,
+    pub min_ollama_version: Option<String>,
+    pub installed: bool,
+    pub recommended: bool,
+}
+
+/// Small, high-quality Ollama embedding models suitable for memory search.
+pub fn embedding_model_catalog() -> Vec<OllamaEmbeddingModel> {
+    vec![
+        OllamaEmbeddingModel {
+            id: "embeddinggemma:300m".into(),
+            display_name: "EmbeddingGemma 300M".into(),
+            dimensions: 768,
+            size_mb: 622,
+            context_window: 2_048,
+            languages: vec!["100+ languages".into(), "code".into()],
+            min_ollama_version: Some("0.11.10".into()),
+            installed: false,
+            recommended: true,
+        },
+        OllamaEmbeddingModel {
+            id: "qwen3-embedding:0.6b".into(),
+            display_name: "Qwen3 Embedding 0.6B".into(),
+            dimensions: 1_024,
+            size_mb: 639,
+            context_window: 32_768,
+            languages: vec!["100+ languages".into(), "code".into()],
+            min_ollama_version: None,
+            installed: false,
+            recommended: false,
+        },
+        OllamaEmbeddingModel {
+            id: "nomic-embed-text:v1.5".into(),
+            display_name: "Nomic Embed Text v1.5".into(),
+            dimensions: 768,
+            size_mb: 274,
+            context_window: 8_192,
+            languages: vec!["en".into()],
+            min_ollama_version: Some("0.1.26".into()),
+            installed: false,
+            recommended: false,
+        },
+        OllamaEmbeddingModel {
+            id: "all-minilm:22m".into(),
+            display_name: "All MiniLM 22M".into(),
+            dimensions: 384,
+            size_mb: 46,
+            context_window: 512,
+            languages: vec!["en".into()],
+            min_ollama_version: Some("0.1.26".into()),
+            installed: false,
+            recommended: false,
+        },
+    ]
+}
+
+pub async fn list_models_with_status() -> Vec<OllamaEmbeddingModel> {
+    let installed = list_ollama_model_names().await.unwrap_or_default();
+    let installed: std::collections::HashSet<String> = installed.into_iter().collect();
+    embedding_model_catalog()
+        .into_iter()
+        .map(|mut model| {
+            model.installed = installed.contains(&model.id);
+            model
+        })
+        .collect()
+}
+
+pub fn embedding_config_for_model(model: &OllamaEmbeddingModel) -> EmbeddingConfig {
+    EmbeddingConfig {
+        enabled: true,
+        provider_type: EmbeddingProviderType::OpenaiCompatible,
+        api_base_url: Some(OLLAMA_BASE_URL.to_string()),
+        api_key: Some("ollama".to_string()),
+        api_model: Some(model.id.clone()),
+        api_dimensions: Some(model.dimensions),
+        local_model_id: None,
+        fallback_provider_type: None,
+        fallback_api_base_url: None,
+        fallback_api_key: None,
+        fallback_api_model: None,
+        fallback_api_dimensions: None,
+    }
+}
+
+fn resolve_catalog_model(model_id: &str) -> Result<OllamaEmbeddingModel> {
+    embedding_model_catalog()
+        .into_iter()
+        .find(|model| model.id == model_id)
+        .ok_or_else(|| anyhow!("Unsupported Ollama embedding model: {model_id}"))
+}
+
+pub fn ollama_version_meets_min(version: &str, minimum: &str) -> bool {
+    fn parse(v: &str) -> Vec<u32> {
+        v.split(|c: char| !c.is_ascii_digit())
+            .filter(|part| !part.is_empty())
+            .take(3)
+            .map(|part| part.parse::<u32>().unwrap_or(0))
+            .collect()
+    }
+
+    let mut current = parse(version);
+    let mut required = parse(minimum);
+    current.resize(3, 0);
+    required.resize(3, 0);
+    current >= required
+}
+
+async fn ensure_version_compatible(model: &OllamaEmbeddingModel) -> Result<()> {
+    let Some(minimum) = model.min_ollama_version.as_deref() else {
+        return Ok(());
+    };
+    let version = match detect_ollama_version().await {
+        Ok(Some(version)) => version,
+        Ok(None) | Err(_) => return Ok(()),
+    };
+    if !ollama_version_meets_min(&version, minimum) {
+        return Err(anyhow!(
+            "{} requires Ollama {minimum}+; installed version is {version}",
+            model.display_name
+        ));
+    }
+    Ok(())
+}
+
+pub fn save_embedding_config_for_model(model: &OllamaEmbeddingModel) -> Result<EmbeddingConfig> {
+    let config = embedding_config_for_model(model);
+    let applied = config.clone();
+    crate::config::mutate_config(("embedding", PROVIDER_SOURCE), |store| {
+        store.embedding = applied;
+        Ok(())
+    })?;
+    crate::memory::apply_embedding_config_to_backend(&config, PROVIDER_SOURCE)?;
+    app_info!(
+        "memory",
+        "local_embedding",
+        "Ollama embedding configured with model {} ({}d)",
+        model.id,
+        model.dimensions
+    );
+    Ok(config)
+}
+
+pub async fn pull_and_activate<F>(
+    requested: OllamaEmbeddingModel,
+    on_progress: F,
+) -> Result<EmbeddingConfig>
+where
+    F: Fn(&PullProgress) + Send + Sync + 'static,
+{
+    let model = resolve_catalog_model(&requested.id)?;
+    ensure_version_compatible(&model).await?;
+
+    let on_progress = std::sync::Arc::new(on_progress);
+    let cb = on_progress.clone();
+    pull_model(&model.id, move |p| cb(p)).await?;
+
+    on_progress(&PullProgress {
+        model_id: model.id.clone(),
+        phase: "configure-embedding".into(),
+        percent: Some(99),
+    });
+    let config = save_embedding_config_for_model(&model)?;
+    on_progress(&PullProgress {
+        model_id: model.id.clone(),
+        phase: "done".into(),
+        percent: Some(100),
+    });
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_keeps_recommended_model_first() {
+        let catalog = embedding_model_catalog();
+        assert_eq!(
+            catalog.first().map(|m| m.id.as_str()),
+            Some("embeddinggemma:300m")
+        );
+        assert!(catalog.first().map(|m| m.recommended).unwrap_or(false));
+        assert!(catalog[1..]
+            .windows(2)
+            .all(|w| w[0].size_mb >= w[1].size_mb));
+    }
+
+    #[test]
+    fn compares_ollama_versions() {
+        assert!(ollama_version_meets_min("0.11.10", "0.11.10"));
+        assert!(ollama_version_meets_min("0.12.6", "0.11.10"));
+        assert!(ollama_version_meets_min("v0.11.10", "0.11.9"));
+        assert!(!ollama_version_meets_min("0.11.9", "0.11.10"));
+        assert!(!ollama_version_meets_min("0.1.25", "0.1.26"));
+    }
+
+    #[test]
+    fn builds_openai_compatible_embedding_config() {
+        let model = resolve_catalog_model("embeddinggemma:300m").expect("model");
+        let config = embedding_config_for_model(&model);
+        assert!(config.enabled);
+        assert_eq!(
+            config.provider_type,
+            EmbeddingProviderType::OpenaiCompatible
+        );
+        assert_eq!(config.api_base_url.as_deref(), Some(OLLAMA_BASE_URL));
+        assert_eq!(config.api_key.as_deref(), Some("ollama"));
+        assert_eq!(config.api_model.as_deref(), Some("embeddinggemma:300m"));
+        assert_eq!(config.api_dimensions, Some(768));
+    }
+}

--- a/crates/ha-core/src/local_llm/mod.rs
+++ b/crates/ha-core/src/local_llm/mod.rs
@@ -20,7 +20,7 @@ use crate::security::ssrf::{check_url, SsrfPolicy};
 pub mod types;
 pub use types::*;
 
-const OLLAMA_BASE_URL: &str = "http://127.0.0.1:11434";
+pub const OLLAMA_BASE_URL: &str = "http://127.0.0.1:11434";
 #[cfg(unix)]
 const OLLAMA_INSTALL_URL: &str = "https://ollama.com/install.sh";
 const PROVIDER_SOURCE: &str = "local-llm-wizard";
@@ -176,6 +176,65 @@ async fn ping_ollama() -> bool {
         .await
         .map(|r| r.status().is_success())
         .unwrap_or(false)
+}
+
+#[derive(Debug, Deserialize)]
+struct TagsResponse {
+    models: Vec<TagModel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TagModel {
+    name: Option<String>,
+    model: Option<String>,
+}
+
+/// Return the model names currently present in the local Ollama store.
+/// An unreachable daemon is treated as an empty list so callers can still
+/// render their catalog while surfacing daemon status separately.
+pub async fn list_ollama_model_names() -> Result<Vec<String>> {
+    let resp = ping_client()
+        .get(format!("{OLLAMA_BASE_URL}/api/tags"))
+        .send()
+        .await
+        .context("GET /api/tags")?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(anyhow!("Ollama /api/tags returned {status}: {body}"));
+    }
+    let tags = resp
+        .json::<TagsResponse>()
+        .await
+        .context("parse /api/tags")?;
+    Ok(tags
+        .models
+        .into_iter()
+        .filter_map(|m| m.model.or(m.name))
+        .collect())
+}
+
+#[derive(Debug, Deserialize)]
+struct VersionResponse {
+    version: String,
+}
+
+/// Return the local Ollama daemon version, when it is reachable.
+pub async fn detect_ollama_version() -> Result<Option<String>> {
+    let resp = ping_client()
+        .get(format!("{OLLAMA_BASE_URL}/api/version"))
+        .send()
+        .await
+        .context("GET /api/version")?;
+    if !resp.status().is_success() {
+        return Ok(None);
+    }
+    Ok(Some(
+        resp.json::<VersionResponse>()
+            .await
+            .context("parse /api/version")?
+            .version,
+    ))
 }
 
 // ── Ollama lifecycle ──────────────────────────────────────────────

--- a/crates/ha-core/src/local_llm/types.rs
+++ b/crates/ha-core/src/local_llm/types.rs
@@ -102,8 +102,9 @@ pub struct PullProgress {
     pub model_id: String,
     /// Phase string from Ollama (`"pulling manifest"`, `"downloading"`,
     /// `"verifying digest"`, `"writing manifest"`, `"success"`, …) plus our
-    /// own post-download phases: `"register-provider"`, `"done"`. Stays a
-    /// raw String so unknown future phases pass through unmodified.
+    /// own post-download phases: `"register-provider"`,
+    /// `"configure-embedding"`, `"done"`. Stays a raw String so unknown
+    /// future phases pass through unmodified.
     pub phase: String,
     /// 0..=100, only set when both completed and total are known.
     pub percent: Option<u8>,

--- a/crates/ha-core/src/memory/helpers.rs
+++ b/crates/ha-core/src/memory/helpers.rs
@@ -1,4 +1,6 @@
 use super::types::*;
+use super::EmbeddingConfig;
+use anyhow::{anyhow, Result};
 
 /// Clean each word (keep alphanumeric / `_` / `-`), wrap non-empty results in
 /// double quotes for FTS5 MATCH literal matching, and OR-join them. Returns
@@ -65,6 +67,37 @@ pub fn load_multimodal_config() -> MultimodalConfig {
 /// Load embedding cache config from config.json.
 pub fn load_embedding_cache_config() -> EmbeddingCacheConfig {
     crate::config::cached_config().embedding_cache.clone()
+}
+
+/// Apply the current embedding config to the in-memory backend, if present.
+///
+/// Config writes happen in several shells (Tauri commands, HTTP routes, and
+/// settings tools). Keeping the hot-reload side effect here prevents server
+/// mode from lagging behind the persisted `config.json` value.
+pub fn apply_embedding_config_to_backend(config: &EmbeddingConfig, source: &str) -> Result<()> {
+    let backend =
+        crate::get_memory_backend().ok_or_else(|| anyhow!("Memory backend not initialized"))?;
+
+    if config.enabled {
+        let provider = crate::memory::create_embedding_provider(config)?;
+        backend.set_embedder(provider);
+        app_info!(
+            "memory",
+            "embedding",
+            "Embedding provider applied after config save (source={})",
+            source
+        );
+    } else {
+        backend.clear_embedder();
+        app_info!(
+            "memory",
+            "embedding",
+            "Embedding provider cleared after config save (source={})",
+            source
+        );
+    }
+
+    Ok(())
 }
 
 /// Extract keywords from a query, filtering English + Chinese stopwords for

--- a/crates/ha-core/src/memory/mod.rs
+++ b/crates/ha-core/src/memory/mod.rs
@@ -15,7 +15,7 @@ pub mod types;
 // so that `crate::memory::XXX` continues to work.
 
 pub use embedding::*;
-pub use helpers::{load_dedup_config, load_extract_config};
+pub use helpers::{apply_embedding_config_to_backend, load_dedup_config, load_extract_config};
 pub use import::*;
 pub use recall_summary::{maybe_summarize_recall, RecallSummaryConfig};
 pub use sqlite::SqliteMemoryBackend;

--- a/crates/ha-core/src/memory/sqlite/backend.rs
+++ b/crates/ha-core/src/memory/sqlite/backend.rs
@@ -203,6 +203,26 @@ impl SqliteMemoryBackend {
 
     /// Ensure the vec0 virtual table exists with the correct dimensions.
     pub(crate) fn ensure_vec_table(&self, conn: &Connection, dims: u32) -> Result<()> {
+        let existing_sql: Option<String> = conn
+            .query_row(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memories_vec'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let expected_dim = format!("float[{}]", dims);
+        if let Some(sql) = existing_sql {
+            if !sql.contains(&expected_dim) {
+                app_warn!(
+                    "memory",
+                    "embedding",
+                    "Recreating memories_vec for embedding dimension change to {}",
+                    dims
+                );
+                conn.execute_batch("DROP TABLE IF EXISTS memories_vec;")?;
+            }
+        }
+
         let sql = format!(
             "CREATE VIRTUAL TABLE IF NOT EXISTS memories_vec USING vec0(rowid INTEGER PRIMARY KEY, embedding float[{}])",
             dims
@@ -599,4 +619,33 @@ pub(crate) fn row_to_entry(row: &rusqlite::Row) -> rusqlite::Result<MemoryEntry>
         attachment_path: row.get("attachment_path").ok().flatten(),
         attachment_mime: row.get("attachment_mime").ok().flatten(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vec_table_sql(conn: &Connection) -> String {
+        conn.query_row(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memories_vec'",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("memories_vec sql")
+    }
+
+    #[test]
+    fn ensure_vec_table_recreates_when_dimensions_change() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("memory.db");
+        let backend = SqliteMemoryBackend::open(&db_path).expect("open backend");
+        let conn = backend.write_conn().expect("write conn");
+
+        backend.ensure_vec_table(&conn, 384).expect("create 384");
+        assert!(vec_table_sql(&conn).contains("float[384]"));
+
+        backend.ensure_vec_table(&conn, 768).expect("recreate 768");
+        assert!(vec_table_sql(&conn).contains("float[768]"));
+        assert!(!vec_table_sql(&conn).contains("float[384]"));
+    }
 }

--- a/crates/ha-server/src/lib.rs
+++ b/crates/ha-server/src/lib.rs
@@ -378,6 +378,12 @@ fn build_router_with_cors(
             "/memory/local-embedding-models",
             get(routes::memory::list_local_embedding_models),
         )
+        // Local Ollama embedding assistant
+        .route(
+            "/local-embedding/models",
+            get(routes::local_embedding::list_models),
+        )
+        .route("/local-embedding/pull", post(routes::local_embedding::pull))
         // Config
         .route("/config/user", get(routes::config::get_user_config))
         .route("/config/user", put(routes::config::save_user_config))

--- a/crates/ha-server/src/routes/config.rs
+++ b/crates/ha-server/src/routes/config.rs
@@ -434,10 +434,22 @@ pub async fn get_embedding_config() -> Result<Json<ha_core::memory::EmbeddingCon
 pub async fn save_embedding_config(
     Json(body): Json<ConfigBody<ha_core::memory::EmbeddingConfig>>,
 ) -> Result<Json<Value>, AppError> {
+    let config = body.config;
+    let applied = config.clone();
     ha_core::config::mutate_config(("embedding", "http"), |store| {
-        store.embedding = body.config;
+        store.embedding = applied;
         Ok(())
     })?;
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = ha_core::memory::apply_embedding_config_to_backend(&config, "http") {
+            ha_core::app_warn!(
+                "memory",
+                "embedding",
+                "Failed to hot-reload embedding provider after HTTP config save: {}",
+                e
+            );
+        }
+    });
     Ok(Json(json!({ "saved": true })))
 }
 

--- a/crates/ha-server/src/routes/local_embedding.rs
+++ b/crates/ha-server/src/routes/local_embedding.rs
@@ -1,0 +1,39 @@
+//! Local Ollama embedding assistant routes.
+
+use axum::extract::State;
+use axum::Json;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use ha_core::local_embedding::{
+    list_models_with_status, pull_and_activate, OllamaEmbeddingModel,
+    EVENT_LOCAL_EMBEDDING_PULL_PROGRESS,
+};
+
+use crate::error::AppError;
+use crate::AppContext;
+
+#[derive(Debug, Deserialize)]
+pub struct PullBody {
+    pub model: OllamaEmbeddingModel,
+}
+
+/// `GET /api/local-embedding/models` — static catalog plus local install state.
+pub async fn list_models() -> Json<Value> {
+    Json(json!(list_models_with_status().await))
+}
+
+/// `POST /api/local-embedding/pull` — pull an Ollama embedding model and
+/// write the memory embedding config. Progress is broadcast on EventBus.
+pub async fn pull(
+    State(ctx): State<Arc<AppContext>>,
+    Json(body): Json<PullBody>,
+) -> Result<Json<Value>, AppError> {
+    let bus = ctx.event_bus.clone();
+    let config = pull_and_activate(body.model, move |p| {
+        bus.emit(EVENT_LOCAL_EMBEDDING_PULL_PROGRESS, json!(p));
+    })
+    .await?;
+    Ok(Json(json!(config)))
+}

--- a/crates/ha-server/src/routes/mod.rs
+++ b/crates/ha-server/src/routes/mod.rs
@@ -20,6 +20,7 @@ pub mod dreaming;
 pub mod filesystem;
 pub mod generated_images;
 pub mod health;
+pub mod local_embedding;
 pub mod local_llm;
 pub mod logging;
 pub mod mcp;

--- a/src-tauri/src/commands/local_embedding.rs
+++ b/src-tauri/src/commands/local_embedding.rs
@@ -1,0 +1,25 @@
+use crate::commands::CmdError;
+use ha_core::local_embedding::{
+    list_models_with_status, pull_and_activate, OllamaEmbeddingModel,
+    EVENT_LOCAL_EMBEDDING_PULL_PROGRESS,
+};
+use serde_json::json;
+
+#[tauri::command]
+pub async fn local_embedding_list_models() -> Result<Vec<OllamaEmbeddingModel>, CmdError> {
+    Ok(list_models_with_status().await)
+}
+
+#[tauri::command]
+pub async fn local_embedding_pull_and_activate(
+    model: OllamaEmbeddingModel,
+) -> Result<ha_core::memory::EmbeddingConfig, CmdError> {
+    let bus = ha_core::get_event_bus()
+        .cloned()
+        .ok_or_else(|| CmdError::msg("EventBus not initialized"))?;
+    pull_and_activate(model, move |p| {
+        bus.emit(EVENT_LOCAL_EMBEDDING_PULL_PROGRESS, json!(p));
+    })
+    .await
+    .map_err(Into::into)
+}

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -1,7 +1,7 @@
 use crate::commands::CmdError;
 use crate::get_memory_backend;
 use crate::memory;
-use ha_core::{app_info, app_warn};
+use ha_core::app_warn;
 
 #[tauri::command]
 pub async fn memory_add(entry: memory::NewMemory) -> Result<i64, CmdError> {
@@ -299,34 +299,15 @@ pub async fn save_embedding_config(config: memory::EmbeddingConfig) -> Result<()
 
     // Apply embedder in background to avoid blocking the command response
     tokio::task::spawn_blocking(move || {
-        if let Some(backend) = get_memory_backend() {
-            if should_enable {
-                match memory::create_embedding_provider(&config) {
-                    Ok(provider) => {
-                        backend.set_embedder(provider);
-                        app_info!(
-                            "memory",
-                            "embedding",
-                            "Embedding provider applied after config save"
-                        );
-                    }
-                    Err(e) => {
-                        app_warn!(
-                            "memory",
-                            "embedding",
-                            "Failed to apply embedding provider: {}",
-                            e
-                        );
-                    }
-                }
-            } else {
-                backend.clear_embedder();
-                app_info!(
-                    "memory",
-                    "embedding",
-                    "Embedding provider cleared after config save"
-                );
-            }
+        if let Err(e) = memory::apply_embedding_config_to_backend(&config, "settings-ui") {
+            let action = if should_enable { "apply" } else { "clear" };
+            app_warn!(
+                "memory",
+                "embedding",
+                "Failed to {} embedding provider: {}",
+                action,
+                e
+            );
         }
     });
     Ok(())

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod dashboard;
 pub mod docker;
 pub mod dreaming;
 pub mod filesystem;
+pub mod local_embedding;
 pub mod local_llm;
 pub mod logging;
 pub mod mcp;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub use ha_core::docker;
 pub use ha_core::failover;
 pub use ha_core::file_extract;
 pub use ha_core::guardian;
+pub use ha_core::local_embedding;
 pub use ha_core::logging;
 pub use ha_core::memory;
 pub use ha_core::memory_extract;
@@ -265,6 +266,8 @@ pub fn run() {
             commands::local_llm::local_llm_install_ollama,
             commands::local_llm::local_llm_start_ollama,
             commands::local_llm::local_llm_pull_and_activate,
+            commands::local_embedding::local_embedding_list_models,
+            commands::local_embedding::local_embedding_pull_and_activate,
             commands::memory::memory_stats,
             commands::memory::get_extract_config,
             commands::memory::save_extract_config,

--- a/src/components/settings/memory-panel/EmbeddingModelSection.tsx
+++ b/src/components/settings/memory-panel/EmbeddingModelSection.tsx
@@ -4,8 +4,10 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Download, Loader2, Check, Zap, Wifi, Sparkles } from "lucide-react"
+import { toast } from "sonner"
 import TestResultDisplay, { parseTestResult } from "../TestResultDisplay"
 import type { useMemoryData } from "./useMemoryData"
+import LocalEmbeddingAssistantCard from "./LocalEmbeddingAssistantCard"
 
 type MemoryData = ReturnType<typeof useMemoryData>
 
@@ -26,6 +28,7 @@ export default function EmbeddingModelSection({ data }: EmbeddingModelSectionPro
     embeddingTestResult, setEmbeddingTestResult,
     embeddingSaving,
     embeddingSaveStatus,
+    reloadEmbeddingConfig,
     batchLoading,
     saveEmbeddingConfig,
     handleReembedAll,
@@ -227,6 +230,27 @@ export default function EmbeddingModelSection({ data }: EmbeddingModelSectionPro
           ))}
         </div>
       )}
+
+      <LocalEmbeddingAssistantCard
+        onActivated={(config) => {
+          const dimsChanged =
+            embeddingConfig.apiDimensions != null &&
+            config.apiDimensions != null &&
+            embeddingConfig.apiDimensions !== config.apiDimensions
+          const replacedEnabledEmbedding =
+            embeddingConfig.enabled &&
+            (embeddingConfig.providerType !== config.providerType ||
+              (embeddingConfig.apiBaseUrl ?? null) !== (config.apiBaseUrl ?? null) ||
+              (embeddingConfig.apiModel ?? null) !== (config.apiModel ?? null) ||
+              (embeddingConfig.localModelId ?? null) !== (config.localModelId ?? null))
+          setEmbeddingConfig(config)
+          setEmbeddingDirty(false)
+          void reloadEmbeddingConfig()
+          if ((dimsChanged || replacedEnabledEmbedding) && totalCount > 0) {
+            toast.info(t("settings.localEmbedding.reembedHint"))
+          }
+        }}
+      />
 
       {/* Test & Save buttons */}
       <div className="flex items-center gap-2 mt-4">

--- a/src/components/settings/memory-panel/LocalEmbeddingAssistantCard.tsx
+++ b/src/components/settings/memory-panel/LocalEmbeddingAssistantCard.tsx
@@ -1,0 +1,418 @@
+import { useCallback, useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  Cpu,
+  ChevronDown,
+  ChevronUp,
+  Download,
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  Sparkles,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { IconTip } from "@/components/ui/tooltip"
+import { parsePayload } from "@/lib/transport"
+import { withEventListener } from "@/lib/transport-events"
+import { getTransport } from "@/lib/transport-provider"
+import { logger } from "@/lib/logger"
+import { cn } from "@/lib/utils"
+import {
+  InstallProgressDialog,
+  type ProgressFrame,
+} from "@/components/settings/local-llm/InstallProgressDialog"
+import type { EmbeddingConfig, OllamaEmbeddingModel } from "./types"
+
+type OllamaPhase = "not-installed" | "installed" | "running"
+type InstallProgressKind = "step" | "log" | "error"
+
+interface OllamaStatus {
+  phase: OllamaPhase
+  baseUrl: string
+  installScriptSupported: boolean
+}
+
+interface PullProgressPayload {
+  modelId: string
+  phase: string
+  percent?: number | null
+}
+
+interface InstallProgressPayload {
+  kind: InstallProgressKind
+  message: string
+}
+
+interface DesktopOpenResult {
+  ok?: boolean
+}
+
+const EVENT_LOCAL_LLM_INSTALL_PROGRESS = "local_llm:install_progress"
+const EVENT_LOCAL_EMBEDDING_PULL_PROGRESS = "local_embedding:pull_progress"
+const MAX_DIALOG_LOG_LINES = 240
+
+const PHASE_KEY: Record<string, string> = {
+  starting: "settings.localLlm.phases.starting",
+  "pulling manifest": "settings.localLlm.phases.pullingManifest",
+  downloading: "settings.localLlm.phases.downloading",
+  "verifying digest": "settings.localLlm.phases.verifying",
+  "writing manifest": "settings.localLlm.phases.writingManifest",
+  success: "settings.localLlm.phases.success",
+  "configure-embedding": "settings.localEmbedding.phases.configureEmbedding",
+  done: "settings.localLlm.phases.done",
+}
+
+function formatSize(mb: number): string {
+  if (mb >= 1024) return `${(mb / 1024).toFixed(1)} GB`
+  return `${mb} MB`
+}
+
+function formatLogLine(message: string): string {
+  return `[${new Date().toLocaleTimeString()}] ${message}`
+}
+
+export default function LocalEmbeddingAssistantCard({
+  onActivated,
+}: {
+  onActivated: (config: EmbeddingConfig) => void
+}) {
+  const { t } = useTranslation()
+  const [models, setModels] = useState<OllamaEmbeddingModel[]>([])
+  const [ollama, setOllama] = useState<OllamaStatus | null>(null)
+  const [chosen, setChosen] = useState<OllamaEmbeddingModel | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [showAlternatives, setShowAlternatives] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [dialogTitle, setDialogTitle] = useState("")
+  const [dialogSubtitle, setDialogSubtitle] = useState<string | undefined>(undefined)
+  const [dialogFrame, setDialogFrame] = useState<ProgressFrame | null>(null)
+  const [dialogLogs, setDialogLogs] = useState<string[]>([])
+  const [dialogDone, setDialogDone] = useState(false)
+  const [dialogError, setDialogError] = useState<string | null>(null)
+
+  const appendDialogLog = useCallback((message: string) => {
+    const trimmed = message.trim()
+    if (!trimmed) return
+    const line = formatLogLine(trimmed)
+    setDialogLogs((prev) => {
+      if (prev[prev.length - 1] === line) return prev
+      return [...prev.slice(-(MAX_DIALOG_LOG_LINES - 1)), line]
+    })
+  }, [])
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      const [nextModels, status] = await Promise.all([
+        getTransport().call<OllamaEmbeddingModel[]>("local_embedding_list_models"),
+        getTransport().call<OllamaStatus>("local_llm_detect_ollama"),
+      ])
+      setModels(nextModels)
+      setOllama(status)
+      setChosen((current) =>
+        current ? (nextModels.find((model) => model.id === current.id) ?? current) : current,
+      )
+    } catch (e) {
+      logger.error("settings", "LocalEmbeddingAssistant::refresh", "Failed to refresh", e)
+      setError(String(e))
+    } finally {
+      setRefreshing(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const phaseLabel = useCallback(
+    (phase: string | undefined) => {
+      if (!phase) return ""
+      const key = PHASE_KEY[phase.toLowerCase()]
+      return key ? t(key) : phase
+    },
+    [t],
+  )
+
+  const openDownloadPage = useCallback(() => {
+    const url = "https://ollama.com/download"
+    const openInBrowser = () => window.open(url, "_blank", "noopener")
+    void getTransport()
+      .call<DesktopOpenResult | void>("open_url", { url })
+      .then((result) => {
+        if (result && typeof result === "object" && result.ok === false) {
+          openInBrowser()
+        }
+      })
+      .catch(openInBrowser)
+  }, [])
+
+  const activateModel = useCallback(
+    async (model: OllamaEmbeddingModel) => {
+      if (ollama?.phase === "not-installed" && !ollama.installScriptSupported) {
+        openDownloadPage()
+        return
+      }
+
+      setBusy(true)
+      setError(null)
+      setDialogOpen(true)
+      setDialogTitle(t("settings.localEmbedding.install.title"))
+      setDialogSubtitle(model.id)
+      setDialogFrame({
+        phase: "starting",
+        message: t("settings.localLlm.phases.starting"),
+        percent: null,
+      })
+      setDialogLogs([])
+      setDialogDone(false)
+      setDialogError(null)
+
+      const handleInstallProgress = (raw: unknown) => {
+        const p = parsePayload<InstallProgressPayload>(raw)
+        if (p.kind === "step") {
+          setDialogFrame({ phase: p.message, message: p.message })
+          appendDialogLog(p.message)
+        } else if (p.kind === "log") {
+          appendDialogLog(p.message)
+        } else if (p.kind === "error") {
+          setDialogError(p.message)
+          appendDialogLog(p.message)
+        }
+      }
+
+      const handlePullProgress = (raw: unknown) => {
+        const p = parsePayload<PullProgressPayload>(raw)
+        const label = phaseLabel(p.phase) || p.phase
+        const progressSuffix = p.percent == null ? "" : ` ${Math.round(p.percent)}%`
+        setDialogFrame({
+          phase: p.phase,
+          message: label,
+          percent: p.percent ?? null,
+        })
+        appendDialogLog(`${label}${progressSuffix}`)
+      }
+
+      try {
+        if (ollama?.phase === "not-installed") {
+          await withEventListener(EVENT_LOCAL_LLM_INSTALL_PROGRESS, handleInstallProgress, () =>
+            getTransport().call("local_llm_install_ollama"),
+          )
+        }
+
+        if (ollama?.phase !== "running") {
+          const label = t("settings.localLlm.buttons.startOllama")
+          setDialogFrame({ phase: "starting", message: label, percent: null })
+          appendDialogLog(label)
+          await getTransport().call("local_llm_start_ollama")
+        }
+
+        const config = await withEventListener(
+          EVENT_LOCAL_EMBEDDING_PULL_PROGRESS,
+          handlePullProgress,
+          () =>
+            getTransport().call<EmbeddingConfig>("local_embedding_pull_and_activate", {
+              model,
+            }),
+        )
+
+        onActivated(config)
+        setDialogDone(true)
+        appendDialogLog(t("settings.localLlm.phases.done"))
+        await refresh()
+        setTimeout(() => setDialogOpen(false), 800)
+      } catch (e) {
+        const msg = String(e)
+        setDialogError(msg)
+        appendDialogLog(msg)
+        setError(t("settings.localEmbedding.error.activateFailed", { message: msg }))
+      } finally {
+        setBusy(false)
+      }
+    },
+    [appendDialogLog, ollama, onActivated, openDownloadPage, phaseLabel, refresh, t],
+  )
+
+  const recommended = chosen ?? models.find((model) => model.recommended) ?? models[0] ?? null
+
+  if (!recommended) {
+    return (
+      <div className="rounded-lg border border-dashed border-border bg-card/40 p-3">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {t("settings.localEmbedding.detecting")}
+        </div>
+      </div>
+    )
+  }
+
+  const primaryAction = () => {
+    if (!ollama) return null
+
+    if (ollama?.phase === "not-installed" && !ollama.installScriptSupported) {
+      return (
+        <Button variant="secondary" size="sm" onClick={openDownloadPage}>
+          <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
+          {t("settings.localEmbedding.buttons.downloadOllama")}
+        </Button>
+      )
+    }
+
+    const label =
+      recommended.installed && ollama?.phase === "running"
+        ? t("settings.localEmbedding.buttons.enable", { model: recommended.displayName })
+        : t("settings.localEmbedding.buttons.activate", { model: recommended.displayName })
+
+    return (
+      <Button size="sm" onClick={() => void activateModel(recommended)} disabled={busy}>
+        {busy ? (
+          <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+        ) : (
+          <Download className="h-3.5 w-3.5 mr-1.5" />
+        )}
+        {label}
+      </Button>
+    )
+  }
+
+  return (
+    <>
+      <div className="rounded-lg border border-primary/25 bg-primary/5 p-3 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3 min-w-0">
+            <div className="w-8 h-8 rounded-lg bg-primary/10 text-primary flex items-center justify-center shrink-0">
+              <Sparkles className="h-4 w-4" />
+            </div>
+            <div className="min-w-0">
+              <div className="text-sm font-semibold text-foreground">
+                {t("settings.localEmbedding.title")}
+              </div>
+              <div className="text-[11px] text-muted-foreground mt-0.5">
+                {t("settings.localEmbedding.subtitle")}
+              </div>
+            </div>
+          </div>
+          <IconTip label={t("common.refresh")}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0"
+              onClick={() => void refresh()}
+              disabled={refreshing}
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+            </Button>
+          </IconTip>
+        </div>
+
+        <div className="rounded-lg border border-border/60 bg-card p-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-sm font-medium text-foreground">
+                  {recommended.displayName}
+                </span>
+                {recommended.recommended && (
+                  <span className="text-[10px] uppercase tracking-wide text-emerald-700 dark:text-emerald-300 bg-emerald-500/10 border border-emerald-500/25 px-1.5 py-0.5 rounded">
+                    {t("settings.localEmbedding.recommended")}
+                  </span>
+                )}
+                {recommended.installed && (
+                  <span className="text-[10px] uppercase tracking-wide text-sky-700 dark:text-sky-300 bg-sky-500/10 border border-sky-500/25 px-1.5 py-0.5 rounded">
+                    {t("settings.localEmbedding.installed")}
+                  </span>
+                )}
+              </div>
+              <div className="text-[11px] text-muted-foreground mt-1 flex items-center gap-1.5 flex-wrap">
+                <Cpu className="h-3 w-3" />
+                <span>{formatSize(recommended.sizeMb)}</span>
+                <span>·</span>
+                <span>
+                  {t("settings.localEmbedding.dimensions", { n: recommended.dimensions })}
+                </span>
+                <span>·</span>
+                <span>
+                  {t("settings.localEmbedding.contextWindow", {
+                    n: recommended.contextWindow.toLocaleString(),
+                  })}
+                </span>
+                <span>·</span>
+                <span>{recommended.languages.join(", ")}</span>
+                {recommended.minOllamaVersion && (
+                  <>
+                    <span>·</span>
+                    <span>Ollama {recommended.minOllamaVersion}+</span>
+                  </>
+                )}
+              </div>
+            </div>
+            <div className="shrink-0">{primaryAction()}</div>
+          </div>
+
+          {models.length > 1 && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="mt-2 h-7 px-2 text-[11px] text-muted-foreground"
+              onClick={() => setShowAlternatives((v) => !v)}
+            >
+              {showAlternatives ? (
+                <ChevronUp className="h-3 w-3 mr-1" />
+              ) : (
+                <ChevronDown className="h-3 w-3 mr-1" />
+              )}
+              {showAlternatives
+                ? t("settings.localEmbedding.hideAlternatives")
+                : t("settings.localEmbedding.showAlternatives")}
+            </Button>
+          )}
+
+          {showAlternatives && (
+            <div className="mt-2 space-y-1 border-t border-border/60 pt-2">
+              {models.map((model) => {
+                const active = model.id === recommended.id
+                return (
+                  <Button
+                    key={model.id}
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setChosen(model)}
+                    className={cn(
+                      "w-full h-auto justify-between px-2 py-1.5 text-left text-[11px]",
+                      active
+                        ? "bg-primary/10 text-foreground"
+                        : "text-muted-foreground hover:bg-secondary",
+                    )}
+                  >
+                    <span className="truncate">{model.displayName}</span>
+                    <span className="font-mono text-[10px] text-muted-foreground/80 shrink-0">
+                      {formatSize(model.sizeMb)} · {model.dimensions}d
+                    </span>
+                  </Button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        {error && <p className="text-[11px] text-destructive whitespace-pre-wrap">{error}</p>}
+      </div>
+
+      <InstallProgressDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        title={dialogTitle}
+        subtitle={dialogSubtitle}
+        frame={dialogFrame}
+        logs={dialogLogs}
+        done={dialogDone}
+        error={dialogError}
+        cancellable={false}
+      />
+    </>
+  )
+}

--- a/src/components/settings/memory-panel/types.ts
+++ b/src/components/settings/memory-panel/types.ts
@@ -65,6 +65,18 @@ export interface LocalEmbeddingModel {
   downloaded: boolean
 }
 
+export interface OllamaEmbeddingModel {
+  id: string
+  displayName: string
+  dimensions: number
+  sizeMb: number
+  contextWindow: number
+  languages: string[]
+  minOllamaVersion?: string | null
+  installed: boolean
+  recommended: boolean
+}
+
 export type { AgentInfo } from "@/types/chat"
 
 export interface MemoryStats {

--- a/src/components/settings/memory-panel/useMemoryData.ts
+++ b/src/components/settings/memory-panel/useMemoryData.ts
@@ -434,6 +434,7 @@ export function useMemoryData({ agentId, isAgentMode }: UseMemoryDataParams) {
     setEmbeddingTestResult: statsHook.setEmbeddingTestResult,
     embeddingSaving: statsHook.embeddingSaving,
     embeddingSaveStatus: statsHook.embeddingSaveStatus,
+    reloadEmbeddingConfig: statsHook.reloadEmbeddingConfig,
 
     // Dedup config state (from sub-hook)
     dedupConfig: statsHook.dedupConfig,

--- a/src/components/settings/memory-panel/useMemoryStats.ts
+++ b/src/components/settings/memory-panel/useMemoryStats.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react"
+import { useCallback, useState, useEffect } from "react"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import type {
@@ -29,26 +29,28 @@ export function useMemoryStats() {
   const [dedupConfig, setDedupConfig] = useState({ thresholdHigh: 0.02, thresholdMerge: 0.012 })
   const [dedupExpanded, setDedupExpanded] = useState(false)
 
+  const loadEmbedding = useCallback(async () => {
+    try {
+      const [config, presetList, models, dedup] = await Promise.all([
+        getTransport().call<EmbeddingConfig>("get_embedding_config"),
+        getTransport().call<EmbeddingPreset[]>("get_embedding_presets"),
+        getTransport().call<LocalEmbeddingModel[]>("list_local_embedding_models"),
+        getTransport().call<{ thresholdHigh: number; thresholdMerge: number }>("get_dedup_config"),
+      ])
+      setEmbeddingConfig(config)
+      setPresets(presetList)
+      setLocalModels(models)
+      setDedupConfig(dedup)
+      setEmbeddingDirty(false)
+    } catch (e) {
+      logger.error("settings", "MemoryPanel::loadEmbedding", "Failed to load embedding config", e)
+    }
+  }, [])
+
   // ── Load embedding config ──
   useEffect(() => {
-    async function loadEmbedding() {
-      try {
-        const [config, presetList, models, dedup] = await Promise.all([
-          getTransport().call<EmbeddingConfig>("get_embedding_config"),
-          getTransport().call<EmbeddingPreset[]>("get_embedding_presets"),
-          getTransport().call<LocalEmbeddingModel[]>("list_local_embedding_models"),
-          getTransport().call<{ thresholdHigh: number; thresholdMerge: number }>("get_dedup_config"),
-        ])
-        setEmbeddingConfig(config)
-        setPresets(presetList)
-        setLocalModels(models)
-        setDedupConfig(dedup)
-      } catch (e) {
-        logger.error("settings", "MemoryPanel::loadEmbedding", "Failed to load embedding config", e)
-      }
-    }
-    loadEmbedding()
-  }, [])
+    void loadEmbedding()
+  }, [loadEmbedding])
 
   async function saveEmbeddingConfig() {
     setEmbeddingSaving(true)
@@ -81,6 +83,7 @@ export function useMemoryStats() {
     embeddingTestResult, setEmbeddingTestResult,
     embeddingSaving,
     embeddingSaveStatus,
+    reloadEmbeddingConfig: loadEmbedding,
     dedupConfig, setDedupConfig,
     dedupExpanded, setDedupExpanded,
     saveEmbeddingConfig,

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1938,6 +1938,32 @@
         "installFailed": "فشل التثبيت: {{message}}",
         "pullFailed": "فشل التنزيل: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1938,6 +1938,32 @@
         "installFailed": "Install failed: {{message}}",
         "pullFailed": "Pull failed: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1938,6 +1938,32 @@
         "installFailed": "Fallo de instalación: {{message}}",
         "pullFailed": "Fallo en la descarga: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1938,6 +1938,32 @@
         "installFailed": "インストール失敗: {{message}}",
         "pullFailed": "ダウンロード失敗: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1938,6 +1938,32 @@
         "installFailed": "설치 실패: {{message}}",
         "pullFailed": "다운로드 실패: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -1938,6 +1938,32 @@
         "installFailed": "Pemasangan gagal: {{message}}",
         "pullFailed": "Muat turun gagal: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1938,6 +1938,32 @@
         "installFailed": "Falha na instalação: {{message}}",
         "pullFailed": "Falha no download: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1938,6 +1938,32 @@
         "installFailed": "Ошибка установки: {{message}}",
         "pullFailed": "Ошибка загрузки: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1938,6 +1938,32 @@
         "installFailed": "Kurulum başarısız: {{message}}",
         "pullFailed": "İndirme başarısız: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -1938,6 +1938,32 @@
         "installFailed": "Cài đặt thất bại: {{message}}",
         "pullFailed": "Tải thất bại: {{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "Local Embedding Assistant",
+      "subtitle": "Install a small Ollama embedding model and enable vector search",
+      "detecting": "Detecting local embedding models…",
+      "recommended": "Recommended",
+      "installed": "Downloaded",
+      "dimensions": "{{n}} dimensions",
+      "contextWindow": "{{n}} context",
+      "showAlternatives": "Other embedding models",
+      "hideAlternatives": "Hide embedding models",
+      "buttons": {
+        "activate": "Install & enable {{model}}",
+        "enable": "Enable {{model}}",
+        "downloadOllama": "Download Ollama"
+      },
+      "install": {
+        "title": "Setting up local embedding"
+      },
+      "phases": {
+        "configureEmbedding": "Configuring vector search"
+      },
+      "error": {
+        "activateFailed": "Failed to enable local embedding: {{message}}"
+      },
+      "reembedHint": "Embedding dimensions changed. Use Re-embed All to update existing memories."
     }
   },
   "tz": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1938,6 +1938,32 @@
         "installFailed": "安裝失敗：{{message}}",
         "pullFailed": "下載失敗：{{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "本地 Embedding 助手",
+      "subtitle": "一鍵安裝 Ollama 小型 Embedding 模型並啟用向量搜尋",
+      "detecting": "正在偵測本地 Embedding 模型…",
+      "recommended": "推薦",
+      "installed": "已下載",
+      "dimensions": "{{n}} 維",
+      "contextWindow": "{{n}} 上下文",
+      "showAlternatives": "查看其他 Embedding 模型",
+      "hideAlternatives": "收起 Embedding 模型",
+      "buttons": {
+        "activate": "安裝並啟用 {{model}}",
+        "enable": "啟用 {{model}}",
+        "downloadOllama": "下載 Ollama"
+      },
+      "install": {
+        "title": "正在設定本地 Embedding"
+      },
+      "phases": {
+        "configureEmbedding": "正在設定向量搜尋"
+      },
+      "error": {
+        "activateFailed": "啟用本地 Embedding 失敗：{{message}}"
+      },
+      "reembedHint": "Embedding 維度已變更，請使用「重新生成全部向量」更新現有記憶。"
     }
   },
   "tz": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1938,6 +1938,32 @@
         "installFailed": "安装失败：{{message}}",
         "pullFailed": "下载失败：{{message}}"
       }
+    },
+    "localEmbedding": {
+      "title": "本地 Embedding 助手",
+      "subtitle": "一键安装 Ollama 小型 Embedding 模型并启用向量搜索",
+      "detecting": "正在检测本地 Embedding 模型…",
+      "recommended": "推荐",
+      "installed": "已下载",
+      "dimensions": "{{n}} 维",
+      "contextWindow": "{{n}} 上下文",
+      "showAlternatives": "查看其他 Embedding 模型",
+      "hideAlternatives": "收起 Embedding 模型",
+      "buttons": {
+        "activate": "安装并启用 {{model}}",
+        "enable": "启用 {{model}}",
+        "downloadOllama": "下载 Ollama"
+      },
+      "install": {
+        "title": "正在配置本地 Embedding"
+      },
+      "phases": {
+        "configureEmbedding": "正在配置向量搜索"
+      },
+      "error": {
+        "activateFailed": "启用本地 Embedding 失败：{{message}}"
+      },
+      "reembedHint": "Embedding 维度已变化，请使用“重新生成全部向量”更新现有记忆。"
     }
   },
   "tz": {

--- a/src/lib/transport-http.ts
+++ b/src/lib/transport-http.ts
@@ -350,6 +350,8 @@ const COMMAND_MAP: Record<string, EndpointDef> = {
   local_llm_install_ollama:        { method: "POST",   path: "/api/local-llm/install" },
   local_llm_start_ollama:          { method: "POST",   path: "/api/local-llm/start" },
   local_llm_pull_and_activate:     { method: "POST",   path: "/api/local-llm/pull" },
+  local_embedding_list_models:     { method: "GET",    path: "/api/local-embedding/models" },
+  local_embedding_pull_and_activate: { method: "POST",  path: "/api/local-embedding/pull" },
 
   // -- Skills --
   get_skills:                      { method: "GET",    path: "/api/skills" },


### PR DESCRIPTION
## Summary
- Add an Ollama local embedding assistant to Memory vector-search settings.
- Introduce an Ollama embedding catalog with `embeddinggemma:300m` as the recommended model and one-click pull/activation.
- Reuse the existing OpenAI-compatible `EmbeddingConfig` path against `http://127.0.0.1:11434` and hot-reload the memory embedder after saves.
- Recreate `memories_vec` when embedding dimensions change and prompt users to re-embed existing memories.

## User Impact
- Users can install/start Ollama, pull a small embedding model, and enable local vector search from the settings UI without manual provider setup.
- Existing memory stores avoid silent dimension mismatch when switching between 384/768/1024-dimensional embedding models.

## Validation
- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `cargo test -p ha-core -p ha-server --locked`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `node scripts/sync-i18n.mjs --check`