### PR TITLE
fix(slash): 对齐 GUI/IM 行为 + 完善 /help

### DIFF
--- a/crates/ha-core/src/app_init.rs
+++ b/crates/ha-core/src/app_init.rs
@@ -458,6 +458,103 @@ fn spawn_channel_listeners() {
             channel_db.clone(),
             registry.clone(),
         );
+        spawn_channel_menu_resync_listener(registry.clone());
+    }
+}
+
+/// Subscribe to `skills:catalog_changed` and config events that touch the
+/// slash-command catalog (skill enable/disable, extra dirs) and re-sync each
+/// running IM channel's bot menu.
+///
+/// Debounced with a 2s trailing-edge timer so a bulk import or a chain of
+/// `bump_skill_version` calls collapses into one `setMyCommands` /
+/// `bulk_overwrite_global_commands` round-trip per affected account.
+fn spawn_channel_menu_resync_listener(registry: Arc<channel::ChannelRegistry>) {
+    let Some(bus) = crate::globals::get_event_bus() else {
+        app_warn!(
+            "channel",
+            "menu_sync",
+            "EventBus not initialized — IM menu auto-resync disabled"
+        );
+        return;
+    };
+    let mut rx = bus.subscribe();
+
+    tokio::spawn(async move {
+        const DEBOUNCE: std::time::Duration = std::time::Duration::from_secs(2);
+        let mut pending: Option<tokio::time::Instant> = None;
+
+        loop {
+            // Either wake on a new event, or wake when the debounce window
+            // closes for a previously-buffered event.
+            let recv = if let Some(deadline) = pending {
+                tokio::select! {
+                    _ = tokio::time::sleep_until(deadline) => {
+                        pending = None;
+                        let synced = registry.sync_commands_for_all().await;
+                        if synced > 0 {
+                            app_info!(
+                                "channel",
+                                "menu_sync",
+                                "Re-synced slash command menus on {} running account(s)",
+                                synced
+                            );
+                        }
+                        continue;
+                    }
+                    ev = rx.recv() => ev,
+                }
+            } else {
+                rx.recv().await
+            };
+
+            match recv {
+                Ok(event) => {
+                    if menu_resync_event_relevant(&event) {
+                        pending = Some(tokio::time::Instant::now() + DEBOUNCE);
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    // We dropped events — re-sync defensively rather than
+                    // miss a real change.
+                    app_warn!(
+                        "channel",
+                        "menu_sync",
+                        "EventBus lagged {} events — forcing menu re-sync",
+                        n
+                    );
+                    pending = Some(tokio::time::Instant::now() + DEBOUNCE);
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+}
+
+fn menu_resync_event_relevant(event: &crate::event_bus::AppEvent) -> bool {
+    match event.name.as_str() {
+        "skills:catalog_changed" => true,
+        "config:changed" => {
+            // Only react to config writes that touch the slash-command
+            // surface — provider tweaks, theme changes, etc. shouldn't
+            // trigger redundant `setMyCommands` calls.
+            //
+            // The category prefix `skill` covers the actual emission sites:
+            //   - `skills` / `extra_skills_dirs` / `disabled_skills` (CRUD path)
+            //   - `skill_env` / `skill_env_check` (env path that affects which
+            //     skills the system_prompt catalog considers usable)
+            //   - `skills.auto_review` (impacts whether new drafts get promoted)
+            // The persistence-layer fallback (`category: "app"`) is intentionally
+            // excluded — that's the duplicate event for paths that already
+            // emitted a typed one.
+            event
+                .payload
+                .get("category")
+                .and_then(|c| c.as_str())
+                .map(|c| c.starts_with("skill"))
+                .unwrap_or(false)
+        }
+        _ => false,
     }
 }
 

--- a/crates/ha-core/src/app_init.rs
+++ b/crates/ha-core/src/app_init.rs
@@ -515,8 +515,6 @@ fn spawn_channel_menu_resync_listener(registry: Arc<channel::ChannelRegistry>) {
                     }
                 }
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    // We dropped events — re-sync defensively rather than
-                    // miss a real change.
                     app_warn!(
                         "channel",
                         "menu_sync",
@@ -531,29 +529,28 @@ fn spawn_channel_menu_resync_listener(registry: Arc<channel::ChannelRegistry>) {
     });
 }
 
+/// Config categories whose changes can shift the slash-command catalog. Kept
+/// as an explicit list (rather than a `starts_with("skill")` heuristic) so a
+/// future unrelated `skill_*` field can't silently force IM bot menu re-syncs.
+/// Matches the categories used in `skills::commands::*` and `tools::settings`.
+const MENU_RESYNC_CATEGORIES: &[&str] = &[
+    "skills",
+    "extra_skills_dirs",
+    "disabled_skills",
+    "skill_env",
+    "skill_env_check",
+    "skills.auto_review",
+];
+
 fn menu_resync_event_relevant(event: &crate::event_bus::AppEvent) -> bool {
     match event.name.as_str() {
         "skills:catalog_changed" => true,
-        "config:changed" => {
-            // Only react to config writes that touch the slash-command
-            // surface — provider tweaks, theme changes, etc. shouldn't
-            // trigger redundant `setMyCommands` calls.
-            //
-            // The category prefix `skill` covers the actual emission sites:
-            //   - `skills` / `extra_skills_dirs` / `disabled_skills` (CRUD path)
-            //   - `skill_env` / `skill_env_check` (env path that affects which
-            //     skills the system_prompt catalog considers usable)
-            //   - `skills.auto_review` (impacts whether new drafts get promoted)
-            // The persistence-layer fallback (`category: "app"`) is intentionally
-            // excluded — that's the duplicate event for paths that already
-            // emitted a typed one.
-            event
-                .payload
-                .get("category")
-                .and_then(|c| c.as_str())
-                .map(|c| c.starts_with("skill"))
-                .unwrap_or(false)
-        }
+        "config:changed" => event
+            .payload
+            .get("category")
+            .and_then(|c| c.as_str())
+            .map(|c| MENU_RESYNC_CATEGORIES.contains(&c))
+            .unwrap_or(false),
         _ => false,
     }
 }

--- a/crates/ha-core/src/channel/discord/mod.rs
+++ b/crates/ha-core/src/channel/discord/mod.rs
@@ -22,7 +22,8 @@ struct RunningAccount {
     bot_id: String,
     #[allow(dead_code)]
     bot_username: String,
-    #[allow(dead_code)]
+    /// Discord application id, needed to re-sync slash commands without
+    /// re-fetching `/users/@me`.
     application_id: String,
 }
 
@@ -60,18 +61,60 @@ impl DiscordPlugin {
     }
 
     /// Sync slash commands to Discord's Application Commands API.
-    /// Called once after successful authentication. Non-fatal on failure.
+    ///
+    /// Called from `start_account` (first-time install) and from the trait
+    /// `sync_commands` impl (driven by skill / config changes — see
+    /// `ChannelRegistry::sync_commands_for_account`). Non-fatal on failure
+    /// — the bot remains usable, just with a stale menu until the next
+    /// successful sync.
     async fn sync_commands_to_discord(api: &DiscordApi, application_id: &str) {
-        let commands = crate::slash_commands::registry::all_commands();
+        // Pull the merged catalog (built-ins + invocable skills, minus
+        // `IM_DISABLED_COMMANDS`) so Discord users see the same set as
+        // Telegram and the desktop slash menu.
+        let defs = match crate::slash_commands::list_slash_commands().await {
+            Ok(v) => v,
+            Err(e) => {
+                app_warn!(
+                    "channel",
+                    "discord",
+                    "list_slash_commands failed: {} — falling back to built-in only",
+                    e
+                );
+                crate::slash_commands::registry::all_commands()
+            }
+        };
 
-        // Convert to Discord Application Command format (type 1 = CHAT_INPUT)
-        let discord_commands: Vec<serde_json::Value> = commands
-            .iter()
+        // Discord caps global application commands at 100; truncate the tail
+        // (skill commands sit after built-ins) to keep the registration call
+        // idempotent. Truncated entries are still callable, just hidden from
+        // the auto-complete UI.
+        const DISCORD_GLOBAL_CMD_CAP: usize = 100;
+        let mut filtered: Vec<crate::slash_commands::types::SlashCommandDef> = defs
+            .into_iter()
             .filter(|cmd| !crate::slash_commands::registry::is_im_disabled(&cmd.name))
+            .collect();
+        if filtered.len() > DISCORD_GLOBAL_CMD_CAP {
+            app_warn!(
+                "channel",
+                "discord",
+                "Slash command count {} exceeds Discord cap {} — truncating tail",
+                filtered.len(),
+                DISCORD_GLOBAL_CMD_CAP
+            );
+            filtered.truncate(DISCORD_GLOBAL_CMD_CAP);
+        }
+
+        // Convert to Discord Application Command format (type 1 = CHAT_INPUT).
+        // Discord requires lowercase command names matching ^[-_\p{L}\p{N}]{1,32}$
+        // — built-ins already comply, and `skills::normalize_skill_command_name`
+        // produces the same shape, so no further sanitization is needed here.
+        let discord_commands: Vec<serde_json::Value> = filtered
+            .iter()
             .map(|cmd| {
+                let description = cmd.description_en();
                 let mut command = serde_json::json!({
                     "name": cmd.name,
-                    "description": cmd.description_en(),
+                    "description": description,
                     "type": 1, // CHAT_INPUT
                 });
 
@@ -90,7 +133,7 @@ impl DiscordPlugin {
                             .collect();
                         command["options"] = serde_json::json!([{
                             "name": "value",
-                            "description": cmd.description_en(),
+                            "description": description,
                             "type": 3, // STRING
                             "required": !cmd.args_optional,
                             "choices": choices
@@ -503,5 +546,19 @@ impl ChannelPlugin for DiscordPlugin {
         let me = api.get_current_user().await?;
         let username = me["username"].as_str().unwrap_or("unknown");
         Ok(username.to_string())
+    }
+
+    async fn sync_commands(&self, account: &ChannelAccountConfig) -> Result<()> {
+        // Pull api + application_id together under a single lock so we don't
+        // race a concurrent stop_account that would leave us with a stale api.
+        let (api, application_id) = {
+            let accounts = self.accounts.lock().await;
+            let acc = accounts.get(&account.id).ok_or_else(|| {
+                anyhow::anyhow!("Discord account '{}' is not running", account.id)
+            })?;
+            (acc.api.clone(), acc.application_id.clone())
+        };
+        Self::sync_commands_to_discord(&api, &application_id).await;
+        Ok(())
     }
 }

--- a/crates/ha-core/src/channel/discord/mod.rs
+++ b/crates/ha-core/src/channel/discord/mod.rs
@@ -68,47 +68,13 @@ impl DiscordPlugin {
     /// — the bot remains usable, just with a stale menu until the next
     /// successful sync.
     async fn sync_commands_to_discord(api: &DiscordApi, application_id: &str) {
-        // Pull the merged catalog (built-ins + invocable skills, minus
-        // `IM_DISABLED_COMMANDS`) so Discord users see the same set as
-        // Telegram and the desktop slash menu.
-        let defs = match crate::slash_commands::list_slash_commands().await {
-            Ok(v) => v,
-            Err(e) => {
-                app_warn!(
-                    "channel",
-                    "discord",
-                    "list_slash_commands failed: {} — falling back to built-in only",
-                    e
-                );
-                crate::slash_commands::registry::all_commands()
-            }
-        };
+        // Single source of truth for the IM-bot catalog (filter, cap, fallback);
+        // Discord just projects each entry into its CHAT_INPUT JSON below.
+        // Skill names already pass Discord's `^[-_\p{L}\p{N}]{1,32}$` rule via
+        // `skills::normalize_skill_command_name`, so no re-sanitisation needed.
+        let entries = crate::slash_commands::im_menu_entries().await;
 
-        // Discord caps global application commands at 100; truncate the tail
-        // (skill commands sit after built-ins) to keep the registration call
-        // idempotent. Truncated entries are still callable, just hidden from
-        // the auto-complete UI.
-        const DISCORD_GLOBAL_CMD_CAP: usize = 100;
-        let mut filtered: Vec<crate::slash_commands::types::SlashCommandDef> = defs
-            .into_iter()
-            .filter(|cmd| !crate::slash_commands::registry::is_im_disabled(&cmd.name))
-            .collect();
-        if filtered.len() > DISCORD_GLOBAL_CMD_CAP {
-            app_warn!(
-                "channel",
-                "discord",
-                "Slash command count {} exceeds Discord cap {} — truncating tail",
-                filtered.len(),
-                DISCORD_GLOBAL_CMD_CAP
-            );
-            filtered.truncate(DISCORD_GLOBAL_CMD_CAP);
-        }
-
-        // Convert to Discord Application Command format (type 1 = CHAT_INPUT).
-        // Discord requires lowercase command names matching ^[-_\p{L}\p{N}]{1,32}$
-        // — built-ins already comply, and `skills::normalize_skill_command_name`
-        // produces the same shape, so no further sanitization is needed here.
-        let discord_commands: Vec<serde_json::Value> = filtered
+        let discord_commands: Vec<serde_json::Value> = entries
             .iter()
             .map(|cmd| {
                 let description = cmd.description_en();
@@ -118,18 +84,11 @@ impl DiscordPlugin {
                     "type": 1, // CHAT_INPUT
                 });
 
-                // Add string option for commands that accept arguments
                 if cmd.has_args {
                     if let Some(ref options) = cmd.arg_options {
-                        // Use choices for commands with predefined options
                         let choices: Vec<serde_json::Value> = options
                             .iter()
-                            .map(|opt| {
-                                serde_json::json!({
-                                    "name": opt,
-                                    "value": opt
-                                })
-                            })
+                            .map(|opt| serde_json::json!({ "name": opt, "value": opt }))
                             .collect();
                         command["options"] = serde_json::json!([{
                             "name": "value",

--- a/crates/ha-core/src/channel/registry.rs
+++ b/crates/ha-core/src/channel/registry.rs
@@ -195,6 +195,83 @@ impl ChannelRegistry {
             .collect()
     }
 
+    /// Re-sync slash command menus for a single running account.
+    ///
+    /// Looks up the live `ChannelAccountConfig` from `cached_config` because
+    /// the registry only holds an opaque `account_id` per worker. Returns
+    /// `Ok(false)` (with a warn log) if the account isn't running or the
+    /// config row is missing — re-sync is best-effort, never fatal.
+    pub async fn sync_commands_for_account(&self, account_id: &str) -> Result<bool> {
+        let channel_id = {
+            let workers = self.workers.lock().await;
+            match workers.get(account_id) {
+                Some(h) => h.channel_id.clone(),
+                None => return Ok(false),
+            }
+        };
+
+        let account_cfg = {
+            let cfg = crate::config::cached_config();
+            cfg.channels.find_account(account_id).cloned()
+        };
+        let Some(account_cfg) = account_cfg else {
+            app_warn!(
+                "channel",
+                "registry",
+                "sync_commands: account '{}' is running but missing from config",
+                account_id
+            );
+            return Ok(false);
+        };
+
+        let plugin = self
+            .plugins
+            .get(&channel_id)
+            .ok_or_else(|| anyhow::anyhow!("No plugin registered for channel: {}", channel_id))?;
+
+        match plugin.sync_commands(&account_cfg).await {
+            Ok(()) => Ok(true),
+            Err(e) => {
+                app_warn!(
+                    "channel",
+                    "registry",
+                    "sync_commands failed for account '{}': {}",
+                    account_id,
+                    e
+                );
+                Ok(false)
+            }
+        }
+    }
+
+    /// Re-sync slash command menus for every running account. Each account
+    /// is attempted independently so a stale Telegram connection doesn't
+    /// block Discord from picking up the change.
+    pub async fn sync_commands_for_all(&self) -> usize {
+        let account_ids: Vec<String> = {
+            let workers = self.workers.lock().await;
+            workers.keys().cloned().collect()
+        };
+
+        let mut synced = 0usize;
+        for account_id in account_ids {
+            match self.sync_commands_for_account(&account_id).await {
+                Ok(true) => synced += 1,
+                Ok(false) => {}
+                Err(e) => {
+                    app_warn!(
+                        "channel",
+                        "registry",
+                        "sync_commands_for_account('{}') errored: {}",
+                        account_id,
+                        e
+                    );
+                }
+            }
+        }
+        synced
+    }
+
     /// Stop all running accounts. Called during app shutdown.
     pub async fn stop_all(&self) {
         let account_ids: Vec<String> = {

--- a/crates/ha-core/src/channel/registry.rs
+++ b/crates/ha-core/src/channel/registry.rs
@@ -195,18 +195,17 @@ impl ChannelRegistry {
             .collect()
     }
 
-    /// Re-sync slash command menus for a single running account.
-    ///
-    /// Looks up the live `ChannelAccountConfig` from `cached_config` because
-    /// the registry only holds an opaque `account_id` per worker. Returns
-    /// `Ok(false)` (with a warn log) if the account isn't running or the
-    /// config row is missing — re-sync is best-effort, never fatal.
-    pub async fn sync_commands_for_account(&self, account_id: &str) -> Result<bool> {
+    /// Re-sync slash command menus for a single running account. Returns 1 on
+    /// success, 0 if the account isn't running, the config row is missing, or
+    /// the plugin call failed (warn-logged). Re-sync is best-effort —
+    /// `Err` is reserved for "no plugin registered for this channel id"
+    /// invariant violations the caller should propagate.
+    pub async fn sync_commands_for_account(&self, account_id: &str) -> Result<usize> {
         let channel_id = {
             let workers = self.workers.lock().await;
             match workers.get(account_id) {
                 Some(h) => h.channel_id.clone(),
-                None => return Ok(false),
+                None => return Ok(0),
             }
         };
 
@@ -221,16 +220,17 @@ impl ChannelRegistry {
                 "sync_commands: account '{}' is running but missing from config",
                 account_id
             );
-            return Ok(false);
+            return Ok(0);
         };
 
         let plugin = self
             .plugins
             .get(&channel_id)
-            .ok_or_else(|| anyhow::anyhow!("No plugin registered for channel: {}", channel_id))?;
+            .ok_or_else(|| anyhow::anyhow!("No plugin registered for channel: {}", channel_id))?
+            .clone();
 
         match plugin.sync_commands(&account_cfg).await {
-            Ok(()) => Ok(true),
+            Ok(()) => Ok(1),
             Err(e) => {
                 app_warn!(
                     "channel",
@@ -239,14 +239,15 @@ impl ChannelRegistry {
                     account_id,
                     e
                 );
-                Ok(false)
+                Ok(0)
             }
         }
     }
 
-    /// Re-sync slash command menus for every running account. Each account
-    /// is attempted independently so a stale Telegram connection doesn't
-    /// block Discord from picking up the change.
+    /// Re-sync slash command menus for every running account. Each account is
+    /// attempted independently so a stale Telegram connection doesn't block
+    /// Discord from picking up the change. Sequential because a typical user
+    /// only has 1-3 IM accounts and matches the `stop_all` shape.
     pub async fn sync_commands_for_all(&self) -> usize {
         let account_ids: Vec<String> = {
             let workers = self.workers.lock().await;
@@ -256,8 +257,7 @@ impl ChannelRegistry {
         let mut synced = 0usize;
         for account_id in account_ids {
             match self.sync_commands_for_account(&account_id).await {
-                Ok(true) => synced += 1,
-                Ok(false) => {}
+                Ok(n) => synced += n,
                 Err(e) => {
                     app_warn!(
                         "channel",
@@ -270,6 +270,16 @@ impl ChannelRegistry {
             }
         }
         synced
+    }
+
+    /// Unified entry-point that callers (Tauri / HTTP / event listener) can use
+    /// without branching themselves: `Some(id)` → sync that single account,
+    /// `None` → sync every running account.
+    pub async fn sync_commands(&self, account_id: Option<&str>) -> Result<usize> {
+        match account_id {
+            Some(id) => self.sync_commands_for_account(id).await,
+            None => Ok(self.sync_commands_for_all().await),
+        }
     }
 
     /// Stop all running accounts. Called during app shutdown.

--- a/crates/ha-core/src/channel/telegram/mod.rs
+++ b/crates/ha-core/src/channel/telegram/mod.rs
@@ -48,16 +48,20 @@ impl TelegramPlugin {
     }
 
     /// Sync slash commands to Telegram's bot menu via setMyCommands.
-    /// Called once after successful authentication. Non-fatal on failure.
+    ///
+    /// Called from `start_account` (first-time install) and from the trait
+    /// `sync_commands` impl (driven by skill / config changes — see
+    /// `ChannelRegistry::sync_commands_for_account`). Non-fatal on failure
+    /// — the bot remains usable, just with a stale menu until the next
+    /// successful sync.
     async fn sync_commands_to_menu(api: &TelegramBotApi) {
-        let commands = crate::slash_commands::registry::all_commands();
+        let entries = crate::slash_commands::im_menu_entries().await;
 
-        let bot_commands: Vec<teloxide::types::BotCommand> = commands
-            .iter()
-            .filter(|cmd| !crate::slash_commands::registry::is_im_disabled(&cmd.name))
-            .map(|cmd| teloxide::types::BotCommand {
-                command: cmd.name.clone(),
-                description: cmd.description_en(),
+        let bot_commands: Vec<teloxide::types::BotCommand> = entries
+            .into_iter()
+            .map(|(name, description)| teloxide::types::BotCommand {
+                command: name,
+                description,
             })
             .collect();
 
@@ -481,5 +485,11 @@ impl ChannelPlugin for TelegramPlugin {
         let api = TelegramBotApi::new(&token, None, None);
         let me = api.get_me().await?;
         Ok(format!("@{}", me.username()))
+    }
+
+    async fn sync_commands(&self, account: &ChannelAccountConfig) -> Result<()> {
+        let api = self.get_api(&account.id).await?;
+        Self::sync_commands_to_menu(&api).await;
+        Ok(())
     }
 }

--- a/crates/ha-core/src/channel/telegram/mod.rs
+++ b/crates/ha-core/src/channel/telegram/mod.rs
@@ -58,10 +58,10 @@ impl TelegramPlugin {
         let entries = crate::slash_commands::im_menu_entries().await;
 
         let bot_commands: Vec<teloxide::types::BotCommand> = entries
-            .into_iter()
-            .map(|(name, description)| teloxide::types::BotCommand {
-                command: name,
-                description,
+            .iter()
+            .map(|cmd| teloxide::types::BotCommand {
+                command: cmd.name.clone(),
+                description: cmd.description_en(),
             })
             .collect();
 

--- a/crates/ha-core/src/channel/traits.rs
+++ b/crates/ha-core/src/channel/traits.rs
@@ -118,6 +118,21 @@ pub trait ChannelPlugin: Send + Sync + 'static {
     /// Validate the given credentials and return the bot name / account label.
     /// Used during account setup to verify the token/API key is valid.
     async fn validate_credentials(&self, credentials: &serde_json::Value) -> Result<String>;
+
+    // ── Slash command menu ────────────────────────────────────────
+
+    /// Re-sync the channel-side slash command menu against the current
+    /// `slash_commands::list_slash_commands` snapshot (built-ins + skills,
+    /// minus `IM_DISABLED_COMMANDS`).
+    ///
+    /// Default = no-op for channels without a slash menu (IRC, WhatsApp,
+    /// iMessage, etc.). Telegram / Discord override to call their
+    /// platform-specific endpoints (setMyCommands / Application Commands).
+    /// Triggered both at `start_account` (first-time install) and on demand
+    /// from skill / config changes via `ChannelRegistry::sync_commands_*`.
+    async fn sync_commands(&self, _account: &ChannelAccountConfig) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Default access-control logic shared by all channel plugins.

--- a/crates/ha-core/src/skills/types.rs
+++ b/crates/ha-core/src/skills/types.rs
@@ -13,8 +13,17 @@ pub(super) const DEFAULT_MAX_CANDIDATES_PER_ROOT: usize = 300;
 static SKILL_CACHE_VERSION: AtomicU64 = AtomicU64::new(0);
 
 /// Bump the global skill cache version, invalidating cached entries.
+///
+/// Also emits `skills:catalog_changed` on the global EventBus so passive
+/// observers (e.g. `ChannelRegistry::sync_commands_for_all` re-syncing
+/// Telegram / Discord bot menus) can react. The emission is best-effort —
+/// no bus during early init = silent skip; subscribers are responsible for
+/// debouncing if they expect storms (e.g. bulk skill imports).
 pub fn bump_skill_version() {
     SKILL_CACHE_VERSION.fetch_add(1, Ordering::Relaxed);
+    if let Some(bus) = crate::globals::get_event_bus() {
+        bus.emit("skills:catalog_changed", serde_json::Value::Null);
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/ha-core/src/slash_commands/handlers/awareness.rs
+++ b/crates/ha-core/src/slash_commands/handlers/awareness.rs
@@ -40,9 +40,11 @@ pub fn handle_awareness(args: &str) -> Result<CommandResult, String> {
 }
 
 fn set_enabled(enabled: bool) -> Result<CommandResult, String> {
-    let mut store = crate::config::load_config().map_err(|e| e.to_string())?;
-    store.awareness.enabled = enabled;
-    crate::config::save_config(&store).map_err(|e| e.to_string())?;
+    crate::config::mutate_config(("awareness", "slash-cmd"), |cfg| {
+        cfg.awareness.enabled = enabled;
+        Ok(())
+    })
+    .map_err(|e| e.to_string())?;
     Ok(CommandResult {
         content: format!(
             "Behavior awareness {}.",
@@ -53,13 +55,15 @@ fn set_enabled(enabled: bool) -> Result<CommandResult, String> {
 }
 
 fn set_mode(mode: AwarenessMode) -> Result<CommandResult, String> {
-    let mut store = crate::config::load_config().map_err(|e| e.to_string())?;
-    store.awareness.mode = mode;
-    // Enabling a concrete mode implies the feature is on.
-    if !matches!(mode, AwarenessMode::Off) {
-        store.awareness.enabled = true;
-    }
-    crate::config::save_config(&store).map_err(|e| e.to_string())?;
+    crate::config::mutate_config(("awareness", "slash-cmd"), |cfg| {
+        cfg.awareness.mode = mode;
+        // Enabling a concrete mode implies the feature is on.
+        if !matches!(mode, AwarenessMode::Off) {
+            cfg.awareness.enabled = true;
+        }
+        Ok(())
+    })
+    .map_err(|e| e.to_string())?;
     let label = match mode {
         AwarenessMode::Off => "off",
         AwarenessMode::Structured => "structured (zero LLM cost)",

--- a/crates/ha-core/src/slash_commands/handlers/mod.rs
+++ b/crates/ha-core/src/slash_commands/handlers/mod.rs
@@ -79,7 +79,7 @@ pub async fn dispatch(
 
         // ── Utility ──
         "permission" => utility::handle_permission(args),
-        "help" => Ok(utility::handle_help()),
+        "help" => Ok(utility::handle_help(session_id).await),
         "status" => {
             let store = crate::config::cached_config();
             utility::handle_status(session_db()?, &store, session_id, agent_id)

--- a/crates/ha-core/src/slash_commands/handlers/mod.rs
+++ b/crates/ha-core/src/slash_commands/handlers/mod.rs
@@ -79,7 +79,7 @@ pub async fn dispatch(
 
         // ── Utility ──
         "permission" => utility::handle_permission(args),
-        "help" => Ok(utility::handle_help(session_id).await),
+        "help" => Ok(utility::handle_help(session_id)),
         "status" => {
             let store = crate::config::cached_config();
             utility::handle_status(session_db()?, &store, session_id, agent_id)

--- a/crates/ha-core/src/slash_commands/handlers/utility.rs
+++ b/crates/ha-core/src/slash_commands/handlers/utility.rs
@@ -2,6 +2,7 @@ use crate::config::AppConfig;
 use crate::provider;
 use crate::session::{MessageRole, SessionDB};
 use crate::slash_commands::registry;
+use crate::slash_commands::truncate_description;
 use crate::slash_commands::types::{
     CommandAction, CommandCategory, CommandResult, SlashCommandDef,
 };
@@ -9,31 +10,18 @@ use std::sync::Arc;
 
 /// /help — Show all available commands.
 ///
-/// Renders one section per `CommandCategory`. Each row shows the command,
-/// its argument placeholder (or the fixed option list), and the English
-/// description from `description_en()`. When invoked from an IM channel
-/// session, commands listed in `IM_DISABLED_COMMANDS` are filtered out and
-/// a footer call-out explains the desktop-only ones.
-pub async fn handle_help(session_id: Option<&str>) -> CommandResult {
-    // Detect IM-channel context defensively — `/help` should still render
-    // when SessionDB hasn't been initialized yet (e.g. very early CLI use).
-    let in_im_channel = session_id
-        .and_then(|sid| {
-            crate::require_session_db()
-                .ok()
-                .and_then(|db| db.get_session(sid).ok().flatten())
-        })
-        .map(|meta| meta.channel_info.is_some())
-        .unwrap_or(false);
+/// Renders one section per `CommandCategory` (using `description_en()` for the
+/// label) plus a `Skills` section. Inside an IM-channel session, commands in
+/// `IM_DISABLED_COMMANDS` are filtered out and a footer call-out explains the
+/// desktop-only ones.
+pub fn handle_help(session_id: Option<&str>) -> CommandResult {
+    let in_im_channel = is_session_in_im_channel(session_id);
 
     let mut commands: Vec<SlashCommandDef> = registry::all_commands();
     if in_im_channel {
         commands.retain(|c| !registry::is_im_disabled(&c.name));
     }
 
-    // Pull invocable skills so users see the skill-as-slash-command catalog
-    // alongside built-ins. Skills are dynamic per agent / extra dirs / disabled
-    // list, so we hit the same surface `list_slash_commands` exposes to the UI.
     let cfg = crate::config::cached_config();
     let skills = crate::skills::get_invocable_skills(&cfg.extra_skills_dirs, &cfg.disabled_skills);
     let reserved: std::collections::HashSet<String> =
@@ -46,7 +34,7 @@ pub async fn handle_help(session_id: Option<&str>) -> CommandResult {
     lines.push(String::new());
 
     // Category order matches the GUI menu (`CATEGORY_ORDER` in
-    // `slash-commands/types.ts`) so the on-screen and `/help` orderings agree.
+    // `slash-commands/types.ts`) so on-screen and `/help` orderings agree.
     let categories: &[(CommandCategory, &str)] = &[
         (CommandCategory::Session, "Session"),
         (CommandCategory::Model, "Model"),
@@ -69,11 +57,9 @@ pub async fn handle_help(session_id: Option<&str>) -> CommandResult {
 
     if !resolved_skills.is_empty() {
         lines.push(format!("**Skills** ({})", resolved_skills.len()));
-        // Cap the inline list so big skill catalogs don't drown the rest of
-        // the help output. Users can scroll the slash-menu UI for the full set.
         const MAX_SKILLS_INLINE: usize = 20;
         for entry in resolved_skills.iter().take(MAX_SKILLS_INLINE) {
-            let desc = truncate(&entry.skill.description, 80);
+            let desc = truncate_description(&entry.skill.description, 80);
             lines.push(format!("- `/{}` — {}", entry.typed_name, desc));
         }
         if resolved_skills.len() > MAX_SKILLS_INLINE {
@@ -104,13 +90,38 @@ pub async fn handle_help(session_id: Option<&str>) -> CommandResult {
     }
 }
 
-/// Render a single row: `` `/cmd <args>` — description``.
-///
-/// Uses fixed `arg_options` for the inline hint when available (e.g.
-/// `/think off|low|medium|high|xhigh`), otherwise falls back to the
-/// `arg_placeholder` from the registry. Description text comes from
-/// `description_en()` which is the same source IM channels use for their
-/// menu sync, so `/help` and the Telegram / Discord menus stay in lockstep.
+/// Resolve whether `session_id` belongs to an IM-channel session. Returns
+/// `false` (with a `app_warn!`) on transient SessionDB errors so `/help`
+/// always renders something — but a real DB failure is still logged for
+/// post-hoc debugging rather than hidden behind an Option-chain.
+fn is_session_in_im_channel(session_id: Option<&str>) -> bool {
+    let Some(sid) = session_id else {
+        return false;
+    };
+    let Ok(db) = crate::require_session_db() else {
+        return false;
+    };
+    match db.get_session(sid) {
+        Ok(Some(meta)) => meta.channel_info.is_some(),
+        Ok(None) => false,
+        Err(e) => {
+            crate::app_warn!(
+                "slash_cmd",
+                "help",
+                "Failed to read session {} for IM-context detection: {}",
+                sid,
+                e
+            );
+            false
+        }
+    }
+}
+
+/// Render a single help row: `` `/cmd <args>` — description``. Uses fixed
+/// `arg_options` for the inline hint when available (e.g.
+/// `/think <off|low|medium|high|xhigh>`), otherwise falls back to
+/// `arg_placeholder`. `description_en()` is the same source IM channels use
+/// for their menu sync, so `/help` and Telegram / Discord menus stay in lockstep.
 fn format_help_row(c: &SlashCommandDef) -> String {
     let arg_hint = match (&c.arg_options, c.arg_placeholder.as_deref()) {
         (Some(opts), _) if !opts.is_empty() => {
@@ -196,7 +207,10 @@ fn render_project_section(session_db: &Arc<SessionDB>, sid: &str) -> Option<Vec<
         .as_deref()
         .filter(|s| !s.trim().is_empty())
     {
-        lines.push(format!("- **Description**: {}", truncate(desc, 200)));
+        lines.push(format!(
+            "- **Description**: {}",
+            truncate_description(desc, 200)
+        ));
     }
     if let Some(default_agent) = project.default_agent_id.as_deref() {
         lines.push(format!("- **Default Agent**: `{}`", default_agent));
@@ -217,7 +231,7 @@ fn render_project_section(session_db: &Arc<SessionDB>, sid: &str) -> Option<Vec<
     {
         lines.push(format!(
             "- **Instructions**: {}",
-            truncate(instructions, 200)
+            truncate_description(instructions, 200)
         ));
     }
 
@@ -233,19 +247,6 @@ fn render_project_section(session_db: &Arc<SessionDB>, sid: &str) -> Option<Vec<
     );
     lines.push(format!("- **Agent Source**: {}", source.label()));
     Some(lines)
-}
-
-/// Char-bounded truncate with ellipsis suffix. Used for status / display.
-fn truncate(s: &str, max_chars: usize) -> String {
-    let mut out = String::new();
-    for (i, ch) in s.chars().enumerate() {
-        if i >= max_chars {
-            out.push('…');
-            break;
-        }
-        out.push(ch);
-    }
-    out
 }
 
 /// /export — Export conversation as Markdown.

--- a/crates/ha-core/src/slash_commands/handlers/utility.rs
+++ b/crates/ha-core/src/slash_commands/handlers/utility.rs
@@ -2,46 +2,129 @@ use crate::config::AppConfig;
 use crate::provider;
 use crate::session::{MessageRole, SessionDB};
 use crate::slash_commands::registry;
-use crate::slash_commands::types::{CommandAction, CommandResult};
+use crate::slash_commands::types::{
+    CommandAction, CommandCategory, CommandResult, SlashCommandDef,
+};
 use std::sync::Arc;
 
 /// /help — Show all available commands.
-pub fn handle_help() -> CommandResult {
-    let commands = registry::all_commands();
-    let mut lines = vec!["**Available Commands**\n".to_string()];
+///
+/// Renders one section per `CommandCategory`. Each row shows the command,
+/// its argument placeholder (or the fixed option list), and the English
+/// description from `description_en()`. When invoked from an IM channel
+/// session, commands listed in `IM_DISABLED_COMMANDS` are filtered out and
+/// a footer call-out explains the desktop-only ones.
+pub async fn handle_help(session_id: Option<&str>) -> CommandResult {
+    // Detect IM-channel context defensively — `/help` should still render
+    // when SessionDB hasn't been initialized yet (e.g. very early CLI use).
+    let in_im_channel = session_id
+        .and_then(|sid| {
+            crate::require_session_db()
+                .ok()
+                .and_then(|db| db.get_session(sid).ok().flatten())
+        })
+        .map(|meta| meta.channel_info.is_some())
+        .unwrap_or(false);
 
-    let categories = [
-        ("Session", "session"),
-        ("Model", "model"),
-        ("Memory", "memory"),
-        ("Agent", "agent"),
-        ("Utility", "utility"),
+    let mut commands: Vec<SlashCommandDef> = registry::all_commands();
+    if in_im_channel {
+        commands.retain(|c| !registry::is_im_disabled(&c.name));
+    }
+
+    // Pull invocable skills so users see the skill-as-slash-command catalog
+    // alongside built-ins. Skills are dynamic per agent / extra dirs / disabled
+    // list, so we hit the same surface `list_slash_commands` exposes to the UI.
+    let cfg = crate::config::cached_config();
+    let skills = crate::skills::get_invocable_skills(&cfg.extra_skills_dirs, &cfg.disabled_skills);
+    let reserved: std::collections::HashSet<String> =
+        commands.iter().map(|c| c.name.clone()).collect();
+    let resolved_skills = crate::slash_commands::resolve_skill_command_names(&skills, &reserved);
+    drop(cfg);
+
+    let mut lines: Vec<String> = Vec::new();
+    lines.push("**Available Commands**".to_string());
+    lines.push(String::new());
+
+    // Category order matches the GUI menu (`CATEGORY_ORDER` in
+    // `slash-commands/types.ts`) so the on-screen and `/help` orderings agree.
+    let categories: &[(CommandCategory, &str)] = &[
+        (CommandCategory::Session, "Session"),
+        (CommandCategory::Model, "Model"),
+        (CommandCategory::Memory, "Memory"),
+        (CommandCategory::Agent, "Agent"),
+        (CommandCategory::Utility, "Utility"),
     ];
 
-    for (label, cat_str) in &categories {
-        let cmds: Vec<_> = commands
-            .iter()
-            .filter(|c| format!("{:?}", c.category).to_lowercase() == *cat_str)
-            .collect();
+    for (cat, label) in categories {
+        let cmds: Vec<&SlashCommandDef> = commands.iter().filter(|c| &c.category == cat).collect();
         if cmds.is_empty() {
             continue;
         }
-        lines.push(format!("\n**{}**", label));
+        lines.push(format!("**{}**", label));
         for c in cmds {
-            let arg_hint = c
-                .arg_placeholder
-                .as_deref()
-                .map(|p| format!(" {}", p))
-                .unwrap_or_default();
-            // Use the command name as description since we can't resolve i18n keys server-side
-            lines.push(format!("- `/{}{}`", c.name, arg_hint));
+            lines.push(format_help_row(c));
         }
+        lines.push(String::new());
+    }
+
+    if !resolved_skills.is_empty() {
+        lines.push(format!("**Skills** ({})", resolved_skills.len()));
+        // Cap the inline list so big skill catalogs don't drown the rest of
+        // the help output. Users can scroll the slash-menu UI for the full set.
+        const MAX_SKILLS_INLINE: usize = 20;
+        for entry in resolved_skills.iter().take(MAX_SKILLS_INLINE) {
+            let desc = truncate(&entry.skill.description, 80);
+            lines.push(format!("- `/{}` — {}", entry.typed_name, desc));
+        }
+        if resolved_skills.len() > MAX_SKILLS_INLINE {
+            lines.push(format!(
+                "- _… and {} more — open the slash menu to browse all_",
+                resolved_skills.len() - MAX_SKILLS_INLINE
+            ));
+        }
+        lines.push(String::new());
+    }
+
+    if in_im_channel {
+        let disabled: Vec<String> = registry::IM_DISABLED_COMMANDS
+            .iter()
+            .map(|n| format!("`/{}`", n))
+            .collect();
+        lines.push(format!(
+            "_IM channels can't run {} — use the desktop or web app for those._",
+            disabled.join(", ")
+        ));
+    } else {
+        lines.push("_Tip: type `/` to open the inline command menu, or click a row above to autofill arguments._".into());
     }
 
     CommandResult {
         content: lines.join("\n"),
         action: Some(CommandAction::DisplayOnly),
     }
+}
+
+/// Render a single row: `` `/cmd <args>` — description``.
+///
+/// Uses fixed `arg_options` for the inline hint when available (e.g.
+/// `/think off|low|medium|high|xhigh`), otherwise falls back to the
+/// `arg_placeholder` from the registry. Description text comes from
+/// `description_en()` which is the same source IM channels use for their
+/// menu sync, so `/help` and the Telegram / Discord menus stay in lockstep.
+fn format_help_row(c: &SlashCommandDef) -> String {
+    let arg_hint = match (&c.arg_options, c.arg_placeholder.as_deref()) {
+        (Some(opts), _) if !opts.is_empty() => {
+            let joined = opts.join("|");
+            if c.args_optional {
+                format!(" [{}]", joined)
+            } else {
+                format!(" <{}>", joined)
+            }
+        }
+        (_, Some(p)) => format!(" {}", p),
+        _ => String::new(),
+    };
+    format!("- `/{}{}` — {}", c.name, arg_hint, c.description_en())
 }
 
 /// /status — Show session status.

--- a/crates/ha-core/src/slash_commands/mod.rs
+++ b/crates/ha-core/src/slash_commands/mod.rs
@@ -159,19 +159,21 @@ pub fn is_slash_command(text: String) -> bool {
     parser::is_command(&text)
 }
 
-/// Snapshot of the slash commands an IM channel should publish in its bot
-/// menu, paired with the English description Telegram / Discord need.
-///
-/// Includes built-in commands minus `IM_DISABLED_COMMANDS` (which are runtime-
-/// rejected anyway), plus invocable skill commands (resolved through the
-/// shared collision-aware table). Telegram caps `setMyCommands` at 100
-/// entries and Discord at 100 global application commands, so we truncate at
-/// 100 with a warn — the truncated tail is still callable, just not in the
-/// menu UI. Skill commands sit after built-ins so the truncation hits the
-/// least-frequently-used surface first.
-pub async fn im_menu_entries() -> Vec<(String, String)> {
-    const IM_MENU_HARD_CAP: usize = 100;
+/// Hard upper bound the IM bot menus enforce on themselves: Telegram caps
+/// `setMyCommands` at 100 entries, Discord caps global application commands
+/// at 100. Truncated tail is still callable by users typing manually — just
+/// hidden from the platform's menu/auto-complete UI.
+pub const IM_MENU_HARD_CAP: usize = 100;
 
+/// Snapshot of the slash commands an IM channel should publish to its bot
+/// menu — `registry::all_commands()` plus invocable skills (collision-resolved),
+/// minus `IM_DISABLED_COMMANDS`, capped at `IM_MENU_HARD_CAP`.
+///
+/// Single source-of-truth for both Telegram (`setMyCommands`) and Discord
+/// (`bulk_overwrite_global_commands`); the platform-specific layers project
+/// each `SlashCommandDef` into their own wire format. `description_en()`
+/// gives a stable English label both platforms can render.
+pub async fn im_menu_entries() -> Vec<SlashCommandDef> {
     let defs = match list_slash_commands().await {
         Ok(v) => v,
         Err(e) => {
@@ -185,13 +187,9 @@ pub async fn im_menu_entries() -> Vec<(String, String)> {
         }
     };
 
-    let mut entries: Vec<(String, String)> = defs
+    let mut entries: Vec<SlashCommandDef> = defs
         .into_iter()
         .filter(|cmd| !registry::is_im_disabled(&cmd.name))
-        .map(|cmd| {
-            let desc = cmd.description_en();
-            (cmd.name, desc)
-        })
         .collect();
 
     if entries.len() > IM_MENU_HARD_CAP {
@@ -209,7 +207,7 @@ pub async fn im_menu_entries() -> Vec<(String, String)> {
 }
 
 /// Truncate a description to `max_chars` characters, appending "…" if truncated.
-fn truncate_description(s: &str, max_chars: usize) -> String {
+pub(crate) fn truncate_description(s: &str, max_chars: usize) -> String {
     if s.chars().count() <= max_chars {
         return s.to_string();
     }

--- a/crates/ha-core/src/slash_commands/mod.rs
+++ b/crates/ha-core/src/slash_commands/mod.rs
@@ -159,6 +159,55 @@ pub fn is_slash_command(text: String) -> bool {
     parser::is_command(&text)
 }
 
+/// Snapshot of the slash commands an IM channel should publish in its bot
+/// menu, paired with the English description Telegram / Discord need.
+///
+/// Includes built-in commands minus `IM_DISABLED_COMMANDS` (which are runtime-
+/// rejected anyway), plus invocable skill commands (resolved through the
+/// shared collision-aware table). Telegram caps `setMyCommands` at 100
+/// entries and Discord at 100 global application commands, so we truncate at
+/// 100 with a warn — the truncated tail is still callable, just not in the
+/// menu UI. Skill commands sit after built-ins so the truncation hits the
+/// least-frequently-used surface first.
+pub async fn im_menu_entries() -> Vec<(String, String)> {
+    const IM_MENU_HARD_CAP: usize = 100;
+
+    let defs = match list_slash_commands().await {
+        Ok(v) => v,
+        Err(e) => {
+            crate::app_warn!(
+                "channel",
+                "menu_sync",
+                "list_slash_commands failed: {} — falling back to built-in only",
+                e
+            );
+            registry::all_commands()
+        }
+    };
+
+    let mut entries: Vec<(String, String)> = defs
+        .into_iter()
+        .filter(|cmd| !registry::is_im_disabled(&cmd.name))
+        .map(|cmd| {
+            let desc = cmd.description_en();
+            (cmd.name, desc)
+        })
+        .collect();
+
+    if entries.len() > IM_MENU_HARD_CAP {
+        crate::app_warn!(
+            "channel",
+            "menu_sync",
+            "Slash command count {} exceeds IM menu cap {} — truncating tail",
+            entries.len(),
+            IM_MENU_HARD_CAP
+        );
+        entries.truncate(IM_MENU_HARD_CAP);
+    }
+
+    entries
+}
+
 /// Truncate a description to `max_chars` characters, appending "…" if truncated.
 fn truncate_description(s: &str, max_chars: usize) -> String {
     if s.chars().count() <= max_chars {

--- a/crates/ha-server/src/lib.rs
+++ b/crates/ha-server/src/lib.rs
@@ -1021,6 +1021,10 @@ fn build_router_with_cors(
         )
         .route("/channel/health", get(routes::channel::health_all))
         .route(
+            "/channel/sync-commands",
+            post(routes::channel::sync_commands),
+        )
+        .route(
             "/channel/validate",
             post(routes::channel::validate_credentials),
         )

--- a/crates/ha-server/src/routes/channel.rs
+++ b/crates/ha-server/src/routes/channel.rs
@@ -115,6 +115,41 @@ pub async fn stop_account(Path(account_id): Path<String>) -> Result<Json<Value>,
     Ok(Json(json!({ "stopped": true })))
 }
 
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncCommandsBody {
+    /// Optional account id; absent → re-sync every running account.
+    #[serde(default)]
+    pub account_id: Option<String>,
+}
+
+/// `POST /api/channel/sync-commands`
+///
+/// Re-sync the IM bot menu (Telegram setMyCommands / Discord application
+/// commands) for one or all running accounts. The auto-sync listener
+/// (`app_init::spawn_channel_menu_resync_listener`) covers the common case;
+/// this route exposes a manual trigger for the settings UI and for ops
+/// recovery after a missed event.
+pub async fn sync_commands(body: Option<Json<SyncCommandsBody>>) -> Result<Json<Value>, AppError> {
+    let account_id = body.and_then(|Json(b)| b.account_id);
+    let reg = registry()?;
+    let count = match account_id {
+        Some(id) => {
+            if reg
+                .sync_commands_for_account(&id)
+                .await
+                .map_err(|e| AppError::internal(e.to_string()))?
+            {
+                1
+            } else {
+                0
+            }
+        }
+        None => reg.sync_commands_for_all().await,
+    };
+    Ok(Json(json!({ "synced": count })))
+}
+
 /// `GET /api/channel/accounts/{id}/health`
 pub async fn health(Path(account_id): Path<String>) -> Result<Json<ChannelHealth>, AppError> {
     let reg = registry()?;

--- a/crates/ha-server/src/routes/channel.rs
+++ b/crates/ha-server/src/routes/channel.rs
@@ -126,27 +126,15 @@ pub struct SyncCommandsBody {
 /// `POST /api/channel/sync-commands`
 ///
 /// Re-sync the IM bot menu (Telegram setMyCommands / Discord application
-/// commands) for one or all running accounts. The auto-sync listener
-/// (`app_init::spawn_channel_menu_resync_listener`) covers the common case;
-/// this route exposes a manual trigger for the settings UI and for ops
-/// recovery after a missed event.
+/// commands) for one or all running accounts. Auto-sync is wired up in
+/// `app_init::spawn_channel_menu_resync_listener`; this route is the manual
+/// trigger for the settings UI and for ops recovery after a missed event.
 pub async fn sync_commands(body: Option<Json<SyncCommandsBody>>) -> Result<Json<Value>, AppError> {
     let account_id = body.and_then(|Json(b)| b.account_id);
-    let reg = registry()?;
-    let count = match account_id {
-        Some(id) => {
-            if reg
-                .sync_commands_for_account(&id)
-                .await
-                .map_err(|e| AppError::internal(e.to_string()))?
-            {
-                1
-            } else {
-                0
-            }
-        }
-        None => reg.sync_commands_for_all().await,
-    };
+    let count = registry()?
+        .sync_commands(account_id.as_deref())
+        .await
+        .map_err(|e| AppError::internal(e.to_string()))?;
     Ok(Json(json!({ "synced": count })))
 }
 

--- a/docs/architecture/api-reference.md
+++ b/docs/architecture/api-reference.md
@@ -661,6 +661,7 @@ Tauri ↔ COMMAND_MAP 差集为 7 条合法非 REST 命令（4 条 Desktop-only 
 | `channel_remove_account` | `DELETE /api/channel/accounts/{accountId}` | ✅ |
 | `channel_start_account` | `POST /api/channel/accounts/{accountId}/start` | ✅ |
 | `channel_stop_account` | `POST /api/channel/accounts/{accountId}/stop` | ✅ |
+| `channel_sync_commands` | `POST /api/channel/sync-commands` | ✅ |
 | `channel_health` | `GET /api/channel/accounts/{accountId}/health` | ✅ |
 | `channel_health_all` | `GET /api/channel/health` | ✅ |
 | `channel_validate_credentials` | `POST /api/channel/validate` | ✅ |

--- a/docs/architecture/slash-commands.md
+++ b/docs/architecture/slash-commands.md
@@ -164,13 +164,13 @@ sequenceDiagram
 | `/recap` | `[--full\|--range=7d\|--range=30d]` | 生成深度复盘报告（后台流式），`--full` 跳转 Dashboard | `RecapCard` 或 `OpenDashboardTab` |
 | `/awareness` | `[on\|off\|mode <x>\|status]` | 控制行为感知功能的全局开关与模式（详见下方） | `DisplayOnly` |
 
-**`/permission` 可选值**：
+**`/permission` 可选值**（与 `permission/engine.rs` 的三档 `SessionMode` 对齐）：
 
 | 值 | 说明 |
 |---|---|
-| `auto` | 自动批准工具调用 |
-| `ask` / `ask_every_time` | 每次工具调用前询问用户 |
-| `full` / `full_approve` | 完全批准模式 |
+| `default` | 标准审批：保护路径 / 危险命令永远弹窗，其余按 AllowAlways / Smart preset |
+| `smart` | 自动放行 LLM 自报"高置信度"的工具调用，必要时跑 judge model 二次确认（详见 [permission-system.md](permission-system.md)） |
+| `yolo` | 跳过所有审批（仍受 Plan Mode、保护路径硬闸约束） |
 
 ### 🎯 Skill — 动态技能命令
 
@@ -391,8 +391,10 @@ Channel 对有 `arg_options` 的命令提供 inline keyboard 按钮：
 |---|---|
 | `/think` | `off`, `low`, `medium`, `high`, `xhigh` |
 | `/plan` | `enter`, `exit`, `show`, `approve`, `pause`, `resume` |
-| `/permission` | `auto`, `ask`, `full` |
+| `/permission` | `default`, `smart`, `yolo` |
 | `/awareness` | `on`, `off`, `mode structured`, `mode llm`, `mode off`, `status` |
+| `/team` | `create`, `status`, `pause`, `resume`, `dissolve` |
+| `/recap` | `--full`, `--range=7d`, `--range=30d` |
 
 ---
 

--- a/docs/architecture/slash-commands.md
+++ b/docs/architecture/slash-commands.md
@@ -318,6 +318,28 @@ stateDiagram-v2
 
 ---
 
+## IM 渠道菜单同步时机
+
+Telegram (`setMyCommands`) 和 Discord (Application Commands API) 的命令菜单需要主动推送，下面三个时机覆盖全部场景：
+
+1. **`start_account` 第一次拉起**——`telegram/mod.rs::sync_commands_to_menu` / `discord/mod.rs::sync_commands_to_discord` 在认证成功后立即同步一次
+2. **EventBus 自动 re-sync**——`app_init::spawn_channel_menu_resync_listener` 订阅以下事件，命中后 **2s 防抖**触发 `ChannelRegistry::sync_commands_for_all`：
+   - `skills:catalog_changed`：[`skills::types::bump_skill_version`](../../crates/ha-core/src/skills/types.rs) 在每次 skill 增删 / 启停后 emit
+   - `config:changed`（仅 `category` ∈ `skill` / `skills` / `extra_skills_dirs` / `disabled_skills`）
+3. **手动触发**——`channel_sync_commands(account_id?)` Tauri 命令 / `POST /api/channel/sync-commands`，可针对单 account 或全量 running，给设置页「同步命令」按钮 + 运维兜底用
+
+`ChannelPlugin` trait 用 `async fn sync_commands(&self, account: &ChannelAccountConfig) -> Result<()>` 默认 no-op，只有 Telegram / Discord override（其他渠道如 IRC / WhatsApp / iMessage 没有 slash 菜单概念，默认实现就够）。
+
+**菜单内容**与 GUI / `/help` 完全一致——走同一个 [`slash_commands::im_menu_entries`](../../crates/ha-core/src/slash_commands/mod.rs) 入口，包含：
+
+- `registry::all_commands()` 内置命令，过滤 `IM_DISABLED_COMMANDS`（`/agent` / `/project`）
+- 用户可调用 skill 命令（`get_invocable_skills` + `resolve_skill_command_names`，命名冲突走 `_skill` / `_N` 后缀）
+- 100 条硬上限：Telegram 和 Discord 都把全局命令上限定在 100，超出尾部截断（仍可硬键入触发，只是不进菜单），并 `app_warn!`
+
+> **失败语义**：单个 account 同步失败是 warn 级别（典型场景：Bot token 过期、网络暂时不通），不影响其它 account；菜单保留旧版本直到下次成功。
+
+---
+
 ## CommandAction 类型一览
 
 `CommandResult.action` 字段告诉前端需要执行什么副作用：

--- a/docs/plans/review-followups.md
+++ b/docs/plans/review-followups.md
@@ -332,6 +332,25 @@
 - **影响面**：3 个 slash command 在 GUI 体验降级（功能正常，反馈不及时），不影响 IM 渠道
 - **触发时机建议**：下一次动 `ChatScreen` 或 Recap UI 时顺手收掉
 
+### F-034 Skill 目录扫描没有 `SKILL_CACHE_VERSION`-keyed 缓存
+
+- **来源**：2026-05-01 slash command audit `/simplify` review（efficiency agent）
+- **现象**：[`crates/ha-core/src/skills/discovery.rs::load_all_skills_with_budget`](../../crates/ha-core/src/skills/discovery.rs) 每次调用都重新走文件系统扫描 bundled + `~/.agents/skills` + `extra_skills_dirs` + managed + project 五类目录，无任何缓存。 hot 调用方包括：
+  - [`slash_commands::im_menu_entries`](../../crates/ha-core/src/slash_commands/mod.rs)（Telegram + Discord 同步、`/help`、`list_slash_commands` 都消费）
+  - `system_prompt` 渲染（每次 LLM 请求构造 prompt 时都跑一次）
+  - `skill_search` 工具
+  - `handle_help`（独立调 `get_invocable_skills`，效率 agent 也提到）
+  
+  IM menu 自动 re-sync 场景特别痛：debounce 触发后，N 个 running account 串行 sync_commands_for_account 各调一次 `im_menu_entries → list_slash_commands → get_invocable_skills`，等于 N 次完整文件系统扫描背靠背
+- **为什么留**：本次 audit 的目标是把"IM 菜单不刷"的功能性 bug 收掉，缓存层属于独立性能优化；现成有 `skills::types::SKILL_CACHE_VERSION: AtomicU64` 全局计数器（`bump_skill_version` 已经在所有 mutate 路径埋好），缓存基础设施齐备，缺的只是消费方
+- **改的话要做什么**：
+  1. 在 `skills/discovery.rs` 加 `static SKILL_CACHE: OnceLock<RwLock<Option<(u64, Arc<Vec<SkillEntry>>)>>>`，`load_all_skills_with_budget` 入口先 read：`(version, entries)` 的 `version == SKILL_CACHE_VERSION.load(Relaxed)` 直接返回 Arc clone，否则正常扫描后 write 缓存
+  2. 缓存 key 还要包含 `extra_skills_dirs` 和 `disabled_skills`（不同输入可能命中相同 version）—— 用 `(SKILL_CACHE_VERSION, hash(extra_skills_dirs + disabled_skills))` 复合 key，或者干脆每次写 `bump_skill_version()` 即可（这两个字段写完都会 bump，存量代码已经如此）
+  3. `get_invocable_skills` 跟着改成消费 `Arc<Vec<SkillEntry>>` slice，避免 clone 整个 Vec
+  4. 为 `tools/settings.rs::update_app_config` 的 skill 类 category 补 `bump_skill_version()`（当前 audit 的 listener 是通过监听 `config:changed { category: "skills" }` 兜的，但缓存 invalidation 也需要这个 bump，否则缓存看不到变更）
+- **影响面**：性能 only，没有正确性问题。N 个 IM account 重 sync 时减少 N-1 次文件系统扫描；每次 LLM 请求 system_prompt 构造也省一次扫描。粗估 50ms × N 节省
+- **触发时机建议**：下一次做性能优化 PR 时；或者用户报"启动慢""LLM 第一次响应慢"时
+
 ---
 
 ## Closed

--- a/docs/plans/review-followups.md
+++ b/docs/plans/review-followups.md
@@ -320,6 +320,18 @@
 - **影响面**：UX bug for 9 个语言用户。Settings 中相关 panel 看英文不会崩溃，但显著降低非英语 / 非中文用户的体验
 - **触发时机建议**：等收到非英 / 非中文用户反馈，或翻译团队 / 志愿者主动认领；不阻塞功能 PR
 
+### F-033 `recapCard` / `openDashboardTab` / `skillFork` 在 ChatScreen 是空 case
+
+- **来源**：2026-05-01 slash command audit `/simplify` review（quality agent）
+- **现象**：[`src/components/chat/ChatScreen.tsx`](../../src/components/chat/ChatScreen.tsx) `handleCommandAction` 把这 3 个 `CommandAction` variant 当 no-op 处理，仅靠 switch 之前 push 的 event 气泡（`result.content`）告诉用户后台在跑。后端 `recap_progress` EventBus 流目前只被 Dashboard Recap tab 订阅，对话内没有渲染 RecapCard；`openDashboardTab` 没有 App 级 navigate 回调，不会跳页；`skillFork` 走 EventBus 注入回 user message，已生效，只是没有运行中状态卡片
+- **为什么留**：补这三块需要新组件（RecapCard 流式）+ App 级 prop drilling，不在当期 audit PR 范围；后端事件已经 stable，前端补做不会破坏接口
+- **改的话要做什么**：
+  1. `recapCard`：在 chat 渲染流抽出一个 `RecapCard` 组件，订阅 `recap_progress` 过滤 `action.reportId`，复用 Dashboard `RecapTab` 的渲染层
+  2. `openDashboardTab`：把 `setView("dashboard", { tab })` 挂到 `App.tsx`，`ChatScreen` props 加 `onOpenDashboardTab(tab: string)` 触发
+  3. `skillFork`：可选——加个轻量 "skill running" 卡片，订阅 EventBus skill_run_progress；当前 result.content 文本提示已经够用
+- **影响面**：3 个 slash command 在 GUI 体验降级（功能正常，反馈不及时），不影响 IM 渠道
+- **触发时机建议**：下一次动 `ChatScreen` 或 Recap UI 时顺手收掉
+
 ---
 
 ## Closed

--- a/src-tauri/src/commands/channel.rs
+++ b/src-tauri/src/commands/channel.rs
@@ -106,29 +106,17 @@ pub async fn channel_stop_account(account_id: String) -> Result<(), CmdError> {
 // ── Slash command menu sync ──────────────────────────────────────
 
 /// Re-sync the IM bot menu (Telegram setMyCommands / Discord application
-/// commands) for one or all running accounts. Returns the number of
-/// accounts synced.
+/// commands) for one or all running accounts. Returns the count of accounts
+/// successfully synced.
 ///
 /// Usually fires automatically via the EventBus listener on skill changes
 /// (see `app_init::spawn_channel_menu_resync_listener`); this command
-/// covers the manual "Sync now" button + edge cases where event-bus
-/// delivery was missed (lag warning).
+/// covers the manual "Sync now" button and recovery from missed events.
 #[tauri::command]
 pub async fn channel_sync_commands(account_id: Option<String>) -> Result<usize, CmdError> {
     let registry = crate::get_channel_registry()
         .ok_or_else(|| CmdError::msg("Channel registry not initialized"))?;
-
-    let count = match account_id {
-        Some(id) => {
-            if registry.sync_commands_for_account(&id).await? {
-                1
-            } else {
-                0
-            }
-        }
-        None => registry.sync_commands_for_all().await,
-    };
-    Ok(count)
+    Ok(registry.sync_commands(account_id.as_deref()).await?)
 }
 
 // ── Health ───────────────────────────────────────────────────────

--- a/src-tauri/src/commands/channel.rs
+++ b/src-tauri/src/commands/channel.rs
@@ -103,6 +103,34 @@ pub async fn channel_stop_account(account_id: String) -> Result<(), CmdError> {
     registry.stop_account(&account_id).await.map_err(Into::into)
 }
 
+// ── Slash command menu sync ──────────────────────────────────────
+
+/// Re-sync the IM bot menu (Telegram setMyCommands / Discord application
+/// commands) for one or all running accounts. Returns the number of
+/// accounts synced.
+///
+/// Usually fires automatically via the EventBus listener on skill changes
+/// (see `app_init::spawn_channel_menu_resync_listener`); this command
+/// covers the manual "Sync now" button + edge cases where event-bus
+/// delivery was missed (lag warning).
+#[tauri::command]
+pub async fn channel_sync_commands(account_id: Option<String>) -> Result<usize, CmdError> {
+    let registry = crate::get_channel_registry()
+        .ok_or_else(|| CmdError::msg("Channel registry not initialized"))?;
+
+    let count = match account_id {
+        Some(id) => {
+            if registry.sync_commands_for_account(&id).await? {
+                1
+            } else {
+                0
+            }
+        }
+        None => registry.sync_commands_for_all().await,
+    };
+    Ok(count)
+}
+
 // ── Health ───────────────────────────────────────────────────────
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -597,6 +597,7 @@ pub fn run() {
             commands::channel::channel_remove_account,
             commands::channel::channel_start_account,
             commands::channel::channel_stop_account,
+            commands::channel::channel_sync_commands,
             commands::channel::channel_health,
             commands::channel::channel_health_all,
             commands::channel::channel_validate_credentials,

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -815,8 +815,8 @@ export default function ChatScreen({
             logger.error("ui", "ChatScreen::slashExport", "Export failed", e)
           }
           break
-        case "setPermissionMode":
-          stream.setPermissionMode(action.mode)
+        case "setToolPermission":
+          stream.setPermissionMode(action.mode as SessionMode)
           break
         case "displayOnly":
           // Already handled above by adding event message
@@ -896,6 +896,23 @@ export default function ChatScreen({
           void handleNewChatInProject(action.projectId, undefined, false)
           break
         }
+        case "recapCard":
+          // Recap streams in the background; the Dashboard Recap tab is the
+          // current canonical viewer. The chat bubble (result.content) already
+          // tells the user a live summary is being prepared.
+          // Followup: render an inline streaming RecapCard subscribed to
+          // `recap_progress` filtered by `action.reportId`.
+          break
+        case "openDashboardTab":
+          // The Dashboard tab is App-level. The chat bubble (result.content)
+          // already prompts the user to open it; deep-linking the tab from
+          // ChatScreen needs an App-level callback (followup).
+          break
+        case "skillFork":
+          // Skill fork output is injected back into the conversation as a
+          // user message via the EventBus once the sub-agent finishes.
+          // result.content already announces the run id.
+          break
       }
     },
     [

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -816,7 +816,7 @@ export default function ChatScreen({
           }
           break
         case "setToolPermission":
-          stream.setPermissionMode(action.mode as SessionMode)
+          stream.setPermissionMode(action.mode)
           break
         case "displayOnly":
           // Already handled above by adding event message
@@ -896,22 +896,11 @@ export default function ChatScreen({
           void handleNewChatInProject(action.projectId, undefined, false)
           break
         }
+        // result.content (rendered above as an event chip) is the only
+        // user-facing surface today; richer wiring tracked in F-033.
         case "recapCard":
-          // Recap streams in the background; the Dashboard Recap tab is the
-          // current canonical viewer. The chat bubble (result.content) already
-          // tells the user a live summary is being prepared.
-          // Followup: render an inline streaming RecapCard subscribed to
-          // `recap_progress` filtered by `action.reportId`.
-          break
         case "openDashboardTab":
-          // The Dashboard tab is App-level. The chat bubble (result.content)
-          // already prompts the user to open it; deep-linking the tab from
-          // ChatScreen needs an App-level callback (followup).
-          break
         case "skillFork":
-          // Skill fork output is injected back into the conversation as a
-          // user message via the EventBus once the sub-agent finishes.
-          // result.content already announces the run id.
           break
       }
     },

--- a/src/components/chat/slash-commands/types.ts
+++ b/src/components/chat/slash-commands/types.ts
@@ -25,7 +25,7 @@ export type CommandAction =
   | { type: "sessionCleared" }
   | { type: "passThrough"; message: string }
   | { type: "exportFile"; content: string; filename: string }
-  | { type: "setPermissionMode"; mode: "default" | "smart" | "yolo" }
+  | { type: "setToolPermission"; mode: "default" | "smart" | "yolo" }
   | { type: "displayOnly" }
   | { type: "showModelPicker"; models: ModelPickerItem[]; activeProviderId?: string; activeModelId?: string }
   | { type: "enterPlanMode" }
@@ -38,6 +38,9 @@ export type CommandAction =
   | { type: "showContextBreakdown"; breakdown: ContextBreakdown }
   | { type: "showProjectPicker"; projects: ProjectPickerItem[] }
   | { type: "enterProject"; projectId: string }
+  | { type: "skillFork"; runId: string; skillName: string }
+  | { type: "recapCard"; reportId: string }
+  | { type: "openDashboardTab"; tab: string }
 
 /** Per-category context window usage snapshot (mirrors Rust `ContextBreakdown`). */
 export interface ContextBreakdown {

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -2964,7 +2964,10 @@
       "skill": "المهارات"
     },
     "noResults": "لا توجد أوامر مطابقة",
-    "buttonTip": "أوامر سريعة"
+    "buttonTip": "أوامر سريعة",
+    "project": {
+      "description": "التبديل إلى مشروع أو اختياره"
+    }
   },
   "planMode": {
     "enter": "الدخول إلى Plan Mode",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2964,7 +2964,10 @@
       "skill": "Skills"
     },
     "noResults": "No matching commands",
-    "buttonTip": "Quick Commands"
+    "buttonTip": "Quick Commands",
+    "project": {
+      "description": "Switch to or pick a project"
+    }
   },
   "planMode": {
     "enter": "Enter Plan Mode",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2964,7 +2964,10 @@
       "skill": "Skills"
     },
     "noResults": "No hay comandos coincidentes",
-    "buttonTip": "Comandos rápidos"
+    "buttonTip": "Comandos rápidos",
+    "project": {
+      "description": "Cambiar a un proyecto o elegir uno"
+    }
   },
   "planMode": {
     "enter": "Entrar en Plan Mode",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2964,7 +2964,10 @@
       "skill": "スキル"
     },
     "noResults": "一致するコマンドはありません",
-    "buttonTip": "クイックコマンド"
+    "buttonTip": "クイックコマンド",
+    "project": {
+      "description": "プロジェクトを切り替え/選択"
+    }
   },
   "planMode": {
     "enter": "プランモードに入る",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2964,7 +2964,10 @@
       "skill": "스킬"
     },
     "noResults": "일치하는 명령이 없습니다",
-    "buttonTip": "빠른 명령"
+    "buttonTip": "빠른 명령",
+    "project": {
+      "description": "프로젝트로 전환 또는 선택"
+    }
   },
   "planMode": {
     "enter": "계획 모드 진입",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -2964,7 +2964,10 @@
       "skill": "Skills"
     },
     "noResults": "Tiada arahan yang sepadan",
-    "buttonTip": "Arahan pantas"
+    "buttonTip": "Arahan pantas",
+    "project": {
+      "description": "Tukar ke atau pilih projek"
+    }
   },
   "planMode": {
     "enter": "Masuk Plan Mode",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -2964,7 +2964,10 @@
       "skill": "Skills"
     },
     "noResults": "Nenhum comando correspondente",
-    "buttonTip": "Comandos rápidos"
+    "buttonTip": "Comandos rápidos",
+    "project": {
+      "description": "Trocar para ou escolher um projeto"
+    }
   },
   "planMode": {
     "enter": "Entrar em Plan Mode",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -2964,7 +2964,10 @@
       "skill": "Навыки"
     },
     "noResults": "Подходящих команд нет",
-    "buttonTip": "Быстрые команды"
+    "buttonTip": "Быстрые команды",
+    "project": {
+      "description": "Переключиться на проект или выбрать его"
+    }
   },
   "planMode": {
     "enter": "Войти в Plan Mode",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -2964,7 +2964,10 @@
       "skill": "Skills"
     },
     "noResults": "Eşleşen komut yok",
-    "buttonTip": "Hızlı komutlar"
+    "buttonTip": "Hızlı komutlar",
+    "project": {
+      "description": "Bir projeye geç veya seç"
+    }
   },
   "planMode": {
     "enter": "Plan Mode'a gir",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -2964,7 +2964,10 @@
       "skill": "Kỹ năng"
     },
     "noResults": "Không có lệnh khớp",
-    "buttonTip": "Lệnh nhanh"
+    "buttonTip": "Lệnh nhanh",
+    "project": {
+      "description": "Chuyển hoặc chọn dự án"
+    }
   },
   "planMode": {
     "enter": "Vào Plan Mode",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2964,7 +2964,10 @@
       "skill": "技能"
     },
     "noResults": "没有匹配的命令",
-    "buttonTip": "快捷指令"
+    "buttonTip": "快捷指令",
+    "project": {
+      "description": "切換或選擇項目"
+    }
   },
   "planMode": {
     "enter": "進入計劃模式",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2964,7 +2964,10 @@
       "skill": "技能"
     },
     "noResults": "没有匹配的命令",
-    "buttonTip": "快捷指令"
+    "buttonTip": "快捷指令",
+    "project": {
+      "description": "切换或选择项目"
+    }
   },
   "planMode": {
     "enter": "进入计划模式",

--- a/src/lib/transport-http.ts
+++ b/src/lib/transport-http.ts
@@ -426,6 +426,7 @@ const COMMAND_MAP: Record<string, EndpointDef> = {
   channel_remove_account:          { method: "DELETE", path: "/api/channel/accounts/{accountId}" },
   channel_start_account:           { method: "POST",   path: "/api/channel/accounts/{accountId}/start" },
   channel_stop_account:            { method: "POST",   path: "/api/channel/accounts/{accountId}/stop" },
+  channel_sync_commands:           { method: "POST",   path: "/api/channel/sync-commands" },
   channel_health:                  { method: "GET",    path: "/api/channel/accounts/{accountId}/health" },
   channel_health_all:              { method: "GET",    path: "/api/channel/health" },
   channel_validate_credentials:    { method: "POST",   path: "/api/channel/validate" },


### PR DESCRIPTION
- 修复 `/permission` 在 GUI 内静默失效：前端 `case "setPermissionMode"`
  与 Rust serde camelCase `setToolPermission` 不匹配，永远落不到分支
- 补齐前端 CommandAction 联合类型缺失的 `recapCard` / `openDashboardTab`
  / `skillFork`，并在 `ChatScreen.handleCommandAction` 内显式 no-op
  收尾（content 文本仍展示，避免静默丢动作）
- 12 个语言包补齐 `slashCommands.project.description`
- `awareness.rs` 由 `load_config + save_config` 改用 `mutate_config`
  契约（避免并发 lost-update）
- `/help` 重写：按 CommandCategory 分组 + `description_en()` 描述 +
  `arg_options` 内联展开 + Skills 段（前 20 条）+ IM 渠道时过滤
  `IM_DISABLED_COMMANDS` 并附说明
- `docs/architecture/slash-commands.md` 修正 `/permission` 选项
  （`auto/ask/full` → `default/smart/yolo`）并补 `/team` `/recap`