### PR TITLE
[codex] Persist session Think effort

### DIFF
--- a/crates/ha-core/src/agent/config.rs
+++ b/crates/ha-core/src/agent/config.rs
@@ -165,13 +165,19 @@ pub async fn live_reasoning_effort(fallback: Option<&str>) -> Option<String> {
     fallback.map(|s| s.to_string())
 }
 
+pub const VALID_REASONING_EFFORTS: [&str; 6] =
+    ["none", "minimal", "low", "medium", "high", "xhigh"];
+
+pub fn is_valid_reasoning_effort(effort: &str) -> bool {
+    VALID_REASONING_EFFORTS.contains(&effort)
+}
+
 /// Clamp reasoning effort to valid range for the given model
 pub fn clamp_reasoning_effort(model: &str, effort: &str) -> Option<String> {
     if effort == "none" {
         return None;
     }
-    let efforts = ["minimal", "low", "medium", "high", "xhigh"];
-    if !efforts.contains(&effort) {
+    if !is_valid_reasoning_effort(effort) {
         return Some("medium".to_string());
     }
     if model.contains("5.1-codex-mini") {

--- a/crates/ha-core/src/agent/mod.rs
+++ b/crates/ha-core/src/agent/mod.rs
@@ -21,7 +21,7 @@ mod types;
 // Re-export public API
 pub use config::{
     build_api_url, get_codex_models, is_complete_endpoint_url, is_valid_codex_model,
-    live_reasoning_effort, USER_AGENT,
+    is_valid_reasoning_effort, live_reasoning_effort, USER_AGENT, VALID_REASONING_EFFORTS,
 };
 pub use config::{build_system_prompt, build_system_prompt_with_session};
 pub(crate) use context::build_compaction_provider;

--- a/crates/ha-core/src/awareness/collect.rs
+++ b/crates/ha-core/src/awareness/collect.rs
@@ -233,6 +233,7 @@ mod tests {
             provider_id: None,
             provider_name: None,
             model_id: None,
+            reasoning_effort: None,
             created_at: "2025-01-01T00:00:00Z".into(),
             updated_at: "2025-01-01T00:00:00Z".into(),
             message_count: 0,

--- a/crates/ha-core/src/channel/worker/dispatcher.rs
+++ b/crates/ha-core/src/channel/worker/dispatcher.rs
@@ -476,6 +476,18 @@ async fn handle_inbound_message(
 
     // 8. Convert inbound media to agent Attachments
     let attachments = convert_inbound_media_to_attachments(&msg.media, &session_id);
+    let reasoning_effort = session_db
+        .get_session(&session_id)
+        .ok()
+        .flatten()
+        .and_then(|meta| meta.reasoning_effort)
+        .or(crate::agent::live_reasoning_effort(None).await);
+    if let (Some(cell), Some(effort)) = (
+        crate::get_reasoning_effort_cell(),
+        reasoning_effort.as_ref(),
+    ) {
+        *cell.lock().await = effort.clone();
+    }
 
     let engine_params = crate::chat_engine::ChatEngineParams {
         session_id: session_id.clone(),
@@ -489,7 +501,7 @@ async fn handle_inbound_message(
         resolved_temperature,
         compact_config: store.compact.clone(),
         extra_system_context: Some(channel_context),
-        reasoning_effort: crate::agent::live_reasoning_effort(None).await,
+        reasoning_effort,
         cancel: match crate::globals::get_channel_cancels() {
             Some(reg) => reg.register(&session_id),
             None => Arc::new(AtomicBool::new(false)),

--- a/crates/ha-core/src/channel/worker/slash.rs
+++ b/crates/ha-core/src/channel/worker/slash.rs
@@ -193,8 +193,19 @@ pub(super) async fn dispatch_slash_for_channel(
         Some(CommandAction::SetEffort { effort }) => {
             if let Err(e) = set_reasoning_effort_core(&effort).await {
                 app_warn!("channel", "worker", "Failed to set effort: {}", e);
-            } else if let Some(bus) = crate::get_event_bus() {
-                bus.emit("slash:effort_changed", serde_json::json!(effort));
+            } else {
+                if let Some(db) = crate::get_session_db() {
+                    let _ = db.update_session_reasoning_effort(session_id, Some(&effort));
+                }
+                if let Some(bus) = crate::get_event_bus() {
+                    bus.emit(
+                        "slash:effort_changed",
+                        serde_json::json!({
+                            "sessionId": session_id,
+                            "effort": effort,
+                        }),
+                    );
+                }
             }
             Ok(ChannelSlashOutcome::Reply {
                 content: result.content,
@@ -419,11 +430,11 @@ async fn set_active_model_core(provider_id: &str, model_id: &str) -> Result<(), 
 
 /// Set reasoning effort. Equivalent to the old `commands::auth::set_reasoning_effort_core`.
 async fn set_reasoning_effort_core(effort: &str) -> Result<(), String> {
-    let valid = ["none", "low", "medium", "high", "xhigh"];
-    if !valid.contains(&effort) {
+    if !crate::agent::is_valid_reasoning_effort(effort) {
         return Err(format!(
             "Invalid reasoning effort: {}. Valid: {:?}",
-            effort, valid
+            effort,
+            crate::agent::VALID_REASONING_EFFORTS
         ));
     }
     let cell = crate::require_reasoning_effort_cell().map_err(|e| e.to_string())?;

--- a/crates/ha-core/src/session/db.rs
+++ b/crates/ha-core/src/session/db.rs
@@ -33,7 +33,7 @@ const SESSION_META_SELECT: &str = "SELECT s.id, s.title, s.agent_id, s.provider_
            ) as has_error,
            s.is_cron, s.parent_session_id, s.plan_mode, s.project_id, s.permission_mode, s.incognito,
            cc.channel_id, cc.account_id, cc.chat_id, cc.chat_type, cc.sender_name,
-           s.working_dir, s.title_source
+           s.working_dir, s.title_source, s.reasoning_effort
      FROM sessions s
      LEFT JOIN channel_conversations cc ON cc.session_id = s.id";
 
@@ -62,6 +62,7 @@ impl SessionDB {
                 provider_id TEXT,
                 provider_name TEXT,
                 model_id TEXT,
+                reasoning_effort TEXT,
                 created_at TEXT NOT NULL,
                 updated_at TEXT NOT NULL,
                 context_json TEXT,
@@ -324,6 +325,15 @@ impl SessionDB {
             .is_ok();
         if !has_working_dir {
             conn.execute_batch("ALTER TABLE sessions ADD COLUMN working_dir TEXT;")?;
+        }
+
+        // Migration: per-session Think / reasoning effort override so the
+        // chat input restores the user's choice after switching sessions.
+        let has_reasoning_effort = conn
+            .prepare("SELECT reasoning_effort FROM sessions LIMIT 1")
+            .is_ok();
+        if !has_reasoning_effort {
+            conn.execute_batch("ALTER TABLE sessions ADD COLUMN reasoning_effort TEXT;")?;
         }
 
         // Migration: track who last set the session title so automatic LLM
@@ -791,6 +801,7 @@ impl SessionDB {
             provider_id: None,
             provider_name: None,
             model_id: None,
+            reasoning_effort: None,
             created_at: now.clone(),
             updated_at: now,
             message_count: 0,
@@ -1230,6 +1241,7 @@ impl SessionDB {
             provider_id: row.get(3)?,
             provider_name: row.get(4)?,
             model_id: row.get(5)?,
+            reasoning_effort: row.get(24).ok().flatten(),
             created_at: row.get(6)?,
             updated_at: row.get(7)?,
             message_count: row.get(8)?,
@@ -1512,6 +1524,23 @@ impl SessionDB {
         Ok(())
     }
 
+    /// Update the session-scoped Think / reasoning effort override.
+    pub fn update_session_reasoning_effort(
+        &self,
+        session_id: &str,
+        reasoning_effort: Option<&str>,
+    ) -> Result<()> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+        conn.execute(
+            "UPDATE sessions SET reasoning_effort = ?1 WHERE id = ?2",
+            params![reasoning_effort, session_id],
+        )?;
+        Ok(())
+    }
+
     /// Update the plan mode state for a session.
     pub fn update_session_plan_mode(
         &self,
@@ -1584,7 +1613,7 @@ impl SessionDB {
     }
 
     /// Narrow read of just `sessions.permission_mode` — avoids the full
-    /// `SESSION_META_SELECT` (22+ cols, 2 COUNT subqueries, channel JOIN)
+    /// `SESSION_META_SELECT` (24+ cols, 2 COUNT subqueries, channel JOIN)
     /// when callers only need the mode (e.g. `/permission` echo).
     pub fn get_session_permission_mode(
         &self,

--- a/crates/ha-core/src/session/types.rs
+++ b/crates/ha-core/src/session/types.rs
@@ -43,6 +43,10 @@ pub struct SessionMeta {
     pub provider_id: Option<String>,
     pub provider_name: Option<String>,
     pub model_id: Option<String>,
+    /// Per-session Think / reasoning effort override. `None` falls back to
+    /// the runtime default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
     pub created_at: String,
     pub updated_at: String,
     pub message_count: i64,
@@ -440,6 +444,7 @@ mod tests {
             provider_id: None,
             provider_name: None,
             model_id: None,
+            reasoning_effort: None,
             created_at: "2026-05-01T00:00:00Z".to_string(),
             updated_at: "2026-05-01T00:00:00Z".to_string(),
             message_count: 0,

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -182,6 +182,28 @@ pub async fn chat(
             .map_err(|e| AppError::bad_request(e.to_string()))?;
     }
 
+    let requested_effort = body
+        .reasoning_effort
+        .as_deref()
+        .map(str::trim)
+        .filter(|effort| !effort.is_empty())
+        .map(str::to_string);
+    let session_effort = db.get_session(&sid)?.and_then(|meta| meta.reasoning_effort);
+    let effort = requested_effort
+        .or(session_effort)
+        .unwrap_or_else(|| "medium".to_string());
+    if !ha_core::agent::is_valid_reasoning_effort(&effort) {
+        return Err(AppError::bad_request(format!(
+            "Invalid reasoning effort: {}. Valid: {:?}",
+            effort,
+            ha_core::agent::VALID_REASONING_EFFORTS
+        )));
+    }
+    db.update_session_reasoning_effort(&sid, Some(&effort))?;
+    if let Some(cell) = ha_core::get_reasoning_effort_cell() {
+        *cell.lock().await = effort.clone();
+    }
+
     let _active_turn_guard = ha_core::chat_engine::active_turn::try_acquire(
         &sid,
         ha_core::chat_engine::stream_seq::ChatSource::Http,
@@ -257,10 +279,6 @@ pub async fn chat(
             .and_then(|def| def.config.model.temperature)
             .or(store.temperature)
     });
-
-    let effort = body
-        .reasoning_effort
-        .unwrap_or_else(|| "medium".to_string());
 
     // Create per-session cancel flag
     let cancel = Arc::new(AtomicBool::new(false));

--- a/crates/ha-server/src/routes/models.rs
+++ b/crates/ha-server/src/routes/models.rs
@@ -4,13 +4,16 @@
 //! `/api/providers/*` endpoints, but live under `/api/models/*` to match the
 //! frontend `COMMAND_MAP` expectations (see `src/lib/transport-http.ts`).
 
+use axum::extract::State;
 use axum::Json;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::sync::Arc;
 
 use ha_core::provider::{self, ActiveModel, AvailableModel, ProviderWriteError};
 
 use crate::error::AppError;
+use crate::AppContext;
 
 fn provider_write_error(err: ProviderWriteError) -> AppError {
     match err {
@@ -37,8 +40,11 @@ pub struct SetFallbackBody {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SetReasoningEffortBody {
     pub effort: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -98,19 +104,30 @@ pub async fn set_fallback_models(
     Ok(Json(json!({ "updated": true })))
 }
 
-/// `POST /api/models/reasoning-effort` — validate + accept a reasoning
-/// effort value. Server mode is stateless (each `/api/chat` request carries
-/// its own `reasoning_effort` field) so this is a validate-only no-op
-/// mirroring the Tauri command's `set_reasoning_effort_core` gate.
+/// `POST /api/models/reasoning-effort` — validate and persist the current
+/// Think / reasoning effort. When `sessionId` is supplied, it is also stored
+/// as a session-scoped override so switching conversations restores it.
 pub async fn set_reasoning_effort(
+    State(ctx): State<Arc<AppContext>>,
     Json(body): Json<SetReasoningEffortBody>,
 ) -> Result<Json<Value>, AppError> {
-    let valid = ["none", "low", "medium", "high", "xhigh"];
-    if !valid.contains(&body.effort.as_str()) {
+    if !ha_core::agent::is_valid_reasoning_effort(&body.effort) {
         return Err(AppError::bad_request(format!(
             "Invalid reasoning effort: {}. Valid: {:?}",
-            body.effort, valid
+            body.effort,
+            ha_core::agent::VALID_REASONING_EFFORTS
         )));
+    }
+    if let Some(cell) = ha_core::get_reasoning_effort_cell() {
+        *cell.lock().await = body.effort.clone();
+    }
+    if let Some(session_id) = body
+        .session_id
+        .as_deref()
+        .filter(|id| !id.trim().is_empty())
+    {
+        ctx.session_db
+            .update_session_reasoning_effort(session_id, Some(&body.effort))?;
     }
     Ok(Json(json!({ "ok": true })))
 }
@@ -123,9 +140,14 @@ pub async fn get_current_settings() -> Result<Json<CurrentSettings>, AppError> {
         .as_ref()
         .map(|am| am.model_id.clone())
         .unwrap_or_else(|| "unknown".to_string());
+    let reasoning_effort = if let Some(cell) = ha_core::get_reasoning_effort_cell() {
+        cell.lock().await.clone()
+    } else {
+        "medium".to_string()
+    };
     Ok(Json(CurrentSettings {
         model,
-        reasoning_effort: "medium".to_string(),
+        reasoning_effort,
         temperature: store.temperature,
         fallback_models: store.fallback_models.clone(),
         active_model: store.active_model.clone(),

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -281,11 +281,11 @@ pub(crate) async fn set_reasoning_effort_core(
     effort: &str,
     state: &AppState,
 ) -> Result<(), CmdError> {
-    let valid = ["none", "low", "medium", "high", "xhigh"];
-    if !valid.contains(&effort) {
+    if !ha_core::agent::is_valid_reasoning_effort(effort) {
         return Err(CmdError::msg(format!(
             "Invalid reasoning effort: {}. Valid: {:?}",
-            effort, valid
+            effort,
+            ha_core::agent::VALID_REASONING_EFFORTS
         )));
     }
     *state.reasoning_effort.lock().await = effort.to_string();
@@ -295,7 +295,14 @@ pub(crate) async fn set_reasoning_effort_core(
 #[tauri::command]
 pub async fn set_reasoning_effort(
     effort: String,
+    session_id: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), CmdError> {
-    set_reasoning_effort_core(&effort, &state).await
+    set_reasoning_effort_core(&effort, &state).await?;
+    if let Some(session_id) = session_id.as_deref().filter(|id| !id.trim().is_empty()) {
+        state
+            .session_db
+            .update_session_reasoning_effort(session_id, Some(&effort))?;
+    }
+    Ok(())
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -48,6 +48,7 @@ pub async fn chat(
     permission_mode: Option<ha_core::permission::SessionMode>,
     plan_mode: Option<String>,
     temperature_override: Option<f64>,
+    reasoning_effort: Option<String>,
     // When set, DB stores `display_text` as the user message while `message` is still
     // fed to the LLM (slash-skill passThrough uses this).
     display_text: Option<String>,
@@ -72,8 +73,6 @@ pub async fn chat(
     // Capture optional permission mode — applied below once we have a session id.
     let permission_mode_pending = permission_mode;
 
-    let effort = state.reasoning_effort.lock().await.clone();
-    let effort_ref_str = effort.clone();
     let db = state.session_db.clone();
     let cancel = state.chat_cancel.clone();
     let logger = state.logger.clone();
@@ -98,6 +97,25 @@ pub async fn chat(
             meta.id
         }
     };
+
+    let requested_effort = reasoning_effort
+        .as_deref()
+        .map(str::trim)
+        .filter(|effort| !effort.is_empty())
+        .map(str::to_string);
+    let session_effort = db.get_session(&sid)?.and_then(|meta| meta.reasoning_effort);
+    let global_effort = state.reasoning_effort.lock().await.clone();
+    let effort = requested_effort.or(session_effort).unwrap_or(global_effort);
+    if !ha_core::agent::is_valid_reasoning_effort(&effort) {
+        return Err(CmdError::msg(format!(
+            "Invalid reasoning effort: {}. Valid: {:?}",
+            effort,
+            ha_core::agent::VALID_REASONING_EFFORTS
+        )));
+    }
+    *state.reasoning_effort.lock().await = effort.clone();
+    db.update_session_reasoning_effort(&sid, Some(&effort))?;
+    let effort_ref_str = effort.clone();
 
     // Apply draft working dir picked before the session existed. Only honored on
     // the auto-create branch — explicit-session callers must use

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -565,6 +565,7 @@ mod tests {
             provider_id: None,
             provider_name: None,
             model_id: None,
+            reasoning_effort: None,
             created_at: "2026-05-01T00:00:00Z".to_string(),
             updated_at: "2026-05-01T00:00:00Z".to_string(),
             message_count: 0,

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -179,6 +179,20 @@ export default function ChatScreen({
   const handleNewChatInProject = session.handleNewChatInProject
   const currentSessionId = session.currentSessionId
   const setAgentName = session.setAgentName
+  const updateSessionMeta = session.updateSessionMeta
+
+  const handleSessionEffortChange = useCallback(
+    async (effort: string) => {
+      const sid = session.currentSessionId
+      if (sid) {
+        updateSessionMeta(sid, (prev) =>
+          prev.reasoningEffort === effort ? prev : { ...prev, reasoningEffort: effort },
+        )
+      }
+      await handleEffortChange(effort, sid)
+    },
+    [handleEffortChange, session.currentSessionId, updateSessionMeta],
+  )
 
   const handleStartNewChat = useCallback(
     async (agentId: string, opts?: { incognito?: boolean }) => {
@@ -305,7 +319,8 @@ export default function ChatScreen({
             (m) => m.providerId === displayModel.providerId && m.modelId === displayModel.modelId,
           )
         : undefined
-      setReasoningEffort(normalizeEffortForModel(displayModelInfo, settings.reasoning_effort, t))
+      const effort = currentSessionMeta?.reasoningEffort ?? settings.reasoning_effort
+      setReasoningEffort(normalizeEffortForModel(displayModelInfo, effort, t))
 
       if (agentConfig?.name) {
         setAgentName(agentConfig.name)
@@ -316,6 +331,7 @@ export default function ChatScreen({
   }, [
     currentSessionMeta?.modelId,
     currentSessionMeta?.providerId,
+    currentSessionMeta?.reasoningEffort,
     currentAgentId,
     globalActiveModelRef,
     setActiveModel,
@@ -584,7 +600,19 @@ export default function ChatScreen({
     // Effort changed from channel (/think)
     unlisteners.push(
       getTransport().listen("slash:effort_changed", (payload) => {
-        setReasoningEffort(payload as string)
+        const data = payload as string | { sessionId?: string; effort?: string }
+        const effort = typeof data === "string" ? data : data.effort
+        if (!effort) return
+        const sid = typeof data === "string" ? undefined : data.sessionId
+        if (!sid || sid === session.currentSessionId) {
+          setReasoningEffort(effort)
+        }
+        if (sid) {
+          session.updateSessionMeta(sid, (prev) =>
+            prev.reasoningEffort === effort ? prev : { ...prev, reasoningEffort: effort },
+          )
+        }
+        session.reloadSessions()
       }),
     )
 
@@ -657,6 +685,7 @@ export default function ChatScreen({
     endedStreamIdsRef,
     planMode: planModeState,
     temperatureOverride: sessionTemperature,
+    reasoningEffort,
     incognitoEnabled,
     draftWorkingDir,
   })
@@ -783,7 +812,7 @@ export default function ChatScreen({
           handleManualModelChange(`${action.providerId}::${action.modelId}`)
           break
         case "setEffort":
-          handleEffortChange(action.effort)
+          handleSessionEffortChange(action.effort)
           break
         case "switchAgent":
           if (action.sessionId) session.handleSwitchSession(action.sessionId)
@@ -924,7 +953,7 @@ export default function ChatScreen({
       stream,
       handleStartNewChat,
       handleManualModelChange,
-      handleEffortChange,
+      handleSessionEffortChange,
       planMode,
       loadSystemPrompt,
       handleNewChatInProject,
@@ -1279,7 +1308,7 @@ export default function ChatScreen({
                   activeModel={activeModel}
                   reasoningEffort={reasoningEffort}
                   onModelChange={handleModelChange}
-                  onEffortChange={handleEffortChange}
+                  onEffortChange={handleSessionEffortChange}
                   attachedFiles={stream.attachedFiles}
                   onAttachFiles={(files) => stream.setAttachedFiles((prev) => [...prev, ...files])}
                   onRemoveFile={(index) =>

--- a/src/components/chat/QuickChatDialog.tsx
+++ b/src/components/chat/QuickChatDialog.tsx
@@ -50,6 +50,7 @@ export default function QuickChatDialog({
     sessions: session.sessions,
     agents: session.agents,
     activeModel: session.activeModel,
+    reasoningEffort: session.reasoningEffort,
     reloadSessions: session.reloadSessions,
     updateSessionMessages: session.updateSessionMessages,
     lastSeqRef: quickStreamSeqRef,

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -86,6 +86,8 @@ export interface UseChatStreamOptions {
   planMode?: string
   /** Session-level temperature override (0.0–2.0). Overrides agent and global settings. */
   temperatureOverride?: number | null
+  /** Session-level Think / reasoning effort. */
+  reasoningEffort?: string | null
   /** New-chat preset; only applied when the backend auto-creates a session. */
   incognitoEnabled?: boolean
   /**
@@ -138,6 +140,7 @@ export function useChatStream({
   endedStreamIdsRef,
   planMode,
   temperatureOverride,
+  reasoningEffort,
   incognitoEnabled = false,
   draftWorkingDir = null,
 }: UseChatStreamOptions): UseChatStreamReturn {
@@ -515,6 +518,7 @@ export function useChatStream({
           permissionMode: permissionModeRef.current,
           planMode: effectivePlanMode && effectivePlanMode !== "off" ? effectivePlanMode : undefined,
           temperatureOverride: temperatureOverride ?? undefined,
+          reasoningEffort: reasoningEffort ?? undefined,
           displayText: options?.displayText?.trim() || undefined,
           isPlanTrigger: options?.isPlanTrigger,
           planComment: options?.planComment,

--- a/src/components/chat/hooks/useModelState.ts
+++ b/src/components/chat/hooks/useModelState.ts
@@ -17,7 +17,7 @@ export interface UseModelStateReturn {
   globalActiveModelRef: React.MutableRefObject<ActiveModel | null>
   applyModelForDisplay: (key: string) => void
   handleModelChange: (key: string) => Promise<void>
-  handleEffortChange: (effort: string) => Promise<void>
+  handleEffortChange: (effort: string, sessionId?: string | null) => Promise<void>
 }
 
 export function useModelState(): UseModelStateReturn {
@@ -45,10 +45,13 @@ export function useModelState(): UseModelStateReturn {
     [availableModels, t],
   )
 
-  const handleEffortChange = useCallback(async (effort: string) => {
+  const handleEffortChange = useCallback(async (effort: string, sessionId?: string | null) => {
     setReasoningEffort(effort)
     try {
-      await getTransport().call("set_reasoning_effort", { effort })
+      await getTransport().call("set_reasoning_effort", {
+        effort,
+        ...(sessionId ? { sessionId } : {}),
+      })
     } catch (e) {
       logger.error("ui", "ChatScreen::effortChange", "Failed to set reasoning effort", e)
     }

--- a/src/components/chat/useQuickChatSession.ts
+++ b/src/components/chat/useQuickChatSession.ts
@@ -345,9 +345,18 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
 
   // Effort change
   const handleEffortChange = useCallback(async (effort: string) => {
+    const sessionId = currentSessionIdRef.current
     setReasoningEffort(effort)
+    if (sessionId) {
+      setSessions((prev) =>
+        prev.map((s) => (s.id === sessionId ? { ...s, reasoningEffort: effort } : s)),
+      )
+    }
     try {
-      await getTransport().call("set_reasoning_effort", { effort })
+      await getTransport().call("set_reasoning_effort", {
+        effort,
+        ...(sessionId ? { sessionId } : {}),
+      })
     } catch (e) {
       logger.error("ui", "QuickChat::effortChange", "Failed to set effort", e)
     }

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -36,6 +36,7 @@ export interface ChatStartArgs {
   permissionMode?: SessionMode;
   planMode?: string;
   temperatureOverride?: number;
+  reasoningEffort?: string;
   displayText?: string;
   /** Marks the user message as a Plan Mode approve/resume trigger so the
    *  backend stamps `attachments_meta = {plan_trigger: true}` and the UI

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -200,6 +200,8 @@ export interface SessionMeta {
   providerId?: string | null
   providerName?: string | null
   modelId?: string | null
+  /** Session-scoped Think / reasoning effort override. */
+  reasoningEffort?: string | null
   createdAt: string
   updatedAt: string
   messageCount: number


### PR DESCRIPTION
## What Changed

- Persist the chat Think / reasoning effort as session metadata and restore it when switching conversations.
- Send the current session Think value through both Tauri and HTTP chat paths so the backend uses the same value the UI shows.
- Teach server-mode model settings to return the live reasoning effort instead of hard-coding `medium`.
- Keep IM channel `/think` changes session-scoped and reflected back into the desktop UI.

## Why

Changing Think in a conversation only updated runtime/global state. When users switched away and back, the UI refreshed from default settings and the selected Think level appeared to reset.

## Validation

Pre-push completed successfully locally:

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `pnpm typecheck`
- `pnpm lint` (passes with existing `ChatScreen.tsx` exhaustive-deps warnings)
- `pnpm test`
- `cargo test -p ha-core -p ha-server --locked`