### PR TITLE
[codex] unify agent selector display

### DIFF
--- a/src/components/chat/AgentSwitcher.tsx
+++ b/src/components/chat/AgentSwitcher.tsx
@@ -14,9 +14,9 @@
  */
 
 import { useEffect, useRef, useState } from "react"
-import { Bot, ChevronDown } from "lucide-react"
+import { ChevronDown } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { getTransport } from "@/lib/transport-provider"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import type { AgentSummaryForSidebar } from "@/types/chat"
 
 interface AgentSwitcherProps {
@@ -36,6 +36,10 @@ export default function AgentSwitcher({
 }: AgentSwitcherProps) {
   const [open, setOpen] = useState(false)
   const containerRef = useRef<HTMLDivElement>(null)
+  const currentAgent = agents.find((agent) => agent.id === currentAgentId) ?? {
+    id: currentAgentId,
+    name: agentName,
+  }
 
   useEffect(() => {
     if (!open) return
@@ -49,7 +53,11 @@ export default function AgentSwitcher({
   }, [open])
 
   if (disabled) {
-    return <span className="text-sm font-medium text-foreground shrink-0">{agentName}</span>
+    return (
+      <span className="shrink-0 text-sm font-medium text-foreground">
+        <AgentSelectDisplay agent={currentAgent} fallbackName={agentName} />
+      </span>
+    )
   }
 
   return (
@@ -62,7 +70,7 @@ export default function AgentSwitcher({
           "hover:text-primary",
         )}
       >
-        <span>{agentName}</span>
+        <AgentSelectDisplay agent={currentAgent} fallbackName={agentName} />
         <ChevronDown
           className={cn("h-3 w-3 text-muted-foreground transition-transform", open && "rotate-180")}
         />
@@ -88,20 +96,7 @@ export default function AgentSwitcher({
                     setOpen(false)
                   }}
                 >
-                  <div className="w-5 h-5 rounded-full bg-primary/15 flex items-center justify-center text-primary shrink-0 text-[10px] overflow-hidden">
-                    {agent.avatar ? (
-                      <img
-                        src={getTransport().resolveAssetUrl(agent.avatar) ?? agent.avatar}
-                        className="w-full h-full object-cover"
-                        alt=""
-                      />
-                    ) : agent.emoji ? (
-                      <span>{agent.emoji}</span>
-                    ) : (
-                      <Bot className="h-3 w-3" />
-                    )}
-                  </div>
-                  <span className="truncate">{agent.name}</span>
+                  <AgentSelectDisplay agent={agent} />
                 </button>
               )
             })

--- a/src/components/chat/project/ProjectDialog.tsx
+++ b/src/components/chat/project/ProjectDialog.tsx
@@ -40,6 +40,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import { cn } from "@/lib/utils"
 import { formatBytes } from "@/lib/format"
 import { isTauriMode } from "@/lib/transport"
@@ -135,6 +136,7 @@ export default function ProjectDialog({
     "idle",
   )
   const [error, setError] = useState("")
+  const selectedDefaultAgent = agents.find((agent) => agent.id === defaultAgentId)
 
   useEffect(() => {
     if (!open) return
@@ -443,14 +445,17 @@ export default function ProjectDialog({
                   onValueChange={(v) => setDefaultAgentId(v === "__none__" ? "" : v)}
                 >
                   <SelectTrigger className="h-10">
-                    <SelectValue placeholder={t("project.inheritGlobal")} />
+                    {selectedDefaultAgent ? (
+                      <AgentSelectDisplay agent={selectedDefaultAgent} />
+                    ) : (
+                      <SelectValue placeholder={t("project.inheritGlobal")} />
+                    )}
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="__none__">{t("project.inheritGlobal")}</SelectItem>
                     {agents.map((a) => (
-                      <SelectItem key={a.id} value={a.id}>
-                        {a.emoji ? `${a.emoji} ` : ""}
-                        {a.name}
+                      <SelectItem key={a.id} value={a.id} textValue={a.name}>
+                        <AgentSelectDisplay agent={a} />
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/components/chat/sidebar/AgentSection.tsx
+++ b/src/components/chat/sidebar/AgentSection.tsx
@@ -134,7 +134,6 @@ export default function AgentSection({
                         )}
                       >
                         {agent.name}
-                        {agent.emoji ? ` ${agent.emoji}` : ""}
                       </span>
                     </button>
                     {/* New chat button */}

--- a/src/components/common/AgentSelectDisplay.tsx
+++ b/src/components/common/AgentSelectDisplay.tsx
@@ -1,0 +1,80 @@
+import { Bot } from "lucide-react"
+
+import { getTransport } from "@/lib/transport-provider"
+import { cn } from "@/lib/utils"
+
+export interface AgentSelectAgent {
+  id?: string
+  name?: string | null
+  emoji?: string | null
+  avatar?: string | null
+}
+
+type AgentAvatarSize = "xs" | "sm" | "md" | "lg"
+
+const avatarSizeClasses: Record<AgentAvatarSize, string> = {
+  xs: "h-4 w-4 text-[9px]",
+  sm: "h-5 w-5 text-[10px]",
+  md: "h-6 w-6 text-xs",
+  lg: "h-9 w-9 text-base",
+}
+
+const botSizeClasses: Record<AgentAvatarSize, string> = {
+  xs: "h-2.5 w-2.5",
+  sm: "h-3 w-3",
+  md: "h-3.5 w-3.5",
+  lg: "h-5 w-5",
+}
+
+export function AgentAvatarBadge({
+  agent,
+  size = "sm",
+  className,
+}: {
+  agent?: AgentSelectAgent | null
+  size?: AgentAvatarSize
+  className?: string
+}) {
+  const avatarUrl = agent?.avatar
+    ? (getTransport().resolveAssetUrl(agent.avatar) ?? agent.avatar)
+    : null
+
+  return (
+    <span
+      className={cn(
+        "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/15 text-primary",
+        avatarSizeClasses[size],
+        className,
+      )}
+    >
+      {avatarUrl ? (
+        <img src={avatarUrl} className="h-full w-full object-cover" alt="" />
+      ) : agent?.emoji ? (
+        <span>{agent.emoji}</span>
+      ) : (
+        <Bot className={cn(botSizeClasses[size], "text-muted-foreground")} />
+      )}
+    </span>
+  )
+}
+
+export function AgentSelectDisplay({
+  agent,
+  fallbackName,
+  size = "sm",
+  className,
+}: {
+  agent?: AgentSelectAgent | null
+  fallbackName?: string
+  size?: AgentAvatarSize
+  className?: string
+}) {
+  const name = agent?.name || fallbackName || agent?.id || ""
+
+  return (
+    <span className={cn("!inline-flex min-w-0 items-center gap-2", className)}>
+      <AgentAvatarBadge agent={agent} size={size} />
+      <span className="truncate">{name}</span>
+    </span>
+  )
+}

--- a/src/components/cron/CronJobForm.tsx
+++ b/src/components/cron/CronJobForm.tsx
@@ -12,7 +12,8 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
-import { X, Bot, Plus, Send } from "lucide-react"
+import { X, Plus, Send } from "lucide-react"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import type { CronDeliveryTarget, CronJob, CronSchedule } from "./CronJobForm.types"
 
 import type { CronFrequency } from "./CronJobForm.types"
@@ -118,6 +119,7 @@ export default function CronJobForm({ job, defaultDate, onSave, onCancel }: Cron
   const [agents, setAgents] = useState<AgentInfo[]>([])
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState("")
+  const selectedAgent = agents.find((a) => a.id === agentId)
 
   useEffect(() => {
     getTransport().call<AgentInfo[]>("list_agents")
@@ -441,27 +443,12 @@ export default function CronJobForm({ job, defaultDate, onSave, onCancel }: Cron
             </label>
             <Select value={agentId} onValueChange={setAgentId}>
               <SelectTrigger>
-                <SelectValue />
+                {selectedAgent ? <AgentSelectDisplay agent={selectedAgent} /> : <SelectValue />}
               </SelectTrigger>
               <SelectContent>
                 {agents.map((a) => (
-                  <SelectItem key={a.id} value={a.id}>
-                    <div className="flex items-center gap-2">
-                      <div className="w-5 h-5 rounded-full bg-primary/15 flex items-center justify-center text-primary shrink-0 text-[10px] overflow-hidden">
-                        {a.avatar ? (
-                          <img
-                            src={getTransport().resolveAssetUrl(a.avatar) ?? a.avatar}
-                            className="w-full h-full object-cover"
-                            alt=""
-                          />
-                        ) : a.emoji ? (
-                          <span>{a.emoji}</span>
-                        ) : (
-                          <Bot className="h-3 w-3" />
-                        )}
-                      </div>
-                      <span>{a.name}</span>
-                    </div>
+                  <SelectItem key={a.id} value={a.id} textValue={a.name}>
+                    <AgentSelectDisplay agent={a} />
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/dashboard/DashboardFilter.tsx
+++ b/src/components/dashboard/DashboardFilter.tsx
@@ -9,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import { X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { DashboardFilter as DashboardFilterState } from "./types"
@@ -16,6 +17,8 @@ import type { DashboardFilter as DashboardFilterState } from "./types"
 interface Agent {
   id: string
   name: string
+  emoji?: string | null
+  avatar?: string | null
 }
 
 interface Provider {
@@ -116,6 +119,7 @@ export default function DashboardFilter({ filter, onChange }: DashboardFilterPro
     () => filter.agentId || filter.providerId || filter.modelId,
     [filter.agentId, filter.providerId, filter.modelId],
   )
+  const selectedAgent = agents.find((a) => a.id === filter.agentId)
 
   const rangeKeys: RangeKey[] = ["today", "7d", "30d", "90d", "all", "custom"]
 
@@ -167,13 +171,17 @@ export default function DashboardFilter({ filter, onChange }: DashboardFilterPro
         onValueChange={(v) => onChange({ ...filter, agentId: v === "__all__" ? null : v })}
       >
         <SelectTrigger className="h-7 w-36 text-xs">
-          <SelectValue placeholder={t("dashboard.filter.allAgents")} />
+          {selectedAgent ? (
+            <AgentSelectDisplay agent={selectedAgent} size="xs" />
+          ) : (
+            <SelectValue placeholder={t("dashboard.filter.allAgents")} />
+          )}
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="__all__">{t("dashboard.filter.allAgents")}</SelectItem>
           {agents.map((a) => (
-            <SelectItem key={a.id} value={a.id}>
-              {a.name}
+            <SelectItem key={a.id} value={a.id} textValue={a.name}>
+              <AgentSelectDisplay agent={a} size="xs" />
             </SelectItem>
           ))}
         </SelectContent>

--- a/src/components/onboarding/steps/OpenClawImportPanel.tsx
+++ b/src/components/onboarding/steps/OpenClawImportPanel.tsx
@@ -15,6 +15,7 @@ import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 
 // ── Types mirroring the backend OpenClawImportPreview ──────────
 
@@ -505,11 +506,8 @@ export function OpenClawImportPanel({
                       <Checkbox checked={checked} />
                     </button>
                     <div className="flex-1 min-w-0">
-                      <div className="flex items-baseline gap-2 flex-wrap">
-                        <span className="font-medium text-sm">
-                          {a.emoji ? `${a.emoji} ` : ""}
-                          {a.name}
-                        </span>
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <AgentSelectDisplay agent={a} className="text-sm font-medium" />
                         {a.alreadyExists && (
                           <span className="text-[10px] text-amber-600">
                             {t("onboarding.importOpenClaw.agents.alreadyExists")}

--- a/src/components/settings/NotificationPanel.tsx
+++ b/src/components/settings/NotificationPanel.tsx
@@ -15,6 +15,7 @@ import {
   loadNotificationConfig,
   type NotificationConfig,
 } from "@/lib/notifications"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import type { AgentConfig } from "./types"
 
 import type { AgentInfo as BaseAgentInfo } from "@/types/chat"
@@ -36,7 +37,7 @@ export default function NotificationPanel() {
       setConfig(cfg)
 
       const agentList =
-        await getTransport().call<{ id: string; name: string; emoji?: string | null }[]>("list_agents")
+        await getTransport().call<BaseAgentInfo[]>("list_agents")
       const agentsWithNotify = await Promise.all(
         agentList.map(async (a) => {
           try {
@@ -109,10 +110,7 @@ export default function NotificationPanel() {
         <div className="space-y-2">
           {agents.map((agent) => (
             <div key={agent.id} className="flex items-center justify-between py-1.5">
-              <span className="text-sm">
-                {agent.emoji ? `${agent.emoji} ` : ""}
-                {agent.name}
-              </span>
+              <AgentSelectDisplay agent={agent} className="text-sm" />
               <Select
                 value={
                   agent.notifyOnComplete === true

--- a/src/components/settings/RecapSettingsPanel.tsx
+++ b/src/components/settings/RecapSettingsPanel.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 
 interface RecapConfig {
   analysisAgent?: string | null
@@ -23,6 +24,7 @@ interface AgentItem {
   id: string
   name: string
   emoji?: string | null
+  avatar?: string | null
 }
 
 const DEFAULT_CONFIG: RecapConfig = {
@@ -117,6 +119,7 @@ export default function RecapSettingsPanel() {
   }
 
   if (!loaded) return null
+  const selectedAgent = agents.find((agent) => agent.id === config.analysisAgent)
 
   return (
     <div className="flex-1 overflow-y-auto p-6">
@@ -137,16 +140,15 @@ export default function RecapSettingsPanel() {
             onValueChange={handleAgentChange}
           >
             <SelectTrigger className="w-56 h-8 text-sm">
-              <SelectValue />
+              {selectedAgent ? <AgentSelectDisplay agent={selectedAgent} /> : <SelectValue />}
             </SelectTrigger>
             <SelectContent>
               <SelectItem value={AGENT_DEFAULT_SENTINEL}>
                 {t("settings.recapAnalysisAgentDefault")}
               </SelectItem>
               {agents.map((agent) => (
-                <SelectItem key={agent.id} value={agent.id}>
-                  {agent.emoji ? `${agent.emoji} ` : ""}
-                  {agent.name}
+                <SelectItem key={agent.id} value={agent.id} textValue={agent.name}>
+                  <AgentSelectDisplay agent={agent} />
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/components/settings/agent-panel/AgentListView.tsx
+++ b/src/components/settings/agent-panel/AgentListView.tsx
@@ -15,6 +15,7 @@ import type { AgentSummary, AgentConfig } from "./types"
 import { DEFAULT_PERSONALITY } from "./types"
 import OpenClawImportDialog from "./OpenClawImportDialog"
 import DefaultAgentSection from "./DefaultAgentSection"
+import { AgentAvatarBadge } from "@/components/common/AgentSelectDisplay"
 
 // ── Agent Create View ───────────────────────────────────────────
 
@@ -219,24 +220,12 @@ export default function AgentListView({ onEditAgent }: { onEditAgent: (id: strin
               className="group h-auto w-full justify-start gap-3 rounded-lg px-3 py-2.5 text-sm font-normal text-foreground hover:bg-secondary/60"
               onClick={() => onEditAgent(agent.id)}
             >
-              {/* Avatar / fallback */}
-              <div className="w-9 h-9 rounded-full bg-primary/15 flex items-center justify-center text-primary shrink-0 overflow-hidden">
-                {agent.avatar ? (
-                  <img
-                    src={getTransport().resolveAssetUrl(agent.avatar) ?? agent.avatar}
-                    className="w-full h-full object-cover"
-                    alt=""
-                  />
-                ) : (
-                  <Bot className="h-5 w-5" />
-                )}
-              </div>
+              <AgentAvatarBadge agent={agent} size="lg" />
 
-              {/* Name + emoji + description */}
+              {/* Name + description */}
               <div className="flex-1 text-left min-w-0">
                 <div className="font-medium truncate flex items-center gap-2">
                   {agent.name}
-                  {agent.emoji ? ` ${agent.emoji}` : ""}
                   {agent.id === "default" && (
                     <span className="text-[10px] px-1.5 py-0.5 rounded bg-secondary text-muted-foreground font-medium">
                       {t("settings.agentDefault")}

--- a/src/components/settings/agent-panel/DefaultAgentSection.tsx
+++ b/src/components/settings/agent-panel/DefaultAgentSection.tsx
@@ -8,7 +8,7 @@ import {
   SelectItem,
   SelectTrigger,
 } from "@/components/ui/select"
-import { Bot } from "lucide-react"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import type { AgentSummary } from "./types"
 
 interface DefaultAgentSectionProps {
@@ -91,7 +91,7 @@ export default function DefaultAgentSection({
       >
         <SelectTrigger className="h-9 w-full max-w-sm overflow-hidden text-sm">
           <div className="flex min-w-0 flex-1 items-center overflow-hidden">
-            <AgentOption agent={selectedAgent} fallbackId={defaultAgentId} />
+            <AgentSelectDisplay agent={selectedAgent} fallbackName={defaultAgentId} />
           </div>
         </SelectTrigger>
         <SelectContent>
@@ -99,23 +99,23 @@ export default function DefaultAgentSection({
             <>
               {defaultAgentId !== "default" && (
                 <SelectItem value={defaultAgentId} textValue={defaultAgentId}>
-                  <AgentOption fallbackId={defaultAgentId} />
+                  <AgentSelectDisplay fallbackName={defaultAgentId} />
                 </SelectItem>
               )}
               <SelectItem value="default" textValue="default">
-                <AgentOption fallbackId="default" />
+                <AgentSelectDisplay fallbackName="default" />
               </SelectItem>
             </>
           ) : (
             <>
               {!selectedAgentExists && (
                 <SelectItem value={defaultAgentId} textValue={defaultAgentId}>
-                  <AgentOption fallbackId={defaultAgentId} />
+                  <AgentSelectDisplay fallbackName={defaultAgentId} />
                 </SelectItem>
               )}
               {sortedAgents.map((a) => (
-                <SelectItem key={a.id} value={a.id} textValue={`${a.name} (${a.id})`}>
-                  <AgentOption agent={a} />
+                <SelectItem key={a.id} value={a.id} textValue={a.name}>
+                  <AgentSelectDisplay agent={a} />
                 </SelectItem>
               ))}
             </>
@@ -123,30 +123,5 @@ export default function DefaultAgentSection({
         </SelectContent>
       </Select>
     </section>
-  )
-}
-
-function AgentOption({ agent, fallbackId }: { agent?: AgentSummary; fallbackId?: string }) {
-  const id = agent?.id ?? fallbackId ?? "default"
-  const name = agent?.name ?? id
-
-  return (
-    <span className="inline-flex min-w-0 items-center gap-2">
-      <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/15 text-[10px] text-primary">
-        {agent?.avatar ? (
-          <img
-            src={getTransport().resolveAssetUrl(agent.avatar) ?? agent.avatar}
-            className="h-full w-full object-cover"
-            alt=""
-          />
-        ) : agent?.emoji ? (
-          <span>{agent.emoji}</span>
-        ) : (
-          <Bot className="h-3 w-3 text-muted-foreground" />
-        )}
-      </span>
-      <span className="truncate">{name}</span>
-      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">({id})</span>
-    </span>
   )
 }

--- a/src/components/settings/channel-panel/AddAccountDialog.tsx
+++ b/src/components/settings/channel-panel/AddAccountDialog.tsx
@@ -23,7 +23,7 @@ import {
 import { Check, Loader2, AlertCircle, ArrowLeft } from "lucide-react"
 import { logger } from "@/lib/logger"
 import ChannelIcon from "@/components/common/ChannelIcon"
-import AgentAvatar from "./AgentAvatar"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import AllowlistTagInput from "./AllowlistTagInput"
 import WeChatConnectSection from "./WeChatConnectSection"
 import TelegramGroupChannelConfig from "./TelegramGroupConfig"
@@ -107,6 +107,7 @@ export default function AddAccountDialog({
   const [wechatConnection, setWeChatConnection] = useState<WeChatConnection | null>(null)
 
   const selectedPlugin = plugins.find((p) => p.meta.id === channelId)
+  const selectedAgent = agents.find((agent) => agent.id === agentId)
 
   const handleSelectChannel = (id: string) => {
     setChannelId(id)
@@ -743,16 +744,17 @@ export default function AddAccountDialog({
                 <Label>{t("channels.boundAgent")}</Label>
                 <Select value={agentId || "__none__"} onValueChange={(v) => setAgentId(v === "__none__" ? "" : v)}>
                   <SelectTrigger>
-                    <SelectValue placeholder={t("channels.boundAgentDefault")} />
+                    {selectedAgent ? (
+                      <AgentSelectDisplay agent={selectedAgent} />
+                    ) : (
+                      <SelectValue placeholder={t("channels.boundAgentDefault")} />
+                    )}
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="__none__">{t("channels.boundAgentDefault")}</SelectItem>
                     {agents.map((a) => (
-                      <SelectItem key={a.id} value={a.id}>
-                        <span className="flex items-center gap-2">
-                          <AgentAvatar agent={a} />
-                          {a.name}
-                        </span>
+                      <SelectItem key={a.id} value={a.id} textValue={a.name}>
+                        <AgentSelectDisplay agent={a} />
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/src/components/settings/channel-panel/EditAccountDialog.tsx
+++ b/src/components/settings/channel-panel/EditAccountDialog.tsx
@@ -22,7 +22,7 @@ import { Switch } from "@/components/ui/switch"
 import { Check, Loader2, AlertCircle } from "lucide-react"
 import { logger } from "@/lib/logger"
 import ChannelIcon from "@/components/common/ChannelIcon"
-import AgentAvatar from "./AgentAvatar"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import AllowlistTagInput from "./AllowlistTagInput"
 import WeChatConnectSection from "./WeChatConnectSection"
 import TelegramGroupChannelConfig from "./TelegramGroupConfig"
@@ -69,6 +69,7 @@ export default function EditAccountDialog({
   const [validationResult, setValidationResult] = useState<string | null>(null)
   const [validationError, setValidationError] = useState<string | null>(null)
   const [wechatConnection, setWeChatConnection] = useState<WeChatConnection | null>(null)
+  const selectedAgent = agents.find((agent) => agent.id === agentId)
 
   // Populate form when account changes
   useEffect(() => {
@@ -250,16 +251,17 @@ export default function EditAccountDialog({
             <Label>{t("channels.boundAgent")}</Label>
             <Select value={agentId || "__none__"} onValueChange={(v) => setAgentId(v === "__none__" ? "" : v)}>
               <SelectTrigger>
-                <SelectValue placeholder={t("channels.boundAgentDefault")} />
+                {selectedAgent ? (
+                  <AgentSelectDisplay agent={selectedAgent} />
+                ) : (
+                  <SelectValue placeholder={t("channels.boundAgentDefault")} />
+                )}
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="__none__">{t("channels.boundAgentDefault")}</SelectItem>
                 {agents.map((a) => (
-                  <SelectItem key={a.id} value={a.id}>
-                    <span className="flex items-center gap-2">
-                      <AgentAvatar agent={a} />
-                      {a.name}
-                    </span>
+                  <SelectItem key={a.id} value={a.id} textValue={a.name}>
+                    <AgentSelectDisplay agent={a} />
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/settings/channel-panel/GroupConfigItem.tsx
+++ b/src/components/settings/channel-panel/GroupConfigItem.tsx
@@ -12,7 +12,7 @@ import {
 import { IconTip } from "@/components/ui/tooltip"
 import { Button } from "@/components/ui/button"
 import { Trash2 } from "lucide-react"
-import AgentAvatar from "./AgentAvatar"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import type { AgentInfo, TelegramGroupConfig } from "./types"
 
 export default function GroupConfigItem({
@@ -33,6 +33,7 @@ export default function GroupConfigItem({
   const [expanded, setExpanded] = useState(false)
 
   const mentionLabel = groupId === "*" ? t("channels.groupIdWildcard") : groupId
+  const selectedAgent = agents.find((agent) => agent.id === config.agentId)
 
   return (
     <div className="rounded-lg border bg-card p-3 space-y-2">
@@ -95,16 +96,17 @@ export default function GroupConfigItem({
             onValueChange={(v) => onUpdate({ agentId: v === "__none__" ? null : v })}
           >
             <SelectTrigger className="h-7 text-xs">
-              <SelectValue placeholder={t("channels.boundAgentDefault")} />
+              {selectedAgent ? (
+                <AgentSelectDisplay agent={selectedAgent} size="xs" />
+              ) : (
+                <SelectValue placeholder={t("channels.boundAgentDefault")} />
+              )}
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="__none__">{t("channels.boundAgentDefault")}</SelectItem>
               {agents.map((a) => (
-                <SelectItem key={a.id} value={a.id}>
-                  <span className="flex items-center gap-2">
-                    <AgentAvatar agent={a} />
-                    {a.name}
-                  </span>
+                <SelectItem key={a.id} value={a.id} textValue={a.name}>
+                  <AgentSelectDisplay agent={a} size="xs" />
                 </SelectItem>
               ))}
             </SelectContent>

--- a/src/components/settings/channel-panel/TelegramGroupConfig.tsx
+++ b/src/components/settings/channel-panel/TelegramGroupConfig.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/select"
 import { IconTip } from "@/components/ui/tooltip"
 import { Plus, Trash2 } from "lucide-react"
-import AgentAvatar from "./AgentAvatar"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import GroupConfigItem from "./GroupConfigItem"
 import type { AgentInfo, TelegramGroupConfig as TelegramGroupConfigType, TelegramChannelConfig } from "./types"
 
@@ -169,69 +169,74 @@ export default function TelegramGroupChannelConfig({
 
         {/* Existing channels */}
         <div className="space-y-2">
-          {Object.entries(channels).map(([cId, cCfg]) => (
-            <div key={cId} className="rounded-lg border bg-card p-3 space-y-2">
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium font-mono">{cId}</span>
-                <IconTip label={t("channels.removeConfig")}>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="h-7 w-7 text-muted-foreground"
-                    onClick={() => removeChannel(cId)}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                </IconTip>
+          {Object.entries(channels).map(([cId, cCfg]) => {
+            const selectedAgent = agents.find((agent) => agent.id === cCfg.agentId)
+
+            return (
+              <div key={cId} className="rounded-lg border bg-card p-3 space-y-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium font-mono">{cId}</span>
+                  <IconTip label={t("channels.removeConfig")}>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-muted-foreground"
+                      onClick={() => removeChannel(cId)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </IconTip>
+                </div>
+                <div className="flex items-center gap-4 flex-wrap">
+                  <div className="flex items-center gap-2">
+                    <Label className="text-xs">{t("channels.channelEnabled")}</Label>
+                    <Switch
+                      checked={cCfg.enabled !== false}
+                      onCheckedChange={(v) => updateChannel(cId, { enabled: v })}
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Label className="text-xs">{t("channels.groupRequireMention")}</Label>
+                    <Select
+                      value={cCfg.requireMention === null || cCfg.requireMention === undefined ? "yes" : cCfg.requireMention ? "yes" : "no"}
+                      onValueChange={(v) => updateChannel(cId, { requireMention: v === "yes" })}
+                    >
+                      <SelectTrigger className="h-7 text-xs w-20">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="yes">✓</SelectItem>
+                        <SelectItem value="no">✗</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex-1 min-w-[160px]">
+                    <Select
+                      value={cCfg.agentId || "__none__"}
+                      onValueChange={(v) => updateChannel(cId, { agentId: v === "__none__" ? null : v })}
+                    >
+                      <SelectTrigger className="h-8 text-xs">
+                        {selectedAgent ? (
+                          <AgentSelectDisplay agent={selectedAgent} size="xs" />
+                        ) : (
+                          <SelectValue placeholder={t("channels.boundAgentDefault")} />
+                        )}
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="__none__">{t("channels.boundAgentDefault")}</SelectItem>
+                        {agents.map((a) => (
+                          <SelectItem key={a.id} value={a.id} textValue={a.name}>
+                            <AgentSelectDisplay agent={a} size="xs" />
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
               </div>
-              <div className="flex items-center gap-4 flex-wrap">
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs">{t("channels.channelEnabled")}</Label>
-                  <Switch
-                    checked={cCfg.enabled !== false}
-                    onCheckedChange={(v) => updateChannel(cId, { enabled: v })}
-                  />
-                </div>
-                <div className="flex items-center gap-2">
-                  <Label className="text-xs">{t("channels.groupRequireMention")}</Label>
-                  <Select
-                    value={cCfg.requireMention === null || cCfg.requireMention === undefined ? "yes" : cCfg.requireMention ? "yes" : "no"}
-                    onValueChange={(v) => updateChannel(cId, { requireMention: v === "yes" })}
-                  >
-                    <SelectTrigger className="h-7 text-xs w-20">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="yes">✓</SelectItem>
-                      <SelectItem value="no">✗</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="flex-1 min-w-[160px]">
-                  <Select
-                    value={cCfg.agentId || "__none__"}
-                    onValueChange={(v) => updateChannel(cId, { agentId: v === "__none__" ? null : v })}
-                  >
-                    <SelectTrigger className="h-8 text-xs">
-                      <SelectValue placeholder={t("channels.boundAgentDefault")} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="__none__">{t("channels.boundAgentDefault")}</SelectItem>
-                      {agents.map((a) => (
-                        <SelectItem key={a.id} value={a.id}>
-                          <span className="flex items-center gap-2">
-                            <AgentAvatar agent={a} />
-                            {a.name}
-                          </span>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-            </div>
-          ))}
+            )
+          })}
         </div>
 
         {/* Add channel */}

--- a/src/components/settings/memory-panel/MemoryListView.tsx
+++ b/src/components/settings/memory-panel/MemoryListView.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import {
   Plus,
   Trash2,
@@ -86,6 +87,7 @@ export default function MemoryListView({ data, isAgentMode, compact }: MemoryLis
     startEdit,
     startAdd,
   } = data
+  const selectedAgent = agents.find((agent) => agent.id === selectedAgentId)
 
   const activeEmbeddingModel = memoryEmbeddingState.selection.enabled
     ? (memoryEmbeddingState.currentModel?.name ??
@@ -274,13 +276,16 @@ export default function MemoryListView({ data, isAgentMode, compact }: MemoryLis
               onValueChange={(v) => setSelectedAgentId(v || null)}
             >
               <SelectTrigger className="w-40 h-7 text-xs">
-                <SelectValue placeholder={t("settings.memorySelectAgent")} />
+                {selectedAgent ? (
+                  <AgentSelectDisplay agent={selectedAgent} size="xs" />
+                ) : (
+                  <SelectValue placeholder={t("settings.memorySelectAgent")} />
+                )}
               </SelectTrigger>
               <SelectContent>
                 {agents.map((a) => (
-                  <SelectItem key={a.id} value={a.id} className="text-xs">
-                    {a.emoji ? `${a.emoji} ` : ""}
-                    {a.name}
+                  <SelectItem key={a.id} value={a.id} className="text-xs" textValue={a.name}>
+                    <AgentSelectDisplay agent={a} size="xs" />
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/settings/teams-panel/AgentSelector.tsx
+++ b/src/components/settings/teams-panel/AgentSelector.tsx
@@ -5,6 +5,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import type { AgentSummary } from "@/components/settings/types"
 
 interface AgentSelectorProps {
@@ -22,19 +23,21 @@ export default function AgentSelector({
   loading,
   disabled,
 }: AgentSelectorProps) {
+  const selectedAgent = agents.find((agent) => agent.id === value)
+
   return (
     <Select value={value} onValueChange={onChange} disabled={disabled || loading}>
       <SelectTrigger className="h-8 text-xs bg-secondary/40">
-        <SelectValue placeholder={loading ? "…" : "Select agent"} />
+        {selectedAgent ? (
+          <AgentSelectDisplay agent={selectedAgent} size="xs" />
+        ) : (
+          <SelectValue placeholder={loading ? "…" : "Select agent"} />
+        )}
       </SelectTrigger>
       <SelectContent>
         {agents.map((a) => (
-          <SelectItem key={a.id} value={a.id}>
-            <span className="inline-flex items-center gap-1.5">
-              <span>{a.emoji ?? "🤖"}</span>
-              <span>{a.name}</span>
-              <span className="text-muted-foreground font-mono text-[10px]">({a.id})</span>
-            </span>
+          <SelectItem key={a.id} value={a.id} textValue={a.name}>
+            <AgentSelectDisplay agent={a} size="xs" />
           </SelectItem>
         ))}
       </SelectContent>


### PR DESCRIPTION
## Summary

- Add a shared Agent select/display helper for avatar-first rendering with emoji and bot icon fallbacks.
- Apply the unified display across chat, cron, dashboard, project, recap, memory, team, notification, onboarding, and channel Agent selection surfaces.
- Remove duplicated emoji-only rendering in Agent picker-style rows so names and avatars behave consistently.

## Validation

- `git diff --check` passed before commit.
- `pnpm typecheck` could not run in this worktree because `node_modules` is missing and `tsc` is not available (`sh: tsc: command not found`).