### PR TITLE
[codex] Cascade stop chat runtime cancellation

### DIFF
--- a/crates/ha-core/src/process_registry.rs
+++ b/crates/ha-core/src/process_registry.rs
@@ -9,6 +9,7 @@ use uuid::Uuid;
 #[allow(dead_code)]
 pub struct ProcessSession {
     pub id: String,
+    pub parent_session_id: Option<String>,
     pub command: String,
     pub pid: Option<u32>,
     pub cwd: String,
@@ -70,9 +71,31 @@ impl ProcessRegistry {
         self.sessions.get_mut(id)
     }
 
+    pub fn set_pid(&mut self, id: &str, pid: Option<u32>) {
+        if let Some(session) = self.sessions.get_mut(id) {
+            session.pid = pid;
+        }
+    }
+
     #[allow(dead_code)]
     pub fn list_running(&self) -> Vec<&ProcessSession> {
         self.sessions.values().filter(|s| !s.exited).collect()
+    }
+
+    pub fn list_running_ids_for_parent_session(
+        &self,
+        parent_session_id: Option<&str>,
+    ) -> Vec<String> {
+        self.sessions
+            .values()
+            .filter(|s| {
+                !s.exited
+                    && parent_session_id
+                        .map(|sid| s.parent_session_id.as_deref() == Some(sid))
+                        .unwrap_or(true)
+            })
+            .map(|s| s.id.clone())
+            .collect()
     }
 
     #[allow(dead_code)]
@@ -92,6 +115,9 @@ impl ProcessRegistry {
         status: ProcessStatus,
     ) {
         if let Some(session) = self.sessions.get_mut(id) {
+            if session.exited {
+                return;
+            }
             session.exited = true;
             session.exit_code = exit_code;
             session.exit_signal = exit_signal;

--- a/crates/ha-core/src/runtime_tasks.rs
+++ b/crates/ha-core/src/runtime_tasks.rs
@@ -61,6 +61,46 @@ pub async fn cancel_runtime_task(
     }
 }
 
+/// Cancel active runtime work associated with a chat session. `None` is a
+/// process-wide emergency stop and intentionally skips cron jobs, which are
+/// scheduled runtime work rather than work owned by the visible chat turn.
+pub async fn cancel_runtime_tasks_for_session(
+    session_id: Option<&str>,
+) -> anyhow::Result<Vec<CancelRuntimeTaskResult>> {
+    let mut results = Vec::new();
+
+    if let Some(db) = crate::async_jobs::get_async_jobs_db() {
+        for job in db.list_running()? {
+            let matches_session = session_id
+                .map(|sid| job.session_id.as_deref() == Some(sid))
+                .unwrap_or(true);
+            if matches_session {
+                results.push(cancel_async_job(&job.job_id)?);
+            }
+        }
+    }
+
+    if let Some(db) = crate::get_session_db() {
+        let runs = match session_id {
+            Some(sid) => db.list_active_subagent_runs(sid)?,
+            None => db.list_all_active_subagent_runs()?,
+        };
+        for run in runs {
+            results.push(cancel_subagent(&run.run_id)?);
+        }
+    }
+
+    let process_ids = {
+        let registry = crate::process_registry::get_registry().lock().await;
+        registry.list_running_ids_for_parent_session(session_id)
+    };
+    for process_id in process_ids {
+        results.push(cancel_process(&process_id).await?);
+    }
+
+    Ok(results)
+}
+
 fn cancel_async_job(id: &str) -> anyhow::Result<CancelRuntimeTaskResult> {
     let Some(db) = crate::async_jobs::get_async_jobs_db() else {
         return Ok(CancelRuntimeTaskResult::new(

--- a/crates/ha-core/src/session/subagent_db.rs
+++ b/crates/ha-core/src/session/subagent_db.rs
@@ -174,6 +174,28 @@ impl SessionDB {
         Ok(runs)
     }
 
+    /// List all active (non-terminal) sub-agent runs.
+    pub fn list_all_active_subagent_runs(&self) -> Result<Vec<crate::subagent::SubagentRun>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+        let mut stmt = conn.prepare(
+            "SELECT run_id, parent_session_id, parent_agent_id, child_agent_id, child_session_id,
+                    task, status, result, error, depth, model_used, started_at, finished_at, duration_ms,
+                    label, attachment_count, input_tokens, output_tokens
+             FROM subagent_runs
+             WHERE status IN ('spawning', 'running')
+             ORDER BY started_at DESC",
+        )?;
+        let rows = stmt.query_map([], Self::row_to_subagent_run)?;
+        let mut runs = Vec::new();
+        for row in rows {
+            runs.push(row?);
+        }
+        Ok(runs)
+    }
+
     /// Count active sub-agent runs for a parent session.
     pub fn count_active_subagent_runs(&self, parent_session_id: &str) -> Result<usize> {
         let conn = self

--- a/crates/ha-core/src/tools/exec.rs
+++ b/crates/ha-core/src/tools/exec.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde_json::Value;
+use std::process::Stdio;
 #[cfg(unix)]
 use std::sync::OnceLock;
 
@@ -121,6 +122,66 @@ async fn handle_exec_approval_timeout(
     }
 }
 
+#[derive(Debug)]
+enum ExecWaitError {
+    Wait(std::io::Error),
+    Timeout { timeout_secs: u64 },
+}
+
+async fn spawn_exec_waiter(
+    session_id: String,
+    mut cmd: tokio::process::Command,
+    timeout_secs: u64,
+    max_output: usize,
+) -> Result<tokio::task::JoinHandle<Result<String>>> {
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    #[cfg(unix)]
+    cmd.process_group(0);
+    cmd.kill_on_drop(true);
+    let child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            let mut registry = get_registry().lock().await;
+            registry.mark_exited(&session_id, None, None, ProcessStatus::Failed);
+            return Err(anyhow::anyhow!("Failed to execute command: {}", e));
+        }
+    };
+    let pid = child.id();
+    let cancelled_before_pid_registered = {
+        let mut registry = get_registry().lock().await;
+        let already_exited = registry
+            .get_session(&session_id)
+            .map(|session| session.exited)
+            .unwrap_or(true);
+        registry.set_pid(&session_id, pid);
+        already_exited
+    };
+    if cancelled_before_pid_registered {
+        if let Some(pid) = pid {
+            crate::platform::terminate_process_tree(pid);
+        }
+    }
+
+    Ok(tokio::spawn(async move {
+        let result = match tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            child.wait_with_output(),
+        )
+        .await
+        {
+            Ok(Ok(output)) => Ok(output),
+            Ok(Err(e)) => Err(ExecWaitError::Wait(e)),
+            Err(_) => {
+                if let Some(pid) = pid {
+                    crate::platform::terminate_process_tree(pid);
+                }
+                Err(ExecWaitError::Timeout { timeout_secs })
+            }
+        };
+        finish_exec_sync(&session_id, result, max_output).await
+    }))
+}
+
 pub(crate) async fn tool_exec(args: &Value, ctx: &super::ToolExecContext) -> Result<String> {
     let command = args
         .get("command")
@@ -217,6 +278,7 @@ pub(crate) async fn tool_exec(args: &Value, ctx: &super::ToolExecContext) -> Res
     let session_id = create_session_id();
     let session = ProcessSession {
         id: session_id.clone(),
+        parent_session_id: ctx.session_id.clone(),
         command: command.to_string(),
         pid: None,
         cwd: session_cwd.clone(),
@@ -502,50 +564,12 @@ pub(crate) async fn tool_exec(args: &Value, ctx: &super::ToolExecContext) -> Res
 
     // ── Normal execution path ──────────────────────────────────
 
-    // If background=true, spawn and return immediately
-    if background {
-        let sid = session_id.clone();
-        let timeout = timeout_secs;
-        tokio::spawn(async move {
-            let result =
-                tokio::time::timeout(std::time::Duration::from_secs(timeout), cmd.output()).await;
-            let mut registry = get_registry().lock().await;
-            match result {
-                Ok(Ok(output)) => {
-                    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-                    let exit_code = output.status.code().unwrap_or(-1);
-                    registry.append_output(&sid, "stdout", &stdout);
-                    if !stderr.is_empty() {
-                        registry.append_output(&sid, "stderr", &format!("[stderr] {}", stderr));
-                    }
-                    let status = if exit_code == 0 {
-                        ProcessStatus::Completed
-                    } else {
-                        ProcessStatus::Failed
-                    };
-                    registry.mark_exited(&sid, Some(exit_code), None, status);
-                }
-                Ok(Err(e)) => {
-                    registry.append_output(&sid, "stderr", &format!("Failed to execute: {}", e));
-                    registry.mark_exited(&sid, None, None, ProcessStatus::Failed);
-                }
-                Err(_) => {
-                    registry.append_output(
-                        &sid,
-                        "stderr",
-                        &format!("Command timed out after {}s", timeout),
-                    );
-                    registry.mark_exited(
-                        &sid,
-                        None,
-                        Some("SIGKILL".to_string()),
-                        ProcessStatus::Failed,
-                    );
-                }
-            }
-        });
+    let mut exec_handle =
+        spawn_exec_waiter(session_id.clone(), cmd, timeout_secs, max_output).await?;
 
+    // If background=true, return immediately after the process is spawned and
+    // registered. The detached waiter updates the process registry on exit.
+    if background {
         {
             let mut registry = get_registry().lock().await;
             if let Some(s) = registry.get_session_mut(&session_id) {
@@ -559,56 +583,47 @@ pub(crate) async fn tool_exec(args: &Value, ctx: &super::ToolExecContext) -> Res
         ));
     }
 
-    // Non-background: run with yield_ms support
-    let cmd_future =
-        tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), cmd.output());
-
     // If yield_ms is specified (and not default 10s for non-background), use it
     let wants_yield = args.get("yield_ms").is_some();
 
     if wants_yield {
-        // Wait yield_ms, if not done, background it
+        // Wait yield_ms, if not done, leave the already-spawned waiter
+        // detached and mark the session as backgrounded.
         let yield_duration = std::time::Duration::from_millis(yield_ms);
-        let sid = session_id.clone();
 
-        match tokio::time::timeout(yield_duration, cmd_future).await {
-            Ok(result) => {
-                // Command finished within yield window
-                return finish_exec_sync(&sid, result, max_output).await;
-            }
+        match tokio::time::timeout(yield_duration, &mut exec_handle).await {
+            Ok(joined) => return joined.map_err(|e| anyhow::anyhow!("Exec task failed: {}", e))?,
             Err(_) => {
                 // yield_ms elapsed, command still running — background it
                 {
                     let mut registry = get_registry().lock().await;
-                    if let Some(s) = registry.get_session_mut(&sid) {
+                    if let Some(s) = registry.get_session_mut(&session_id) {
                         s.backgrounded = true;
                     }
                 }
 
                 return Ok(format!(
                     "Command still running after {}ms (session {}). Use process(action=\"poll\", session_id=\"{}\") to check status.",
-                    yield_ms, sid, sid
+                    yield_ms, session_id, session_id
                 ));
             }
         }
     }
 
     // Standard synchronous execution
-    let result = cmd_future.await;
-    finish_exec_sync(&session_id, result, max_output).await
+    exec_handle
+        .await
+        .map_err(|e| anyhow::anyhow!("Exec task failed: {}", e))?
 }
 
 /// Finish a synchronous exec and return result
 async fn finish_exec_sync(
     session_id: &str,
-    result: std::result::Result<
-        std::result::Result<std::process::Output, std::io::Error>,
-        tokio::time::error::Elapsed,
-    >,
+    result: std::result::Result<std::process::Output, ExecWaitError>,
     max_output: usize,
 ) -> Result<String> {
     match result {
-        Ok(Ok(output)) => {
+        Ok(output) => {
             let stdout = String::from_utf8_lossy(&output.stdout);
             let stderr = String::from_utf8_lossy(&output.stderr);
             let exit_code = output.status.code().unwrap_or(-1);
@@ -650,14 +665,13 @@ async fn finish_exec_sync(
 
             Ok(result_text)
         }
-        Ok(Err(e)) => {
+        Err(ExecWaitError::Wait(e)) => {
             let mut registry = get_registry().lock().await;
             registry.mark_exited(session_id, None, None, ProcessStatus::Failed);
             Err(anyhow::anyhow!("Failed to execute command: {}", e))
         }
-        Err(_) => {
+        Err(ExecWaitError::Timeout { timeout_secs }) => {
             let mut registry = get_registry().lock().await;
-            let timeout = DEFAULT_EXEC_TIMEOUT_SECS;
             registry.mark_exited(
                 session_id,
                 None,
@@ -666,7 +680,7 @@ async fn finish_exec_sync(
             );
             Err(anyhow::anyhow!(
                 "Command timed out after {}s. If this command is expected to take longer, re-run with a higher timeout (e.g., exec timeout=3600).",
-                timeout
+                timeout_secs
             ))
         }
     }

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -296,24 +296,53 @@ pub async fn stop_chat(
     State(ctx): State<Arc<AppContext>>,
     Json(body): Json<StopChatRequest>,
 ) -> Result<Json<Value>, AppError> {
-    let cancels = ctx.chat_cancels.read().unwrap();
-    if let Some(sid) = body.session_id.as_deref() {
-        if let Some(cancel) = cancels.get(sid) {
-            cancel.store(true, Ordering::SeqCst);
-            return Ok(Json(json!({ "stopped": true, "scope": "session" })));
+    let mut stopped = false;
+    let mut stopped_count = 0usize;
+    let mut active_session_ids = Vec::new();
+    {
+        let cancels = ctx.chat_cancels.read().unwrap();
+        if let Some(sid) = body.session_id.as_deref() {
+            if let Some(cancel) = cancels.get(sid) {
+                cancel.store(true, Ordering::SeqCst);
+                stopped = true;
+                stopped_count = 1;
+            }
+        } else {
+            for (sid, cancel) in cancels.iter() {
+                cancel.store(true, Ordering::SeqCst);
+                active_session_ids.push(sid.clone());
+                stopped_count += 1;
+            }
+            stopped = stopped_count > 0;
         }
-        return Ok(Json(
-            json!({ "stopped": false, "reason": "no active chat for session" }),
-        ));
     }
-    let mut count = 0usize;
-    for cancel in cancels.values() {
-        cancel.store(true, Ordering::SeqCst);
-        count += 1;
+
+    let runtime_cancellations = if let Some(sid) = body.session_id.as_deref() {
+        ha_core::runtime_tasks::cancel_runtime_tasks_for_session(Some(sid)).await?
+    } else if active_session_ids.is_empty() {
+        ha_core::runtime_tasks::cancel_runtime_tasks_for_session(None).await?
+    } else {
+        let mut out = Vec::new();
+        for sid in active_session_ids {
+            out.extend(ha_core::runtime_tasks::cancel_runtime_tasks_for_session(Some(&sid)).await?);
+        }
+        out
+    };
+
+    if body.session_id.is_some() {
+        return Ok(Json(json!({
+            "stopped": stopped,
+            "scope": "session",
+            "reason": if stopped { Value::Null } else { json!("no active chat for session") },
+            "runtimeCancellations": runtime_cancellations,
+        })));
     }
-    Ok(Json(
-        json!({ "stopped": true, "scope": "all", "count": count }),
-    ))
+    Ok(Json(json!({
+        "stopped": stopped,
+        "scope": "all",
+        "count": stopped_count,
+        "runtimeCancellations": runtime_cancellations,
+    })))
 }
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -632,8 +632,29 @@ pub async fn chat(
 }
 
 #[tauri::command]
-pub async fn stop_chat(state: State<'_, AppState>) -> Result<(), CmdError> {
+pub async fn stop_chat(
+    session_id: Option<String>,
+    state: State<'_, AppState>,
+) -> Result<(), CmdError> {
     state.chat_cancel.store(true, Ordering::SeqCst);
+    match ha_core::runtime_tasks::cancel_runtime_tasks_for_session(session_id.as_deref()).await {
+        Ok(results) => {
+            app_info!(
+                "chat",
+                "stop_chat",
+                "Stop chat requested; runtime cancellations attempted: {}",
+                results.len()
+            );
+        }
+        Err(e) => {
+            app_warn!(
+                "chat",
+                "stop_chat",
+                "Stop chat runtime cancellation failed: {}",
+                e
+            );
+        }
+    }
     Ok(())
 }
 

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -207,7 +207,9 @@ export function useChatStream({
 
   async function handleStop() {
     try {
-      await getTransport().call("stop_chat")
+      await getTransport().call("stop_chat", {
+        sessionId: currentSessionIdRef.current ?? currentSessionId ?? null,
+      })
     } catch (e) {
       logger.error("ui", "ChatScreen::stop", "Failed to stop chat", e)
     }


### PR DESCRIPTION
## Summary
- Make stop-chat cascade into runtime cancellation for the current chat session.
- Track process sessions by parent chat session so active exec processes can be cancelled with the same runtime path.
- Change normal exec spawning to register child PIDs, preserve stdout/stderr capture, and create a Unix process group for reliable process-tree termination.

## Impact
- Pressing stop during a chat turn now cancels associated async jobs, subagents, and process sessions instead of only flipping the model-stream cancel flag.
- Synchronous non-PTY exec commands can now be stopped once spawned, including commands like package installs or test runs.
- Cron cancellation remains explicit through cron/runtime cancellation instead of being tied to ordinary chat stop.

## Validation
- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `cargo test -p ha-core -p ha-server --locked`

All validation passed via the pre-push hook on `git push`.