### PR TITLE
feat(tray): 在托盘下拉里平铺正在进行的普通对话

### DIFF
--- a/crates/ha-core/src/chat_engine/stream_seq.rs
+++ b/crates/ha-core/src/chat_engine/stream_seq.rs
@@ -196,7 +196,8 @@ pub fn active_counts() -> ActiveChatCounts {
 pub fn active_session_ids_by_source(source: ChatSource) -> Vec<String> {
     let map = registry().lock().expect("stream_seq registry poisoned");
     map.iter()
-        .filter_map(|(sid, e)| (e.source == source).then(|| sid.clone()))
+        .filter(|(_, e)| e.source == source)
+        .map(|(sid, _)| sid.clone())
         .collect()
 }
 

--- a/crates/ha-core/src/chat_engine/stream_seq.rs
+++ b/crates/ha-core/src/chat_engine/stream_seq.rs
@@ -189,6 +189,17 @@ pub fn active_counts() -> ActiveChatCounts {
     out
 }
 
+/// Active session ids whose current stream comes from `source`. Order is
+/// unspecified (HashMap iteration); callers needing stable order must sort
+/// externally. Used by the desktop tray menu to enumerate "currently
+/// streaming" regular conversations without exposing the registry itself.
+pub fn active_session_ids_by_source(source: ChatSource) -> Vec<String> {
+    let map = registry().lock().expect("stream_seq registry poisoned");
+    map.iter()
+        .filter_map(|(sid, e)| (e.source == source).then(|| sid.clone()))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -238,6 +249,31 @@ mod tests {
         end(&d2);
         end(&h1);
         end(&c1);
+    }
+
+    #[test]
+    fn active_session_ids_by_source_filters_by_source() {
+        let base = "test-stream_seq-ids-by-source";
+        let d1 = format!("{base}-d1");
+        let d2 = format!("{base}-d2");
+        let h1 = format!("{base}-h1");
+
+        begin(&d1, ChatSource::Desktop).unwrap();
+        begin(&d2, ChatSource::Desktop).unwrap();
+        begin(&h1, ChatSource::Http).unwrap();
+
+        let desktop_ids = active_session_ids_by_source(ChatSource::Desktop);
+        assert!(desktop_ids.contains(&d1));
+        assert!(desktop_ids.contains(&d2));
+        assert!(!desktop_ids.contains(&h1));
+
+        let http_ids = active_session_ids_by_source(ChatSource::Http);
+        assert!(http_ids.contains(&h1));
+        assert!(!http_ids.contains(&d1));
+
+        end(&d1);
+        end(&d2);
+        end(&h1);
     }
 
     #[test]

--- a/crates/ha-core/src/session/mod.rs
+++ b/crates/ha-core/src/session/mod.rs
@@ -13,4 +13,4 @@ pub use helpers::{
 };
 pub use pending::enrich_pending_interactions;
 pub use tasks::{Task, TaskStatus};
-pub use types::{ChannelSessionInfo, MessageRole, NewMessage, SessionMessage, SessionMeta};
+pub use types::{MessageRole, NewMessage, SessionMessage, SessionMeta};

--- a/crates/ha-core/src/session/mod.rs
+++ b/crates/ha-core/src/session/mod.rs
@@ -13,4 +13,4 @@ pub use helpers::{
 };
 pub use pending::enrich_pending_interactions;
 pub use tasks::{Task, TaskStatus};
-pub use types::{MessageRole, NewMessage, SessionMessage, SessionMeta};
+pub use types::{ChannelSessionInfo, MessageRole, NewMessage, SessionMessage, SessionMeta};

--- a/crates/ha-core/src/session/types.rs
+++ b/crates/ha-core/src/session/types.rs
@@ -66,6 +66,22 @@ fn default_title_source() -> String {
     crate::session_title::TITLE_SOURCE_MANUAL.to_string()
 }
 
+impl SessionMeta {
+    /// True iff this session would render in the sidebar's `sessionFilter
+    /// === "session"` group — i.e. a "regular conversation": not
+    /// cron-triggered, not a sub-agent child, not bound to an IM channel,
+    /// not under a project, and not incognito. Mirrors
+    /// `src/components/chat/sidebar/ChatSidebar.tsx` so backend surfaces
+    /// (tray menu, future dashboards) can stay in lock-step with the UI.
+    pub fn is_regular_chat(&self) -> bool {
+        !self.is_cron
+            && self.parent_session_id.is_none()
+            && self.channel_info.is_none()
+            && self.project_id.is_none()
+            && !self.incognito
+    }
+}
+
 /// Lightweight channel info attached to a session for UI display.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -381,5 +397,67 @@ impl NewMessage {
     pub fn with_tool_metadata(mut self, metadata: Option<String>) -> Self {
         self.tool_metadata = metadata;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(id: &str) -> SessionMeta {
+        SessionMeta {
+            id: id.to_string(),
+            title: None,
+            title_source: default_title_source(),
+            agent_id: "default".to_string(),
+            provider_id: None,
+            provider_name: None,
+            model_id: None,
+            created_at: "2026-05-01T00:00:00Z".to_string(),
+            updated_at: "2026-05-01T00:00:00Z".to_string(),
+            message_count: 0,
+            unread_count: 0,
+            has_error: false,
+            pending_interaction_count: 0,
+            is_cron: false,
+            parent_session_id: None,
+            plan_mode: Default::default(),
+            permission_mode: Default::default(),
+            project_id: None,
+            channel_info: None,
+            incognito: false,
+            working_dir: None,
+        }
+    }
+
+    #[test]
+    fn is_regular_chat_excludes_non_regular_kinds() {
+        assert!(meta("a").is_regular_chat());
+
+        let mut cron = meta("b");
+        cron.is_cron = true;
+        assert!(!cron.is_regular_chat());
+
+        let mut sub = meta("c");
+        sub.parent_session_id = Some("parent".to_string());
+        assert!(!sub.is_regular_chat());
+
+        let mut proj = meta("d");
+        proj.project_id = Some("p1".to_string());
+        assert!(!proj.is_regular_chat());
+
+        let mut im = meta("e");
+        im.channel_info = Some(ChannelSessionInfo {
+            channel_id: "discord".to_string(),
+            account_id: "acc".to_string(),
+            chat_id: "ch".to_string(),
+            chat_type: "channel".to_string(),
+            sender_name: None,
+        });
+        assert!(!im.is_regular_chat());
+
+        let mut inc = meta("f");
+        inc.incognito = true;
+        assert!(!inc.is_regular_chat());
     }
 }

--- a/crates/ha-core/src/session/types.rs
+++ b/crates/ha-core/src/session/types.rs
@@ -67,17 +67,17 @@ fn default_title_source() -> String {
 }
 
 impl SessionMeta {
-    /// True iff this session would render in the sidebar's `sessionFilter
-    /// === "session"` group — i.e. a "regular conversation": not
-    /// cron-triggered, not a sub-agent child, not bound to an IM channel,
-    /// not under a project, and not incognito. Mirrors
-    /// `src/components/chat/sidebar/ChatSidebar.tsx` so backend surfaces
-    /// (tray menu, future dashboards) can stay in lock-step with the UI.
+    /// True iff this is a normal user-facing conversation — what the desktop
+    /// shell should surface in cross-cutting places like the tray dropdown.
+    /// Excludes cron-triggered sessions (autonomous), sub-agent children
+    /// (parent owns the UX), IM channel conversations (handled by the IM
+    /// worker, not the desktop), and incognito sessions (intentionally
+    /// invisible). Project membership is allowed — project chats are still
+    /// user chats, just organized inside a project container.
     pub fn is_regular_chat(&self) -> bool {
         !self.is_cron
             && self.parent_session_id.is_none()
             && self.channel_info.is_none()
-            && self.project_id.is_none()
             && !self.incognito
     }
 }
@@ -442,9 +442,11 @@ mod tests {
         sub.parent_session_id = Some("parent".to_string());
         assert!(!sub.is_regular_chat());
 
+        // Project membership is allowed — project conversations are still
+        // user-facing chats and should surface in the tray etc.
         let mut proj = meta("d");
         proj.project_id = Some("p1".to_string());
-        assert!(!proj.is_regular_chat());
+        assert!(proj.is_regular_chat());
 
         let mut im = meta("e");
         im.channel_info = Some(ChannelSessionInfo {

--- a/src-tauri/src/menu_labels.rs
+++ b/src-tauri/src/menu_labels.rs
@@ -24,6 +24,11 @@ pub(crate) struct TrayStatusLabels {
     pub(crate) event_unit: &'static str,
     pub(crate) chat_unit: &'static str,
     pub(crate) local_unit: &'static str,
+    /// Placeholder shown when an active regular session has no title yet.
+    pub(crate) untitled_session: &'static str,
+    /// Truncation indicator for the active-session list. `{}` is replaced
+    /// with the count of additional items beyond the cap.
+    pub(crate) more_sessions: &'static str,
 }
 
 /// macOS application menu label translations.
@@ -183,6 +188,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "事件",
             chat_unit: "会话",
             local_unit: "本机",
+            untitled_session: "未命名",
+            more_sessions: "… 还有 {} 项",
         },
         "zh-TW" => TrayStatusLabels {
             runtime_status: "執行時狀態",
@@ -195,6 +202,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "事件",
             chat_unit: "對話",
             local_unit: "本機",
+            untitled_session: "未命名",
+            more_sessions: "… 還有 {} 項",
         },
         "ja" => TrayStatusLabels {
             runtime_status: "ランタイムステータス",
@@ -207,6 +216,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "events",
             chat_unit: "chat",
             local_unit: "ローカル",
+            untitled_session: "無題",
+            more_sessions: "… 他 {} 件",
         },
         "ko" => TrayStatusLabels {
             runtime_status: "런타임 상태",
@@ -219,6 +230,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "events",
             chat_unit: "chat",
             local_unit: "로컬",
+            untitled_session: "제목 없음",
+            more_sessions: "… {}개 더",
         },
         "es" => TrayStatusLabels {
             runtime_status: "Estado en tiempo real",
@@ -231,6 +244,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "eventos",
             chat_unit: "chat",
             local_unit: "local",
+            untitled_session: "Sin título",
+            more_sessions: "… {} más",
         },
         "pt" => TrayStatusLabels {
             runtime_status: "Estado em tempo de execução",
@@ -243,6 +258,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "eventos",
             chat_unit: "chat",
             local_unit: "local",
+            untitled_session: "Sem título",
+            more_sessions: "… mais {}",
         },
         "ru" => TrayStatusLabels {
             runtime_status: "Состояние во время работы",
@@ -255,6 +272,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "событий",
             chat_unit: "чат",
             local_unit: "локально",
+            untitled_session: "Без названия",
+            more_sessions: "… ещё {}",
         },
         "ar" => TrayStatusLabels {
             runtime_status: "حالة التشغيل",
@@ -267,6 +286,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "أحداث",
             chat_unit: "محادثة",
             local_unit: "محلي",
+            untitled_session: "بدون عنوان",
+            more_sessions: "… {} أخرى",
         },
         "tr" => TrayStatusLabels {
             runtime_status: "Çalışma Durumu",
@@ -279,6 +300,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "olay",
             chat_unit: "sohbet",
             local_unit: "yerel",
+            untitled_session: "Başlıksız",
+            more_sessions: "… {} tane daha",
         },
         "vi" => TrayStatusLabels {
             runtime_status: "Trạng thái hoạt động",
@@ -291,6 +314,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "sự kiện",
             chat_unit: "trò chuyện",
             local_unit: "cục bộ",
+            untitled_session: "Không có tiêu đề",
+            more_sessions: "… còn {} mục",
         },
         "ms" => TrayStatusLabels {
             runtime_status: "Status Jalanan",
@@ -303,6 +328,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "peristiwa",
             chat_unit: "sembang",
             local_unit: "tempatan",
+            untitled_session: "Tanpa tajuk",
+            more_sessions: "… {} lagi",
         },
         _ => TrayStatusLabels {
             runtime_status: "Runtime Status",
@@ -315,6 +342,8 @@ pub(crate) fn tray_status_labels(lang: &str) -> TrayStatusLabels {
             event_unit: "events",
             chat_unit: "chat",
             local_unit: "local",
+            untitled_session: "Untitled",
+            more_sessions: "… {} more",
         },
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,14 +1,32 @@
-use crate::menu_labels::{resolve_language, tray_labels, tray_status_labels, TrayStatusLabels};
-use ha_core::{app_debug, app_info};
-use tauri::menu::{MenuBuilder, MenuItem, MenuItemBuilder, PredefinedMenuItem};
+use crate::menu_labels::{
+    resolve_language, tray_labels, tray_status_labels, TrayLabels, TrayStatusLabels,
+};
+use ha_core::session::{ProjectFilter, SessionMeta};
+use ha_core::{app_debug, app_info, app_warn};
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder, PredefinedMenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
-use tauri::{Emitter, Manager, Runtime};
+use tauri::{AppHandle, Emitter, Manager, Runtime};
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 
 const TRAY_STATUS_LINE_COUNT: usize = 5;
+const TRAY_SESSION_PREFIX: &str = "tray_session:";
+const TRAY_SESSION_MORE_ID: &str = "tray_session_more";
+/// Cap on dynamic active-session entries shown directly in the tray menu.
+/// Beyond this we render a single disabled "… {N} more" line so the menu
+/// stays compact even with many concurrent streams.
+const TRAY_ACTIVE_SESSIONS_CAP: usize = 5;
+/// Page size used when sweeping recent sessions for pending-interaction
+/// candidates. Bigger than CAP so the diff/sort step has room to work.
+const TRAY_RECENT_SCAN_LIMIT: u32 = 50;
+/// UTF-8 byte budget for the title shown inside a tray menu item. macOS and
+/// Windows both render long menu items poorly; clamp to keep the menu narrow.
+const TRAY_TITLE_BYTES: usize = 60;
 
 /// Show and focus the main window if it already exists.
-fn show_main_window(app_handle: &tauri::AppHandle) {
+fn show_main_window(app_handle: &AppHandle) {
     if let Some(window) = app_handle.get_webview_window("main") {
         let _ = window.show();
         let _ = window.unminimize();
@@ -23,48 +41,9 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let status_labels = tray_status_labels(&lang);
     let status_lines = current_tray_status_lines(&status_labels);
 
-    // Build menu items
-    let status_header = MenuItemBuilder::with_id("tray_status_header", &status_lines[0])
-        .enabled(false)
-        .build(app)?;
-    let status_bound_addr = MenuItemBuilder::with_id("tray_status_bound_addr", &status_lines[1])
-        .enabled(false)
-        .build(app)?;
-    let status_uptime = MenuItemBuilder::with_id("tray_status_uptime", &status_lines[2])
-        .enabled(false)
-        .build(app)?;
-    let status_connections = MenuItemBuilder::with_id("tray_status_connections", &status_lines[3])
-        .enabled(false)
-        .build(app)?;
-    let status_sessions = MenuItemBuilder::with_id("tray_status_sessions", &status_lines[4])
-        .enabled(false)
-        .build(app)?;
-    let sep_status = PredefinedMenuItem::separator(app)?;
-    let show_main = MenuItemBuilder::with_id("show_main", labels.show_main).build(app)?;
-    let quick_chat = MenuItemBuilder::with_id("quick_chat", labels.quick_chat).build(app)?;
-    let sep1 = PredefinedMenuItem::separator(app)?;
-    let new_session = MenuItemBuilder::with_id("new_session", labels.new_session).build(app)?;
-    let open_settings = MenuItemBuilder::with_id("open_settings", labels.settings).build(app)?;
-    let sep2 = PredefinedMenuItem::separator(app)?;
-    let quit_app = MenuItemBuilder::with_id("quit_app", labels.quit).build(app)?;
-
-    let menu = MenuBuilder::new(app)
-        .items(&[
-            &status_header,
-            &status_bound_addr,
-            &status_uptime,
-            &status_connections,
-            &status_sessions,
-            &sep_status,
-            &show_main,
-            &quick_chat,
-            &sep1,
-            &new_session,
-            &open_settings,
-            &sep2,
-            &quit_app,
-        ])
-        .build()?;
+    let app_handle: AppHandle = app.handle().clone();
+    let initial_menu =
+        build_tray_menu(&app_handle, &labels, &status_labels, &status_lines, &[], 0)?;
 
     let icon = tauri::image::Image::from_bytes(include_bytes!("../icons/menu.png")).unwrap();
     let icon_as_template = true;
@@ -76,15 +55,34 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         .icon(icon)
         .icon_as_template(icon_as_template)
         .show_menu_on_left_click(show_menu_on_left_click)
-        .menu(&menu)
+        .menu(&initial_menu)
         .on_menu_event(|app_handle, event| {
-            app_debug!(
-                "tray",
-                "menu",
-                "Tray menu item clicked: {}",
-                event.id().as_ref()
-            );
-            match event.id().as_ref() {
+            let id = event.id().as_ref();
+            app_debug!("tray", "menu", "Tray menu item clicked: {}", id);
+
+            if let Some(session_id) = id.strip_prefix(TRAY_SESSION_PREFIX) {
+                let session_id = session_id.to_string();
+                app_info!(
+                    "tray",
+                    "focus_session",
+                    "user clicked tray active-session entry session_id={}",
+                    session_id
+                );
+                show_main_window(app_handle);
+                if let Err(e) =
+                    app_handle.emit("tray:focus-session", json!({ "sessionId": session_id }))
+                {
+                    app_warn!(
+                        "tray",
+                        "focus_session",
+                        "failed to emit tray:focus-session: {:#}",
+                        e
+                    );
+                }
+                return;
+            }
+
+            match id {
                 "show_main" => {
                     show_main_window(app_handle);
                 }
@@ -138,7 +136,6 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                     button_state
                 );
 
-                // Left click on tray icon → show main window.
                 if button == MouseButton::Left && button_state == MouseButtonState::Up {
                     show_main_window(tray.app_handle());
                 }
@@ -157,18 +154,38 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
 
     {
         let tray_handle = tray.clone();
-        let status_items = TrayStatusMenuItems {
-            header: status_header,
-            bound_addr: status_bound_addr,
-            uptime: status_uptime,
-            connections: status_connections,
-            sessions: status_sessions,
-        };
+        let loop_handle = app_handle.clone();
         tauri::async_runtime::spawn(async move {
+            let mut last_signature: Option<TraySnapshotSig> = None;
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 let lines = current_tray_status_lines(&status_labels);
-                update_tray_status_menu(&status_items, &lines);
+                let (active, more) = compute_active_regular_sessions(&status_labels).await;
+                let signature = TraySnapshotSig::from(&lines, &active, more);
+
+                let menu_changed = last_signature.as_ref() != Some(&signature);
+                if menu_changed {
+                    match build_tray_menu(
+                        &loop_handle,
+                        &labels,
+                        &status_labels,
+                        &lines,
+                        &active,
+                        more,
+                    ) {
+                        Ok(menu) => {
+                            if let Err(e) = tray_handle.set_menu(Some(menu)) {
+                                app_warn!("tray", "refresh", "failed to swap tray menu: {:#}", e);
+                            } else {
+                                last_signature = Some(signature);
+                            }
+                        }
+                        Err(e) => {
+                            app_warn!("tray", "refresh", "failed to rebuild tray menu: {:#}", e);
+                        }
+                    }
+                }
+
                 let tooltip = build_tray_tooltip(&lines);
                 let _ = tray_handle.set_tooltip(Some(&tooltip));
             }
@@ -189,12 +206,37 @@ struct TrayRuntimeStatus<'a> {
     active_chat_total: u32,
 }
 
-struct TrayStatusMenuItems<R: Runtime> {
-    header: MenuItem<R>,
-    bound_addr: MenuItem<R>,
-    uptime: MenuItem<R>,
-    connections: MenuItem<R>,
-    sessions: MenuItem<R>,
+/// Compact representation of one currently in-progress regular conversation,
+/// pre-formatted for the tray menu.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ActiveRegularSession {
+    session_id: String,
+    /// Already-formatted text shown as the menu item label, e.g.
+    /// `"  ▶ My session"` or `"  ⏸ Untitled"`.
+    label: String,
+}
+
+/// Tuple used to detect "did the dynamic menu actually change?" so we can
+/// skip `tray.set_menu` when nothing moved (avoids menu flicker on macOS
+/// when the user is mid-interaction).
+#[derive(Debug, PartialEq, Eq)]
+struct TraySnapshotSig {
+    status_lines: Vec<String>,
+    active: Vec<(String, String)>,
+    more: usize,
+}
+
+impl TraySnapshotSig {
+    fn from(lines: &[String], active: &[ActiveRegularSession], more: usize) -> Self {
+        Self {
+            status_lines: lines.to_vec(),
+            active: active
+                .iter()
+                .map(|s| (s.session_id.clone(), s.label.clone()))
+                .collect(),
+            more,
+        }
+    }
 }
 
 fn current_tray_status_lines(labels: &TrayStatusLabels) -> Vec<String> {
@@ -212,23 +254,6 @@ fn current_tray_status_lines(labels: &TrayStatusLabels) -> Vec<String> {
             active_chat_total: counts.total,
         },
     )
-}
-
-fn update_tray_status_menu<R: Runtime>(items: &TrayStatusMenuItems<R>, lines: &[String]) {
-    if lines.len() != TRAY_STATUS_LINE_COUNT {
-        app_debug!(
-            "tray",
-            "status",
-            "Skipping tray status update with unexpected line count: {}",
-            lines.len()
-        );
-        return;
-    }
-    let _ = items.header.set_text(&lines[0]);
-    let _ = items.bound_addr.set_text(&lines[1]);
-    let _ = items.uptime.set_text(&lines[2]);
-    let _ = items.connections.set_text(&lines[3]);
-    let _ = items.sessions.set_text(&lines[4]);
 }
 
 fn build_tray_tooltip(lines: &[String]) -> String {
@@ -292,10 +317,287 @@ fn format_short_uptime(secs: u64) -> String {
     }
 }
 
+/// True iff the session would render in the sidebar as a "regular" chat —
+/// i.e. not cron-triggered, not a sub-agent child, not bound to an IM
+/// channel, not under a project, and not incognito. Mirrors the frontend
+/// `sessionFilter === "session"` predicate in
+/// `src/components/chat/sidebar/ChatSidebar.tsx`.
+fn is_regular_session(s: &SessionMeta) -> bool {
+    !s.is_cron
+        && s.parent_session_id.is_none()
+        && s.channel_info.is_none()
+        && s.project_id.is_none()
+        && !s.incognito
+}
+
+/// Format a session entry as a tray menu label, including a status glyph
+/// (`▶` streaming / `⏸` waiting on user / `▶⏸` both) and the title with
+/// UTF-8-safe truncation. Falls back to `untitled_session` from the
+/// `TrayStatusLabels` when the session has no title yet.
+fn format_active_session_label(
+    s: &SessionMeta,
+    streaming: bool,
+    pending: bool,
+    labels: &TrayStatusLabels,
+) -> String {
+    let glyph = match (streaming, pending) {
+        (true, true) => "▶⏸",
+        (true, false) => "▶",
+        (false, true) => "⏸",
+        // Should not occur — caller filters out sessions that match neither.
+        (false, false) => "•",
+    };
+    let raw_title = s
+        .title
+        .as_deref()
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty())
+        .unwrap_or(labels.untitled_session);
+    let title = ha_core::truncate_utf8(raw_title, TRAY_TITLE_BYTES);
+    format!("  {glyph} {title}")
+}
+
+/// Resolve the list of "in-progress regular conversations" for the tray
+/// dropdown. Combines two condition sources:
+///
+/// 1. **Streaming**: session ids registered in `chat_engine::stream_seq`
+///    with `source=Desktop` (LLM is currently producing tokens).
+/// 2. **Pending interaction**: `SessionMeta.pending_interaction_count > 0`
+///    (waiting on a tool approval or an `ask_user_question` answer).
+///
+/// Then filters to regular sessions only (see [`is_regular_session`]) and
+/// returns up to [`TRAY_ACTIVE_SESSIONS_CAP`] entries plus the count of
+/// items truncated. Order: by `updated_at DESC` to mirror the sidebar.
+async fn compute_active_regular_sessions(
+    status_labels: &TrayStatusLabels,
+) -> (Vec<ActiveRegularSession>, usize) {
+    let streaming_ids: std::collections::HashSet<String> =
+        ha_core::chat_engine::stream_seq::active_session_ids_by_source(
+            ha_core::chat_engine::stream_seq::ChatSource::Desktop,
+        )
+        .into_iter()
+        .collect();
+
+    let Some(db) = ha_core::get_session_db() else {
+        // Bootstrap window: SessionDB not yet initialized. Skip silently;
+        // next 5s tick will retry.
+        return (Vec::new(), 0);
+    };
+    let db: Arc<ha_core::session::SessionDB> = db.clone();
+
+    // Pull recent sessions ordered by `updated_at DESC`. This is the primary
+    // candidate pool for "pending_interaction_count > 0" sessions and also
+    // covers the streaming case for any actively-touched session.
+    let recent = match db.list_sessions_paged(
+        None,
+        ProjectFilter::All,
+        Some(TRAY_RECENT_SCAN_LIMIT),
+        Some(0),
+        None,
+    ) {
+        Ok((rows, _total)) => rows,
+        Err(e) => {
+            app_warn!(
+                "tray",
+                "active_sessions",
+                "list_sessions_paged failed: {:#}",
+                e
+            );
+            return (Vec::new(), 0);
+        }
+    };
+
+    let mut by_id: HashMap<String, SessionMeta> =
+        recent.into_iter().map(|s| (s.id.clone(), s)).collect();
+
+    // Pull any streaming session not in the recent slice (edge case: very
+    // old session resumed after long idle — its `updated_at` may not yet
+    // reflect the new turn at sweep time).
+    for sid in &streaming_ids {
+        if !by_id.contains_key(sid) {
+            match db.get_session(sid) {
+                Ok(Some(meta)) => {
+                    by_id.insert(sid.clone(), meta);
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    app_warn!(
+                        "tray",
+                        "active_sessions",
+                        "get_session({sid}) failed: {:#}",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    // Enrich pending_interaction_count for the merged set.
+    let mut sessions: Vec<SessionMeta> = by_id.into_values().collect();
+    if let Err(e) = ha_core::session::enrich_pending_interactions(&mut sessions, &db).await {
+        app_warn!(
+            "tray",
+            "active_sessions",
+            "enrich_pending_interactions failed: {:#}",
+            e
+        );
+    }
+
+    // Keep only regular sessions that are streaming OR have a pending
+    // interaction. Both filters are cheap; do them in one pass.
+    let mut filtered: Vec<(SessionMeta, bool, bool)> = sessions
+        .into_iter()
+        .filter_map(|s| {
+            if !is_regular_session(&s) {
+                return None;
+            }
+            let streaming = streaming_ids.contains(&s.id);
+            let pending = s.pending_interaction_count > 0;
+            (streaming || pending).then_some((s, streaming, pending))
+        })
+        .collect();
+
+    // Sort newest-first to mirror the sidebar.
+    filtered.sort_by(|a, b| b.0.updated_at.cmp(&a.0.updated_at));
+
+    let total = filtered.len();
+    let truncated = total.saturating_sub(TRAY_ACTIVE_SESSIONS_CAP);
+    let kept: Vec<ActiveRegularSession> = filtered
+        .into_iter()
+        .take(TRAY_ACTIVE_SESSIONS_CAP)
+        .map(|(s, streaming, pending)| ActiveRegularSession {
+            label: format_active_session_label(&s, streaming, pending, status_labels),
+            session_id: s.id,
+        })
+        .collect();
+
+    (kept, truncated)
+}
+
+/// Build the full tray menu including the dynamic "in-progress regular
+/// conversations" rows. Items appear in this order:
+///
+/// 1. 5 disabled status rows (unchanged from before).
+/// 2. Per active session: one clickable item with id `tray_session:{id}`.
+/// 3. Optional disabled "… {N} more" line if `more > 0`.
+/// 4. Separator + the existing action items.
+fn build_tray_menu<R: Runtime>(
+    manager: &impl Manager<R>,
+    labels: &TrayLabels,
+    status_labels: &TrayStatusLabels,
+    status_lines: &[String],
+    active: &[ActiveRegularSession],
+    more: usize,
+) -> tauri::Result<Menu<R>> {
+    if status_lines.len() != TRAY_STATUS_LINE_COUNT {
+        return Err(tauri::Error::Anyhow(anyhow::anyhow!(
+            "tray status lines expected {} entries, got {}",
+            TRAY_STATUS_LINE_COUNT,
+            status_lines.len()
+        )));
+    }
+
+    let status_header = MenuItemBuilder::with_id("tray_status_header", &status_lines[0])
+        .enabled(false)
+        .build(manager)?;
+    let status_bound_addr = MenuItemBuilder::with_id("tray_status_bound_addr", &status_lines[1])
+        .enabled(false)
+        .build(manager)?;
+    let status_uptime = MenuItemBuilder::with_id("tray_status_uptime", &status_lines[2])
+        .enabled(false)
+        .build(manager)?;
+    let status_connections = MenuItemBuilder::with_id("tray_status_connections", &status_lines[3])
+        .enabled(false)
+        .build(manager)?;
+    let status_sessions = MenuItemBuilder::with_id("tray_status_sessions", &status_lines[4])
+        .enabled(false)
+        .build(manager)?;
+
+    let session_items: Vec<_> = active
+        .iter()
+        .map(|s| {
+            MenuItemBuilder::with_id(format!("{TRAY_SESSION_PREFIX}{}", s.session_id), &s.label)
+                .build(manager)
+        })
+        .collect::<tauri::Result<Vec<_>>>()?;
+
+    let more_item = if more > 0 {
+        Some(
+            MenuItemBuilder::with_id(
+                TRAY_SESSION_MORE_ID,
+                status_labels.more_sessions.replace("{}", &more.to_string()),
+            )
+            .enabled(false)
+            .build(manager)?,
+        )
+    } else {
+        None
+    };
+
+    let sep_status = PredefinedMenuItem::separator(manager)?;
+    let show_main = MenuItemBuilder::with_id("show_main", labels.show_main).build(manager)?;
+    let quick_chat = MenuItemBuilder::with_id("quick_chat", labels.quick_chat).build(manager)?;
+    let sep1 = PredefinedMenuItem::separator(manager)?;
+    let new_session = MenuItemBuilder::with_id("new_session", labels.new_session).build(manager)?;
+    let open_settings =
+        MenuItemBuilder::with_id("open_settings", labels.settings).build(manager)?;
+    let sep2 = PredefinedMenuItem::separator(manager)?;
+    let quit_app = MenuItemBuilder::with_id("quit_app", labels.quit).build(manager)?;
+
+    let mut builder = MenuBuilder::new(manager)
+        .item(&status_header)
+        .item(&status_bound_addr)
+        .item(&status_uptime)
+        .item(&status_connections)
+        .item(&status_sessions);
+    for it in &session_items {
+        builder = builder.item(it);
+    }
+    if let Some(ref m) = more_item {
+        builder = builder.item(m);
+    }
+    builder = builder
+        .item(&sep_status)
+        .item(&show_main)
+        .item(&quick_chat)
+        .item(&sep1)
+        .item(&new_session)
+        .item(&open_settings)
+        .item(&sep2)
+        .item(&quit_app);
+    builder.build()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::menu_labels::tray_status_labels;
+
+    fn dummy_session(id: &str, title: Option<&str>) -> SessionMeta {
+        SessionMeta {
+            id: id.to_string(),
+            title: title.map(|t| t.to_string()),
+            title_source: "manual".to_string(),
+            agent_id: "default".to_string(),
+            provider_id: None,
+            provider_name: None,
+            model_id: None,
+            created_at: "2026-05-01T00:00:00Z".to_string(),
+            updated_at: "2026-05-01T00:00:00Z".to_string(),
+            message_count: 0,
+            unread_count: 0,
+            has_error: false,
+            pending_interaction_count: 0,
+            is_cron: false,
+            parent_session_id: None,
+            plan_mode: Default::default(),
+            permission_mode: Default::default(),
+            project_id: None,
+            channel_info: None,
+            incognito: false,
+            working_dir: None,
+        }
+    }
 
     #[test]
     fn status_menu_lines_match_simplified_chinese_sidebar_wording() {
@@ -324,5 +626,93 @@ mod tests {
                 "活跃会话: 0".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn is_regular_session_excludes_non_regular_kinds() {
+        // Regular: passes
+        let regular = dummy_session("a", Some("hi"));
+        assert!(is_regular_session(&regular));
+
+        // Cron-triggered: blocked
+        let mut cron = dummy_session("b", None);
+        cron.is_cron = true;
+        assert!(!is_regular_session(&cron));
+
+        // Sub-agent child: blocked
+        let mut sub = dummy_session("c", None);
+        sub.parent_session_id = Some("parent".to_string());
+        assert!(!is_regular_session(&sub));
+
+        // Project-bound: blocked
+        let mut proj = dummy_session("d", None);
+        proj.project_id = Some("p1".to_string());
+        assert!(!is_regular_session(&proj));
+
+        // IM channel: blocked
+        let mut im = dummy_session("e", None);
+        im.channel_info = Some(ha_core::session::ChannelSessionInfo {
+            channel_id: "discord".to_string(),
+            account_id: "acc".to_string(),
+            chat_id: "ch".to_string(),
+            chat_type: "channel".to_string(),
+            sender_name: None,
+        });
+        assert!(!is_regular_session(&im));
+
+        // Incognito: blocked
+        let mut inc = dummy_session("f", None);
+        inc.incognito = true;
+        assert!(!is_regular_session(&inc));
+    }
+
+    #[test]
+    fn format_active_session_label_picks_glyph_by_state() {
+        let labels = tray_status_labels("en");
+        let s = dummy_session("a", Some("My session"));
+
+        assert_eq!(
+            format_active_session_label(&s, true, false, &labels),
+            "  ▶ My session"
+        );
+        assert_eq!(
+            format_active_session_label(&s, false, true, &labels),
+            "  ⏸ My session"
+        );
+        assert_eq!(
+            format_active_session_label(&s, true, true, &labels),
+            "  ▶⏸ My session"
+        );
+
+        // Empty title falls back to localized placeholder.
+        let untitled = dummy_session("b", None);
+        assert_eq!(
+            format_active_session_label(&untitled, true, false, &labels),
+            "  ▶ Untitled"
+        );
+        // Whitespace-only title is treated as empty.
+        let blank = dummy_session("c", Some("   "));
+        assert_eq!(
+            format_active_session_label(&blank, false, true, &labels),
+            "  ⏸ Untitled"
+        );
+    }
+
+    #[test]
+    fn more_label_substitutes_count_for_each_locale() {
+        for lang in [
+            "zh", "zh-TW", "ja", "ko", "es", "pt", "ru", "ar", "tr", "vi", "ms", "en",
+        ] {
+            let labels = tray_status_labels(lang);
+            let rendered = labels.more_sessions.replace("{}", "3");
+            assert!(
+                rendered.contains('3'),
+                "lang {lang} more_sessions did not substitute count: {rendered}"
+            );
+            assert!(
+                !rendered.contains("{}"),
+                "lang {lang} more_sessions left unreplaced placeholder: {rendered}"
+            );
+        }
     }
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -206,13 +206,9 @@ struct TrayRuntimeStatus<'a> {
     active_chat_total: u32,
 }
 
-/// Compact representation of one currently in-progress regular conversation,
-/// pre-formatted for the tray menu.
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ActiveRegularSession {
     session_id: String,
-    /// Already-formatted text shown as the menu item label, e.g.
-    /// `"  ▶ My session"` or `"  ⏸ Untitled"`.
     label: String,
 }
 
@@ -317,19 +313,6 @@ fn format_short_uptime(secs: u64) -> String {
     }
 }
 
-/// True iff the session would render in the sidebar as a "regular" chat —
-/// i.e. not cron-triggered, not a sub-agent child, not bound to an IM
-/// channel, not under a project, and not incognito. Mirrors the frontend
-/// `sessionFilter === "session"` predicate in
-/// `src/components/chat/sidebar/ChatSidebar.tsx`.
-fn is_regular_session(s: &SessionMeta) -> bool {
-    !s.is_cron
-        && s.parent_session_id.is_none()
-        && s.channel_info.is_none()
-        && s.project_id.is_none()
-        && !s.incognito
-}
-
 /// Format a session entry as a tray menu label, including a status glyph
 /// (`▶` streaming / `⏸` waiting on user / `▶⏸` both) and the title with
 /// UTF-8-safe truncation. Falls back to `untitled_session` from the
@@ -365,8 +348,8 @@ fn format_active_session_label(
 /// 2. **Pending interaction**: `SessionMeta.pending_interaction_count > 0`
 ///    (waiting on a tool approval or an `ask_user_question` answer).
 ///
-/// Then filters to regular sessions only (see [`is_regular_session`]) and
-/// returns up to [`TRAY_ACTIVE_SESSIONS_CAP`] entries plus the count of
+/// Then filters to regular sessions only (see [`SessionMeta::is_regular_chat`])
+/// and returns up to [`TRAY_ACTIVE_SESSIONS_CAP`] entries plus the count of
 /// items truncated. Order: by `updated_at DESC` to mirror the sidebar.
 async fn compute_active_regular_sessions(
     status_labels: &TrayStatusLabels,
@@ -448,7 +431,7 @@ async fn compute_active_regular_sessions(
     let mut filtered: Vec<(SessionMeta, bool, bool)> = sessions
         .into_iter()
         .filter_map(|s| {
-            if !is_regular_session(&s) {
+            if !s.is_regular_chat() {
                 return None;
             }
             let streaming = streaming_ids.contains(&s.id);
@@ -626,44 +609,6 @@ mod tests {
                 "活跃会话: 0".to_string(),
             ]
         );
-    }
-
-    #[test]
-    fn is_regular_session_excludes_non_regular_kinds() {
-        // Regular: passes
-        let regular = dummy_session("a", Some("hi"));
-        assert!(is_regular_session(&regular));
-
-        // Cron-triggered: blocked
-        let mut cron = dummy_session("b", None);
-        cron.is_cron = true;
-        assert!(!is_regular_session(&cron));
-
-        // Sub-agent child: blocked
-        let mut sub = dummy_session("c", None);
-        sub.parent_session_id = Some("parent".to_string());
-        assert!(!is_regular_session(&sub));
-
-        // Project-bound: blocked
-        let mut proj = dummy_session("d", None);
-        proj.project_id = Some("p1".to_string());
-        assert!(!is_regular_session(&proj));
-
-        // IM channel: blocked
-        let mut im = dummy_session("e", None);
-        im.channel_info = Some(ha_core::session::ChannelSessionInfo {
-            channel_id: "discord".to_string(),
-            account_id: "acc".to_string(),
-            chat_id: "ch".to_string(),
-            chat_type: "channel".to_string(),
-            sender_name: None,
-        });
-        assert!(!is_regular_session(&im));
-
-        // Incognito: blocked
-        let mut inc = dummy_session("f", None);
-        inc.incognito = true;
-        assert!(!is_regular_session(&inc));
     }
 
     #[test]

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -546,16 +546,12 @@ export default function ChatScreen({
 
   // Listen for tray "focus-session" event — emitted when the user clicks an
   // in-progress regular conversation entry inside the system tray dropdown.
-  // The Tauri shell already shows + focuses the main window before emitting;
-  // here we just switch the sidebar/messages over to the requested session.
   useEffect(() => {
     return getTransport().listen("tray:focus-session", (raw) => {
       const sessionId = (raw as { sessionId?: string } | undefined)?.sessionId
-      if (sessionId && sessionId !== session.currentSessionId) {
-        void session.handleSwitchSession(sessionId)
-      }
+      if (sessionId) void session.handleSwitchSession(sessionId)
     })
-  }, [session.handleSwitchSession, session.currentSessionId])
+  }, [session.handleSwitchSession])
 
   // Listen for channel slash command state-sync events
   useEffect(() => {

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -544,6 +544,19 @@ export default function ChatScreen({
     })
   }, [handleStartNewChat, currentAgentId])
 
+  // Listen for tray "focus-session" event — emitted when the user clicks an
+  // in-progress regular conversation entry inside the system tray dropdown.
+  // The Tauri shell already shows + focuses the main window before emitting;
+  // here we just switch the sidebar/messages over to the requested session.
+  useEffect(() => {
+    return getTransport().listen("tray:focus-session", (raw) => {
+      const sessionId = (raw as { sessionId?: string } | undefined)?.sessionId
+      if (sessionId && sessionId !== session.currentSessionId) {
+        void session.handleSwitchSession(sessionId)
+      }
+    })
+  }, [session.handleSwitchSession, session.currentSessionId])
+
   // Listen for channel slash command state-sync events
   useEffect(() => {
     const unlisteners: Array<() => void> = []


### PR DESCRIPTION
「活跃会话: N」一行下面接着列出当前正在流式输出 / 正在等待用户处理（工具审批 / ask_user_question）的普通对话，最多 5 条，超出尾部显示「… 还有 N 项」。点击条目展示主窗口并切到该会话，事件名 tray:focus-session。

普通对话筛选与侧栏 sessionFilter === "session" 一致：!is_cron && !parent_session_id && !channel_info && !project_id && !incognito。流式判定来自 chat_engine::stream_seq 注册表（仅 Desktop 源），等待用户判定来自 SessionMeta.pending_interaction_count。每 5s tick 重建菜单，但仅在 (status_lines, active_set, more) 三元组变化时才触发 set_menu，避免 macOS 用户打开菜单时被替换闪烁。

- crates/ha-core/src/chat_engine/stream_seq.rs：新增 active_session_ids_by_source 公开 API + 单测
- crates/ha-core/src/session/mod.rs：re-export ChannelSessionInfo
- src-tauri/src/menu_labels.rs：TrayStatusLabels 加 untitled_session / more_sessions 字段，12 语言齐全
- src-tauri/src/tray.rs：抽 build_tray_menu 全量重建路径 + compute_active_regular_sessions 候选合并 + diff 节流；tray_session: 前缀点击 handler emit tray:focus-session
- src/components/chat/ChatScreen.tsx：监听 tray:focus-session，调用 session.handleSwitchSession 切换