### PR TITLE
[codex] Unify background task result copy

### DIFF
--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -15,7 +15,6 @@ import { AssistantContentBlocks, AssistantLegacyContent } from "./MessageContent
 import type { Message, AgentSummaryForSidebar } from "@/types/chat"
 import ModelPickerCard from "@/components/chat/ModelPickerCard"
 import ContextBreakdownCard from "@/components/chat/context-view/ContextBreakdownCard"
-import { getToolDisplayName } from "./executionStatus"
 
 export interface MessageBubbleProps {
   msg: Message
@@ -88,24 +87,37 @@ function parseSubagentResultDetail(content: string): string | undefined {
   return match?.[1]?.trim()
 }
 
+function parseSubagentResultStatus(content: string): string {
+  const status = content.match(/^Status:\s*(\S+)/m)?.[1]
+  switch (status) {
+    case "completed":
+      return "completed"
+    case "timeout":
+      return "timed_out"
+    case "killed":
+      return "cancelled"
+    case "running":
+    case "spawning":
+      return "running"
+    case "error":
+      return "failed"
+    default:
+      return "completed"
+  }
+}
+
 function getSubagentResultDisplay(
   msg: Message,
-  agents: AgentSummaryForSidebar[],
   t: TFunction,
 ): { name: string; statusText: string; isToolJob: boolean; detail?: string } {
   const agentId = msg.subagentResultAgentId
+  const name = String(t("chat.asyncToolJobFallbackName"))
   if (agentId?.startsWith(TOOL_JOB_AGENT_PREFIX)) {
     const payload = parseToolJobPayload(msg.content)
-    const toolName = payload?.toolName || agentId.slice(TOOL_JOB_AGENT_PREFIX.length)
     const status =
       payload?.status && TOOL_JOB_STATUSES.has(payload.status) ? payload.status : "completed"
-    const fallbackName = toolName
-      ? getToolDisplayName(t, toolName)
-      : String(t("chat.asyncToolJobFallbackName"))
     return {
-      name: toolName
-        ? String(t(`chat.asyncToolJobNames.${toolName}`, { defaultValue: fallbackName }))
-        : fallbackName,
+      name,
       statusText: String(
         t(`chat.asyncToolJobStatuses.${status}`, {
           defaultValue: t("chat.asyncToolJobStatuses.completed"),
@@ -116,12 +128,14 @@ function getSubagentResultDisplay(
     }
   }
 
+  const status = parseSubagentResultStatus(msg.content)
   return {
-    name:
-      agents.find((a) => a.id === agentId)?.name ||
-      agentId ||
-      String(t("chat.subagent")),
-    statusText: String(t("chat.subagentResultCompleted")),
+    name,
+    statusText: String(
+      t(`chat.asyncToolJobStatuses.${status}`, {
+        defaultValue: t("chat.asyncToolJobStatuses.completed"),
+      }),
+    ),
     isToolJob: false,
     detail: parseSubagentResultDetail(msg.content),
   }
@@ -240,8 +254,7 @@ function MessageBubbleInner({
   }
 
   if (msg.isSubagentResult) {
-    const resultDisplay = getSubagentResultDisplay(msg, agents, t)
-    const ResultIcon = resultDisplay.isToolJob ? Timer : Network
+    const resultDisplay = getSubagentResultDisplay(msg, t)
     const hasDetail = !!resultDisplay.detail
     return (
       <div className="flex flex-col items-center gap-1 w-full max-w-[80%]">
@@ -256,27 +269,15 @@ function MessageBubbleInner({
           className={cn(
             "flex flex-wrap items-center gap-1.5 max-w-full px-3 py-1.5 rounded-full border text-xs transition-colors",
             hasDetail && "cursor-pointer",
-            resultDisplay.isToolJob
-              ? "bg-sky-500/8 border-sky-500/20 text-sky-400/80 hover:bg-sky-500/15"
-              : "bg-purple-500/8 border-purple-500/20 text-purple-400/80 hover:bg-purple-500/15",
+            "bg-sky-500/8 border-sky-500/20 text-sky-400/80 hover:bg-sky-500/15",
             !hasDetail && "disabled:cursor-default",
           )}
         >
-          <ResultIcon
-            className={cn(
-              "w-3 h-3 shrink-0",
-              resultDisplay.isToolJob ? "text-sky-500" : "text-purple-500",
-            )}
-          />
-          <span
-            className={cn(
-              "font-medium",
-              resultDisplay.isToolJob ? "text-sky-500" : "text-purple-500",
-            )}
-          >
+          <Timer className="w-3 h-3 shrink-0 text-sky-500" />
+          <span className="font-medium text-sky-500">
             {resultDisplay.name}
           </span>
-          <span className={resultDisplay.isToolJob ? "text-sky-400/50" : "text-purple-400/50"}>
+          <span className="text-sky-400/50">
             ·
           </span>
           <span>{resultDisplay.statusText}</span>
@@ -285,7 +286,7 @@ function MessageBubbleInner({
               className={cn(
                 "w-3 h-3 shrink-0 transition-transform duration-200",
                 resultExpanded && "rotate-180",
-                resultDisplay.isToolJob ? "text-sky-500/70" : "text-purple-500/70",
+                "text-sky-500/70",
               )}
             />
           )}

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -116,7 +116,7 @@
     "toolCalling": "جارٍ استدعاء الأدوات...",
     "startConversation": "ابدأ محادثة",
     "subagentFrom": "مفوّض من {{agent}}",
-    "subagentResultCompleted": "اكتملت، وأُضيفت النتيجة إلى المحادثة",
+    "subagentResultCompleted": "اكتملت",
     "asyncToolJobFallbackName": "مهمة في الخلفية",
     "asyncToolJobNames": {
       "exec": "تنفيذ أمر",
@@ -126,11 +126,11 @@
       "browser": "إجراء المتصفح"
     },
     "asyncToolJobStatuses": {
-      "completed": "اكتملت، وأُضيفت النتيجة إلى المحادثة",
-      "failed": "فشلت، وأُضيف الخطأ إلى المحادثة",
-      "timed_out": "انتهت المهلة، وأُضيفت التفاصيل إلى المحادثة",
+      "completed": "عادت النتيجة",
+      "failed": "فشل التنفيذ",
+      "timed_out": "انتهت مهلة التنفيذ",
       "cancelled": "أُلغيت",
-      "interrupted": "انقطعت، وأُضيفت التفاصيل إلى المحادثة",
+      "interrupted": "انقطعت",
       "running": "ما زالت قيد التشغيل"
     },
     "newChat": "محادثة جديدة",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -116,7 +116,7 @@
     "toolCalling": "Calling tools...",
     "startConversation": "Start a conversation",
     "subagentFrom": "Invoked by {{agent}}",
-    "subagentResultCompleted": "Completed, result added to this chat",
+    "subagentResultCompleted": "Completed",
     "asyncToolJobFallbackName": "Background task",
     "asyncToolJobNames": {
       "exec": "Command execution",
@@ -126,11 +126,11 @@
       "browser": "Browser action"
     },
     "asyncToolJobStatuses": {
-      "completed": "Completed, result added to this chat",
-      "failed": "Failed, error added to this chat",
-      "timed_out": "Timed out, details added to this chat",
+      "completed": "Result is back",
+      "failed": "Execution failed",
+      "timed_out": "Execution timed out",
       "cancelled": "Cancelled",
-      "interrupted": "Interrupted, details added to this chat",
+      "interrupted": "Interrupted",
       "running": "Still running"
     },
     "newChat": "New Chat",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -116,7 +116,7 @@
     "toolCalling": "Llamando herramientas...",
     "startConversation": "Iniciar conversación",
     "subagentFrom": "Delegado por {{agent}}",
-    "subagentResultCompleted": "Completado, resultado añadido al chat",
+    "subagentResultCompleted": "Completado",
     "asyncToolJobFallbackName": "Tarea en segundo plano",
     "asyncToolJobNames": {
       "exec": "Ejecución de comando",
@@ -126,11 +126,11 @@
       "browser": "Acción del navegador"
     },
     "asyncToolJobStatuses": {
-      "completed": "Completado, resultado añadido al chat",
-      "failed": "Falló, error añadido al chat",
-      "timed_out": "Agotó el tiempo, detalles añadidos al chat",
+      "completed": "El resultado volvió",
+      "failed": "Falló la ejecución",
+      "timed_out": "La ejecución agotó el tiempo",
       "cancelled": "Cancelado",
-      "interrupted": "Interrumpido, detalles añadidos al chat",
+      "interrupted": "Interrumpido",
       "running": "Sigue en ejecución"
     },
     "newChat": "Nuevo chat",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -116,7 +116,7 @@
     "toolCalling": "ツール呼び出し中...",
     "startConversation": "会話を開始",
     "subagentFrom": "{{agent}} からの委任",
-    "subagentResultCompleted": "完了しました。結果をこのチャットに追加しました",
+    "subagentResultCompleted": "完了しました",
     "asyncToolJobFallbackName": "バックグラウンドタスク",
     "asyncToolJobNames": {
       "exec": "コマンド実行",
@@ -126,11 +126,11 @@
       "browser": "ブラウザ操作"
     },
     "asyncToolJobStatuses": {
-      "completed": "完了しました。結果をこのチャットに追加しました",
-      "failed": "失敗しました。エラーをこのチャットに追加しました",
-      "timed_out": "タイムアウトしました。詳細をこのチャットに追加しました",
+      "completed": "結果が戻りました",
+      "failed": "実行に失敗しました",
+      "timed_out": "実行がタイムアウトしました",
       "cancelled": "キャンセルされました",
-      "interrupted": "中断されました。詳細をこのチャットに追加しました",
+      "interrupted": "中断されました",
       "running": "まだ実行中です"
     },
     "newChat": "新しいチャット",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -116,7 +116,7 @@
     "toolCalling": "도구 호출 중...",
     "startConversation": "대화 시작",
     "subagentFrom": "{{agent}} 에서 위임",
-    "subagentResultCompleted": "완료됨, 결과가 대화에 추가됨",
+    "subagentResultCompleted": "완료됨",
     "asyncToolJobFallbackName": "백그라운드 작업",
     "asyncToolJobNames": {
       "exec": "명령 실행",
@@ -126,11 +126,11 @@
       "browser": "브라우저 작업"
     },
     "asyncToolJobStatuses": {
-      "completed": "완료됨, 결과가 대화에 추가됨",
-      "failed": "실패함, 오류가 대화에 추가됨",
-      "timed_out": "시간 초과됨, 세부 정보가 대화에 추가됨",
+      "completed": "결과가 돌아왔습니다",
+      "failed": "실행 실패",
+      "timed_out": "실행 시간 초과",
       "cancelled": "취소됨",
-      "interrupted": "중단됨, 세부 정보가 대화에 추가됨",
+      "interrupted": "중단됨",
       "running": "아직 실행 중"
     },
     "newChat": "새 대화",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -116,7 +116,7 @@
     "toolCalling": "Memanggil alat...",
     "startConversation": "Mulakan perbualan",
     "subagentFrom": "Diberikan kuasa oleh {{agent}}",
-    "subagentResultCompleted": "Siap, hasil ditambahkan ke sembang",
+    "subagentResultCompleted": "Siap",
     "asyncToolJobFallbackName": "Tugasan latar belakang",
     "asyncToolJobNames": {
       "exec": "Pelaksanaan arahan",
@@ -126,11 +126,11 @@
       "browser": "Tindakan pelayar"
     },
     "asyncToolJobStatuses": {
-      "completed": "Siap, hasil ditambahkan ke sembang",
-      "failed": "Gagal, ralat ditambahkan ke sembang",
-      "timed_out": "Tamat masa, butiran ditambahkan ke sembang",
+      "completed": "Hasil telah kembali",
+      "failed": "Pelaksanaan gagal",
+      "timed_out": "Pelaksanaan tamat masa",
       "cancelled": "Dibatalkan",
-      "interrupted": "Terganggu, butiran ditambahkan ke sembang",
+      "interrupted": "Terganggu",
       "running": "Masih berjalan"
     },
     "newChat": "Perbualan baharu",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -116,7 +116,7 @@
     "toolCalling": "Chamando ferramentas...",
     "startConversation": "Iniciar conversa",
     "subagentFrom": "Delegado por {{agent}}",
-    "subagentResultCompleted": "Concluído, resultado adicionado à conversa",
+    "subagentResultCompleted": "Concluído",
     "asyncToolJobFallbackName": "Tarefa em segundo plano",
     "asyncToolJobNames": {
       "exec": "Execução de comando",
@@ -126,11 +126,11 @@
       "browser": "Ação do navegador"
     },
     "asyncToolJobStatuses": {
-      "completed": "Concluído, resultado adicionado à conversa",
-      "failed": "Falhou, erro adicionado à conversa",
-      "timed_out": "Tempo esgotado, detalhes adicionados à conversa",
+      "completed": "O resultado voltou",
+      "failed": "Execução falhou",
+      "timed_out": "Execução expirou",
       "cancelled": "Cancelado",
-      "interrupted": "Interrompido, detalhes adicionados à conversa",
+      "interrupted": "Interrompido",
       "running": "Ainda em execução"
     },
     "newChat": "Nova conversa",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -116,7 +116,7 @@
     "toolCalling": "Вызов инструментов...",
     "startConversation": "Начать разговор",
     "subagentFrom": "Делегировано от {{agent}}",
-    "subagentResultCompleted": "Завершено, результат добавлен в чат",
+    "subagentResultCompleted": "Завершено",
     "asyncToolJobFallbackName": "Фоновая задача",
     "asyncToolJobNames": {
       "exec": "Выполнение команды",
@@ -126,11 +126,11 @@
       "browser": "Действие браузера"
     },
     "asyncToolJobStatuses": {
-      "completed": "Завершено, результат добавлен в чат",
-      "failed": "Сбой, ошибка добавлена в чат",
-      "timed_out": "Время истекло, подробности добавлены в чат",
+      "completed": "Результат вернулся",
+      "failed": "Выполнение не удалось",
+      "timed_out": "Время выполнения истекло",
       "cancelled": "Отменено",
-      "interrupted": "Прервано, подробности добавлены в чат",
+      "interrupted": "Прервано",
       "running": "Всё ещё выполняется"
     },
     "newChat": "Новый чат",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -116,7 +116,7 @@
     "toolCalling": "Araç çağrılıyor...",
     "startConversation": "Sohbet başlat",
     "subagentFrom": "{{agent}} tarafından devredildi",
-    "subagentResultCompleted": "Tamamlandı, sonuç sohbete eklendi",
+    "subagentResultCompleted": "Tamamlandı",
     "asyncToolJobFallbackName": "Arka plan görevi",
     "asyncToolJobNames": {
       "exec": "Komut yürütme",
@@ -126,11 +126,11 @@
       "browser": "Tarayıcı işlemi"
     },
     "asyncToolJobStatuses": {
-      "completed": "Tamamlandı, sonuç sohbete eklendi",
-      "failed": "Başarısız oldu, hata sohbete eklendi",
-      "timed_out": "Zaman aşımına uğradı, ayrıntılar sohbete eklendi",
+      "completed": "Sonuç geri geldi",
+      "failed": "Yürütme başarısız",
+      "timed_out": "Yürütme zaman aşımına uğradı",
       "cancelled": "İptal edildi",
-      "interrupted": "Kesintiye uğradı, ayrıntılar sohbete eklendi",
+      "interrupted": "Kesintiye uğradı",
       "running": "Hâlâ çalışıyor"
     },
     "newChat": "Yeni Sohbet",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -116,7 +116,7 @@
     "toolCalling": "Đang gọi công cụ...",
     "startConversation": "Bắt đầu hội thoại",
     "subagentFrom": "Được ủy quyền bởi {{agent}}",
-    "subagentResultCompleted": "Đã hoàn tất, kết quả đã được thêm vào cuộc trò chuyện",
+    "subagentResultCompleted": "Đã hoàn tất",
     "asyncToolJobFallbackName": "Tác vụ nền",
     "asyncToolJobNames": {
       "exec": "Thực thi lệnh",
@@ -126,11 +126,11 @@
       "browser": "Thao tác trình duyệt"
     },
     "asyncToolJobStatuses": {
-      "completed": "Đã hoàn tất, kết quả đã được thêm vào cuộc trò chuyện",
-      "failed": "Thất bại, lỗi đã được thêm vào cuộc trò chuyện",
-      "timed_out": "Đã hết thời gian, chi tiết đã được thêm vào cuộc trò chuyện",
+      "completed": "Kết quả đã quay lại",
+      "failed": "Thực thi thất bại",
+      "timed_out": "Thực thi hết thời gian",
       "cancelled": "Đã hủy",
-      "interrupted": "Bị gián đoạn, chi tiết đã được thêm vào cuộc trò chuyện",
+      "interrupted": "Bị gián đoạn",
       "running": "Vẫn đang chạy"
     },
     "newChat": "Cuộc trò chuyện mới",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -116,7 +116,7 @@
     "toolCalling": "工具調用中...",
     "startConversation": "開始對話",
     "subagentFrom": "由 {{agent}} 指派",
-    "subagentResultCompleted": "已完成，結果已加入對話",
+    "subagentResultCompleted": "已完成",
     "asyncToolJobFallbackName": "背景任務",
     "asyncToolJobNames": {
       "exec": "命令執行",
@@ -126,12 +126,12 @@
       "browser": "瀏覽器操作"
     },
     "asyncToolJobStatuses": {
-      "completed": "已完成，結果已加入對話",
-      "failed": "失敗了，錯誤已加入對話",
-      "timed_out": "逾時了，詳情已加入對話",
+      "completed": "結果回來了",
+      "failed": "執行失敗",
+      "timed_out": "執行逾時",
       "cancelled": "已取消",
-      "interrupted": "已中斷，詳情已加入對話",
-      "running": "仍在執行"
+      "interrupted": "已中斷",
+      "running": "還在執行"
     },
     "newChat": "新建對話",
     "tasks": "任務",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -116,7 +116,7 @@
     "toolCalling": "工具调用中...",
     "startConversation": "开始对话",
     "subagentFrom": "由 {{agent}} 指派",
-    "subagentResultCompleted": "已完成，结果已加入对话",
+    "subagentResultCompleted": "已完成",
     "asyncToolJobFallbackName": "后台任务",
     "asyncToolJobNames": {
       "exec": "命令执行",
@@ -126,12 +126,12 @@
       "browser": "浏览器操作"
     },
     "asyncToolJobStatuses": {
-      "completed": "已完成，结果已加入对话",
-      "failed": "失败了，错误已加入对话",
-      "timed_out": "超时了，详情已加入对话",
+      "completed": "结果回来了",
+      "failed": "执行失败",
+      "timed_out": "执行超时",
       "cancelled": "已取消",
-      "interrupted": "已中断，详情已加入对话",
-      "running": "仍在运行"
+      "interrupted": "已中断",
+      "running": "还在运行"
     },
     "newChat": "新建对话",
     "tasks": "任务",


### PR DESCRIPTION
## Summary
- Use one main chip label for async tool and sub-agent result injections: background task.
- Map async tool statuses and sub-agent statuses to the same localized status copy.
- Make success read as a returned background result, e.g. `后台任务 · 结果回来了`, while failures read as concise execution states.

## Impact
- Users can immediately tell this is a background task result coming back, without seeing internal tool or sub-agent implementation names.
- Details remain available through the expandable result panel.

## Checks
- Not run per request.