### PR TITLE
[codex] Fix message usage details popover

### DIFF
--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -559,7 +559,7 @@ export default function ChatTitleBar({
                           {t("chat.lastRoundInputTokens")}
                         </span>
                         <span className="font-medium text-foreground tabular-nums">
-                          ⚡️{t("chat.statusCacheHit")} {formatCompactTokenCount(lastInput)}
+                          {formatCompactTokenCount(lastInput)}
                         </span>
                       </div>
                     )}

--- a/src/components/chat/chatUtils.ts
+++ b/src/components/chat/chatUtils.ts
@@ -40,10 +40,10 @@ export function isCenteredSystemMessage(msg: Message): boolean {
   )
 }
 
-/** Format token count: ≥10000 → "12.3k tokens", else "1,234 tokens" */
+/** Format token count: ≥10000 → "12.3k", else "1,234". */
 export function formatTokens(n: number): string {
-  if (n >= 10000) return `${(n / 1000).toFixed(1)}k tokens`
-  return `${n.toLocaleString()} tokens`
+  if (n >= 10000) return `${(n / 1000).toFixed(1)}k`
+  return n.toLocaleString()
 }
 
 /** Fold a streaming `usage` event into an existing `MessageUsage`. Shared

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -504,15 +504,15 @@ function MessageBubbleInner({
                   </button>
                 </IconTip>
                 {detailsIndex === index && (
-                  <div className="absolute bottom-full mb-1 z-50 min-w-[220px] rounded-lg border border-border bg-popover p-2.5 shadow-lg left-0">
+                  <div className="absolute bottom-full left-0 z-50 mb-1 w-64 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover p-2.5 shadow-lg">
                     <div className="space-y-1.5 text-xs">
                       {msg.model && (
-                        <div className="flex items-center justify-between gap-3">
+                        <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                           <span className="text-muted-foreground whitespace-nowrap shrink-0">
                             {t("chat.statusModel")}
                           </span>
                           <IconTip label={msg.model}>
-                            <span className="font-medium text-foreground truncate max-w-[160px]">
+                            <span className="block truncate text-right font-medium text-foreground">
                               {msg.model}
                             </span>
                           </IconTip>
@@ -531,23 +531,23 @@ function MessageBubbleInner({
                         if (inputTokens == null) return null
                         return (
                           <>
-                            <div className="flex items-center justify-between gap-3">
+                            <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                               <span className="text-muted-foreground whitespace-nowrap shrink-0">
                                 {showLastInput
                                   ? t("chat.inputTokensCumulative")
                                   : t("chat.inputTokens")}
                               </span>
-                              <span className="font-medium text-foreground tabular-nums">
+                              <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
                                 {formatTokens(inputTokens)}
                               </span>
                             </div>
                             {showLastInput && lastInputTokens != null && (
-                              <div className="flex items-center justify-between gap-3">
+                              <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                                 <span className="text-muted-foreground whitespace-nowrap shrink-0">
                                   {t("chat.lastRoundInputTokens")}
                                 </span>
-                                <span className="font-medium text-foreground tabular-nums">
-                                  ⚡️{t("chat.statusCacheHit")} {formatTokens(lastInputTokens)}
+                                <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                                  {formatTokens(lastInputTokens)}
                                 </span>
                               </div>
                             )}
@@ -555,11 +555,11 @@ function MessageBubbleInner({
                         )
                       })()}
                       {msg.usage?.outputTokens != null && (
-                        <div className="flex items-center justify-between gap-3">
+                        <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                           <span className="text-muted-foreground whitespace-nowrap shrink-0">
                             {t("chat.outputTokens")}
                           </span>
-                          <span className="font-medium text-foreground tabular-nums">
+                          <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
                             {formatTokens(msg.usage.outputTokens)}
                           </span>
                         </div>
@@ -567,22 +567,22 @@ function MessageBubbleInner({
                       {msg.usage?.inputTokens != null && msg.usage?.outputTokens != null && (
                         <>
                           <div className="border-t border-border" />
-                          <div className="flex items-center justify-between gap-3">
+                          <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                             <span className="text-muted-foreground whitespace-nowrap shrink-0">
                               {t("chat.totalTokens")}
                             </span>
-                            <span className="font-medium text-foreground tabular-nums">
+                            <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
                               {formatTokens(msg.usage.inputTokens + msg.usage.outputTokens)}
                             </span>
                           </div>
                         </>
                       )}
                       {msg.usage?.durationMs != null && (
-                        <div className="flex items-center justify-between gap-3">
+                        <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                           <span className="text-muted-foreground whitespace-nowrap shrink-0">
                             {t("chat.duration")}
                           </span>
-                          <span className="font-medium text-foreground tabular-nums">
+                          <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
                             {formatDuration(msg.usage.durationMs)}
                           </span>
                         </div>

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -240,7 +240,7 @@
     "openFile": "انقر لفتح الملف",
     "revealInFolder": "إظهار في المجلد",
     "inputTokens": "إدخال",
-    "inputTokensCumulative": "الإدخال التراكمي",
+    "inputTokensCumulative": "إجمالي الإدخال",
     "lastRoundInputTokens": "إدخال الجولة الأخيرة",
     "outputTokens": "إخراج",
     "totalTokens": "الإجمالي",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -240,7 +240,7 @@
     "openFile": "Click to open file",
     "revealInFolder": "Reveal in folder",
     "inputTokens": "Input",
-    "inputTokensCumulative": "Cumulative input",
+    "inputTokensCumulative": "Total input",
     "lastRoundInputTokens": "Last-round input",
     "outputTokens": "Output",
     "totalTokens": "Total",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -240,7 +240,7 @@
     "openFile": "Hacer clic para abrir el archivo",
     "revealInFolder": "Mostrar en la carpeta",
     "inputTokens": "Entrada",
-    "inputTokensCumulative": "Entrada acumulada",
+    "inputTokensCumulative": "Entrada total",
     "lastRoundInputTokens": "Entrada de la última ronda",
     "outputTokens": "Salida",
     "totalTokens": "Total",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -240,7 +240,7 @@
     "openFile": "クリックしてファイルを開く",
     "revealInFolder": "フォルダーで表示",
     "inputTokens": "入力",
-    "inputTokensCumulative": "累積入力",
+    "inputTokensCumulative": "入力合計",
     "lastRoundInputTokens": "最終ラウンド入力",
     "outputTokens": "出力",
     "totalTokens": "合計",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -240,7 +240,7 @@
     "openFile": "클릭하여 파일 열기",
     "revealInFolder": "폴더에서 표시",
     "inputTokens": "입력",
-    "inputTokensCumulative": "누적 입력",
+    "inputTokensCumulative": "총 입력",
     "lastRoundInputTokens": "마지막 라운드 입력",
     "outputTokens": "출력",
     "totalTokens": "합계",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -240,7 +240,7 @@
     "openFile": "Klik untuk buka fail",
     "revealInFolder": "Tunjuk dalam folder",
     "inputTokens": "Input",
-    "inputTokensCumulative": "Input terkumpul",
+    "inputTokensCumulative": "Jumlah input",
     "lastRoundInputTokens": "Input pusingan akhir",
     "outputTokens": "Output",
     "totalTokens": "Jumlah",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -240,7 +240,7 @@
     "openFile": "Clique para abrir o arquivo",
     "revealInFolder": "Mostrar na pasta",
     "inputTokens": "Entrada",
-    "inputTokensCumulative": "Entrada acumulada",
+    "inputTokensCumulative": "Entrada total",
     "lastRoundInputTokens": "Entrada da última rodada",
     "outputTokens": "Saída",
     "totalTokens": "Total",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -240,7 +240,7 @@
     "openFile": "Нажмите, чтобы открыть файл",
     "revealInFolder": "Показать в папке",
     "inputTokens": "Ввод",
-    "inputTokensCumulative": "Накопленный ввод",
+    "inputTokensCumulative": "Всего ввода",
     "lastRoundInputTokens": "Ввод последнего раунда",
     "outputTokens": "Вывод",
     "totalTokens": "Всего",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -240,7 +240,7 @@
     "openFile": "Dosyayı açmak için tıklayın",
     "revealInFolder": "Klasörde göster",
     "inputTokens": "Giriş",
-    "inputTokensCumulative": "Kümülatif giriş",
+    "inputTokensCumulative": "Toplam giriş",
     "lastRoundInputTokens": "Son tur girişi",
     "outputTokens": "Çıkış",
     "totalTokens": "Toplam",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -240,7 +240,7 @@
     "openFile": "Nhấn để mở tệp",
     "revealInFolder": "Hiện trong thư mục",
     "inputTokens": "Đầu vào",
-    "inputTokensCumulative": "Đầu vào tích lũy",
+    "inputTokensCumulative": "Tổng đầu vào",
     "lastRoundInputTokens": "Đầu vào vòng cuối",
     "outputTokens": "Đầu ra",
     "totalTokens": "Tổng",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -240,7 +240,7 @@
     "openFile": "點擊打開文件",
     "revealInFolder": "打開所在文件夾",
     "inputTokens": "輸入",
-    "inputTokensCumulative": "累計輸入",
+    "inputTokensCumulative": "輸入總計",
     "lastRoundInputTokens": "最後一輪輸入",
     "outputTokens": "輸出",
     "totalTokens": "總計",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -240,7 +240,7 @@
     "openFile": "点击打开文件",
     "revealInFolder": "打开所在文件夹",
     "inputTokens": "输入",
-    "inputTokensCumulative": "累计输入",
+    "inputTokensCumulative": "输入总计",
     "lastRoundInputTokens": "最后一轮输入",
     "outputTokens": "输出",
     "totalTokens": "总计",


### PR DESCRIPTION
## Summary

- Tighten the assistant message usage details popover into a fixed two-column layout so large values stay aligned and do not wrap awkwardly.
- Remove the redundant `tokens` suffix from message-level usage values to match the session details display.
- Rename the cumulative input label to a clearer "Total input" meaning across all locales.
- Remove the misleading cache-hit prefix from "last-round input" in both message details and session details.

## Why

The details popover could wrap the last-round input value in a confusing way, and the previous `⚡ Hit` prefix suggested the value was cache-hit usage even though it was actually the model's last-round input size.

## Impact

Users should see a cleaner usage details popover with clearer token accounting labels. Real cache write/hit metrics remain in the session details cache section when providers report those fields.

## Validation

- `git diff --check`
- locale JSON parse check
- `node scripts/sync-i18n.mjs --check`
- `pnpm typecheck`

## Notes

The branch was pushed with `HA_SKIP_PREPUSH=1` per request, so the full pre-push suite was not rerun after cleaning the PR branch.