### PR TITLE
[codex] Add Markdown link type icons

### DIFF
--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -50,6 +50,11 @@ pub struct ChatRequest {
     /// See Tauri `chat` command — DB stores this while `message` goes to the LLM.
     #[serde(default)]
     pub display_text: Option<String>,
+    /// When true, persists the user row with
+    /// `attachments_meta = {"plan_trigger": true}` so the UI renders it as a
+    /// Plan Mode approve/resume chip (mirrors the Tauri `chat` command).
+    #[serde(default)]
+    pub is_plan_trigger: Option<bool>,
     /// Draft working dir picked before the session was materialized. Only
     /// honored when this call also creates the session (mirrors the Tauri
     /// `chat` command).
@@ -166,7 +171,13 @@ pub async fn chat(
     let persisted_content = ha_core::non_empty_trim_or(body.display_text.as_deref(), &body.message);
 
     // Save user message to DB
-    let user_msg = session::NewMessage::user(persisted_content);
+    let mut user_msg = session::NewMessage::user(persisted_content);
+    // Plan Mode trigger marker — UI renders these as a system chip instead of
+    // a regular user bubble. Mirrors the Tauri command.
+    if body.is_plan_trigger.unwrap_or(false) {
+        user_msg.attachments_meta =
+            Some(serde_json::json!({ "plan_trigger": true }).to_string());
+    }
     let _ = db.append_message(&sid, &user_msg);
 
     // Auto-generate fallback title from first user message (prefer display text so titles read naturally).

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -175,8 +175,7 @@ pub async fn chat(
     // Plan Mode trigger marker — UI renders these as a system chip instead of
     // a regular user bubble. Mirrors the Tauri command.
     if body.is_plan_trigger.unwrap_or(false) {
-        user_msg.attachments_meta =
-            Some(serde_json::json!({ "plan_trigger": true }).to_string());
+        user_msg.attachments_meta = Some(serde_json::json!({ "plan_trigger": true }).to_string());
     }
     let _ = db.append_message(&sid, &user_msg);
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -51,6 +51,10 @@ pub async fn chat(
     // When set, DB stores `display_text` as the user message while `message` is still
     // fed to the LLM (slash-skill passThrough uses this).
     display_text: Option<String>,
+    // When true, the persisted user row is tagged with
+    // `attachments_meta = {"plan_trigger": true}` so the UI can render it as a
+    // system chip instead of a regular user bubble (Plan Mode approve/resume).
+    is_plan_trigger: Option<bool>,
     // Draft working dir picked before the session was materialized. Only honored
     // when this call also creates the session — applies via the same
     // `update_session_working_dir` validation as the explicit setter command.
@@ -214,7 +218,14 @@ pub async fn chat(
 
     // Save user message to DB
     let mut user_msg = session::NewMessage::user(persisted_content);
-    user_msg.attachments_meta = attachments_meta;
+    // Plan Mode trigger marker takes precedence over attachments meta — these
+    // sends never carry user attachments (the LLM-bound `message` is a short
+    // canned trigger, not a real user input).
+    user_msg.attachments_meta = if is_plan_trigger.unwrap_or(false) {
+        Some(serde_json::json!({ "plan_trigger": true }).to_string())
+    } else {
+        attachments_meta
+    };
     let _ = db.append_message(&sid, &user_msg);
 
     // Log chat start

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -855,6 +855,7 @@ export default function ChatScreen({
           stream.handleSend(t("planMode.executeCommand"), {
             planMode: "executing",
             displayText: t("planMode.executionApproved"),
+            isPlanTrigger: true,
           })
           break
         case "showPlan":
@@ -933,6 +934,7 @@ export default function ChatScreen({
     stream.handleSend(t("planMode.executeCommand"), {
       planMode: "executing",
       displayText: t("planMode.executionApproved"),
+      isPlanTrigger: true,
     })
   }, [planMode, stream, t])
 
@@ -940,6 +942,7 @@ export default function ChatScreen({
     stream.handleSend(t("planMode.executeCommand"), {
       planMode: "executing",
       displayText: t("planMode.executionResumed"),
+      isPlanTrigger: true,
     })
   }, [stream, t])
 

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { ArrowDown, Ghost } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useVirtualFeed } from "@/components/common/useVirtualFeed"
+import { isCenteredSystemMessage } from "./chatUtils"
 import MessageBubble from "./MessageBubble"
 import MessageContextMenu from "./MessageContextMenu"
 import LoadMoreRow from "./LoadMoreRow"
@@ -151,8 +152,11 @@ export default function MessageList({
       if (row.type === "empty") return 240
       if (row.type === "planRunning") return 52
       if (row.type === "askUser" || row.type === "planCard") return 180
+      // Centered system chips (event / sub-agent result / cron / plan trigger)
+      // ride on `role: "user"` rows, so this branch must run before the user
+      // bubble fallback.
+      if (isCenteredSystemMessage(row.msg)) return 48
       if (row.msg.role === "user") return 76
-      if (row.msg.role === "event" || row.msg.isSubagentResult || row.msg.isCronTrigger) return 48
       return 120
     },
     [rows],
@@ -287,7 +291,7 @@ export default function MessageList({
             className={cn(
               "flex rounded-lg transition-colors",
               msg.dbId === highlightMessageId && "message-hit-pulse",
-              msg.role === "event" || msg.isSubagentResult || msg.isCronTrigger
+              isCenteredSystemMessage(msg)
                 ? "justify-center"
                 : msg.role === "user" && !msg.fromAgentId
                   ? "justify-end"

--- a/src/components/chat/QuickChatMessages.tsx
+++ b/src/components/chat/QuickChatMessages.tsx
@@ -65,7 +65,7 @@ export default function QuickChatMessages({
       if (!row) return 72
       if (row.type === "loadMore") return 32
       if (row.type === "viewFullChat") return 28
-      if (row.msg.role === "event") return 28
+      if (row.msg.role === "event" || row.msg.isPlanTrigger) return 28
       if (row.msg.role === "user") return 58
       return 72
     },
@@ -128,7 +128,7 @@ export default function QuickChatMessages({
     }
 
     const { msg, originalIndex } = row
-    if (msg.role === "event") {
+    if (msg.role === "event" || msg.isPlanTrigger) {
       return <div className="text-xs text-center text-muted-foreground py-1">{msg.content}</div>
     }
 

--- a/src/components/chat/chatUtils.ts
+++ b/src/components/chat/chatUtils.ts
@@ -28,6 +28,18 @@ function parseMediaItemsHeader(result: string): MediaItem[] | undefined {
   return undefined
 }
 
+/** True when a message should render as a centered system chip (event,
+ *  sub-agent result, cron trigger, plan-mode approve/resume) rather than as
+ *  a user/assistant bubble. */
+export function isCenteredSystemMessage(msg: Message): boolean {
+  return (
+    msg.role === "event" ||
+    !!msg.isSubagentResult ||
+    !!msg.isCronTrigger ||
+    !!msg.isPlanTrigger
+  )
+}
+
 /** Format token count: ≥10000 → "12.3k tokens", else "1,234 tokens" */
 export function formatTokens(n: number): string {
   if (n >= 10000) return `${(n / 1000).toFixed(1)}k tokens`
@@ -168,11 +180,12 @@ export function parseSessionMessages(
   let firstUserSeen = false
   for (const msg of msgs) {
     if (msg.role === "user") {
-      // Detect sub-agent result / cron trigger messages via attachments_meta marker
+      // Detect sub-agent result / cron trigger / plan trigger messages via attachments_meta marker
       let isSubagentResult = false
       let subagentResultAgentId: string | undefined
       let isCronTrigger = false
       let cronJobName: string | undefined
+      let isPlanTrigger = false
       let channelInbound: { channelId: string; senderName?: string } | undefined
       if (msg.attachmentsMeta) {
         try {
@@ -184,6 +197,9 @@ export function parseSessionMessages(
           if (meta?.cron_trigger) {
             isCronTrigger = true
             cronJobName = meta.cron_trigger.job_name
+          }
+          if (meta?.plan_trigger) {
+            isPlanTrigger = true
           }
           if (meta?.channel_inbound) {
             channelInbound = {
@@ -207,6 +223,7 @@ export function parseSessionMessages(
         subagentResultAgentId,
         isCronTrigger,
         cronJobName,
+        isPlanTrigger,
         channelInbound,
       })
     } else if (msg.role === "tool" && msg.toolCallId) {

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -41,6 +41,17 @@ function isActiveStreamError(error: unknown): boolean {
   return errorText(error).includes(ACTIVE_STREAM_ERROR_CODE)
 }
 
+interface SendOptions {
+  displayText?: string
+  planMode?: string
+  isPlanTrigger?: boolean
+}
+
+interface PendingSend {
+  text: string
+  options?: SendOptions
+}
+
 export interface UseChatStreamOptions {
   messages: Message[]
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>
@@ -93,10 +104,7 @@ export interface UseChatStreamReturn {
   setShowCodexAuthExpired: React.Dispatch<React.SetStateAction<boolean>>
   permissionMode: SessionMode
   setPermissionMode: React.Dispatch<React.SetStateAction<SessionMode>>
-  handleSend: (
-    directText?: string,
-    options?: { displayText?: string; planMode?: string },
-  ) => Promise<void>
+  handleSend: (directText?: string, options?: SendOptions) => Promise<void>
   handleStop: () => Promise<void>
   handleApprovalResponse: (
     requestId: string,
@@ -132,8 +140,31 @@ export function useChatStream({
   const { t } = useTranslation()
   const [input, setInput] = useState("")
   const [attachedFiles, setAttachedFiles] = useState<File[]>([])
-  const [pendingMessage, setPendingMessage] = useState<string | null>(null)
-  const pendingMessageRef = useRef<string | null>(null)
+  // Pending send queued while a response is streaming. Stores the LLM-bound
+  // `text` plus the original `options` (displayText / planMode / isPlanTrigger)
+  // so the replay path can resend with the exact same metadata — otherwise a
+  // queued plan-mode approve would lose its `isPlanTrigger` flag and render
+  // as a plain user bubble.
+  const [pendingSend, setPendingSendState] = useState<PendingSend | null>(null)
+  const pendingSendRef = useRef<PendingSend | null>(null)
+  // External views: keep the original `pendingMessage: string | null` API for
+  // ChatScreen / ChatInput, derived from the user-facing displayed text.
+  const pendingMessage = pendingSend
+    ? pendingSend.options?.displayText?.trim() || pendingSend.text
+    : null
+  const setPendingMessage = useCallback<
+    React.Dispatch<React.SetStateAction<string | null>>
+  >((value) => {
+    setPendingSendState((prev) => {
+      const next =
+        typeof value === "function"
+          ? (value as (p: string | null) => string | null)(
+              prev ? prev.options?.displayText?.trim() || prev.text : null,
+            )
+          : value
+      return next === null ? null : { text: next }
+    })
+  }, [])
   const [showCodexAuthExpired, setShowCodexAuthExpired] = useState(false)
   const [permissionMode, setPermissionModeState] = useState<SessionMode>("default")
   const permissionModeRef = useRef<SessionMode>("default")
@@ -172,6 +203,11 @@ export function useChatStream({
   // Auto-send pending messages setting
   const autoSendPendingRef = useRef(true)
   const autoSendRef = useRef(false)
+  // Holds a programmatic queued send (Plan Mode approve, slash-skill expansion)
+  // so the auto-send effect can replay it with the original options instead of
+  // rerouting through the input box. User-typed drafts go via `setInput` and
+  // leave this ref null.
+  const queuedReplayRef = useRef<PendingSend | null>(null)
 
   // Delta batch buffer
   const deltaBuffersRef = useRef(createStreamDeltaBuffers())
@@ -205,8 +241,8 @@ export function useChatStream({
 
   // Keep refs in sync
   useEffect(() => {
-    pendingMessageRef.current = pendingMessage
-  }, [pendingMessage])
+    pendingSendRef.current = pendingSend
+  }, [pendingSend])
   useEffect(() => {
     permissionModeRef.current = permissionMode
   }, [permissionMode])
@@ -269,16 +305,16 @@ export function useChatStream({
    * Send a message. If `directText` is provided, use it directly instead of the input box.
    * This avoids flashing text in the input (used by Plan Mode approve).
    */
-  async function handleSend(
-    directText?: string,
-    options?: { displayText?: string; planMode?: string },
-  ) {
+  async function handleSend(directText?: string, options?: SendOptions) {
     const rawText = directText ?? input
     if (!rawText.trim()) return
 
-    // If currently loading, queue the message as pending
+    // If currently loading, queue the message as pending. Capture both the
+    // LLM-bound text and the original options so the replay below resends
+    // with identical metadata (Plan Mode triggers carry `isPlanTrigger`,
+    // slash-skill expansions carry `displayText`, etc.).
     if (loading) {
-      setPendingMessage(rawText.trim())
+      setPendingSendState({ text: rawText.trim(), options })
       if (!directText) setInput("")
       return
     }
@@ -291,7 +327,13 @@ export function useChatStream({
     setInput("")
     setAttachedFiles([])
     const now = new Date().toISOString()
-    setMessages((prev) => [...prev, { role: "user", content: displayed, timestamp: now }])
+    const optimisticUserMessage = {
+      role: "user" as const,
+      content: displayed,
+      timestamp: now,
+      ...(options?.isPlanTrigger && { isPlanTrigger: true }),
+    }
+    setMessages((prev) => [...prev, optimisticUserMessage])
     setLoading(true)
 
     // Process attached files: images → base64 data, non-images → save to disk via Rust
@@ -438,7 +480,7 @@ export function useChatStream({
       // Track loading state for this session
       const freshMessages = [
         ...messages,
-        { role: "user" as const, content: displayed, timestamp: now },
+        optimisticUserMessage,
         {
           role: "assistant" as const,
           content: "",
@@ -469,6 +511,7 @@ export function useChatStream({
           planMode: effectivePlanMode && effectivePlanMode !== "off" ? effectivePlanMode : undefined,
           temperatureOverride: temperatureOverride ?? undefined,
           displayText: options?.displayText?.trim() || undefined,
+          isPlanTrigger: options?.isPlanTrigger,
           workingDir: currentSessionId ? undefined : draftWorkingDir ?? undefined,
         },
         onEvent,
@@ -601,22 +644,46 @@ export function useChatStream({
       reloadSessions()
 
       // Handle pending message after loading finishes
-      if (pendingMessageRef.current) {
-        const pending = pendingMessageRef.current
-        setPendingMessage(null)
-        setInput(pending)
-        if (autoSendPendingRef.current) {
+      const queued = pendingSendRef.current
+      if (queued) {
+        setPendingSendState(null)
+        if (queued.options) {
+          // Programmatic queued send (Plan Mode approve, slash-skill
+          // expansion). Replay through the auto-send effect with the
+          // original options so `isPlanTrigger` / `displayText` / `planMode`
+          // survive — and skip the input box so the LLM-bound text doesn't
+          // leak into what the user is editing. Button-driven, so always
+          // auto-fires regardless of `autoSendPending`.
+          queuedReplayRef.current = queued
           autoSendRef.current = true
+        } else {
+          // User-typed draft queued while loading — restore for editing
+          // / auto-send per the user setting.
+          setInput(queued.text)
+          if (autoSendPendingRef.current) {
+            autoSendRef.current = true
+          }
         }
       }
     }
   }
 
-  // Auto-send: fires after React flushes the input state + loading=false
+  // Auto-send: fires after React flushes the input state + loading=false.
+  // Two replay paths:
+  //   1. `queuedReplayRef` set → programmatic send (Plan Mode approve etc.)
+  //      with the original options preserved.
+  //   2. Otherwise → user-typed draft restored to `input`, dispatched as a
+  //      regular send.
   useEffect(() => {
-    if (autoSendRef.current && input.trim() && !loading) {
+    if (!autoSendRef.current || loading) return
+    const replay = queuedReplayRef.current
+    if (replay) {
       autoSendRef.current = false
-      handleSend()
+      queuedReplayRef.current = null
+      void handleSend(replay.text, replay.options)
+    } else if (input.trim()) {
+      autoSendRef.current = false
+      void handleSend()
     }
   }, [input, loading]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -3,7 +3,7 @@ import { getTransport } from "@/lib/transport-provider"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { IconTip } from "@/components/ui/tooltip"
-import { Copy, Check, Info, Network, Timer } from "lucide-react"
+import { Copy, Check, Info, Network, Timer, PlayCircle } from "lucide-react"
 import ChannelIcon from "@/components/common/ChannelIcon"
 import { formatTokens, formatDuration, formatMessageTime, extractModifiedFiles } from "../chatUtils"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
@@ -171,6 +171,15 @@ function MessageBubbleInner({
 
   if (msg.isCronTrigger) {
     return <CronTriggerBubble msg={msg} t={t} />
+  }
+
+  if (msg.isPlanTrigger) {
+    return (
+      <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-muted/50 border border-border/50 text-xs text-muted-foreground max-w-[80%]">
+        <PlayCircle className="w-3 h-3 shrink-0 text-muted-foreground/80" />
+        <span>{msg.content}</span>
+      </div>
+    )
   }
 
   return (

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -9,6 +9,22 @@ import {
 import { Streamdown, type AnimateOptions, type PluginConfig } from "streamdown"
 import { code } from "@streamdown/code"
 import { cjk } from "@streamdown/cjk"
+import {
+  File as FileIcon,
+  FileArchive,
+  FileAudio,
+  FileCode,
+  FileImage,
+  FileSpreadsheet,
+  FileText,
+  FileType,
+  FileVideo,
+  Globe,
+  Hash,
+  Link2,
+  Mail,
+  type LucideIcon,
+} from "lucide-react"
 import "streamdown/styles.css"
 import i18next from "i18next"
 import { getTransport } from "@/lib/transport-provider"
@@ -96,6 +112,168 @@ function normalizeLocalPath(href: string): string {
   return href.replace(/#L\d+(-L?\d+)?$/, "")
 }
 
+const IMAGE_EXTENSIONS = new Set([
+  "avif",
+  "bmp",
+  "gif",
+  "ico",
+  "jpeg",
+  "jpg",
+  "png",
+  "svg",
+  "webp",
+])
+
+const AUDIO_EXTENSIONS = new Set([
+  "aac",
+  "aiff",
+  "flac",
+  "m4a",
+  "mp3",
+  "ogg",
+  "opus",
+  "wav",
+  "weba",
+])
+
+const VIDEO_EXTENSIONS = new Set([
+  "avi",
+  "m4v",
+  "mkv",
+  "mov",
+  "mp4",
+  "mpeg",
+  "mpg",
+  "ogv",
+  "webm",
+])
+
+const ARCHIVE_EXTENSIONS = new Set([
+  "7z",
+  "bz2",
+  "dmg",
+  "gz",
+  "rar",
+  "tar",
+  "tgz",
+  "txz",
+  "xz",
+  "zip",
+])
+
+const SPREADSHEET_EXTENSIONS = new Set(["csv", "ods", "tsv", "xls", "xlsm", "xlsx"])
+
+const DOCUMENT_EXTENSIONS = new Set([
+  "doc",
+  "docx",
+  "log",
+  "md",
+  "mdx",
+  "odt",
+  "rtf",
+  "tex",
+  "txt",
+])
+
+const PRESENTATION_EXTENSIONS = new Set(["key", "odp", "ppt", "pptx"])
+
+const CONFIG_EXTENSIONS = new Set([
+  "conf",
+  "config",
+  "env",
+  "ini",
+  "lock",
+  "plist",
+  "properties",
+  "toml",
+  "yaml",
+  "yml",
+])
+
+const DATA_EXTENSIONS = new Set(["json", "jsonl", "parquet", "sqlite", "sqlite3", "xml"])
+
+const CODE_EXTENSIONS = new Set([
+  "c",
+  "cjs",
+  "cpp",
+  "cs",
+  "css",
+  "go",
+  "html",
+  "java",
+  "js",
+  "jsx",
+  "kt",
+  "lua",
+  "mjs",
+  "py",
+  "rs",
+  "scss",
+  "sh",
+  "sql",
+  "svelte",
+  "swift",
+  "ts",
+  "tsx",
+  "vue",
+])
+
+type LinkKind =
+  | "anchor"
+  | "archive"
+  | "audio"
+  | "code"
+  | "config"
+  | "data"
+  | "document"
+  | "file"
+  | "image"
+  | "link"
+  | "mail"
+  | "pdf"
+  | "presentation"
+  | "spreadsheet"
+  | "video"
+  | "web"
+
+interface LinkIconInfo {
+  Icon: LucideIcon
+  kind: LinkKind
+}
+
+function hrefExtension(href: string): string | null {
+  const path = href.split(/[?#]/, 1)[0] ?? ""
+  const lastSegment = path.split("/").pop() ?? ""
+  const dotIndex = lastSegment.lastIndexOf(".")
+  if (dotIndex <= 0 || dotIndex === lastSegment.length - 1) return null
+  return lastSegment.slice(dotIndex + 1).toLowerCase()
+}
+
+function linkIconForHref(href: string | undefined, local: boolean): LinkIconInfo | null {
+  if (!href || href === "streamdown:incomplete-link") return null
+  const extension = hrefExtension(href)
+  if (extension === "pdf") return { Icon: FileText, kind: "pdf" }
+  if (extension && IMAGE_EXTENSIONS.has(extension)) return { Icon: FileImage, kind: "image" }
+  if (extension && AUDIO_EXTENSIONS.has(extension)) return { Icon: FileAudio, kind: "audio" }
+  if (extension && VIDEO_EXTENSIONS.has(extension)) return { Icon: FileVideo, kind: "video" }
+  if (extension && ARCHIVE_EXTENSIONS.has(extension)) return { Icon: FileArchive, kind: "archive" }
+  if (extension && SPREADSHEET_EXTENSIONS.has(extension)) {
+    return { Icon: FileSpreadsheet, kind: "spreadsheet" }
+  }
+  if (extension && PRESENTATION_EXTENSIONS.has(extension)) {
+    return { Icon: FileType, kind: "presentation" }
+  }
+  if (extension && DOCUMENT_EXTENSIONS.has(extension)) return { Icon: FileType, kind: "document" }
+  if (extension && CONFIG_EXTENSIONS.has(extension)) return { Icon: FileCode, kind: "config" }
+  if (extension && DATA_EXTENSIONS.has(extension)) return { Icon: FileCode, kind: "data" }
+  if (extension && CODE_EXTENSIONS.has(extension)) return { Icon: FileCode, kind: "code" }
+  if (local) return { Icon: FileIcon, kind: "file" }
+  if (href.startsWith("mailto:")) return { Icon: Mail, kind: "mail" }
+  if (href.startsWith("#")) return { Icon: Hash, kind: "anchor" }
+  if (/^https?:\/\//i.test(href)) return { Icon: Globe, kind: "web" }
+  return { Icon: Link2, kind: "link" }
+}
+
 function MarkdownLink({
   href,
   children,
@@ -107,6 +285,8 @@ function MarkdownLink({
   const isIncomplete = href === "streamdown:incomplete-link"
   const local = isLocalPath(href)
   const disabledLocal = local && !getTransport().supportsLocalFileOps()
+  const linkIcon = linkIconForHref(href, local)
+  const LinkIcon = linkIcon?.Icon
   // Native `title` 而非 shadcn Tooltip：Streamdown 流式消息可能渲染上百
   // anchor，包 TooltipTrigger 会爆 DOM 并破坏 anchor 组件签名。Markdown
   // 内联 disabled 提示属合理例外。
@@ -115,12 +295,13 @@ function MarkdownLink({
       {...rest}
       href={href}
       className={cn(
-        "wrap-anywhere font-medium text-primary underline",
+        "wrap-anywhere markdown-link font-medium",
         disabledLocal && "cursor-not-allowed opacity-70",
         className,
       )}
       title={disabledLocal ? i18next.t("common.markdownLinkLocalDisabled") : rest.title}
       data-incomplete={isIncomplete || undefined}
+      data-link-kind={linkIcon?.kind}
       data-streamdown="link"
       onClick={(event) => {
         if (!href || isIncomplete) return
@@ -135,7 +316,8 @@ function MarkdownLink({
         }
       }}
     >
-      {children}
+      {LinkIcon && <LinkIcon aria-hidden="true" className="markdown-link-icon" />}
+      <span className="markdown-link-label">{children}</span>
     </a>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -268,6 +268,165 @@
   cursor: zoom-in;
 }
 
+.markdown-content [data-streamdown="link"] {
+  color: hsl(210 100% 32%);
+  border-radius: 0.25rem;
+  margin-inline: -0.08em;
+  padding-inline: 0.08em;
+  background:
+    linear-gradient(
+      color-mix(in srgb, hsl(210 100% 50%) 12%, transparent),
+      color-mix(in srgb, hsl(210 100% 50%) 12%, transparent)
+    )
+    left 85% / 100% 0.38em no-repeat;
+  text-decoration-line: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 42%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+  transition:
+    color 140ms ease,
+    background-color 140ms ease,
+    text-decoration-color 140ms ease;
+}
+
+.markdown-content [data-streamdown="link"]:hover {
+  color: hsl(210 100% 26%);
+  background-color: color-mix(in srgb, hsl(210 100% 50%) 12%, transparent);
+  text-decoration-color: currentColor;
+}
+
+.markdown-content [data-streamdown="link"]:focus-visible {
+  outline-color: color-mix(in srgb, currentColor 48%, transparent);
+}
+
+.markdown-content [data-streamdown="link"] .markdown-link-icon {
+  display: inline-block;
+  width: 0.88em;
+  height: 0.88em;
+  margin-right: 0.2em;
+  vertical-align: -0.1em;
+  opacity: 0.82;
+  stroke-width: 2.35;
+}
+
+.markdown-content [data-streamdown="link"]:hover .markdown-link-icon {
+  opacity: 1;
+}
+
+.markdown-content [data-link-kind="image"] .markdown-link-icon {
+  color: hsl(145 62% 36%);
+}
+
+.markdown-content [data-link-kind="audio"] .markdown-link-icon {
+  color: hsl(276 70% 50%);
+}
+
+.markdown-content [data-link-kind="video"] .markdown-link-icon {
+  color: hsl(25 88% 48%);
+}
+
+.markdown-content [data-link-kind="pdf"] .markdown-link-icon {
+  color: hsl(0 72% 50%);
+}
+
+.markdown-content [data-link-kind="archive"] .markdown-link-icon {
+  color: hsl(38 90% 42%);
+}
+
+.markdown-content [data-link-kind="spreadsheet"] .markdown-link-icon {
+  color: hsl(155 68% 32%);
+}
+
+.markdown-content [data-link-kind="document"] .markdown-link-icon,
+.markdown-content [data-link-kind="presentation"] .markdown-link-icon {
+  color: hsl(220 78% 48%);
+}
+
+.markdown-content [data-link-kind="code"] .markdown-link-icon,
+.markdown-content [data-link-kind="config"] .markdown-link-icon,
+.markdown-content [data-link-kind="data"] .markdown-link-icon {
+  color: hsl(262 72% 54%);
+}
+
+.markdown-content [data-link-kind="file"] .markdown-link-icon {
+  color: hsl(215 18% 42%);
+}
+
+.markdown-content [data-link-kind="web"] .markdown-link-icon {
+  color: hsl(202 86% 42%);
+}
+
+.markdown-content [data-link-kind="mail"] .markdown-link-icon,
+.markdown-content [data-link-kind="anchor"] .markdown-link-icon,
+.markdown-content [data-link-kind="link"] .markdown-link-icon {
+  color: currentColor;
+}
+
+.markdown-content [data-streamdown="link"] .markdown-link-label {
+  display: inline;
+}
+
+.dark .markdown-content [data-streamdown="link"] {
+  color: hsl(199 100% 72%);
+  background:
+    linear-gradient(
+      color-mix(in srgb, hsl(199 100% 72%) 16%, transparent),
+      color-mix(in srgb, hsl(199 100% 72%) 16%, transparent)
+    )
+    left 85% / 100% 0.38em no-repeat;
+  text-decoration-color: color-mix(in srgb, currentColor 48%, transparent);
+}
+
+.dark .markdown-content [data-streamdown="link"]:hover {
+  color: hsl(199 100% 82%);
+  background-color: color-mix(in srgb, hsl(199 100% 72%) 14%, transparent);
+}
+
+.dark .markdown-content [data-link-kind="image"] .markdown-link-icon {
+  color: hsl(145 72% 62%);
+}
+
+.dark .markdown-content [data-link-kind="audio"] .markdown-link-icon {
+  color: hsl(276 82% 76%);
+}
+
+.dark .markdown-content [data-link-kind="video"] .markdown-link-icon {
+  color: hsl(30 96% 68%);
+}
+
+.dark .markdown-content [data-link-kind="pdf"] .markdown-link-icon {
+  color: hsl(0 88% 72%);
+}
+
+.dark .markdown-content [data-link-kind="archive"] .markdown-link-icon {
+  color: hsl(42 96% 66%);
+}
+
+.dark .markdown-content [data-link-kind="spreadsheet"] .markdown-link-icon {
+  color: hsl(155 72% 58%);
+}
+
+.dark .markdown-content [data-link-kind="document"] .markdown-link-icon,
+.dark .markdown-content [data-link-kind="presentation"] .markdown-link-icon {
+  color: hsl(220 90% 74%);
+}
+
+.dark .markdown-content [data-link-kind="code"] .markdown-link-icon,
+.dark .markdown-content [data-link-kind="config"] .markdown-link-icon,
+.dark .markdown-content [data-link-kind="data"] .markdown-link-icon {
+  color: hsl(262 90% 76%);
+}
+
+.dark .markdown-content [data-link-kind="file"] .markdown-link-icon {
+  color: hsl(215 18% 68%);
+}
+
+.dark .markdown-content [data-link-kind="web"] .markdown-link-icon {
+  color: hsl(199 100% 72%);
+}
+
 /* Streamdown's default code block chrome is roomy for chat. Keep the
    controls, but tighten the header and code body to suit short snippets. */
 .markdown-content [data-streamdown="code-block"] {

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -37,6 +37,10 @@ export interface ChatStartArgs {
   planMode?: string;
   temperatureOverride?: number;
   displayText?: string;
+  /** Marks the user message as a Plan Mode approve/resume trigger so the
+   *  backend stamps `attachments_meta = {plan_trigger: true}` and the UI
+   *  renders it as a system chip instead of a regular user bubble. */
+  isPlanTrigger?: boolean;
   workingDir?: string | null;
   // Tauri's invoke serializes extra unknown fields without complaint, and
   // HTTP's POST body is plain JSON — keep this open so HTTP impl can

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -115,6 +115,10 @@ export interface Message {
   subagentResultAgentId?: string
   /** If true, this user message was triggered by a cron job */
   isCronTrigger?: boolean
+  /** If true, this user message is a Plan Mode trigger (approve / resume) —
+   *  sent to the LLM as a normal user turn but rendered as a system chip
+   *  in the UI to distinguish it from real user input. */
+  isPlanTrigger?: boolean
   /** If true, this message is a hidden skill prompt — sent to LLM but not shown in the UI */
   isMeta?: boolean
   /** The cron job name that triggered this message */


### PR DESCRIPTION
## Summary

- Add semantic icons to Markdown links based on target type and file extension.
- Style Markdown links with clearer visual affordance, hover/focus states, and dark-mode support.
- Add subtle icon color treatment for web, file, image, audio, video, PDF, archive, spreadsheet, document, presentation, code, config, and data links.

## Impact

Markdown links in chat and other shared Markdown-rendered surfaces are easier to scan while preserving the existing link opening behavior for local files and external URLs.