### PR TITLE
[codex] quiet repeated Ollama running log

### DIFF
--- a/crates/ha-core/src/local_llm/mod.rs
+++ b/crates/ha-core/src/local_llm/mod.rs
@@ -311,7 +311,7 @@ pub async fn detect_ollama_version() -> Result<Option<String>> {
 /// the daemon already responds, returns Ok early.
 pub async fn start_ollama() -> Result<()> {
     if ping_ollama().await {
-        app_info!("local_llm", "start_ollama", "already running");
+        app_debug!("local_llm", "start_ollama", "already running");
         return Ok(());
     }
     let binary = usable_ollama_binary()


### PR DESCRIPTION
## 变更

- 将 `local_llm::start_ollama` 中 Ollama 已运行时的日志从 `INFO` 降为 `DEBUG`。

## 原因

本地模型自动维护 watchdog 每 60 秒会确保 Ollama 可用。Ollama 正常运行时反复打印 `start_ollama — already running` 会污染默认 INFO 日志；真正的启动失败、模型列表读取失败、预加载失败仍会按 warning/error 输出。

## 验证

- `cargo check -p ha-core`