### PR TITLE
[codex] stabilize message feed state

### DIFF
--- a/src/components/chat/MessageList.test.tsx
+++ b/src/components/chat/MessageList.test.tsx
@@ -77,6 +77,19 @@ function getScroller(): HTMLElement {
   return el
 }
 
+function makeMessages(count: number, prefix: string): Message[] {
+  return Array.from({ length: count }, (_, i) =>
+    baseMessage({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: `${prefix}-${i}`,
+      dbId: i + 1,
+      timestamp: `2026-04-26T00:${String(Math.floor(i / 60)).padStart(2, "0")}:${String(
+        i % 60,
+      ).padStart(2, "0")}.000Z`,
+    }),
+  )
+}
+
 describe("MessageList", () => {
   test("renders non-meta messages and hides isMeta entries", () => {
     render(
@@ -350,5 +363,81 @@ describe("MessageList", () => {
       block: "start",
       behavior: "smooth",
     })
+  })
+
+  test("does not force-scroll to the last user message when switching sessions", () => {
+    const scrollIntoViewSpy = vi.fn()
+    Element.prototype.scrollIntoView = scrollIntoViewSpy
+
+    const { rerender } = render(
+      <MessageList
+        messages={[
+          baseMessage({ role: "user", content: "session one question", dbId: 1 }),
+          baseMessage({ role: "assistant", content: "session one answer", dbId: 2 }),
+        ]}
+        loading={false}
+        agents={[]}
+        hasMore={false}
+        loadingMore={false}
+        onLoadMore={vi.fn()}
+        sessionId="s1"
+      />,
+    )
+
+    scrollIntoViewSpy.mockClear()
+
+    rerender(
+      <MessageList
+        messages={[
+          baseMessage({ role: "user", content: "session two question", dbId: 11 }),
+          baseMessage({ role: "assistant", content: "session two answer", dbId: 12 }),
+        ]}
+        loading={false}
+        agents={[]}
+        hasMore={false}
+        loadingMore={false}
+        onLoadMore={vi.fn()}
+        sessionId="s2"
+      />,
+    )
+
+    expect(scrollIntoViewSpy).not.toHaveBeenCalled()
+  })
+
+  test("resets the rendered window when the loaded message set shrinks", () => {
+    const longMessages = makeMessages(231, "long")
+    const shortMessages = makeMessages(10, "short")
+    const { rerender } = render(
+      <MessageList
+        messages={longMessages}
+        loading={false}
+        agents={[]}
+        hasMore={false}
+        loadingMore={false}
+        onLoadMore={vi.fn()}
+        sessionId="s1"
+      />,
+    )
+
+    const el = getScroller()
+    patchScrollMetrics(el, { scrollHeight: 2000, clientHeight: 600, scrollTop: 1400 })
+    act(() => {
+      fireEvent.scroll(el)
+    })
+
+    rerender(
+      <MessageList
+        messages={shortMessages}
+        loading={false}
+        agents={[]}
+        hasMore={false}
+        loadingMore={false}
+        onLoadMore={vi.fn()}
+        sessionId="s1"
+      />,
+    )
+
+    expect(screen.getByText("short-0")).toBeTruthy()
+    expect(screen.getByText("short-9")).toBeTruthy()
   })
 })

--- a/src/components/chat/MessageList.test.tsx
+++ b/src/components/chat/MessageList.test.tsx
@@ -8,13 +8,11 @@ import MessageList from "./MessageList"
 import type { AskUserQuestionGroup } from "./ask-user/AskUserQuestionBlock"
 import type { PlanCardData } from "./plan-mode/PlanCardBlock"
 
-const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation(
-  (cb: FrameRequestCallback) => {
-    cb(0)
-    return 0
-  },
+const originalScrollIntoView = Object.getOwnPropertyDescriptor(
+  Element.prototype,
+  "scrollIntoView",
 )
-vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+const originalScrollTo = Object.getOwnPropertyDescriptor(Element.prototype, "scrollTo")
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -37,13 +35,42 @@ vi.mock("./plan-mode/PlanCardBlock", () => ({
 }))
 
 beforeEach(() => {
-  rafSpy.mockClear()
+  vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+    (cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    },
+  )
+  vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+  installElementMethod("scrollIntoView")
+  installElementMethod("scrollTo")
 })
 
 afterEach(() => {
   cleanup()
-  vi.clearAllMocks()
+  vi.restoreAllMocks()
+  restoreElementMethod("scrollIntoView", originalScrollIntoView)
+  restoreElementMethod("scrollTo", originalScrollTo)
 })
+
+function installElementMethod(name: "scrollIntoView" | "scrollTo") {
+  Object.defineProperty(Element.prototype, name, {
+    configurable: true,
+    writable: true,
+    value: () => {},
+  })
+}
+
+function restoreElementMethod(
+  name: "scrollIntoView" | "scrollTo",
+  descriptor: PropertyDescriptor | undefined,
+) {
+  if (descriptor) {
+    Object.defineProperty(Element.prototype, name, descriptor)
+  } else {
+    delete (Element.prototype as Partial<Record<"scrollIntoView" | "scrollTo", unknown>>)[name]
+  }
+}
 
 function baseMessage(patch: Partial<Message>): Message {
   return {
@@ -271,8 +298,9 @@ describe("MessageList", () => {
 
   test("scrolls to a search target by dbId and reports it as handled", () => {
     const onScrollTargetHandled = vi.fn()
-    const scrollIntoViewSpy = vi.fn()
-    Element.prototype.scrollIntoView = scrollIntoViewSpy
+    const scrollIntoViewSpy = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => {})
 
     render(
       <MessageList
@@ -297,8 +325,7 @@ describe("MessageList", () => {
   })
 
   test("shows the jump-to-bottom button while loading and not at bottom, and clicking calls scrollTo", () => {
-    const scrollToSpy = vi.fn()
-    Element.prototype.scrollTo = scrollToSpy
+    const scrollToSpy = vi.spyOn(Element.prototype, "scrollTo").mockImplementation(() => {})
 
     render(
       <MessageList
@@ -326,8 +353,9 @@ describe("MessageList", () => {
   })
 
   test("forces auto-follow scroll when a new user message arrives", () => {
-    const scrollIntoViewSpy = vi.fn()
-    Element.prototype.scrollIntoView = scrollIntoViewSpy
+    const scrollIntoViewSpy = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => {})
 
     const { rerender } = render(
       <MessageList
@@ -366,8 +394,9 @@ describe("MessageList", () => {
   })
 
   test("does not force-scroll to the last user message when switching sessions", () => {
-    const scrollIntoViewSpy = vi.fn()
-    Element.prototype.scrollIntoView = scrollIntoViewSpy
+    const scrollIntoViewSpy = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(() => {})
 
     const { rerender } = render(
       <MessageList

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -113,9 +113,22 @@ export default function MessageList({
   // Reset on session swap via the prop-derived state pattern below.
   const [displayedStart, setDisplayedStart] = useState(0)
   const [displayedStartSession, setDisplayedStartSession] = useState(sessionKey)
+  const [displayedStartMessagesLength, setDisplayedStartMessagesLength] = useState(
+    messages.length,
+  )
   if (displayedStartSession !== sessionKey) {
     setDisplayedStartSession(sessionKey)
+    setDisplayedStartMessagesLength(messages.length)
     setDisplayedStart(0)
+  } else if (displayedStartMessagesLength !== messages.length) {
+    const prevLength = displayedStartMessagesLength
+    setDisplayedStartMessagesLength(messages.length)
+    if (
+      displayedStart !== 0 &&
+      (messages.length < prevLength || displayedStart >= messages.length)
+    ) {
+      setDisplayedStart(0)
+    }
   }
   // Refs mirror state/props for the scroll listener which is bound in an
   // effect with deps {sessionKey, hasMore, loadingMore, onLoadMore} — keeping
@@ -316,7 +329,13 @@ export default function MessageList({
   // user bubble into view and re-arm follow-bottom so the assistant stream tails.
   const lastUserKey = useMemo(() => getLatestUserTurnKey(messages), [messages])
   const lastSeenUserKeyRef = useRef<string | null>(lastUserKey)
+  const lastSeenUserSessionRef = useRef(sessionKey)
   useEffect(() => {
+    if (lastSeenUserSessionRef.current !== sessionKey) {
+      lastSeenUserSessionRef.current = sessionKey
+      lastSeenUserKeyRef.current = lastUserKey
+      return
+    }
     if (!lastUserKey || lastUserKey === lastSeenUserKeyRef.current) return
     lastSeenUserKeyRef.current = lastUserKey
 
@@ -344,7 +363,7 @@ export default function MessageList({
     } else {
       el.scrollTop = el.scrollHeight
     }
-  }, [lastUserKey])
+  }, [lastUserKey, sessionKey])
 
   // Search-result jump: scroll target dbId into view + 2s highlight pulse.
   // If the target is outside the windowed slice (`displayedStart > targetIdx`),

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -121,6 +121,7 @@ export default function MessageList({
     setDisplayedStartMessagesLength(messages.length)
     setDisplayedStart(0)
   } else if (displayedStartMessagesLength !== messages.length) {
+    // Message content streaming reuses the same item, so this only runs on append/reload.
     const prevLength = displayedStartMessagesLength
     setDisplayedStartMessagesLength(messages.length)
     if (

--- a/src/components/team/TeamMessageFeed.test.tsx
+++ b/src/components/team/TeamMessageFeed.test.tsx
@@ -101,9 +101,9 @@ describe("TeamMessageFeed", () => {
       />,
     )
 
-    const input = screen.getByPlaceholderText("Message team... (@name for DM)")
+    const input = screen.getByPlaceholderText("Message team... (@name for DM)") as HTMLInputElement
     fireEvent.change(input, { target: { value: "draft for team a" } })
-    expect(input).toHaveValue("draft for team a")
+    expect(input.value).toBe("draft for team a")
 
     rerender(
       <TeamMessageFeed
@@ -114,7 +114,9 @@ describe("TeamMessageFeed", () => {
       />,
     )
 
-    expect(screen.getByPlaceholderText("Message team... (@name for DM)")).toHaveValue("")
+    expect(
+      (screen.getByPlaceholderText("Message team... (@name for DM)") as HTMLInputElement).value,
+    ).toBe("")
   })
 
   test("resets the rendered window when the loaded message set shrinks", () => {
@@ -147,4 +149,4 @@ describe("TeamMessageFeed", () => {
     expect(screen.getByText("short-0")).toBeTruthy()
     expect(screen.getByText("short-9")).toBeTruthy()
   })
-}
+})

--- a/src/components/team/TeamMessageFeed.test.tsx
+++ b/src/components/team/TeamMessageFeed.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
+
+import { TeamMessageFeed } from "./TeamMessageFeed"
+import type { TeamMember, TeamMessage } from "./teamTypes"
+
+const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+  (cb: FrameRequestCallback) => {
+    cb(0)
+    return 0
+  },
+)
+vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+beforeEach(() => {
+  rafSpy.mockClear()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const members: TeamMember[] = [
+  {
+    memberId: "lead",
+    teamId: "team-a",
+    name: "Lead",
+    agentId: "default",
+    role: "lead",
+    status: "idle",
+    color: "#2563eb",
+    joinedAt: "2026-04-26T00:00:00.000Z",
+  },
+]
+
+function teamMessage(patch: Partial<TeamMessage>): TeamMessage {
+  return {
+    messageId: "m1",
+    teamId: "team-a",
+    fromMemberId: "lead",
+    content: "",
+    messageType: "chat",
+    timestamp: "2026-04-26T00:00:00.000Z",
+    ...patch,
+  }
+}
+
+function makeMessages(count: number, prefix: string, teamId = "team-a"): TeamMessage[] {
+  return Array.from({ length: count }, (_, i) =>
+    teamMessage({
+      messageId: `${teamId}-${i}`,
+      teamId,
+      content: `${prefix}-${i}`,
+      timestamp: `2026-04-26T00:${String(Math.floor(i / 60)).padStart(2, "0")}:${String(
+        i % 60,
+      ).padStart(2, "0")}.000Z`,
+    }),
+  )
+}
+
+function patchScrollMetrics(
+  container: HTMLElement,
+  metrics: { scrollHeight: number; clientHeight: number; scrollTop?: number },
+) {
+  Object.defineProperty(container, "scrollHeight", {
+    configurable: true,
+    get: () => metrics.scrollHeight,
+  })
+  Object.defineProperty(container, "clientHeight", {
+    configurable: true,
+    get: () => metrics.clientHeight,
+  })
+  if (metrics.scrollTop !== undefined) {
+    container.scrollTop = metrics.scrollTop
+  }
+}
+
+function getScroller(): HTMLElement {
+  const el = document.querySelector<HTMLElement>(".overflow-y-auto")
+  if (!el) throw new Error("scroll container not found")
+  return el
+}
+
+describe("TeamMessageFeed", () => {
+  test("clears the draft when switching teams", () => {
+    const { rerender } = render(
+      <TeamMessageFeed
+        teamId="team-a"
+        messages={[]}
+        members={members}
+        onSendMessage={vi.fn()}
+      />,
+    )
+
+    const input = screen.getByPlaceholderText("Message team... (@name for DM)")
+    fireEvent.change(input, { target: { value: "draft for team a" } })
+    expect(input).toHaveValue("draft for team a")
+
+    rerender(
+      <TeamMessageFeed
+        teamId="team-b"
+        messages={[]}
+        members={members}
+        onSendMessage={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByPlaceholderText("Message team... (@name for DM)")).toHaveValue("")
+  })
+
+  test("resets the rendered window when the loaded message set shrinks", () => {
+    const longMessages = makeMessages(231, "long")
+    const shortMessages = makeMessages(10, "short")
+    const { rerender } = render(
+      <TeamMessageFeed
+        teamId="team-a"
+        messages={longMessages}
+        members={members}
+        onSendMessage={vi.fn()}
+      />,
+    )
+
+    const el = getScroller()
+    patchScrollMetrics(el, { scrollHeight: 2000, clientHeight: 600, scrollTop: 1400 })
+    act(() => {
+      fireEvent.scroll(el)
+    })
+
+    rerender(
+      <TeamMessageFeed
+        teamId="team-a"
+        messages={shortMessages}
+        members={members}
+        onSendMessage={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText("short-0")).toBeTruthy()
+    expect(screen.getByText("short-9")).toBeTruthy()
+  })
+}

--- a/src/components/team/TeamMessageFeed.tsx
+++ b/src/components/team/TeamMessageFeed.tsx
@@ -54,6 +54,7 @@ export function TeamMessageFeed({
     setDisplayedStartMessagesLength(messages.length)
     setDisplayedStart(0)
   } else if (displayedStartMessagesLength !== messages.length) {
+    // Message content streaming reuses the same item, so this only runs on append/reload.
     const prevLength = displayedStartMessagesLength
     setDisplayedStartMessagesLength(messages.length)
     if (

--- a/src/components/team/TeamMessageFeed.tsx
+++ b/src/components/team/TeamMessageFeed.tsx
@@ -8,6 +8,7 @@ import type { TeamMessage, TeamMember } from "./teamTypes"
 import { TeamMessageBubble } from "./TeamMessageBubble"
 
 interface TeamMessageFeedProps {
+  teamId: string
   messages: TeamMessage[]
   members: TeamMember[]
   onSendMessage: (to: string | null, content: string) => void
@@ -22,6 +23,7 @@ const MAX_DOM_MESSAGES = 200
 const UNLOAD_BATCH = 30
 
 export function TeamMessageFeed({
+  teamId,
   messages,
   members,
   onSendMessage,
@@ -31,19 +33,35 @@ export function TeamMessageFeed({
 }: TeamMessageFeedProps) {
   const { t } = useTranslation()
   const [draft, setDraft] = useState("")
+  const [draftTeam, setDraftTeam] = useState(teamId)
+  if (draftTeam !== teamId) {
+    setDraftTeam(teamId)
+    setDraft("")
+  }
   const containerRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
-
-  const teamId = messages[messages.length - 1]?.teamId ?? "team-feed"
 
   const atBottomRef = useRef(true)
 
   // Windowed view: see MessageList for rationale.
   const [displayedStart, setDisplayedStart] = useState(0)
   const [displayedStartTeam, setDisplayedStartTeam] = useState<string>(teamId)
+  const [displayedStartMessagesLength, setDisplayedStartMessagesLength] = useState(
+    messages.length,
+  )
   if (displayedStartTeam !== teamId) {
     setDisplayedStartTeam(teamId)
+    setDisplayedStartMessagesLength(messages.length)
     setDisplayedStart(0)
+  } else if (displayedStartMessagesLength !== messages.length) {
+    const prevLength = displayedStartMessagesLength
+    setDisplayedStartMessagesLength(messages.length)
+    if (
+      displayedStart !== 0 &&
+      (messages.length < prevLength || displayedStart >= messages.length)
+    ) {
+      setDisplayedStart(0)
+    }
   }
   const displayedStartRef = useRef(displayedStart)
   // eslint-disable-next-line react-hooks/refs -- ref-as-snapshot

--- a/src/components/team/TeamPanel.tsx
+++ b/src/components/team/TeamPanel.tsx
@@ -160,6 +160,7 @@ export function TeamPanel({
 
           <TabsContent value="messages" className="flex-1 min-h-0">
             <TeamMessageFeed
+              teamId={teamId}
               messages={messages}
               members={members}
               onSendMessage={sendMessage}

--- a/src/components/team/useTeam.test.tsx
+++ b/src/components/team/useTeam.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
-import { cleanup, render, screen } from "@testing-library/react"
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
 
 import { useTeam } from "./useTeam"
-import type { Team, TeamMessage } from "./teamTypes"
+import type { Team, TeamMember, TeamMessage, TeamTask } from "./teamTypes"
 
 const transportMock = vi.hoisted(() => ({
   call: vi.fn(),
@@ -71,6 +71,16 @@ function pendingRequest(): Promise<never> {
   })
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
 describe("useTeam", () => {
   test("clears loaded data immediately when switching teams", async () => {
     transportMock.call.mockImplementation((command: string, args?: { teamId?: string }) => {
@@ -94,6 +104,47 @@ describe("useTeam", () => {
     rerender(<Harness teamId="team-b" />)
 
     expect(screen.queryByText("old team message")).toBeNull()
+    expect(screen.getByTestId("loading").textContent).toBe("true")
+  })
+
+  test("ignores a stale reload that resolves after switching teams", async () => {
+    const teamA = deferred<Team | null>()
+    const membersA = deferred<TeamMember[]>()
+    const messagesA = deferred<[TeamMessage[], boolean]>()
+    const tasksA = deferred<TeamTask[]>()
+
+    transportMock.call.mockImplementation((command: string, args?: { teamId?: string }) => {
+      if (args?.teamId === "team-a") {
+        if (command === "get_team") return teamA.promise
+        if (command === "get_team_members") return membersA.promise
+        if (command === "get_team_messages") {
+          return messagesA.promise
+        }
+        if (command === "get_team_tasks") return tasksA.promise
+      }
+      if (args?.teamId === "team-b") {
+        return pendingRequest()
+      }
+      return Promise.resolve([])
+    })
+
+    const { rerender } = render(<Harness teamId="team-a" />)
+    await waitFor(() =>
+      expect(transportMock.call).toHaveBeenCalledWith("get_team", { teamId: "team-a" }),
+    )
+
+    rerender(<Harness teamId="team-b" />)
+    expect(screen.getByTestId("loading").textContent).toBe("true")
+
+    await act(async () => {
+      teamA.resolve(team("team-a"))
+      membersA.resolve([])
+      messagesA.resolve([[message("team-a", "stale team message")], false])
+      tasksA.resolve([])
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByText("stale team message")).toBeNull()
     expect(screen.getByTestId("loading").textContent).toBe("true")
   })
 })

--- a/src/components/team/useTeam.test.tsx
+++ b/src/components/team/useTeam.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { cleanup, render, screen } from "@testing-library/react"
+
+import { useTeam } from "./useTeam"
+import type { Team, TeamMessage } from "./teamTypes"
+
+const transportMock = vi.hoisted(() => ({
+  call: vi.fn(),
+  listen: vi.fn(() => vi.fn()),
+}))
+
+vi.mock("@/lib/transport-provider", () => ({
+  getTransport: () => transportMock,
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  transportMock.call.mockReset()
+  transportMock.listen.mockReset()
+  transportMock.listen.mockImplementation(() => vi.fn())
+})
+
+function team(teamId: string): Team {
+  return {
+    teamId,
+    name: teamId,
+    leadSessionId: "session-1",
+    leadAgentId: "default",
+    status: "active",
+    createdAt: "2026-04-26T00:00:00.000Z",
+    updatedAt: "2026-04-26T00:00:00.000Z",
+    config: {
+      maxMembers: 3,
+      autoDissolveOnComplete: false,
+    },
+  }
+}
+
+function message(teamId: string, content: string): TeamMessage {
+  return {
+    messageId: `${teamId}-message`,
+    teamId,
+    fromMemberId: "lead",
+    content,
+    messageType: "chat",
+    timestamp: "2026-04-26T00:00:00.000Z",
+  }
+}
+
+function Harness({ teamId }: { teamId: string | null }) {
+  const state = useTeam(teamId)
+  return (
+    <div>
+      <div data-testid="loading">{String(state.loading)}</div>
+      {state.messages.map((msg) => (
+        <div key={msg.messageId}>{msg.content}</div>
+      ))}
+    </div>
+  )
+}
+
+function pendingRequest(): Promise<never> {
+  return new Promise(() => {
+    // Keep the request pending so the test can inspect the immediate switch state.
+  })
+}
+
+describe("useTeam", () => {
+  test("clears loaded data immediately when switching teams", async () => {
+    transportMock.call.mockImplementation((command: string, args?: { teamId?: string }) => {
+      if (args?.teamId === "team-a") {
+        if (command === "get_team") return Promise.resolve(team("team-a"))
+        if (command === "get_team_members") return Promise.resolve([])
+        if (command === "get_team_messages") {
+          return Promise.resolve([[message("team-a", "old team message")], false])
+        }
+        if (command === "get_team_tasks") return Promise.resolve([])
+      }
+      if (args?.teamId === "team-b") {
+        return pendingRequest()
+      }
+      return Promise.resolve([])
+    })
+
+    const { rerender } = render(<Harness teamId="team-a" />)
+    expect(await screen.findByText("old team message")).toBeTruthy()
+
+    rerender(<Harness teamId="team-b" />)
+
+    expect(screen.queryByText("old team message")).toBeNull()
+    expect(screen.getByTestId("loading")).toHaveTextContent("true")
+  })
+})

--- a/src/components/team/useTeam.test.tsx
+++ b/src/components/team/useTeam.test.tsx
@@ -94,6 +94,6 @@ describe("useTeam", () => {
     rerender(<Harness teamId="team-b" />)
 
     expect(screen.queryByText("old team message")).toBeNull()
-    expect(screen.getByTestId("loading")).toHaveTextContent("true")
+    expect(screen.getByTestId("loading").textContent).toBe("true")
   })
 })

--- a/src/components/team/useTeam.ts
+++ b/src/components/team/useTeam.ts
@@ -21,6 +21,17 @@ export function useTeam(teamId: string | null) {
   const [loading, setLoading] = useState(false)
   const [hasMore, setHasMore] = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
+  const [stateTeamId, setStateTeamId] = useState(teamId)
+  if (stateTeamId !== teamId) {
+    setStateTeamId(teamId)
+    setTeam(null)
+    setMembers([])
+    setMessages([])
+    setTasks([])
+    setHasMore(false)
+    setLoadingMore(false)
+    setLoading(Boolean(teamId))
+  }
   const teamIdRef = useRef(teamId)
   teamIdRef.current = teamId
 
@@ -50,7 +61,9 @@ export function useTeam(teamId: string | null) {
     } catch {
       // Ignore errors during reload
     } finally {
-      setLoading(false)
+      if (teamIdRef.current === teamId) {
+        setLoading(false)
+      }
     }
   }, [teamId])
 
@@ -90,13 +103,6 @@ export function useTeam(teamId: string | null) {
   useEffect(() => {
     if (teamId) {
       reload()
-    } else {
-      setTeam(null)
-      setMembers([])
-      setMessages([])
-      setTasks([])
-      setHasMore(false)
-      setLoadingMore(false)
     }
   }, [teamId, reload])
 


### PR DESCRIPTION
## Summary
- Stabilize MessageList window state when loaded messages shrink and avoid treating session switches as new user turns.
- Give TeamMessageFeed a real teamId boundary, clear draft/window state on team switches, and clear stale team data immediately in useTeam.
- Add regression coverage for MessageList, TeamMessageFeed, and useTeam state transitions, including a stale team reload race.

## Validation
- git diff --check
- pnpm typecheck
- pnpm lint (0 errors; existing ChatScreen exhaustive-deps warnings remain)
- pnpm test
