### PR TITLE
[codex] 修复会话搜索框获焦

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -97,6 +97,10 @@ export default function ChatScreen({
   // In-session "find in page" search bar state
   const [searchBarOpen, setSearchBarOpen] = useState(false)
   const [searchFocusSignal, setSearchFocusSignal] = useState(0)
+  const openSessionSearch = useCallback(() => {
+    setSearchBarOpen(true)
+    setSearchFocusSignal((n) => n + 1)
+  }, [])
 
   // System prompt viewer state
   const [showSystemPrompt, setShowSystemPrompt] = useState(false)
@@ -558,12 +562,11 @@ export default function ChatScreen({
       // Open (or keep open) and bump the focus signal so the search bar
       // re-focuses its input even if Cmd+F is pressed while it's already
       // visible.
-      setSearchBarOpen(true)
-      setSearchFocusSignal((n) => n + 1)
+      openSessionSearch()
     }
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
-  }, [currentSessionId])
+  }, [currentSessionId, openSessionSearch])
 
   // Listen for tray "new-session" event to trigger new chat
   useEffect(() => {
@@ -1218,10 +1221,7 @@ export default function ChatScreen({
           onViewSystemPrompt={loadSystemPrompt}
           systemPromptLoading={systemPromptLoading}
           onCommandAction={handleCommandAction}
-          onToggleSearch={() => {
-            setSearchBarOpen((v) => !v)
-            setSearchFocusSignal((n) => n + 1)
-          }}
+          onOpenSearch={openSessionSearch}
           searchOpen={searchBarOpen}
           effectiveWorkingDir={effectiveWorkingDir}
           workingDirSource={workingDirSource}

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -57,8 +57,8 @@ interface ChatTitleBarProps {
    * without going through the text input.
    */
   onCommandAction?: (result: import("@/components/chat/slash-commands/types").CommandResult) => void
-  /** Toggles the in-session "find in page" search bar. */
-  onToggleSearch?: () => void
+  /** Opens or refocuses the in-session "find in page" search bar. */
+  onOpenSearch?: () => void
   /** Whether the in-session search bar is currently open (controls active styling). */
   searchOpen?: boolean
   /**
@@ -100,7 +100,7 @@ export default function ChatTitleBar({
   onViewSystemPrompt,
   systemPromptLoading,
   onCommandAction,
-  onToggleSearch,
+  onOpenSearch,
   searchOpen,
   effectiveWorkingDir,
   workingDirSource,
@@ -294,14 +294,14 @@ export default function ChatTitleBar({
       </div>
       <div className="flex items-end gap-1">
         {/* In-session Search Button */}
-        {currentSessionId && onToggleSearch && (
+        {currentSessionId && onOpenSearch && (
           <IconTip label={t("chat.sessionSearch")}>
             <button
               className={cn(
                 "pb-1.5 text-muted-foreground hover:text-foreground transition-colors",
                 searchOpen && "text-foreground",
               )}
-              onClick={onToggleSearch}
+              onClick={onOpenSearch}
             >
               <Search className="h-4 w-4" />
             </button>

--- a/src/components/chat/SessionSearchBar.tsx
+++ b/src/components/chat/SessionSearchBar.tsx
@@ -49,9 +49,27 @@ export default function SessionSearchBar({
   }, [onJumpTo])
 
   useEffect(() => {
-    inputRef.current?.focus()
-    inputRef.current?.select()
+    const focusInput = () => {
+      inputRef.current?.focus({ preventScroll: true })
+      inputRef.current?.select()
+    }
+    focusInput()
+    const frame = window.requestAnimationFrame(focusInput)
+    return () => window.cancelAnimationFrame(frame)
   }, [focusSignal])
+
+  const focusSearchInput = useCallback(() => {
+    inputRef.current?.focus({ preventScroll: true })
+  }, [])
+
+  const handleSearchSurfaceMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement | null
+    if (target?.closest("button")) return
+    if (target !== inputRef.current) {
+      e.preventDefault()
+    }
+    focusSearchInput()
+  }
 
   useEffect(() => {
     const q = query.trim()
@@ -138,10 +156,14 @@ export default function SessionSearchBar({
 
   return (
     <div className="px-4 pt-1 pb-2 bg-background border-b border-border/30 animate-in fade-in slide-in-from-top-1 duration-150">
-      <div className="flex items-center gap-2 rounded-md bg-muted/50 px-2.5 py-1.5 focus-within:bg-muted/80 transition-colors">
-        <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
+      <div
+        className="flex items-center gap-2 rounded-md bg-muted/50 px-2.5 py-1.5 focus-within:bg-muted/80 transition-colors"
+        onMouseDown={handleSearchSurfaceMouseDown}
+      >
+        <Search className="pointer-events-none h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />
         <input
           ref={inputRef}
+          aria-label={t("chat.sessionSearch") || ""}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/src/components/chat/sidebar/SessionList.tsx
+++ b/src/components/chat/sidebar/SessionList.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useCallback, useMemo, useRef } from "react"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import { useTranslation } from "react-i18next"
@@ -103,8 +103,21 @@ export default function SessionList({
   onMoveToProject,
 }: SessionListProps) {
   const { t } = useTranslation()
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   const isSearching = searchQuery.trim().length > 0
+  const focusSearchInput = useCallback(() => {
+    searchInputRef.current?.focus({ preventScroll: true })
+  }, [])
+
+  const handleSearchSurfaceMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement | null
+    if (target?.closest("button")) return
+    if (target !== searchInputRef.current) {
+      e.preventDefault()
+    }
+    focusSearchInput()
+  }
 
   // Client-side second-level filter by session type for search results.
   const visibleResults = useMemo(() => {
@@ -116,9 +129,11 @@ export default function SessionList({
   return (
     <>
       {/* Search input */}
-      <div className="relative px-3 pt-2 pb-1.5">
+      <div className="relative px-3 pt-2 pb-1.5" onMouseDown={handleSearchSurfaceMouseDown}>
         <Search className="absolute left-5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/60 pointer-events-none" />
         <Input
+          ref={searchInputRef}
+          aria-label={t("chat.searchPlaceholder") || ""}
           value={searchQuery}
           onChange={(e) => onSearchQueryChange(e.target.value)}
           placeholder={t("chat.searchPlaceholder")}


### PR DESCRIPTION
## Summary

修复聊天会话内搜索框唤起后无法可靠获焦输入的问题。

## Changes

- 将标题栏搜索按钮从 toggle 行为改为打开/重新聚焦搜索框，避免搜索框已打开时再次点击反而关闭。
- 会话内搜索框打开后立即聚焦，并在下一帧补一次聚焦，降低 Tauri/WebKit 桌面窗口里挂载和动画阶段的焦点竞争影响。
- 搜索框外层搜索区域点击时主动把焦点送到真正的 input，避免点到图标、padding 或背景区域时无法输入。
- 左侧会话列表搜索框同步补充整块搜索区域聚焦行为。

## Validation

- `pnpm typecheck`
- pre-push: `cargo fmt --all --check`
- pre-push: `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- pre-push: `pnpm typecheck`
- pre-push: `pnpm lint`，通过，保留 3 个既有 React hooks warnings
- pre-push: `pnpm test`
- pre-push: `cargo test -p ha-core -p ha-server --locked`

所有 pre-push 检查已通过。第一次正常 push 在检查通过后遇到 SSH 连接断开，随后使用仓库支持的 `HA_SKIP_PREPUSH=1` 仅跳过重复检查完成推送。