### PR TITLE
[codex] Smooth message pagination

### DIFF
--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -50,6 +50,11 @@ pub struct ChatRequest {
     /// See Tauri `chat` command — DB stores this while `message` goes to the LLM.
     #[serde(default)]
     pub display_text: Option<String>,
+    /// When true, persists the user row with
+    /// `attachments_meta = {"plan_trigger": true}` so the UI renders it as a
+    /// Plan Mode approve/resume chip (mirrors the Tauri `chat` command).
+    #[serde(default)]
+    pub is_plan_trigger: Option<bool>,
     /// Draft working dir picked before the session was materialized. Only
     /// honored when this call also creates the session (mirrors the Tauri
     /// `chat` command).
@@ -166,7 +171,13 @@ pub async fn chat(
     let persisted_content = ha_core::non_empty_trim_or(body.display_text.as_deref(), &body.message);
 
     // Save user message to DB
-    let user_msg = session::NewMessage::user(persisted_content);
+    let mut user_msg = session::NewMessage::user(persisted_content);
+    // Plan Mode trigger marker — UI renders these as a system chip instead of
+    // a regular user bubble. Mirrors the Tauri command.
+    if body.is_plan_trigger.unwrap_or(false) {
+        user_msg.attachments_meta =
+            Some(serde_json::json!({ "plan_trigger": true }).to_string());
+    }
     let _ = db.append_message(&sid, &user_msg);
 
     // Auto-generate fallback title from first user message (prefer display text so titles read naturally).

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -175,8 +175,7 @@ pub async fn chat(
     // Plan Mode trigger marker — UI renders these as a system chip instead of
     // a regular user bubble. Mirrors the Tauri command.
     if body.is_plan_trigger.unwrap_or(false) {
-        user_msg.attachments_meta =
-            Some(serde_json::json!({ "plan_trigger": true }).to_string());
+        user_msg.attachments_meta = Some(serde_json::json!({ "plan_trigger": true }).to_string());
     }
     let _ = db.append_message(&sid, &user_msg);
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -51,6 +51,10 @@ pub async fn chat(
     // When set, DB stores `display_text` as the user message while `message` is still
     // fed to the LLM (slash-skill passThrough uses this).
     display_text: Option<String>,
+    // When true, the persisted user row is tagged with
+    // `attachments_meta = {"plan_trigger": true}` so the UI can render it as a
+    // system chip instead of a regular user bubble (Plan Mode approve/resume).
+    is_plan_trigger: Option<bool>,
     // Draft working dir picked before the session was materialized. Only honored
     // when this call also creates the session — applies via the same
     // `update_session_working_dir` validation as the explicit setter command.
@@ -214,7 +218,14 @@ pub async fn chat(
 
     // Save user message to DB
     let mut user_msg = session::NewMessage::user(persisted_content);
-    user_msg.attachments_meta = attachments_meta;
+    // Plan Mode trigger marker takes precedence over attachments meta — these
+    // sends never carry user attachments (the LLM-bound `message` is a short
+    // canned trigger, not a real user input).
+    user_msg.attachments_meta = if is_plan_trigger.unwrap_or(false) {
+        Some(serde_json::json!({ "plan_trigger": true }).to_string())
+    } else {
+        attachments_meta
+    };
     let _ = db.append_message(&sid, &user_msg);
 
     // Log chat start

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -855,6 +855,7 @@ export default function ChatScreen({
           stream.handleSend(t("planMode.executeCommand"), {
             planMode: "executing",
             displayText: t("planMode.executionApproved"),
+            isPlanTrigger: true,
           })
           break
         case "showPlan":
@@ -933,6 +934,7 @@ export default function ChatScreen({
     stream.handleSend(t("planMode.executeCommand"), {
       planMode: "executing",
       displayText: t("planMode.executionApproved"),
+      isPlanTrigger: true,
     })
   }, [planMode, stream, t])
 
@@ -940,6 +942,7 @@ export default function ChatScreen({
     stream.handleSend(t("planMode.executeCommand"), {
       planMode: "executing",
       displayText: t("planMode.executionResumed"),
+      isPlanTrigger: true,
     })
   }, [stream, t])
 

--- a/src/components/chat/MessageList.test.tsx
+++ b/src/components/chat/MessageList.test.tsx
@@ -23,26 +23,28 @@ vi.mock("react-i18next", () => ({
 }))
 
 vi.mock("@/components/common/useVirtualFeed", () => ({
-  useVirtualFeed: vi.fn((options: { rows: { key: string }[]; forceFollowKey?: string | number | null }) => {
-    virtualFeedMock.latestOptions = options
-    return {
-      scrollRef: { current: null },
-      virtualizer: {
-        measureElement: vi.fn(),
-        scrollToIndex: vi.fn(),
-      },
-      virtualItems: options.rows.map((row: { key: string }, index: number) => ({
-        index,
-        key: row.key,
-        start: index * 100,
-      })),
-      totalSize: options.rows.length * 100,
-      isAutoFollowPaused: virtualFeedMock.state.isAutoFollowPaused,
-      hasUnseenOutput: virtualFeedMock.state.hasUnseenOutput,
-      resumeAutoFollow: virtualFeedMock.resumeAutoFollow,
-      pauseAutoFollow: virtualFeedMock.pauseAutoFollow,
-    }
-  }),
+  useVirtualFeed: vi.fn(
+    (options: { rows: { key: string }[]; forceFollowKey?: string | number | null }) => {
+      virtualFeedMock.latestOptions = options
+      return {
+        scrollRef: { current: null },
+        virtualizer: {
+          measureElement: vi.fn(),
+          scrollToIndex: vi.fn(),
+        },
+        virtualItems: options.rows.map((row: { key: string }, index: number) => ({
+          index,
+          key: row.key,
+          start: index * 100,
+        })),
+        totalSize: options.rows.length * 100,
+        isAutoFollowPaused: virtualFeedMock.state.isAutoFollowPaused,
+        hasUnseenOutput: virtualFeedMock.state.hasUnseenOutput,
+        resumeAutoFollow: virtualFeedMock.resumeAutoFollow,
+        pauseAutoFollow: virtualFeedMock.pauseAutoFollow,
+      }
+    },
+  ),
 }))
 
 vi.mock("./MessageBubble", () => ({
@@ -182,7 +184,7 @@ describe("MessageList virtualization surface", () => {
       />,
     )
 
-    expect(virtualFeedMock.latestOptions?.forceFollowKey).toBe("user-turn:1:db:2")
+    expect(virtualFeedMock.latestOptions?.forceFollowKey).toBe("user-turn:db:2")
   })
 
   test("forces auto-follow when a newly sent user message already has an assistant placeholder", () => {
@@ -211,7 +213,7 @@ describe("MessageList virtualization surface", () => {
     )
 
     expect(virtualFeedMock.latestOptions?.forceFollowKey).toBe(
-      "user-turn:1:ts:2026-04-26T00:01:00.000Z",
+      "user-turn:ts:2026-04-26T00:01:00.000Z",
     )
   })
 })

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -9,7 +9,7 @@ import MessageContextMenu from "./MessageContextMenu"
 import LoadMoreRow from "./LoadMoreRow"
 import AskUserQuestionBlock from "./ask-user/AskUserQuestionBlock"
 import PlanCardBlock from "./plan-mode/PlanCardBlock"
-import { getLatestUserTurnKey } from "./chatScrollKeys"
+import { getLatestMessageOutputKey, getLatestUserTurnKey } from "./chatScrollKeys"
 import type { AskUserQuestionGroup } from "./ask-user/AskUserQuestionBlock"
 import type { PlanCardData } from "./plan-mode/PlanCardBlock"
 import type { Message, AgentSummaryForSidebar } from "@/types/chat"
@@ -48,7 +48,9 @@ interface MessageListProps {
   onSwitchSession?: (sessionId: string) => void
   /** Open the right-side diff panel for a file change payload. */
   onOpenDiff?: (
-    metadata: import("@/types/chat").FileChangeMetadata | import("@/types/chat").FileChangesMetadata,
+    metadata:
+      | import("@/types/chat").FileChangeMetadata
+      | import("@/types/chat").FileChangesMetadata,
   ) => void
 }
 
@@ -162,9 +164,8 @@ export default function MessageList({
     [rows],
   )
 
-  const lastMsg = messages[messages.length - 1]
   const latestUserTurnKey = getLatestUserTurnKey(messages)
-  const followKey = `${messages.length}:${lastMsg?.role ?? ""}:${lastMsg?.content.length ?? 0}:${lastMsg?.contentBlocks?.length ?? 0}`
+  const followKey = getLatestMessageOutputKey(messages)
   const {
     scrollRef,
     virtualizer,
@@ -190,7 +191,7 @@ export default function MessageList({
     onStartReached: onLoadMore,
     canLoadMore: hasMore,
     loadingMore,
-    startThreshold: 50,
+    startThreshold: 360,
   })
 
   // Close context menu on outside click or scroll

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { ArrowDown, Ghost } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useVirtualFeed } from "@/components/common/useVirtualFeed"
+import { isCenteredSystemMessage } from "./chatUtils"
 import MessageBubble from "./MessageBubble"
 import MessageContextMenu from "./MessageContextMenu"
 import LoadMoreRow from "./LoadMoreRow"
@@ -151,8 +152,11 @@ export default function MessageList({
       if (row.type === "empty") return 240
       if (row.type === "planRunning") return 52
       if (row.type === "askUser" || row.type === "planCard") return 180
+      // Centered system chips (event / sub-agent result / cron / plan trigger)
+      // ride on `role: "user"` rows, so this branch must run before the user
+      // bubble fallback.
+      if (isCenteredSystemMessage(row.msg)) return 48
       if (row.msg.role === "user") return 76
-      if (row.msg.role === "event" || row.msg.isSubagentResult || row.msg.isCronTrigger) return 48
       return 120
     },
     [rows],
@@ -287,7 +291,7 @@ export default function MessageList({
             className={cn(
               "flex rounded-lg transition-colors",
               msg.dbId === highlightMessageId && "message-hit-pulse",
-              msg.role === "event" || msg.isSubagentResult || msg.isCronTrigger
+              isCenteredSystemMessage(msg)
                 ? "justify-center"
                 : msg.role === "user" && !msg.fromAgentId
                   ? "justify-end"

--- a/src/components/chat/QuickChatMessages.test.tsx
+++ b/src/components/chat/QuickChatMessages.test.tsx
@@ -23,24 +23,26 @@ vi.mock("react-i18next", () => ({
 }))
 
 vi.mock("@/components/common/useVirtualFeed", () => ({
-  useVirtualFeed: vi.fn((options: { rows: { key: string }[]; forceFollowKey?: string | number | null }) => {
-    virtualFeedMock.latestOptions = options
-    return {
-      scrollRef: { current: null },
-      virtualizer: {
-        measureElement: vi.fn(),
-      },
-      virtualItems: options.rows.map((row, index) => ({
-        index,
-        key: row.key,
-        start: index * 80,
-      })),
-      totalSize: options.rows.length * 80,
-      isAutoFollowPaused: virtualFeedMock.state.isAutoFollowPaused,
-      hasUnseenOutput: virtualFeedMock.state.hasUnseenOutput,
-      resumeAutoFollow: virtualFeedMock.resumeAutoFollow,
-    }
-  }),
+  useVirtualFeed: vi.fn(
+    (options: { rows: { key: string }[]; forceFollowKey?: string | number | null }) => {
+      virtualFeedMock.latestOptions = options
+      return {
+        scrollRef: { current: null },
+        virtualizer: {
+          measureElement: vi.fn(),
+        },
+        virtualItems: options.rows.map((row, index) => ({
+          index,
+          key: row.key,
+          start: index * 80,
+        })),
+        totalSize: options.rows.length * 80,
+        isAutoFollowPaused: virtualFeedMock.state.isAutoFollowPaused,
+        hasUnseenOutput: virtualFeedMock.state.hasUnseenOutput,
+        resumeAutoFollow: virtualFeedMock.resumeAutoFollow,
+      }
+    },
+  ),
 }))
 
 vi.mock("@/components/common/MarkdownRenderer", () => ({
@@ -101,7 +103,7 @@ describe("QuickChatMessages auto-follow", () => {
       />,
     )
 
-    expect(virtualFeedMock.latestOptions?.forceFollowKey).toBe("user-turn:0:db:1")
+    expect(virtualFeedMock.latestOptions?.forceFollowKey).toBe("user-turn:db:1")
   })
 
   test("forces auto-follow when a newly sent user message already has an assistant placeholder", () => {
@@ -125,7 +127,7 @@ describe("QuickChatMessages auto-follow", () => {
     )
 
     expect(virtualFeedMock.latestOptions?.forceFollowKey).toBe(
-      "user-turn:0:ts:2026-04-26T00:01:00.000Z",
+      "user-turn:ts:2026-04-26T00:01:00.000Z",
     )
   })
 })

--- a/src/components/chat/QuickChatMessages.tsx
+++ b/src/components/chat/QuickChatMessages.tsx
@@ -6,7 +6,7 @@ import { useVirtualFeed } from "@/components/common/useVirtualFeed"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
 import { IconTip } from "@/components/ui/tooltip"
 import LoadMoreRow from "./LoadMoreRow"
-import { getLatestUserTurnKey } from "./chatScrollKeys"
+import { getLatestMessageOutputKey, getLatestUserTurnKey } from "./chatScrollKeys"
 
 interface QuickChatMessagesProps {
   messages: Message[]
@@ -72,13 +72,9 @@ export default function QuickChatMessages({
     [rows],
   )
 
-  const lastMsg = messages[messages.length - 1]
   const latestUserTurnKey = getLatestUserTurnKey(messages)
-  const followKey = `${rows.length}:${lastMsg?.role ?? ""}:${lastMsg?.content.length ?? 0}:${lastMsg?.toolCalls?.length ?? 0}`
-  const canAnchorRow = useCallback(
-    (row: QuickChatRow) => row.type === "message",
-    [],
-  )
+  const followKey = getLatestMessageOutputKey(messages)
+  const canAnchorRow = useCallback((row: QuickChatRow) => row.type === "message", [])
   const {
     scrollRef,
     virtualizer,
@@ -103,6 +99,7 @@ export default function QuickChatMessages({
     onStartReached: onLoadMore,
     canLoadMore: hasMore,
     loadingMore,
+    startThreshold: 180,
   })
   const showJumpToLatest = isAutoFollowPaused && (loading || hasUnseenOutput)
 

--- a/src/components/chat/QuickChatMessages.tsx
+++ b/src/components/chat/QuickChatMessages.tsx
@@ -65,7 +65,7 @@ export default function QuickChatMessages({
       if (!row) return 72
       if (row.type === "loadMore") return 32
       if (row.type === "viewFullChat") return 28
-      if (row.msg.role === "event") return 28
+      if (row.msg.role === "event" || row.msg.isPlanTrigger) return 28
       if (row.msg.role === "user") return 58
       return 72
     },
@@ -128,7 +128,7 @@ export default function QuickChatMessages({
     }
 
     const { msg, originalIndex } = row
-    if (msg.role === "event") {
+    if (msg.role === "event" || msg.isPlanTrigger) {
       return <div className="text-xs text-center text-muted-foreground py-1">{msg.content}</div>
     }
 

--- a/src/components/chat/chatScrollKeys.test.ts
+++ b/src/components/chat/chatScrollKeys.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { getLatestUserTurnKey } from "./chatScrollKeys"
+import { getLatestMessageOutputKey, getLatestUserTurnKey } from "./chatScrollKeys"
 import type { Message } from "@/types/chat"
 
 function message(patch: Partial<Message>): Message {
@@ -24,7 +24,7 @@ describe("getLatestUserTurnKey", () => {
         }),
         message({ role: "assistant", content: "" }),
       ]),
-    ).toBe("user-turn:1:ts:2026-04-26T00:01:00.000Z")
+    ).toBe("user-turn:ts:2026-04-26T00:01:00.000Z")
   })
 
   test("prefers database id when available", () => {
@@ -34,6 +34,22 @@ describe("getLatestUserTurnKey", () => {
         message({ role: "assistant", content: "answer" }),
         message({ role: "user", content: "latest", dbId: 3 }),
       ]),
-    ).toBe("user-turn:2:db:3")
+    ).toBe("user-turn:db:3")
+  })
+
+  test("stays stable when older messages are prepended", () => {
+    const visibleWindow = [
+      message({ role: "assistant", content: "answer", dbId: 20 }),
+      message({ role: "user", content: "latest", dbId: 21 }),
+      message({ role: "assistant", content: "streaming", dbId: 22 }),
+    ]
+    const prepended = [
+      message({ role: "user", content: "older", dbId: 1 }),
+      message({ role: "assistant", content: "older answer", dbId: 2 }),
+      ...visibleWindow,
+    ]
+
+    expect(getLatestUserTurnKey(prepended)).toBe(getLatestUserTurnKey(visibleWindow))
+    expect(getLatestMessageOutputKey(prepended)).toBe(getLatestMessageOutputKey(visibleWindow))
   })
 })

--- a/src/components/chat/chatScrollKeys.ts
+++ b/src/components/chat/chatScrollKeys.ts
@@ -6,11 +6,33 @@ function userTurnIdentity(msg: Message, index: number): string {
   return `idx:${index}`
 }
 
+function messageIdentity(msg: Message, index: number): string {
+  if (typeof msg.dbId === "number") return `db:${msg.dbId}`
+  if (msg.timestamp) return `ts:${msg.timestamp}`
+  return `idx:${index}`
+}
+
 export function getLatestUserTurnKey(messages: Message[]): string | null {
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     const msg = messages[i]
     if (msg.role !== "user") continue
-    return `user-turn:${i}:${userTurnIdentity(msg, i)}`
+    return `user-turn:${userTurnIdentity(msg, i)}`
   }
   return null
+}
+
+export function getLatestMessageOutputKey(messages: Message[]): string | null {
+  const index = messages.length - 1
+  const msg = messages[index]
+  if (!msg) return null
+
+  return [
+    "latest",
+    messageIdentity(msg, index),
+    msg.role,
+    msg.content.length,
+    msg.contentBlocks?.length ?? 0,
+    msg.toolCalls?.length ?? 0,
+    msg.thinking?.length ?? 0,
+  ].join(":")
 }

--- a/src/components/chat/chatUtils.ts
+++ b/src/components/chat/chatUtils.ts
@@ -28,6 +28,18 @@ function parseMediaItemsHeader(result: string): MediaItem[] | undefined {
   return undefined
 }
 
+/** True when a message should render as a centered system chip (event,
+ *  sub-agent result, cron trigger, plan-mode approve/resume) rather than as
+ *  a user/assistant bubble. */
+export function isCenteredSystemMessage(msg: Message): boolean {
+  return (
+    msg.role === "event" ||
+    !!msg.isSubagentResult ||
+    !!msg.isCronTrigger ||
+    !!msg.isPlanTrigger
+  )
+}
+
 /** Format token count: ≥10000 → "12.3k tokens", else "1,234 tokens" */
 export function formatTokens(n: number): string {
   if (n >= 10000) return `${(n / 1000).toFixed(1)}k tokens`
@@ -168,11 +180,12 @@ export function parseSessionMessages(
   let firstUserSeen = false
   for (const msg of msgs) {
     if (msg.role === "user") {
-      // Detect sub-agent result / cron trigger messages via attachments_meta marker
+      // Detect sub-agent result / cron trigger / plan trigger messages via attachments_meta marker
       let isSubagentResult = false
       let subagentResultAgentId: string | undefined
       let isCronTrigger = false
       let cronJobName: string | undefined
+      let isPlanTrigger = false
       let channelInbound: { channelId: string; senderName?: string } | undefined
       if (msg.attachmentsMeta) {
         try {
@@ -184,6 +197,9 @@ export function parseSessionMessages(
           if (meta?.cron_trigger) {
             isCronTrigger = true
             cronJobName = meta.cron_trigger.job_name
+          }
+          if (meta?.plan_trigger) {
+            isPlanTrigger = true
           }
           if (meta?.channel_inbound) {
             channelInbound = {
@@ -207,6 +223,7 @@ export function parseSessionMessages(
         subagentResultAgentId,
         isCronTrigger,
         cronJobName,
+        isPlanTrigger,
         channelInbound,
       })
     } else if (msg.role === "tool" && msg.toolCallId) {

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -41,6 +41,17 @@ function isActiveStreamError(error: unknown): boolean {
   return errorText(error).includes(ACTIVE_STREAM_ERROR_CODE)
 }
 
+interface SendOptions {
+  displayText?: string
+  planMode?: string
+  isPlanTrigger?: boolean
+}
+
+interface PendingSend {
+  text: string
+  options?: SendOptions
+}
+
 export interface UseChatStreamOptions {
   messages: Message[]
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>
@@ -93,10 +104,7 @@ export interface UseChatStreamReturn {
   setShowCodexAuthExpired: React.Dispatch<React.SetStateAction<boolean>>
   permissionMode: SessionMode
   setPermissionMode: React.Dispatch<React.SetStateAction<SessionMode>>
-  handleSend: (
-    directText?: string,
-    options?: { displayText?: string; planMode?: string },
-  ) => Promise<void>
+  handleSend: (directText?: string, options?: SendOptions) => Promise<void>
   handleStop: () => Promise<void>
   handleApprovalResponse: (
     requestId: string,
@@ -132,8 +140,31 @@ export function useChatStream({
   const { t } = useTranslation()
   const [input, setInput] = useState("")
   const [attachedFiles, setAttachedFiles] = useState<File[]>([])
-  const [pendingMessage, setPendingMessage] = useState<string | null>(null)
-  const pendingMessageRef = useRef<string | null>(null)
+  // Pending send queued while a response is streaming. Stores the LLM-bound
+  // `text` plus the original `options` (displayText / planMode / isPlanTrigger)
+  // so the replay path can resend with the exact same metadata — otherwise a
+  // queued plan-mode approve would lose its `isPlanTrigger` flag and render
+  // as a plain user bubble.
+  const [pendingSend, setPendingSendState] = useState<PendingSend | null>(null)
+  const pendingSendRef = useRef<PendingSend | null>(null)
+  // External views: keep the original `pendingMessage: string | null` API for
+  // ChatScreen / ChatInput, derived from the user-facing displayed text.
+  const pendingMessage = pendingSend
+    ? pendingSend.options?.displayText?.trim() || pendingSend.text
+    : null
+  const setPendingMessage = useCallback<
+    React.Dispatch<React.SetStateAction<string | null>>
+  >((value) => {
+    setPendingSendState((prev) => {
+      const next =
+        typeof value === "function"
+          ? (value as (p: string | null) => string | null)(
+              prev ? prev.options?.displayText?.trim() || prev.text : null,
+            )
+          : value
+      return next === null ? null : { text: next }
+    })
+  }, [])
   const [showCodexAuthExpired, setShowCodexAuthExpired] = useState(false)
   const [permissionMode, setPermissionModeState] = useState<SessionMode>("default")
   const permissionModeRef = useRef<SessionMode>("default")
@@ -172,6 +203,11 @@ export function useChatStream({
   // Auto-send pending messages setting
   const autoSendPendingRef = useRef(true)
   const autoSendRef = useRef(false)
+  // Holds a programmatic queued send (Plan Mode approve, slash-skill expansion)
+  // so the auto-send effect can replay it with the original options instead of
+  // rerouting through the input box. User-typed drafts go via `setInput` and
+  // leave this ref null.
+  const queuedReplayRef = useRef<PendingSend | null>(null)
 
   // Delta batch buffer
   const deltaBuffersRef = useRef(createStreamDeltaBuffers())
@@ -205,8 +241,8 @@ export function useChatStream({
 
   // Keep refs in sync
   useEffect(() => {
-    pendingMessageRef.current = pendingMessage
-  }, [pendingMessage])
+    pendingSendRef.current = pendingSend
+  }, [pendingSend])
   useEffect(() => {
     permissionModeRef.current = permissionMode
   }, [permissionMode])
@@ -269,16 +305,16 @@ export function useChatStream({
    * Send a message. If `directText` is provided, use it directly instead of the input box.
    * This avoids flashing text in the input (used by Plan Mode approve).
    */
-  async function handleSend(
-    directText?: string,
-    options?: { displayText?: string; planMode?: string },
-  ) {
+  async function handleSend(directText?: string, options?: SendOptions) {
     const rawText = directText ?? input
     if (!rawText.trim()) return
 
-    // If currently loading, queue the message as pending
+    // If currently loading, queue the message as pending. Capture both the
+    // LLM-bound text and the original options so the replay below resends
+    // with identical metadata (Plan Mode triggers carry `isPlanTrigger`,
+    // slash-skill expansions carry `displayText`, etc.).
     if (loading) {
-      setPendingMessage(rawText.trim())
+      setPendingSendState({ text: rawText.trim(), options })
       if (!directText) setInput("")
       return
     }
@@ -291,7 +327,13 @@ export function useChatStream({
     setInput("")
     setAttachedFiles([])
     const now = new Date().toISOString()
-    setMessages((prev) => [...prev, { role: "user", content: displayed, timestamp: now }])
+    const optimisticUserMessage = {
+      role: "user" as const,
+      content: displayed,
+      timestamp: now,
+      ...(options?.isPlanTrigger && { isPlanTrigger: true }),
+    }
+    setMessages((prev) => [...prev, optimisticUserMessage])
     setLoading(true)
 
     // Process attached files: images → base64 data, non-images → save to disk via Rust
@@ -438,7 +480,7 @@ export function useChatStream({
       // Track loading state for this session
       const freshMessages = [
         ...messages,
-        { role: "user" as const, content: displayed, timestamp: now },
+        optimisticUserMessage,
         {
           role: "assistant" as const,
           content: "",
@@ -469,6 +511,7 @@ export function useChatStream({
           planMode: effectivePlanMode && effectivePlanMode !== "off" ? effectivePlanMode : undefined,
           temperatureOverride: temperatureOverride ?? undefined,
           displayText: options?.displayText?.trim() || undefined,
+          isPlanTrigger: options?.isPlanTrigger,
           workingDir: currentSessionId ? undefined : draftWorkingDir ?? undefined,
         },
         onEvent,
@@ -601,22 +644,46 @@ export function useChatStream({
       reloadSessions()
 
       // Handle pending message after loading finishes
-      if (pendingMessageRef.current) {
-        const pending = pendingMessageRef.current
-        setPendingMessage(null)
-        setInput(pending)
-        if (autoSendPendingRef.current) {
+      const queued = pendingSendRef.current
+      if (queued) {
+        setPendingSendState(null)
+        if (queued.options) {
+          // Programmatic queued send (Plan Mode approve, slash-skill
+          // expansion). Replay through the auto-send effect with the
+          // original options so `isPlanTrigger` / `displayText` / `planMode`
+          // survive — and skip the input box so the LLM-bound text doesn't
+          // leak into what the user is editing. Button-driven, so always
+          // auto-fires regardless of `autoSendPending`.
+          queuedReplayRef.current = queued
           autoSendRef.current = true
+        } else {
+          // User-typed draft queued while loading — restore for editing
+          // / auto-send per the user setting.
+          setInput(queued.text)
+          if (autoSendPendingRef.current) {
+            autoSendRef.current = true
+          }
         }
       }
     }
   }
 
-  // Auto-send: fires after React flushes the input state + loading=false
+  // Auto-send: fires after React flushes the input state + loading=false.
+  // Two replay paths:
+  //   1. `queuedReplayRef` set → programmatic send (Plan Mode approve etc.)
+  //      with the original options preserved.
+  //   2. Otherwise → user-typed draft restored to `input`, dispatched as a
+  //      regular send.
   useEffect(() => {
-    if (autoSendRef.current && input.trim() && !loading) {
+    if (!autoSendRef.current || loading) return
+    const replay = queuedReplayRef.current
+    if (replay) {
       autoSendRef.current = false
-      handleSend()
+      queuedReplayRef.current = null
+      void handleSend(replay.text, replay.options)
+    } else if (input.trim()) {
+      autoSendRef.current = false
+      void handleSend()
     }
   }, [input, loading]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -647,19 +647,18 @@ export function useChatStream({
       const queued = pendingSendRef.current
       if (queued) {
         setPendingSendState(null)
-        if (queued.options) {
+        if (queued.options && (queued.options.isPlanTrigger || autoSendPendingRef.current)) {
           // Programmatic queued send (Plan Mode approve, slash-skill
           // expansion). Replay through the auto-send effect with the
           // original options so `isPlanTrigger` / `displayText` / `planMode`
-          // survive — and skip the input box so the LLM-bound text doesn't
-          // leak into what the user is editing. Button-driven, so always
-          // auto-fires regardless of `autoSendPending`.
+          // survive. Plan triggers are button-driven and should always
+          // continue; slash-skill expansions still respect autoSendPending.
           queuedReplayRef.current = queued
           autoSendRef.current = true
         } else {
-          // User-typed draft queued while loading — restore for editing
-          // / auto-send per the user setting.
-          setInput(queued.text)
+          // User-typed drafts and non-auto-sent programmatic sends are
+          // restored for editing / confirmation using the user-facing text.
+          setInput(queued.options?.displayText?.trim() || queued.text)
           if (autoSendPendingRef.current) {
             autoSendRef.current = true
           }

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -3,7 +3,7 @@ import { getTransport } from "@/lib/transport-provider"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { IconTip } from "@/components/ui/tooltip"
-import { Copy, Check, Info, Network, Timer } from "lucide-react"
+import { Copy, Check, Info, Network, Timer, PlayCircle } from "lucide-react"
 import ChannelIcon from "@/components/common/ChannelIcon"
 import { formatTokens, formatDuration, formatMessageTime, extractModifiedFiles } from "../chatUtils"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
@@ -171,6 +171,15 @@ function MessageBubbleInner({
 
   if (msg.isCronTrigger) {
     return <CronTriggerBubble msg={msg} t={t} />
+  }
+
+  if (msg.isPlanTrigger) {
+    return (
+      <div className="flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-muted/50 border border-border/50 text-xs text-muted-foreground max-w-[80%]">
+        <PlayCircle className="w-3 h-3 shrink-0 text-muted-foreground/80" />
+        <span>{msg.content}</span>
+      </div>
+    )
   }
 
   return (

--- a/src/components/common/useVirtualFeed.test.tsx
+++ b/src/components/common/useVirtualFeed.test.tsx
@@ -19,23 +19,25 @@ const virtualizerMock = vi.hoisted(() => ({
 }))
 
 vi.mock("@tanstack/react-virtual", () => ({
-  useVirtualizer: vi.fn((options: { count: number; getItemKey: (index: number) => string | number }) => {
-    const instance = {
-      scrollToIndex: virtualizerMock.scrollToIndex,
-      measureElement: virtualizerMock.measureElement,
-      getVirtualItems: () =>
-        Array.from({ length: options.count }, (_, index) => ({
-          index,
-          key: options.getItemKey(index),
-          start: index * 40,
-        })),
-      getTotalSize: () => options.count * 40,
-      scrollRect: { height: 300 },
-      shouldAdjustScrollPositionOnItemSizeChange: undefined,
-    }
-    virtualizerMock.latestInstance = instance
-    return instance
-  }),
+  useVirtualizer: vi.fn(
+    (options: { count: number; getItemKey: (index: number) => string | number }) => {
+      const instance = {
+        scrollToIndex: virtualizerMock.scrollToIndex,
+        measureElement: virtualizerMock.measureElement,
+        getVirtualItems: () =>
+          Array.from({ length: options.count }, (_, index) => ({
+            index,
+            key: options.getItemKey(index),
+            start: index * 40,
+          })),
+        getTotalSize: () => options.count * 40,
+        scrollRect: { height: 300 },
+        shouldAdjustScrollPositionOnItemSizeChange: undefined,
+      }
+      virtualizerMock.latestInstance = instance
+      return instance
+    },
+  ),
 }))
 
 interface Row {
@@ -52,9 +54,9 @@ function flushRaf() {
   callbacks.forEach((callback) => callback(performance.now()))
 }
 
-function setScrollMetrics(el: HTMLElement, scrollTop: number) {
+function setScrollMetrics(el: HTMLElement, scrollTop: number, scrollHeight = 1000) {
   Object.defineProperty(el, "scrollHeight", {
-    value: 1000,
+    value: scrollHeight,
     configurable: true,
   })
   Object.defineProperty(el, "clientHeight", {
@@ -69,14 +71,24 @@ function FeedHarness({
   forceFollowKey = null,
   followOutput = false,
   resetKey = "session-a",
+  rowSet = rows,
+  onStartReached,
+  canLoadMore = false,
+  loadingMore = false,
+  startThreshold = 80,
 }: {
   followKey: string
   forceFollowKey?: string | null
   followOutput?: boolean
   resetKey?: string
+  rowSet?: Row[]
+  onStartReached?: () => void | Promise<void>
+  canLoadMore?: boolean
+  loadingMore?: boolean
+  startThreshold?: number
 }) {
   const { scrollRef, isAutoFollowPaused, hasUnseenOutput, resumeAutoFollow } = useVirtualFeed({
-    rows,
+    rows: rowSet,
     getRowKey: (row) => row.id,
     estimateSize: () => 40,
     followKey,
@@ -84,6 +96,10 @@ function FeedHarness({
     followOutput,
     resetKey,
     bottomThreshold: 80,
+    onStartReached,
+    canLoadMore,
+    loadingMore,
+    startThreshold,
   })
 
   return (
@@ -257,5 +273,34 @@ describe("useVirtualFeed auto-follow", () => {
       align: "end",
       behavior: "auto",
     })
+  })
+
+  test("keeps the visible anchor in place when older rows are prepended", () => {
+    const onStartReached = vi.fn()
+    const { rerender } = render(
+      <FeedHarness followKey="a" onStartReached={onStartReached} canLoadMore startThreshold={80} />,
+    )
+    const scroller = screen.getByTestId("scroller")
+
+    setScrollMetrics(scroller, 40, 1000)
+    fireEvent.scroll(scroller)
+
+    expect(onStartReached).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId("paused").textContent).toBe("true")
+
+    setScrollMetrics(scroller, 40, 1040)
+    virtualizerMock.scrollToIndex.mockClear()
+    rerender(
+      <FeedHarness
+        followKey="a"
+        rowSet={[{ id: "older" }, ...rows]}
+        onStartReached={onStartReached}
+        canLoadMore
+        startThreshold={80}
+      />,
+    )
+
+    expect(virtualizerMock.scrollToIndex).toHaveBeenCalledWith(1, { align: "start" })
+    expect(scroller.scrollTop).toBe(80)
   })
 })

--- a/src/components/common/useVirtualFeed.ts
+++ b/src/components/common/useVirtualFeed.ts
@@ -26,6 +26,7 @@ interface UseVirtualFeedOptions<T> {
 interface ScrollAnchor {
   key: RowKey
   offset: number
+  rowCount: number
   scrollHeight: number
   scrollTop: number
 }
@@ -61,7 +62,9 @@ export function useVirtualFeed<T>({
   const lastTouchYRef = useRef<number | null>(null)
   const startLoadPendingRef = useRef(false)
   const pendingAnchorRef = useRef<ScrollAnchor | null>(null)
+  const allowAnchorSizeCorrectionRef = useRef(false)
   const rafIdRef = useRef<number | null>(null)
+  const anchorCorrectionRafRef = useRef<number | null>(null)
   const [isAutoFollowPaused, setIsAutoFollowPausedState] = useState(false)
   const [hasUnseenOutput, setHasUnseenOutputState] = useState(false)
   const [isAtBottom, setIsAtBottomState] = useState(true)
@@ -133,8 +136,10 @@ export function useVirtualFeed<T>({
     useAnimationFrameWithResizeObserver: true,
   })
   virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) => {
+    const shouldMaintainViewport = item.start < (instance.scrollOffset ?? 0)
+    if (allowAnchorSizeCorrectionRef.current) return shouldMaintainViewport
     if (isAutoFollowPausedRef.current) return false
-    return item.start < (instance.scrollOffset ?? 0)
+    return shouldMaintainViewport
   }
 
   const scrollToBottom = useCallback(
@@ -180,16 +185,31 @@ export function useVirtualFeed<T>({
     pendingAnchorRef.current = {
       key: getRowKeyRef.current(row, first.index),
       offset: first.start - el.scrollTop,
+      rowCount: rowsRef.current.length,
       scrollHeight: el.scrollHeight,
       scrollTop: el.scrollTop,
     }
   }, [virtualizer])
+
+  const scheduleAnchorCorrectionEnd = useCallback(() => {
+    if (anchorCorrectionRafRef.current !== null) {
+      cancelAnimationFrame(anchorCorrectionRafRef.current)
+    }
+
+    anchorCorrectionRafRef.current = requestAnimationFrame(() => {
+      anchorCorrectionRafRef.current = requestAnimationFrame(() => {
+        allowAnchorSizeCorrectionRef.current = false
+        anchorCorrectionRafRef.current = null
+      })
+    })
+  }, [])
 
   const triggerStartLoad = useCallback(() => {
     if (!onStartReachedRef.current) return
     if (!canLoadMoreRef.current || loadingMoreRef.current || startLoadPendingRef.current) return
 
     captureAnchor()
+    pauseAutoFollow(false)
     startLoadPendingRef.current = true
     void Promise.resolve(onStartReachedRef.current())
       .catch(() => {
@@ -203,7 +223,7 @@ export function useVirtualFeed<T>({
           pendingAnchorRef.current = null
         }, 250)
       })
-  }, [captureAnchor])
+  }, [captureAnchor, pauseAutoFollow])
 
   useEffect(() => {
     const el = scrollRef.current
@@ -297,25 +317,39 @@ export function useVirtualFeed<T>({
     if (!anchor) return
     const el = scrollRef.current
     if (!el) return
+    if (rows.length === anchor.rowCount && el.scrollHeight === anchor.scrollHeight) return
 
     const index = rows.findIndex((row, i) => getRowKey(row, i) === anchor.key)
-    requestAnimationFrame(() => {
-      const latest = scrollRef.current
-      if (!latest) return
-      if (index >= 0) {
-        virtualizer.scrollToIndex(index, { align: "start" })
-        requestAnimationFrame(() => {
-          const next = scrollRef.current
-          if (!next) return
-          next.scrollTop = Math.max(0, next.scrollTop - anchor.offset)
-        })
-      } else {
-        latest.scrollTop = Math.max(0, anchor.scrollTop + latest.scrollHeight - anchor.scrollHeight)
+    allowAnchorSizeCorrectionRef.current = true
+
+    const fallbackTop = Math.max(0, anchor.scrollTop + el.scrollHeight - anchor.scrollHeight)
+
+    if (index >= 0) {
+      const beforeIndexScrollTop = el.scrollTop
+      virtualizer.scrollToIndex(index, { align: "start" })
+      el.scrollTop =
+        el.scrollTop === beforeIndexScrollTop
+          ? fallbackTop
+          : Math.max(0, el.scrollTop - anchor.offset)
+    } else {
+      el.scrollTop = fallbackTop
+    }
+
+    lastScrollTopRef.current = el.scrollTop
+    updateAtBottom(el)
+    pendingAnchorRef.current = null
+    startLoadPendingRef.current = false
+    scheduleAnchorCorrectionEnd()
+  }, [getRowKey, rows, scheduleAnchorCorrectionEnd, updateAtBottom, virtualizer])
+
+  useEffect(() => {
+    return () => {
+      if (anchorCorrectionRafRef.current !== null) {
+        cancelAnimationFrame(anchorCorrectionRafRef.current)
+        anchorCorrectionRafRef.current = null
       }
-      pendingAnchorRef.current = null
-      startLoadPendingRef.current = false
-    })
-  }, [getRowKey, rows, virtualizer])
+    }
+  }, [])
 
   const lastResetKeyRef = useRef<RowKey | null>(null)
   useLayoutEffect(() => {

--- a/src/components/team/TeamMessageFeed.tsx
+++ b/src/components/team/TeamMessageFeed.tsx
@@ -62,13 +62,12 @@ export function TeamMessageFeed({
     [rows],
   )
 
-  const canAnchorRow = useCallback(
-    (row: TeamFeedRow) => row.type === "message",
-    [],
-  )
+  const canAnchorRow = useCallback((row: TeamFeedRow) => row.type === "message", [])
 
   const lastMessage = messages[messages.length - 1]
-  const followKey = `${messages.length}:${lastMessage?.messageId ?? ""}:${lastMessage?.content.length ?? 0}`
+  const followKey = lastMessage
+    ? `team-latest:${lastMessage.messageId}:${lastMessage.content.length}`
+    : null
   const { scrollRef, virtualizer, virtualItems, totalSize } = useVirtualFeed({
     rows,
     getRowKey,
@@ -83,6 +82,7 @@ export function TeamMessageFeed({
     onStartReached: onLoadMore,
     canLoadMore: hasMore,
     loadingMore,
+    startThreshold: 240,
   })
 
   const handleSend = useCallback(() => {

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -37,6 +37,10 @@ export interface ChatStartArgs {
   planMode?: string;
   temperatureOverride?: number;
   displayText?: string;
+  /** Marks the user message as a Plan Mode approve/resume trigger so the
+   *  backend stamps `attachments_meta = {plan_trigger: true}` and the UI
+   *  renders it as a system chip instead of a regular user bubble. */
+  isPlanTrigger?: boolean;
   workingDir?: string | null;
   // Tauri's invoke serializes extra unknown fields without complaint, and
   // HTTP's POST body is plain JSON — keep this open so HTTP impl can

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -115,6 +115,10 @@ export interface Message {
   subagentResultAgentId?: string
   /** If true, this user message was triggered by a cron job */
   isCronTrigger?: boolean
+  /** If true, this user message is a Plan Mode trigger (approve / resume) —
+   *  sent to the LLM as a normal user turn but rendered as a system chip
+   *  in the UI to distinguish it from real user input. */
+  isPlanTrigger?: boolean
   /** If true, this message is a hidden skill prompt — sent to LLM but not shown in the UI */
   isMeta?: boolean
   /** The cron job name that triggered this message */


### PR DESCRIPTION
## Summary

- Smooth chat message pagination by preserving the visible anchor when older messages load.
- Prevent prepended history from triggering bottom auto-follow in chat, quick chat, and team feeds.
- Preserve queued plan trigger metadata while respecting the auto-send preference for queued skill sends.

## Validation

- Not run during PR creation per request.
- Earlier local validation before this PR: `pnpm typecheck`, targeted Vitest coverage for virtual feed/chat scroll keys/message lists, and Prettier checks.