### PR TITLE
[codex] Hide task database ids

### DIFF
--- a/src/components/chat/message/TaskBlock.tsx
+++ b/src/components/chat/message/TaskBlock.tsx
@@ -74,7 +74,6 @@ export default function TaskBlock({ tool }: TaskBlockProps) {
                 >
                   {label}
                 </span>
-                <span className="shrink-0 text-[10px] text-muted-foreground">#{tk.id}</span>
               </li>
             )
           })}


### PR DESCRIPTION
## Summary

- Hide the internal database task id from chat task progress rows.
- Keep the task id available internally for React keys and backend task updates.

## Why

The `#14`-style label looked like a user-facing task ordinal, but it was actually the SQLite task primary key. Since that id is global/autoincrementing, it can start at unexpected numbers and confuse users.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `pnpm typecheck`
- `pnpm lint` (passed with 3 existing react-hooks warnings in `src/components/chat/ChatScreen.tsx`)
- `pnpm test`
- `cargo test -p ha-core -p ha-server --locked`