### PR TITLE
[codex] Hide subagent unread indicators

### DIFF
--- a/src/components/chat/hooks/useChatSession.ts
+++ b/src/components/chat/hooks/useChatSession.ts
@@ -385,11 +385,12 @@ export function useChatSession({
     })
   }, [reloadSessions])
 
-  // Compute total unread count — exclude channel sessions (IM messages don't count as unread)
+  // Compute total unread count — channel and sub-agent sessions don't surface
+  // global unread indicators in the primary chat entry.
   const totalUnreadCount = useMemo(
     () =>
       sessions.reduce((sum, s) => {
-        if (s.channelInfo || s.id === currentSessionId) return sum
+        if (s.channelInfo || s.parentSessionId || s.id === currentSessionId) return sum
         return sum + s.unreadCount
       }, 0),
     [sessions, currentSessionId],

--- a/src/components/chat/sidebar/SessionItem.tsx
+++ b/src/components/chat/sidebar/SessionItem.tsx
@@ -87,9 +87,11 @@ export default function SessionItem({
   const pendingInteractionCount = session.pendingInteractionCount ?? 0
   const hasPending =
     !isActive && !session.channelInfo && pendingInteractionCount > 0
+  const showUnread = !session.channelInfo && !session.parentSessionId
+  const displayUnreadCount = showUnread ? session.unreadCount : 0
 
   const handleMarkAsRead = useCallback(async () => {
-    if (session.unreadCount === 0) return
+    if (displayUnreadCount === 0) return
     try {
       await getTransport().call("mark_session_read_cmd", {
         sessionId: session.id,
@@ -98,7 +100,7 @@ export default function SessionItem({
     } catch (err) {
       logger.error("chat", "ChatSidebar::markSessionRead", "Failed to mark session as read", err)
     }
-  }, [session.id, session.unreadCount, onMarkAllRead])
+  }, [session.id, displayUnreadCount, onMarkAllRead])
 
   return (
     <ContextMenu>
@@ -139,7 +141,7 @@ export default function SessionItem({
                 <Bot className="h-3.5 w-3.5" />
               )}
             </div>
-            {!isActive && !session.channelInfo && session.unreadCount > 0 && (
+            {!isActive && displayUnreadCount > 0 && (
               <span
                 className="absolute -top-1 -right-1.5 z-10 min-w-[16px] h-[16px] px-0.5 rounded-full text-white text-[9px] font-bold flex items-center justify-center border border-background pointer-events-none leading-none"
                 style={{
@@ -149,7 +151,7 @@ export default function SessionItem({
                     "0 2px 6px rgba(220, 38, 38, 0.45), inset 0 1px 1px rgba(255, 255, 255, 0.25)",
                 }}
               >
-                {session.unreadCount > 99 ? "99+" : session.unreadCount}
+                {displayUnreadCount > 99 ? "99+" : displayUnreadCount}
               </span>
             )}
             {hasPending && (
@@ -286,7 +288,7 @@ export default function SessionItem({
         </ContextMenuItem>
         <ContextMenuItem
           onClick={handleMarkAsRead}
-          disabled={session.unreadCount === 0}
+          disabled={displayUnreadCount === 0}
         >
           <CheckCheck className="h-4 w-4 mr-2" />
           {t("chat.markAsRead")}

--- a/src/components/chat/sidebar/SessionList.tsx
+++ b/src/components/chat/sidebar/SessionList.tsx
@@ -34,6 +34,11 @@ function classifyResult(r: SessionSearchResult): SessionFilterType {
   return "session"
 }
 
+function unreadCountForDisplay(session: SessionMeta): number {
+  if (session.channelInfo || session.parentSessionId) return 0
+  return session.unreadCount
+}
+
 interface SessionListProps {
   sessions: SessionMeta[]
   filteredSessions: SessionMeta[]
@@ -157,9 +162,7 @@ export default function SessionList({
               cron: sessions.filter((s) => s.isCron),
               subagent: sessions.filter((s) => !!s.parentSessionId),
             }[filter]
-            count = filter === "channel"
-              ? 0  // Channel sessions don't show unread counts
-              : filterSessions.reduce((sum, s) => sum + (s.channelInfo ? 0 : s.unreadCount), 0)
+            count = filterSessions.reduce((sum, s) => sum + unreadCountForDisplay(s), 0)
           }
 
           const isActive = sessionFilter === filter
@@ -172,7 +175,7 @@ export default function SessionList({
               cron: sessions.filter((s) => s.isCron),
               subagent: sessions.filter((s) => !!s.parentSessionId),
             }[filter]
-            const unreadSessions = filterSessions.filter((s) => s.unreadCount > 0)
+            const unreadSessions = filterSessions.filter((s) => unreadCountForDisplay(s) > 0)
             if (unreadSessions.length === 0) return
             try {
               await getTransport().call("mark_session_read_batch_cmd", {


### PR DESCRIPTION
## Summary

- Hide unread count badges for sub-agent sessions in the session list.
- Exclude sub-agent sessions from unread totals shown in the session filter tabs.
- Exclude sub-agent sessions from the primary chat sidebar unread dot.

## Why

Sub-agent conversations should not contribute to user-facing unread indicators. The UI now treats channel sessions and sub-agent sessions consistently for unread display purposes while leaving the underlying session metadata unchanged.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `cargo test -p ha-core -p ha-server --locked`