### PR TITLE
[codex] Add Markdown link type icons

### DIFF
--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -9,6 +9,22 @@ import {
 import { Streamdown, type AnimateOptions, type PluginConfig } from "streamdown"
 import { code } from "@streamdown/code"
 import { cjk } from "@streamdown/cjk"
+import {
+  File as FileIcon,
+  FileArchive,
+  FileAudio,
+  FileCode,
+  FileImage,
+  FileSpreadsheet,
+  FileText,
+  FileType,
+  FileVideo,
+  Globe,
+  Hash,
+  Link2,
+  Mail,
+  type LucideIcon,
+} from "lucide-react"
 import "streamdown/styles.css"
 import i18next from "i18next"
 import { getTransport } from "@/lib/transport-provider"
@@ -96,6 +112,168 @@ function normalizeLocalPath(href: string): string {
   return href.replace(/#L\d+(-L?\d+)?$/, "")
 }
 
+const IMAGE_EXTENSIONS = new Set([
+  "avif",
+  "bmp",
+  "gif",
+  "ico",
+  "jpeg",
+  "jpg",
+  "png",
+  "svg",
+  "webp",
+])
+
+const AUDIO_EXTENSIONS = new Set([
+  "aac",
+  "aiff",
+  "flac",
+  "m4a",
+  "mp3",
+  "ogg",
+  "opus",
+  "wav",
+  "weba",
+])
+
+const VIDEO_EXTENSIONS = new Set([
+  "avi",
+  "m4v",
+  "mkv",
+  "mov",
+  "mp4",
+  "mpeg",
+  "mpg",
+  "ogv",
+  "webm",
+])
+
+const ARCHIVE_EXTENSIONS = new Set([
+  "7z",
+  "bz2",
+  "dmg",
+  "gz",
+  "rar",
+  "tar",
+  "tgz",
+  "txz",
+  "xz",
+  "zip",
+])
+
+const SPREADSHEET_EXTENSIONS = new Set(["csv", "ods", "tsv", "xls", "xlsm", "xlsx"])
+
+const DOCUMENT_EXTENSIONS = new Set([
+  "doc",
+  "docx",
+  "log",
+  "md",
+  "mdx",
+  "odt",
+  "rtf",
+  "tex",
+  "txt",
+])
+
+const PRESENTATION_EXTENSIONS = new Set(["key", "odp", "ppt", "pptx"])
+
+const CONFIG_EXTENSIONS = new Set([
+  "conf",
+  "config",
+  "env",
+  "ini",
+  "lock",
+  "plist",
+  "properties",
+  "toml",
+  "yaml",
+  "yml",
+])
+
+const DATA_EXTENSIONS = new Set(["json", "jsonl", "parquet", "sqlite", "sqlite3", "xml"])
+
+const CODE_EXTENSIONS = new Set([
+  "c",
+  "cjs",
+  "cpp",
+  "cs",
+  "css",
+  "go",
+  "html",
+  "java",
+  "js",
+  "jsx",
+  "kt",
+  "lua",
+  "mjs",
+  "py",
+  "rs",
+  "scss",
+  "sh",
+  "sql",
+  "svelte",
+  "swift",
+  "ts",
+  "tsx",
+  "vue",
+])
+
+type LinkKind =
+  | "anchor"
+  | "archive"
+  | "audio"
+  | "code"
+  | "config"
+  | "data"
+  | "document"
+  | "file"
+  | "image"
+  | "link"
+  | "mail"
+  | "pdf"
+  | "presentation"
+  | "spreadsheet"
+  | "video"
+  | "web"
+
+interface LinkIconInfo {
+  Icon: LucideIcon
+  kind: LinkKind
+}
+
+function hrefExtension(href: string): string | null {
+  const path = href.split(/[?#]/, 1)[0] ?? ""
+  const lastSegment = path.split("/").pop() ?? ""
+  const dotIndex = lastSegment.lastIndexOf(".")
+  if (dotIndex <= 0 || dotIndex === lastSegment.length - 1) return null
+  return lastSegment.slice(dotIndex + 1).toLowerCase()
+}
+
+function linkIconForHref(href: string | undefined, local: boolean): LinkIconInfo | null {
+  if (!href || href === "streamdown:incomplete-link") return null
+  const extension = hrefExtension(href)
+  if (extension === "pdf") return { Icon: FileText, kind: "pdf" }
+  if (extension && IMAGE_EXTENSIONS.has(extension)) return { Icon: FileImage, kind: "image" }
+  if (extension && AUDIO_EXTENSIONS.has(extension)) return { Icon: FileAudio, kind: "audio" }
+  if (extension && VIDEO_EXTENSIONS.has(extension)) return { Icon: FileVideo, kind: "video" }
+  if (extension && ARCHIVE_EXTENSIONS.has(extension)) return { Icon: FileArchive, kind: "archive" }
+  if (extension && SPREADSHEET_EXTENSIONS.has(extension)) {
+    return { Icon: FileSpreadsheet, kind: "spreadsheet" }
+  }
+  if (extension && PRESENTATION_EXTENSIONS.has(extension)) {
+    return { Icon: FileType, kind: "presentation" }
+  }
+  if (extension && DOCUMENT_EXTENSIONS.has(extension)) return { Icon: FileType, kind: "document" }
+  if (extension && CONFIG_EXTENSIONS.has(extension)) return { Icon: FileCode, kind: "config" }
+  if (extension && DATA_EXTENSIONS.has(extension)) return { Icon: FileCode, kind: "data" }
+  if (extension && CODE_EXTENSIONS.has(extension)) return { Icon: FileCode, kind: "code" }
+  if (local) return { Icon: FileIcon, kind: "file" }
+  if (href.startsWith("mailto:")) return { Icon: Mail, kind: "mail" }
+  if (href.startsWith("#")) return { Icon: Hash, kind: "anchor" }
+  if (/^https?:\/\//i.test(href)) return { Icon: Globe, kind: "web" }
+  return { Icon: Link2, kind: "link" }
+}
+
 function MarkdownLink({
   href,
   children,
@@ -107,6 +285,8 @@ function MarkdownLink({
   const isIncomplete = href === "streamdown:incomplete-link"
   const local = isLocalPath(href)
   const disabledLocal = local && !getTransport().supportsLocalFileOps()
+  const linkIcon = linkIconForHref(href, local)
+  const LinkIcon = linkIcon?.Icon
   // Native `title` 而非 shadcn Tooltip：Streamdown 流式消息可能渲染上百
   // anchor，包 TooltipTrigger 会爆 DOM 并破坏 anchor 组件签名。Markdown
   // 内联 disabled 提示属合理例外。
@@ -115,12 +295,13 @@ function MarkdownLink({
       {...rest}
       href={href}
       className={cn(
-        "wrap-anywhere font-medium text-primary underline",
+        "wrap-anywhere markdown-link font-medium",
         disabledLocal && "cursor-not-allowed opacity-70",
         className,
       )}
       title={disabledLocal ? i18next.t("common.markdownLinkLocalDisabled") : rest.title}
       data-incomplete={isIncomplete || undefined}
+      data-link-kind={linkIcon?.kind}
       data-streamdown="link"
       onClick={(event) => {
         if (!href || isIncomplete) return
@@ -135,7 +316,8 @@ function MarkdownLink({
         }
       }}
     >
-      {children}
+      {LinkIcon && <LinkIcon aria-hidden="true" className="markdown-link-icon" />}
+      <span className="markdown-link-label">{children}</span>
     </a>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -268,6 +268,165 @@
   cursor: zoom-in;
 }
 
+.markdown-content [data-streamdown="link"] {
+  color: hsl(210 100% 32%);
+  border-radius: 0.25rem;
+  margin-inline: -0.08em;
+  padding-inline: 0.08em;
+  background:
+    linear-gradient(
+      color-mix(in srgb, hsl(210 100% 50%) 12%, transparent),
+      color-mix(in srgb, hsl(210 100% 50%) 12%, transparent)
+    )
+    left 85% / 100% 0.38em no-repeat;
+  text-decoration-line: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 42%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.2em;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+  transition:
+    color 140ms ease,
+    background-color 140ms ease,
+    text-decoration-color 140ms ease;
+}
+
+.markdown-content [data-streamdown="link"]:hover {
+  color: hsl(210 100% 26%);
+  background-color: color-mix(in srgb, hsl(210 100% 50%) 12%, transparent);
+  text-decoration-color: currentColor;
+}
+
+.markdown-content [data-streamdown="link"]:focus-visible {
+  outline-color: color-mix(in srgb, currentColor 48%, transparent);
+}
+
+.markdown-content [data-streamdown="link"] .markdown-link-icon {
+  display: inline-block;
+  width: 0.88em;
+  height: 0.88em;
+  margin-right: 0.2em;
+  vertical-align: -0.1em;
+  opacity: 0.82;
+  stroke-width: 2.35;
+}
+
+.markdown-content [data-streamdown="link"]:hover .markdown-link-icon {
+  opacity: 1;
+}
+
+.markdown-content [data-link-kind="image"] .markdown-link-icon {
+  color: hsl(145 62% 36%);
+}
+
+.markdown-content [data-link-kind="audio"] .markdown-link-icon {
+  color: hsl(276 70% 50%);
+}
+
+.markdown-content [data-link-kind="video"] .markdown-link-icon {
+  color: hsl(25 88% 48%);
+}
+
+.markdown-content [data-link-kind="pdf"] .markdown-link-icon {
+  color: hsl(0 72% 50%);
+}
+
+.markdown-content [data-link-kind="archive"] .markdown-link-icon {
+  color: hsl(38 90% 42%);
+}
+
+.markdown-content [data-link-kind="spreadsheet"] .markdown-link-icon {
+  color: hsl(155 68% 32%);
+}
+
+.markdown-content [data-link-kind="document"] .markdown-link-icon,
+.markdown-content [data-link-kind="presentation"] .markdown-link-icon {
+  color: hsl(220 78% 48%);
+}
+
+.markdown-content [data-link-kind="code"] .markdown-link-icon,
+.markdown-content [data-link-kind="config"] .markdown-link-icon,
+.markdown-content [data-link-kind="data"] .markdown-link-icon {
+  color: hsl(262 72% 54%);
+}
+
+.markdown-content [data-link-kind="file"] .markdown-link-icon {
+  color: hsl(215 18% 42%);
+}
+
+.markdown-content [data-link-kind="web"] .markdown-link-icon {
+  color: hsl(202 86% 42%);
+}
+
+.markdown-content [data-link-kind="mail"] .markdown-link-icon,
+.markdown-content [data-link-kind="anchor"] .markdown-link-icon,
+.markdown-content [data-link-kind="link"] .markdown-link-icon {
+  color: currentColor;
+}
+
+.markdown-content [data-streamdown="link"] .markdown-link-label {
+  display: inline;
+}
+
+.dark .markdown-content [data-streamdown="link"] {
+  color: hsl(199 100% 72%);
+  background:
+    linear-gradient(
+      color-mix(in srgb, hsl(199 100% 72%) 16%, transparent),
+      color-mix(in srgb, hsl(199 100% 72%) 16%, transparent)
+    )
+    left 85% / 100% 0.38em no-repeat;
+  text-decoration-color: color-mix(in srgb, currentColor 48%, transparent);
+}
+
+.dark .markdown-content [data-streamdown="link"]:hover {
+  color: hsl(199 100% 82%);
+  background-color: color-mix(in srgb, hsl(199 100% 72%) 14%, transparent);
+}
+
+.dark .markdown-content [data-link-kind="image"] .markdown-link-icon {
+  color: hsl(145 72% 62%);
+}
+
+.dark .markdown-content [data-link-kind="audio"] .markdown-link-icon {
+  color: hsl(276 82% 76%);
+}
+
+.dark .markdown-content [data-link-kind="video"] .markdown-link-icon {
+  color: hsl(30 96% 68%);
+}
+
+.dark .markdown-content [data-link-kind="pdf"] .markdown-link-icon {
+  color: hsl(0 88% 72%);
+}
+
+.dark .markdown-content [data-link-kind="archive"] .markdown-link-icon {
+  color: hsl(42 96% 66%);
+}
+
+.dark .markdown-content [data-link-kind="spreadsheet"] .markdown-link-icon {
+  color: hsl(155 72% 58%);
+}
+
+.dark .markdown-content [data-link-kind="document"] .markdown-link-icon,
+.dark .markdown-content [data-link-kind="presentation"] .markdown-link-icon {
+  color: hsl(220 90% 74%);
+}
+
+.dark .markdown-content [data-link-kind="code"] .markdown-link-icon,
+.dark .markdown-content [data-link-kind="config"] .markdown-link-icon,
+.dark .markdown-content [data-link-kind="data"] .markdown-link-icon {
+  color: hsl(262 90% 76%);
+}
+
+.dark .markdown-content [data-link-kind="file"] .markdown-link-icon {
+  color: hsl(215 18% 68%);
+}
+
+.dark .markdown-content [data-link-kind="web"] .markdown-link-icon {
+  color: hsl(199 100% 72%);
+}
+
 /* Streamdown's default code block chrome is roomy for chat. Keep the
    controls, but tighten the header and code body to suit short snippets. */
 .markdown-content [data-streamdown="code-block"] {


### PR DESCRIPTION
## Summary

- Add semantic icons to Markdown links based on target type and file extension.
- Style Markdown links with clearer visual affordance, hover/focus states, and dark-mode support.
- Add subtle icon color treatment for web, file, image, audio, video, PDF, archive, spreadsheet, document, presentation, code, config, and data links.

## Impact

Markdown links in chat and other shared Markdown-rendered surfaces are easier to scan while preserving the existing link opening behavior for local files and external URLs.