### PR TITLE
IM channel stability & protocol compliance audit (2026-05-05)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,6 +3006,7 @@ dependencies = [
  "jsonwebtoken",
  "libc",
  "log",
+ "lru",
  "native-tls",
  "objc2",
  "objc2-app-kit",
@@ -3099,6 +3100,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -4379,6 +4382,15 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "weezl",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -72,6 +72,7 @@ hmac = "0.12"
 jsonwebtoken = "9"
 axum = "0.8"
 prost = "0.14"
+lru = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { version = "0.6.4", features = ["std"] }

--- a/crates/ha-core/src/channel/discord/api.rs
+++ b/crates/ha-core/src/channel/discord/api.rs
@@ -3,6 +3,9 @@ use std::time::Duration;
 
 use crate::channel::rate_limit::with_rate_limit_retry;
 
+/// 默认 429 重试上限。改成 5 retries 时只动这里。
+const MAX_RETRY_ATTEMPTS: u32 = 3;
+
 /// Discord REST API client (v10).
 pub struct DiscordApi {
     client: reqwest::Client,
@@ -58,50 +61,61 @@ impl DiscordApi {
         )
     }
 
-    // ── Users ───────────────────────────────────────────────────────
-
-    /// GET /users/@me — validate the bot token and return user object.
-    pub async fn get_current_user(&self) -> Result<serde_json::Value> {
-        let url = self.url("/users/@me");
-        let resp = with_rate_limit_retry(3, || async {
-            self.client
-                .get(&url)
-                .header("Authorization", &self.token)
-                .send()
+    /// 发一个带 Bot token 的 JSON 请求 + 自动 429 重试 + 错误转 anyhow。
+    /// 4xx/5xx 直接返回错误（含响应体片段）；只 GET/POST/PATCH/DELETE 4 个动词。
+    async fn auth_request(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        body: Option<&serde_json::Value>,
+    ) -> Result<reqwest::Response> {
+        let resp = with_rate_limit_retry(MAX_RETRY_ATTEMPTS, || async {
+            let mut req = self
+                .client
+                .request(method.clone(), url)
+                .header("Authorization", &self.token);
+            if let Some(b) = body {
+                req = req.json(b);
+            }
+            req.send()
                 .await
-                .map_err(|e| anyhow!("get_current_user request failed: {}", e))
+                .map_err(|e| anyhow!("Discord {} {} request failed: {}", method, url, e))
         })
         .await?;
 
         if !resp.status().is_success() {
             return Err(Self::parse_error(resp).await);
         }
+        Ok(resp)
+    }
+
+    /// 同 [`auth_request`] 但解析 JSON 响应。
+    async fn auth_request_json<T: serde::de::DeserializeOwned>(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+        body: Option<&serde_json::Value>,
+    ) -> Result<T> {
+        let resp = self.auth_request(method.clone(), url, body).await?;
         resp.json()
             .await
-            .map_err(|e| anyhow!("get_current_user parse failed: {}", e))
+            .map_err(|e| anyhow!("Discord {} {} parse failed: {}", method, url, e))
+    }
+
+    // ── Users ───────────────────────────────────────────────────────
+
+    /// GET /users/@me — validate the bot token and return user object.
+    pub async fn get_current_user(&self) -> Result<serde_json::Value> {
+        self.auth_request_json(reqwest::Method::GET, &self.url("/users/@me"), None)
+            .await
     }
 
     // ── Gateway ─────────────────────────────────────────────────────
 
     /// GET /gateway/bot — get the WebSocket gateway URL and shard info.
     pub async fn get_gateway_bot(&self) -> Result<serde_json::Value> {
-        let url = self.url("/gateway/bot");
-        let resp = with_rate_limit_retry(3, || async {
-            self.client
-                .get(&url)
-                .header("Authorization", &self.token)
-                .send()
-                .await
-                .map_err(|e| anyhow!("get_gateway_bot request failed: {}", e))
-        })
-        .await?;
-
-        if !resp.status().is_success() {
-            return Err(Self::parse_error(resp).await);
-        }
-        resp.json()
+        self.auth_request_json(reqwest::Method::GET, &self.url("/gateway/bot"), None)
             .await
-            .map_err(|e| anyhow!("get_gateway_bot parse failed: {}", e))
     }
 
     // ── Messages ────────────────────────────────────────────────────
@@ -135,23 +149,8 @@ impl DiscordApi {
             body["components"] = serde_json::json!(comps);
         }
 
-        let resp = with_rate_limit_retry(3, || async {
-            self.client
-                .post(&url)
-                .header("Authorization", &self.token)
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| anyhow!("create_message request failed: {}", e))
-        })
-        .await?;
-
-        if !resp.status().is_success() {
-            return Err(Self::parse_error(resp).await);
-        }
-        resp.json()
+        self.auth_request_json(reqwest::Method::POST, &url, Some(&body))
             .await
-            .map_err(|e| anyhow!("create_message parse failed: {}", e))
     }
 
     /// POST /channels/{channel_id}/messages with multipart/form-data attachments.
@@ -248,42 +247,16 @@ impl DiscordApi {
 
         let body = serde_json::json!({ "content": content });
 
-        let resp = with_rate_limit_retry(3, || async {
-            self.client
-                .patch(&url)
-                .header("Authorization", &self.token)
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| anyhow!("edit_message request failed: {}", e))
-        })
-        .await?;
-
-        if !resp.status().is_success() {
-            return Err(Self::parse_error(resp).await);
-        }
-        resp.json()
+        self.auth_request_json(reqwest::Method::PATCH, &url, Some(&body))
             .await
-            .map_err(|e| anyhow!("edit_message parse failed: {}", e))
     }
 
     /// DELETE /channels/{channel_id}/messages/{message_id} — delete a message.
     pub async fn delete_message(&self, channel_id: &str, message_id: &str) -> Result<()> {
         let url = self.url(&format!("/channels/{}/messages/{}", channel_id, message_id));
 
-        let resp = with_rate_limit_retry(3, || async {
-            self.client
-                .delete(&url)
-                .header("Authorization", &self.token)
-                .send()
-                .await
-                .map_err(|e| anyhow!("delete_message request failed: {}", e))
-        })
-        .await?;
-
-        if !resp.status().is_success() {
-            return Err(Self::parse_error(resp).await);
-        }
+        self.auth_request(reqwest::Method::DELETE, &url, None)
+            .await?;
         Ok(())
     }
 
@@ -312,20 +285,8 @@ impl DiscordApi {
             body["data"] = d;
         }
 
-        let resp = with_rate_limit_retry(3, || async {
-            self.client
-                .post(&url)
-                .header("Authorization", &self.token)
-                .json(&body)
-                .send()
-                .await
-                .map_err(|e| anyhow!("create_interaction_response request failed: {}", e))
-        })
-        .await?;
-
-        if !resp.status().is_success() {
-            return Err(Self::parse_error(resp).await);
-        }
+        self.auth_request(reqwest::Method::POST, &url, Some(&body))
+            .await?;
         Ok(())
     }
 
@@ -334,21 +295,8 @@ impl DiscordApi {
     /// POST /channels/{channel_id}/typing — trigger typing indicator.
     pub async fn trigger_typing(&self, channel_id: &str) -> Result<()> {
         let url = self.url(&format!("/channels/{}/typing", channel_id));
-
-        let resp = with_rate_limit_retry(3, || async {
-            self.client
-                .post(&url)
-                .header("Authorization", &self.token)
-                .header("Content-Length", "0")
-                .send()
-                .await
-                .map_err(|e| anyhow!("trigger_typing request failed: {}", e))
-        })
-        .await?;
-
-        if !resp.status().is_success() {
-            return Err(Self::parse_error(resp).await);
-        }
+        // typing endpoint 不带 body；reqwest 自动写 Content-Length: 0
+        self.auth_request(reqwest::Method::POST, &url, None).await?;
         Ok(())
     }
 
@@ -358,22 +306,8 @@ impl DiscordApi {
     /// `type` enum to ChatType for forum threads / guild text channels).
     pub async fn get_channel(&self, channel_id: &str) -> Result<serde_json::Value> {
         let url = self.url(&format!("/channels/{}", channel_id));
-        let resp = with_rate_limit_retry(3, || async {
-            self.client
-                .get(&url)
-                .header("Authorization", &self.token)
-                .send()
-                .await
-                .map_err(|e| anyhow!("get_channel request failed: {}", e))
-        })
-        .await?;
-
-        if !resp.status().is_success() {
-            return Err(Self::parse_error(resp).await);
-        }
-        resp.json()
+        self.auth_request_json(reqwest::Method::GET, &url, None)
             .await
-            .map_err(|e| anyhow!("get_channel parse failed: {}", e))
     }
 
     // ── Application Commands ────────────────────────────────────────
@@ -385,21 +319,9 @@ impl DiscordApi {
         commands: Vec<serde_json::Value>,
     ) -> Result<()> {
         let url = self.url(&format!("/applications/{}/commands", application_id));
-
-        let resp = with_rate_limit_retry(3, || async {
-            self.client
-                .put(&url)
-                .header("Authorization", &self.token)
-                .json(&commands)
-                .send()
-                .await
-                .map_err(|e| anyhow!("bulk_overwrite_global_commands request failed: {}", e))
-        })
-        .await?;
-
-        if !resp.status().is_success() {
-            return Err(Self::parse_error(resp).await);
-        }
+        let body = serde_json::Value::Array(commands);
+        self.auth_request(reqwest::Method::PUT, &url, Some(&body))
+            .await?;
         Ok(())
     }
 }

--- a/crates/ha-core/src/channel/discord/api.rs
+++ b/crates/ha-core/src/channel/discord/api.rs
@@ -1,6 +1,8 @@
 use anyhow::{anyhow, Result};
 use std::time::Duration;
 
+use crate::channel::rate_limit::with_rate_limit_retry;
+
 /// Discord REST API client (v10).
 pub struct DiscordApi {
     client: reqwest::Client,
@@ -60,13 +62,16 @@ impl DiscordApi {
 
     /// GET /users/@me — validate the bot token and return user object.
     pub async fn get_current_user(&self) -> Result<serde_json::Value> {
-        let resp = self
-            .client
-            .get(self.url("/users/@me"))
-            .header("Authorization", &self.token)
-            .send()
-            .await
-            .map_err(|e| anyhow!("get_current_user request failed: {}", e))?;
+        let url = self.url("/users/@me");
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .get(&url)
+                .header("Authorization", &self.token)
+                .send()
+                .await
+                .map_err(|e| anyhow!("get_current_user request failed: {}", e))
+        })
+        .await?;
 
         if !resp.status().is_success() {
             return Err(Self::parse_error(resp).await);
@@ -80,13 +85,16 @@ impl DiscordApi {
 
     /// GET /gateway/bot — get the WebSocket gateway URL and shard info.
     pub async fn get_gateway_bot(&self) -> Result<serde_json::Value> {
-        let resp = self
-            .client
-            .get(self.url("/gateway/bot"))
-            .header("Authorization", &self.token)
-            .send()
-            .await
-            .map_err(|e| anyhow!("get_gateway_bot request failed: {}", e))?;
+        let url = self.url("/gateway/bot");
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .get(&url)
+                .header("Authorization", &self.token)
+                .send()
+                .await
+                .map_err(|e| anyhow!("get_gateway_bot request failed: {}", e))
+        })
+        .await?;
 
         if !resp.status().is_success() {
             return Err(Self::parse_error(resp).await);
@@ -116,8 +124,10 @@ impl DiscordApi {
         let mut body = serde_json::json!({ "content": content });
 
         if let Some(ref_id) = reply_to {
+            // fail_if_not_exists=false: 引用消息已删除时降级为普通消息而不是整条 fail
             body["message_reference"] = serde_json::json!({
-                "message_id": ref_id
+                "message_id": ref_id,
+                "fail_if_not_exists": false,
             });
         }
 
@@ -125,14 +135,16 @@ impl DiscordApi {
             body["components"] = serde_json::json!(comps);
         }
 
-        let resp = self
-            .client
-            .post(&url)
-            .header("Authorization", &self.token)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| anyhow!("create_message request failed: {}", e))?;
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .post(&url)
+                .header("Authorization", &self.token)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow!("create_message request failed: {}", e))
+        })
+        .await?;
 
         if !resp.status().is_success() {
             return Err(Self::parse_error(resp).await);
@@ -170,7 +182,10 @@ impl DiscordApi {
         if let Some(ref_id) = reply_to {
             payload.insert(
                 "message_reference".to_string(),
-                serde_json::json!({ "message_id": ref_id }),
+                serde_json::json!({
+                    "message_id": ref_id,
+                    "fail_if_not_exists": false,
+                }),
             );
         }
         if let Some(comps) = components {
@@ -233,14 +248,16 @@ impl DiscordApi {
 
         let body = serde_json::json!({ "content": content });
 
-        let resp = self
-            .client
-            .patch(&url)
-            .header("Authorization", &self.token)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| anyhow!("edit_message request failed: {}", e))?;
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .patch(&url)
+                .header("Authorization", &self.token)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow!("edit_message request failed: {}", e))
+        })
+        .await?;
 
         if !resp.status().is_success() {
             return Err(Self::parse_error(resp).await);
@@ -254,13 +271,15 @@ impl DiscordApi {
     pub async fn delete_message(&self, channel_id: &str, message_id: &str) -> Result<()> {
         let url = self.url(&format!("/channels/{}/messages/{}", channel_id, message_id));
 
-        let resp = self
-            .client
-            .delete(&url)
-            .header("Authorization", &self.token)
-            .send()
-            .await
-            .map_err(|e| anyhow!("delete_message request failed: {}", e))?;
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .delete(&url)
+                .header("Authorization", &self.token)
+                .send()
+                .await
+                .map_err(|e| anyhow!("delete_message request failed: {}", e))
+        })
+        .await?;
 
         if !resp.status().is_success() {
             return Err(Self::parse_error(resp).await);
@@ -293,14 +312,16 @@ impl DiscordApi {
             body["data"] = d;
         }
 
-        let resp = self
-            .client
-            .post(&url)
-            .header("Authorization", &self.token)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| anyhow!("create_interaction_response request failed: {}", e))?;
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .post(&url)
+                .header("Authorization", &self.token)
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow!("create_interaction_response request failed: {}", e))
+        })
+        .await?;
 
         if !resp.status().is_success() {
             return Err(Self::parse_error(resp).await);
@@ -314,19 +335,45 @@ impl DiscordApi {
     pub async fn trigger_typing(&self, channel_id: &str) -> Result<()> {
         let url = self.url(&format!("/channels/{}/typing", channel_id));
 
-        let resp = self
-            .client
-            .post(&url)
-            .header("Authorization", &self.token)
-            .header("Content-Length", "0")
-            .send()
-            .await
-            .map_err(|e| anyhow!("trigger_typing request failed: {}", e))?;
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .post(&url)
+                .header("Authorization", &self.token)
+                .header("Content-Length", "0")
+                .send()
+                .await
+                .map_err(|e| anyhow!("trigger_typing request failed: {}", e))
+        })
+        .await?;
 
         if !resp.status().is_success() {
             return Err(Self::parse_error(resp).await);
         }
         Ok(())
+    }
+
+    // ── Channels ────────────────────────────────────────────────────
+
+    /// GET /channels/{channel_id} — fetch channel object (used to map Discord
+    /// `type` enum to ChatType for forum threads / guild text channels).
+    pub async fn get_channel(&self, channel_id: &str) -> Result<serde_json::Value> {
+        let url = self.url(&format!("/channels/{}", channel_id));
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .get(&url)
+                .header("Authorization", &self.token)
+                .send()
+                .await
+                .map_err(|e| anyhow!("get_channel request failed: {}", e))
+        })
+        .await?;
+
+        if !resp.status().is_success() {
+            return Err(Self::parse_error(resp).await);
+        }
+        resp.json()
+            .await
+            .map_err(|e| anyhow!("get_channel parse failed: {}", e))
     }
 
     // ── Application Commands ────────────────────────────────────────
@@ -339,14 +386,16 @@ impl DiscordApi {
     ) -> Result<()> {
         let url = self.url(&format!("/applications/{}/commands", application_id));
 
-        let resp = self
-            .client
-            .put(&url)
-            .header("Authorization", &self.token)
-            .json(&commands)
-            .send()
-            .await
-            .map_err(|e| anyhow!("bulk_overwrite_global_commands request failed: {}", e))?;
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .put(&url)
+                .header("Authorization", &self.token)
+                .json(&commands)
+                .send()
+                .await
+                .map_err(|e| anyhow!("bulk_overwrite_global_commands request failed: {}", e))
+        })
+        .await?;
 
         if !resp.status().is_success() {
             return Err(Self::parse_error(resp).await);

--- a/crates/ha-core/src/channel/discord/gateway.rs
+++ b/crates/ha-core/src/channel/discord/gateway.rs
@@ -252,14 +252,62 @@ pub async fn run_gateway_loop(
                     last_heartbeat = tokio::time::Instant::now();
                 }
 
-                msg = ws.recv_text() => {
+                msg = ws.recv_text_with_close() => {
                     let text = match msg {
-                        Some(t) => t,
+                        Some(Ok(t)) => t,
+                        Some(Err(close)) => {
+                            // Discord gateway close codes:
+                            // - 4004 authentication failed (token invalid)
+                            // - 4010 invalid shard
+                            // - 4011 sharding required
+                            // - 4012 invalid API version
+                            // - 4013 invalid intents
+                            // - 4014 disallowed intents (privileged not enabled)
+                            // 这些是 fatal，不应该 RESUME / IDENTIFY 反复重试
+                            // - 4007 invalid seq
+                            // - 4009 session timeout
+                            // 这两个清 session 后 fresh IDENTIFY
+                            // - 其它（4000-4003 / 4005 / 4008）允许 RESUME
+                            // <https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway>
+                            match close.code {
+                                4004 | 4010 | 4011 | 4012 | 4013 | 4014 => {
+                                    app_error!(
+                                        "channel",
+                                        "discord::gateway",
+                                        "Fatal close code {} ({}); aborting account '{}'",
+                                        close.code,
+                                        close.reason,
+                                        account_id
+                                    );
+                                    return;
+                                }
+                                4007 | 4009 => {
+                                    app_warn!(
+                                        "channel",
+                                        "discord::gateway",
+                                        "Recoverable close code {} ({}); fresh IDENTIFY",
+                                        close.code,
+                                        close.reason
+                                    );
+                                    invalidate_session = true;
+                                }
+                                _ => {
+                                    app_warn!(
+                                        "channel",
+                                        "discord::gateway",
+                                        "WebSocket closed (code={}, reason='{}'), reconnecting",
+                                        close.code,
+                                        close.reason
+                                    );
+                                }
+                            }
+                            break;
+                        }
                         None => {
                             app_warn!(
                                 "channel",
                                 "discord::gateway",
-                                "WebSocket closed, reconnecting"
+                                "WebSocket closed without close frame, reconnecting"
                             );
                             break;
                         }

--- a/crates/ha-core/src/channel/discord/mod.rs
+++ b/crates/ha-core/src/channel/discord/mod.rs
@@ -188,7 +188,10 @@ impl ChannelPlugin for DiscordPlugin {
             ],
             supports_typing: true,
             supports_buttons: true,
-            max_message_length: Some(2000),
+            // Discord 官方上限是 2000 字符；UTF-8 字节计算下 emoji surrogate
+            // pair 等多字节字符会顶到 6+ bytes，留 25% 余量到 1500 字节避免触发
+            // "Invalid Form Body" content_too_long
+            max_message_length: Some(1500),
         }
     }
 

--- a/crates/ha-core/src/channel/discord/mod.rs
+++ b/crates/ha-core/src/channel/discord/mod.rs
@@ -1,3 +1,12 @@
+//! Discord Bot channel.
+//!
+//! - **Official API**: <https://discord.com/developers/docs/intro>
+//! - **SDK / Reference**: <https://github.com/discord/discord-api-docs>
+//!   (canonical), gateway opcode 列表
+//!   <https://discord.com/developers/docs/topics/opcodes-and-status-codes>
+//! - **Protocol**: WebSocket Gateway v10 + REST + multipart file upload
+//! - **Last reviewed**: 2026-05-05
+
 pub mod api;
 pub mod format;
 pub mod gateway;

--- a/crates/ha-core/src/channel/feishu/mod.rs
+++ b/crates/ha-core/src/channel/feishu/mod.rs
@@ -1,3 +1,13 @@
+//! Feishu / Lark channel (飞书 / Lark Suite).
+//!
+//! - **Official API**: <https://open.feishu.cn/document/> (cn) /
+//!   <https://open.larksuite.com/document/> (intl)
+//! - **SDK / Reference**: <https://github.com/larksuite/oapi-sdk-nodejs>
+//!   (官方 Node SDK，长连接帧协议 + 鉴权刷新参考实现)
+//! - **Protocol**: WebSocket 事件订阅（pbbp2 protobuf 帧）+ REST
+//!   `/open-apis/im/v1/messages` + `tenant_access_token` (TTL 7200s)
+//! - **Last reviewed**: 2026-05-05
+
 pub mod api;
 pub mod auth;
 pub mod data_cache;

--- a/crates/ha-core/src/channel/googlechat/api.rs
+++ b/crates/ha-core/src/channel/googlechat/api.rs
@@ -85,18 +85,27 @@ impl GoogleChatApi {
 
         let mut body = serde_json::json!({ "text": text });
 
+        // Google Chat API 区分两种 thread 引用：
+        // - `thread.name` —— 已存在线程的 resource name `spaces/{}/threads/{}`
+        // - `thread.threadKey` —— 开发者自定义 key（用于幂等创建/匹配）
+        // 之前一律用 `name` 会让自定义 thread_key（如 cron 自动消息生成的
+        // 任意字符串）触发 INVALID_ARGUMENT。这里按 thread_key 形态自动选用。
+        let mut reply_option_param = "";
         if let Some(tk) = thread_key {
-            body["thread"] = serde_json::json!({ "name": tk });
+            if tk.starts_with("spaces/") && tk.contains("/threads/") {
+                body["thread"] = serde_json::json!({ "name": tk });
+                reply_option_param = "?messageReplyOption=REPLY_MESSAGE_OR_FAIL";
+            } else {
+                body["thread"] = serde_json::json!({ "threadKey": tk });
+                reply_option_param = "?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD";
+            }
         }
 
         if let Some(cards) = cards_v2 {
             body["cardsV2"] = serde_json::Value::Array(cards.to_vec());
         }
 
-        let mut url = format!("{}/{}/messages", CHAT_API_BASE, space);
-        if thread_key.is_some() {
-            url.push_str("?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
-        }
+        let url = format!("{}/{}/messages{}", CHAT_API_BASE, space, reply_option_param);
 
         let resp = self
             .client

--- a/crates/ha-core/src/channel/googlechat/api.rs
+++ b/crates/ha-core/src/channel/googlechat/api.rs
@@ -85,11 +85,9 @@ impl GoogleChatApi {
 
         let mut body = serde_json::json!({ "text": text });
 
-        // Google Chat API 区分两种 thread 引用：
-        // - `thread.name` —— 已存在线程的 resource name `spaces/{}/threads/{}`
-        // - `thread.threadKey` —— 开发者自定义 key（用于幂等创建/匹配）
-        // 之前一律用 `name` 会让自定义 thread_key（如 cron 自动消息生成的
-        // 任意字符串）触发 INVALID_ARGUMENT。这里按 thread_key 形态自动选用。
+        // Google Chat API 两种 thread 引用：`thread.name` 仅接 resource name
+        // `spaces/{}/threads/{}`；其他自定义 key（如 cron 生成的任意字串）
+        // 必须走 `thread.threadKey`，不然返回 INVALID_ARGUMENT。
         let mut reply_option_param = "";
         if let Some(tk) = thread_key {
             if tk.starts_with("spaces/") && tk.contains("/threads/") {

--- a/crates/ha-core/src/channel/googlechat/auth.rs
+++ b/crates/ha-core/src/channel/googlechat/auth.rs
@@ -5,15 +5,14 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 
-/// **BREAKING (2026-05-05)**：旧 scope `chat.bot` 已被 Google 弃用，新创建的
-/// Google Workspace 项目对应 service account 直接换 scope 即生效；但若用户
-/// 在 Google Workspace Admin → API Controls → Domain-wide delegation 仅授权
-/// `chat.bot`，必须重新授权下面这两个 scope 才能拿到 token。
+/// Google Chat **app authentication**（service account JWT-bearer）必须用
+/// `chat.bot` scope；`chat.messages.create` / `chat.spaces.readonly` 是
+/// **user authentication** 专用 scope（OAuth 用户授权流），不能用于本仓
+/// 的 service account 流程，否则 spaces.list / messages.create 会
+/// `PERMISSION_DENIED`。
 ///
-/// 选择理由：
-/// - `chat.messages.create` —— 发送消息（核心能力）
-/// - `chat.spaces.readonly` —— probe 时调 spaces.list 验证连通
-const CHAT_SCOPE: &str = "https://www.googleapis.com/auth/chat.messages.create https://www.googleapis.com/auth/chat.spaces.readonly";
+/// 参考：<https://developers.google.com/workspace/chat/authenticate-authorize-chat-app>
+const CHAT_SCOPE: &str = "https://www.googleapis.com/auth/chat.bot";
 /// Buffer before expiry to refresh the token (5 minutes).
 const EXPIRY_BUFFER_SECS: u64 = 300;
 

--- a/crates/ha-core/src/channel/googlechat/auth.rs
+++ b/crates/ha-core/src/channel/googlechat/auth.rs
@@ -5,7 +5,15 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 
-const CHAT_SCOPE: &str = "https://www.googleapis.com/auth/chat.bot";
+/// **BREAKING (2026-05-05)**：旧 scope `chat.bot` 已被 Google 弃用，新创建的
+/// Google Workspace 项目对应 service account 直接换 scope 即生效；但若用户
+/// 在 Google Workspace Admin → API Controls → Domain-wide delegation 仅授权
+/// `chat.bot`，必须重新授权下面这两个 scope 才能拿到 token。
+///
+/// 选择理由：
+/// - `chat.messages.create` —— 发送消息（核心能力）
+/// - `chat.spaces.readonly` —— probe 时调 spaces.list 验证连通
+const CHAT_SCOPE: &str = "https://www.googleapis.com/auth/chat.messages.create https://www.googleapis.com/auth/chat.spaces.readonly";
 /// Buffer before expiry to refresh the token (5 minutes).
 const EXPIRY_BUFFER_SECS: u64 = 300;
 

--- a/crates/ha-core/src/channel/googlechat/jwt.rs
+++ b/crates/ha-core/src/channel/googlechat/jwt.rs
@@ -1,0 +1,210 @@
+//! Google Chat webhook JWT 验签。
+//!
+//! Google Chat 在向 bot endpoint 发请求时附带 `Authorization: Bearer <JWT>`，
+//! 由 `chat@system.gserviceaccount.com` 签发。bot 必须验：
+//!
+//! 1. 签名（用 Google 公钥 PEM）
+//! 2. `iss == "chat@system.gserviceaccount.com"`
+//! 3. `aud == <bot 的 project number>`（用户在凭据中提供）
+//! 4. 未过期（`exp`）
+//!
+//! 任何一项不通过，请求都视为伪造（任何人能 reach 隧道 URL 的人都可以伪造
+//! `MESSAGE` / `CARD_CLICKED` 事件 → 劫持 LLM 会话或触发任意工具审批）。
+//!
+//! - 公钥源：<https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com>
+//! - 算法：RS256
+//! - 公钥缓存：1 小时（与 Google 文档约定一致）
+
+use anyhow::{anyhow, Result};
+use jsonwebtoken::{decode, decode_header, Algorithm, DecodingKey, Validation};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+const ISSUER: &str = "chat@system.gserviceaccount.com";
+const PUBLIC_KEYS_URL: &str =
+    "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com";
+const CACHE_TTL: Duration = Duration::from_secs(3600);
+
+/// JWT claims we care about (rest ignored).
+#[derive(Debug, serde::Deserialize)]
+struct GoogleChatClaims {
+    iss: String,
+    aud: String,
+    // exp / iat 由 jsonwebtoken 自动校验（Validation::set_audience + leeway）
+}
+
+/// Cached public keys, keyed by `kid` (X.509 PEM string per kid).
+#[derive(Default)]
+struct KeyCache {
+    keys: HashMap<String, String>,
+    fetched_at: Option<Instant>,
+}
+
+/// Public-key fetcher with TTL cache. Shared singleton.
+pub struct GoogleChatJwtVerifier {
+    http_client: reqwest::Client,
+    cache: Arc<Mutex<KeyCache>>,
+}
+
+impl GoogleChatJwtVerifier {
+    pub fn new() -> Self {
+        let http_client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new());
+        Self {
+            http_client,
+            cache: Arc::new(Mutex::new(KeyCache::default())),
+        }
+    }
+
+    /// 从 `Authorization: Bearer <JWT>` 头中提取 token 并完整验签。
+    ///
+    /// `expected_aud` 是 bot 的 Google Cloud project number（用户在凭据中
+    /// 配置）。验签失败返回 Err，调用方应回 401/403。
+    pub async fn verify_authz_header(
+        &self,
+        authz_header: Option<&str>,
+        expected_aud: &str,
+    ) -> Result<()> {
+        let header_value =
+            authz_header.ok_or_else(|| anyhow!("Missing Authorization header"))?;
+        let token = header_value
+            .strip_prefix("Bearer ")
+            .ok_or_else(|| anyhow!("Authorization header is not Bearer"))?;
+        self.verify_token(token, expected_aud).await
+    }
+
+    /// 直接对一个 raw JWT token 字符串验签。
+    pub async fn verify_token(&self, token: &str, expected_aud: &str) -> Result<()> {
+        // 1. 读 header 拿 kid
+        let header = decode_header(token).map_err(|e| anyhow!("Invalid JWT header: {}", e))?;
+        let kid = header
+            .kid
+            .ok_or_else(|| anyhow!("JWT header missing 'kid'"))?;
+
+        // 2. 拿对应 PEM 公钥（必要时刷新缓存）
+        let pem = self.get_key(&kid).await?;
+
+        // 3. 构造 Validation，指定 aud / iss / 算法
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_audience(&[expected_aud]);
+        validation.set_issuer(&[ISSUER]);
+        // exp 默认会被校验；不设置 leeway（jsonwebtoken 默认 0）
+
+        let key = DecodingKey::from_rsa_pem(pem.as_bytes())
+            .map_err(|e| anyhow!("Failed to parse Google public key PEM: {}", e))?;
+
+        let token_data = decode::<GoogleChatClaims>(token, &key, &validation)
+            .map_err(|e| anyhow!("JWT verification failed: {}", e))?;
+
+        // 4. 双保险（Validation 已经 set_issuer + set_audience，但显式校验
+        //    防止 future 版本默认行为漂移）
+        if token_data.claims.iss != ISSUER {
+            return Err(anyhow!(
+                "JWT iss mismatch: expected '{}', got '{}'",
+                ISSUER,
+                token_data.claims.iss
+            ));
+        }
+        if token_data.claims.aud != expected_aud {
+            return Err(anyhow!(
+                "JWT aud mismatch: expected '{}', got '{}'",
+                expected_aud,
+                token_data.claims.aud
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// 取 kid 对应的 PEM 公钥；过期 / miss 时全量拉取一次。
+    async fn get_key(&self, kid: &str) -> Result<String> {
+        // 先看缓存
+        {
+            let cache = self.cache.lock().await;
+            if let Some(fetched_at) = cache.fetched_at {
+                if fetched_at.elapsed() < CACHE_TTL {
+                    if let Some(pem) = cache.keys.get(kid) {
+                        return Ok(pem.clone());
+                    }
+                }
+            }
+        }
+
+        // 重新拉
+        self.refresh_keys().await?;
+
+        let cache = self.cache.lock().await;
+        cache
+            .keys
+            .get(kid)
+            .cloned()
+            .ok_or_else(|| anyhow!("Google public key not found for kid '{}'", kid))
+    }
+
+    async fn refresh_keys(&self) -> Result<()> {
+        let resp = self
+            .http_client
+            .get(PUBLIC_KEYS_URL)
+            .send()
+            .await
+            .map_err(|e| anyhow!("Failed to fetch Google public keys: {}", e))?;
+        if !resp.status().is_success() {
+            return Err(anyhow!(
+                "Google public keys endpoint returned {}",
+                resp.status().as_u16()
+            ));
+        }
+        // Response 形如 `{"<kid>": "-----BEGIN CERTIFICATE-----..."}`
+        let body: HashMap<String, String> = resp
+            .json()
+            .await
+            .map_err(|e| anyhow!("Failed to parse Google public keys JSON: {}", e))?;
+        let mut cache = self.cache.lock().await;
+        cache.keys = body;
+        cache.fetched_at = Some(Instant::now());
+        Ok(())
+    }
+}
+
+impl Default for GoogleChatJwtVerifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn missing_authz_returns_err() {
+        let v = GoogleChatJwtVerifier::new();
+        let r = v.verify_authz_header(None, "12345").await;
+        assert!(r.is_err());
+        let msg = r.unwrap_err().to_string();
+        assert!(msg.contains("Missing Authorization"));
+    }
+
+    #[tokio::test]
+    async fn non_bearer_returns_err() {
+        let v = GoogleChatJwtVerifier::new();
+        let r = v
+            .verify_authz_header(Some("Basic abc=="), "12345")
+            .await;
+        assert!(r.is_err());
+        let msg = r.unwrap_err().to_string();
+        assert!(msg.contains("not Bearer"));
+    }
+
+    #[tokio::test]
+    async fn malformed_token_returns_err() {
+        let v = GoogleChatJwtVerifier::new();
+        let r = v.verify_token("not-a-jwt", "12345").await;
+        assert!(r.is_err());
+    }
+}

--- a/crates/ha-core/src/channel/googlechat/jwt.rs
+++ b/crates/ha-core/src/channel/googlechat/jwt.rs
@@ -146,6 +146,16 @@ impl GoogleChatJwtVerifier {
     }
 
     async fn refresh_keys(&self) -> Result<()> {
+        // 出站 HTTP 必须过 SSRF 校验（AGENTS.md 红线 — 新出站入口严禁自写
+        // IP 校验）。URL 写死指向 googleapis.com，但仍走统一 helper。
+        crate::security::ssrf::check_url(
+            PUBLIC_KEYS_URL,
+            crate::security::ssrf::SsrfPolicy::Default,
+            &[],
+        )
+        .await
+        .map_err(|e| anyhow!("SSRF check failed for Google public keys URL: {}", e))?;
+
         let resp = self
             .http_client
             .get(PUBLIC_KEYS_URL)

--- a/crates/ha-core/src/channel/googlechat/jwt.rs
+++ b/crates/ha-core/src/channel/googlechat/jwt.rs
@@ -70,8 +70,7 @@ impl GoogleChatJwtVerifier {
         authz_header: Option<&str>,
         expected_aud: &str,
     ) -> Result<()> {
-        let header_value =
-            authz_header.ok_or_else(|| anyhow!("Missing Authorization header"))?;
+        let header_value = authz_header.ok_or_else(|| anyhow!("Missing Authorization header"))?;
         let token = header_value
             .strip_prefix("Bearer ")
             .ok_or_else(|| anyhow!("Authorization header is not Bearer"))?;
@@ -193,9 +192,7 @@ mod tests {
     #[tokio::test]
     async fn non_bearer_returns_err() {
         let v = GoogleChatJwtVerifier::new();
-        let r = v
-            .verify_authz_header(Some("Basic abc=="), "12345")
-            .await;
+        let r = v.verify_authz_header(Some("Basic abc=="), "12345").await;
         assert!(r.is_err());
         let msg = r.unwrap_err().to_string();
         assert!(msg.contains("not Bearer"));

--- a/crates/ha-core/src/channel/googlechat/mod.rs
+++ b/crates/ha-core/src/channel/googlechat/mod.rs
@@ -10,6 +10,7 @@
 pub mod api;
 pub mod auth;
 pub mod format;
+pub mod jwt;
 pub mod webhook;
 
 use anyhow::Result;
@@ -81,6 +82,22 @@ impl GoogleChatPlugin {
             .filter(|s| !s.is_empty())
     }
 
+    /// Extract the bot's Google Cloud project number (used as JWT `aud` claim
+    /// when verifying webhook events). 必填——未配置时入站 webhook 一律拒绝。
+    fn extract_project_number(credentials: &serde_json::Value) -> Result<String> {
+        credentials
+            .get("projectNumber")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Missing 'projectNumber' in Google Chat credentials \
+                     (required for JWT webhook verification)"
+                )
+            })
+    }
+
     /// Get the API for a running account.
     async fn get_api(&self, account_id: &str) -> Result<Arc<GoogleChatApi>> {
         let accounts = self.accounts.lock().await;
@@ -130,6 +147,7 @@ impl ChannelPlugin for GoogleChatPlugin {
     ) -> Result<()> {
         let cred_json = Self::extract_credentials_json(&account.credentials)?;
         let _webhook_base_url = Self::extract_webhook_base_url(&account.credentials);
+        let project_number = Self::extract_project_number(&account.credentials)?;
 
         // Create auth and API instances
         let auth = GoogleChatAuth::from_json(&cred_json)?;
@@ -151,7 +169,12 @@ impl ChannelPlugin for GoogleChatPlugin {
 
         // Start webhook server and register handler
         let webhook_server = get_or_start_webhook_server().await?;
-        let handler = webhook::create_webhook_handler(api.clone(), account.id.clone(), inbound_tx);
+        let handler = webhook::create_webhook_handler(
+            api.clone(),
+            account.id.clone(),
+            project_number,
+            inbound_tx,
+        );
         webhook_server
             .register_handler("googlechat", &account.id, handler)
             .await;

--- a/crates/ha-core/src/channel/googlechat/mod.rs
+++ b/crates/ha-core/src/channel/googlechat/mod.rs
@@ -83,19 +83,17 @@ impl GoogleChatPlugin {
     }
 
     /// Extract the bot's Google Cloud project number (used as JWT `aud` claim
-    /// when verifying webhook events). 必填——未配置时入站 webhook 一律拒绝。
-    fn extract_project_number(credentials: &serde_json::Value) -> Result<String> {
+    /// when verifying webhook events).
+    ///
+    /// **Optional**：缺失只让入站 webhook 拒绝（无法验签 JWT），出站发送
+    /// 不依赖此字段——升级前保存的旧账号没有这字段，必须能继续启动出站
+    /// 能力，等用户在编辑弹窗补全 projectNumber 后再开入站。
+    fn extract_project_number(credentials: &serde_json::Value) -> Option<String> {
         credentials
             .get("projectNumber")
             .and_then(|v| v.as_str())
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Missing 'projectNumber' in Google Chat credentials \
-                     (required for JWT webhook verification)"
-                )
-            })
     }
 
     /// Get the API for a running account.
@@ -147,7 +145,7 @@ impl ChannelPlugin for GoogleChatPlugin {
     ) -> Result<()> {
         let cred_json = Self::extract_credentials_json(&account.credentials)?;
         let _webhook_base_url = Self::extract_webhook_base_url(&account.credentials);
-        let project_number = Self::extract_project_number(&account.credentials)?;
+        let project_number = Self::extract_project_number(&account.credentials);
 
         // Create auth and API instances
         let auth = GoogleChatAuth::from_json(&cred_json)?;
@@ -167,24 +165,35 @@ impl ChannelPlugin for GoogleChatPlugin {
             client_email
         );
 
-        // Start webhook server and register handler
-        let webhook_server = get_or_start_webhook_server().await?;
-        let handler = webhook::create_webhook_handler(
-            api.clone(),
-            account.id.clone(),
-            project_number,
-            inbound_tx,
-        );
-        webhook_server
-            .register_handler("googlechat", &account.id, handler)
-            .await;
+        // Start webhook server and register handler only when projectNumber
+        // 已配置；缺失时出站继续工作，入站静默 disable（不阻 start_account）
+        if let Some(project_number) = project_number {
+            let webhook_server = get_or_start_webhook_server().await?;
+            let handler = webhook::create_webhook_handler(
+                api.clone(),
+                account.id.clone(),
+                project_number,
+                inbound_tx,
+            );
+            webhook_server
+                .register_handler("googlechat", &account.id, handler)
+                .await;
 
-        app_info!(
-            "channel",
-            "googlechat",
-            "Webhook handler registered at /webhook/googlechat/{}",
-            account.id
-        );
+            app_info!(
+                "channel",
+                "googlechat",
+                "Webhook handler registered at /webhook/googlechat/{}",
+                account.id
+            );
+        } else {
+            app_warn!(
+                "channel",
+                "googlechat",
+                "Account '{}' has no projectNumber; inbound webhooks disabled. \
+                 Edit account credentials to enable receiving messages.",
+                account.id
+            );
+        }
 
         // Store running account state
         {

--- a/crates/ha-core/src/channel/googlechat/mod.rs
+++ b/crates/ha-core/src/channel/googlechat/mod.rs
@@ -1,3 +1,12 @@
+//! Google Chat (Workspace) channel.
+//!
+//! - **Official API**: <https://developers.google.com/workspace/chat>
+//! - **SDK / Reference**: <https://developers.google.com/workspace/chat/api-overview>
+//! - **Protocol**: HTTPS Webhook（必须验证 Google 签发的 Bearer JWT）+ REST
+//!   `chat.googleapis.com/v1/spaces/{}/messages`；Service Account JWT-bearer
+//!   交换 OAuth token，scope 含 `chat.messages.create` / `chat.spaces.readonly`
+//! - **Last reviewed**: 2026-05-05
+
 pub mod api;
 pub mod auth;
 pub mod format;

--- a/crates/ha-core/src/channel/googlechat/webhook.rs
+++ b/crates/ha-core/src/channel/googlechat/webhook.rs
@@ -61,10 +61,7 @@ pub fn create_webhook_handler(
                 .or_else(|| req.headers.get("Authorization"))
                 .map(|s| s.as_str());
             let verifier = get_jwt_verifier().await;
-            if let Err(e) = verifier
-                .verify_authz_header(authz, &project_number)
-                .await
-            {
+            if let Err(e) = verifier.verify_authz_header(authz, &project_number).await {
                 app_warn!(
                     "channel",
                     "googlechat",

--- a/crates/ha-core/src/channel/googlechat/webhook.rs
+++ b/crates/ha-core/src/channel/googlechat/webhook.rs
@@ -5,24 +5,79 @@ use crate::channel::types::*;
 use crate::channel::webhook_server::{WebhookHandlerFn, WebhookRequest, WebhookResponse};
 
 use super::api::GoogleChatApi;
+use super::jwt::GoogleChatJwtVerifier;
+
+/// Per-process shared JWT verifier (caches Google public keys with 1h TTL).
+static JWT_VERIFIER: tokio::sync::OnceCell<Arc<GoogleChatJwtVerifier>> =
+    tokio::sync::OnceCell::const_new();
+
+async fn get_jwt_verifier() -> Arc<GoogleChatJwtVerifier> {
+    JWT_VERIFIER
+        .get_or_init(|| async { Arc::new(GoogleChatJwtVerifier::new()) })
+        .await
+        .clone()
+}
 
 /// Create a webhook handler function for Google Chat events.
 ///
-/// The handler receives incoming HTTP requests from Google Chat's webhook endpoint,
-/// parses the event payload, and forwards inbound messages through `inbound_tx`.
+/// The handler receives incoming HTTP requests from Google Chat's webhook
+/// endpoint, **强制**验证 Google 签发的 Bearer JWT，然后解析事件 payload
+/// 并通过 `inbound_tx` 转发入站消息。`project_number` 必须与 Google Cloud
+/// 项目号一致（JWT aud claim），否则任何能访问隧道 URL 的人都可以伪造事件。
 pub fn create_webhook_handler(
     api: Arc<GoogleChatApi>,
     account_id: String,
+    project_number: String,
     inbound_tx: mpsc::Sender<MsgContext>,
 ) -> WebhookHandlerFn {
     // Keep api alive for potential future use (e.g. downloading attachments)
     let _api = api;
+    // 空 project_number 直接拒——避免误配置导致鉴权降级
+    let project_number = Arc::new(project_number);
 
     Arc::new(move |req: WebhookRequest| {
         let account_id = account_id.clone();
         let inbound_tx = inbound_tx.clone();
+        let project_number = project_number.clone();
 
         Box::pin(async move {
+            if project_number.is_empty() {
+                app_warn!(
+                    "channel",
+                    "googlechat",
+                    "Rejecting webhook for '{}': project_number not configured",
+                    account_id
+                );
+                return WebhookResponse {
+                    status: 403,
+                    body: r#"{"error":"project_number not configured"}"#.to_string(),
+                };
+            }
+
+            // **必须**验证 Authorization Bearer JWT，否则放任任意伪造事件
+            let authz = req
+                .headers
+                .get("authorization")
+                .or_else(|| req.headers.get("Authorization"))
+                .map(|s| s.as_str());
+            let verifier = get_jwt_verifier().await;
+            if let Err(e) = verifier
+                .verify_authz_header(authz, &project_number)
+                .await
+            {
+                app_warn!(
+                    "channel",
+                    "googlechat",
+                    "Rejected webhook for '{}': JWT verification failed: {}",
+                    account_id,
+                    e
+                );
+                return WebhookResponse {
+                    status: 403,
+                    body: r#"{"error":"unauthorized"}"#.to_string(),
+                };
+            }
+
             // Parse the JSON body
             let body: serde_json::Value = match serde_json::from_slice(&req.body) {
                 Ok(v) => v,
@@ -81,10 +136,19 @@ pub fn create_webhook_handler(
                     );
                 }
                 "CARD_CLICKED" => {
-                    if let Some(action) = body
-                        .pointer("/action/actionMethodName")
+                    // Card v2 按钮 onClick.action.function 在事件回调中以
+                    // `common.invokedFunction` 字段返回（Google Chat API v1
+                    // event schema）；老 Card v1 / FormAction 用
+                    // `action.actionMethodName`。优先 v2，fallback v1，避免
+                    // 用 cardsV2 发出的审批按钮被点击时静默失败。
+                    let action_name = body
+                        .pointer("/common/invokedFunction")
                         .and_then(|v| v.as_str())
-                    {
+                        .or_else(|| {
+                            body.pointer("/action/actionMethodName")
+                                .and_then(|v| v.as_str())
+                        });
+                    if let Some(action) = action_name {
                         crate::channel::worker::ask_user::try_dispatch_interactive_callback(
                             action,
                             "googlechat",

--- a/crates/ha-core/src/channel/imessage/client.rs
+++ b/crates/ha-core/src/channel/imessage/client.rs
@@ -152,17 +152,28 @@ impl IMessageClient {
     /// Reads lines from stdout, dispatches RPC responses to pending callers,
     /// and converts server-initiated notifications (newMessage) into `MsgContext`
     /// sent via `inbound_tx`.
+    ///
+    /// `ready_tx` 在 spawn 出来的 task 进入接收循环（即真正可以处理 RPC
+    /// response）之后立即 send。caller 必须 await 这个 oneshot 之后再调任何
+    /// RPC（如 watch_subscribe）——否则 RPC response 会在 task 启动之前回来，
+    /// pending oneshot 没人接，超时失败。
     pub async fn run_notification_loop(
         &self,
         account_id: String,
         inbound_tx: mpsc::Sender<MsgContext>,
         cancel: CancellationToken,
+        ready_tx: tokio::sync::oneshot::Sender<()>,
     ) {
         let process = self.process.clone();
         let pending = self.pending.clone();
         let stderr_cancel = cancel.clone();
+        let ready_tx = std::sync::Mutex::new(Some(ready_tx));
 
         tokio::spawn(async move {
+            // 进入循环前发 ready 信号
+            if let Some(tx) = ready_tx.lock().ok().and_then(|mut g| g.take()) {
+                let _ = tx.send(());
+            }
             loop {
                 let line = {
                     let mut guard = process.lock().await;
@@ -456,13 +467,17 @@ impl IMessageClient {
             ChatType::Dm
         };
 
-        // Resolve chat_id: prefer chat_id number, then chat_guid, then chat_identifier, then sender
-        let chat_id = if let Some(cid) = payload.chat_id {
-            cid.to_string()
-        } else if let Some(ref guid) = payload.chat_guid {
+        // 解析 chat_id 优先级：chat_guid > chat_identifier > chat_id（数字）
+        // > sender。chat_guid 是 iMessage 协议层最稳定的会话标识（形如
+        // `iMessage;-;chat...`），跨消息复现一致；numeric chat_id 在 imsg
+        // 不同推送中可能缺失，导致同一会话有时映射到 numeric、有时到 guid，
+        // worker 侧把它们看作两个不同会话 → 群聊跨消息历史断裂、记忆丢失。
+        let chat_id = if let Some(ref guid) = payload.chat_guid {
             guid.clone()
         } else if let Some(ref identifier) = payload.chat_identifier {
             identifier.clone()
+        } else if let Some(cid) = payload.chat_id {
+            cid.to_string()
         } else {
             sender.to_string()
         };

--- a/crates/ha-core/src/channel/imessage/client.rs
+++ b/crates/ha-core/src/channel/imessage/client.rs
@@ -167,13 +167,10 @@ impl IMessageClient {
         let process = self.process.clone();
         let pending = self.pending.clone();
         let stderr_cancel = cancel.clone();
-        let ready_tx = std::sync::Mutex::new(Some(ready_tx));
 
         tokio::spawn(async move {
-            // 进入循环前发 ready 信号
-            if let Some(tx) = ready_tx.lock().ok().and_then(|mut g| g.take()) {
-                let _ = tx.send(());
-            }
+            // 进入循环前发 ready 信号；oneshot::send 消耗 self，move 进 spawn 即可
+            let _ = ready_tx.send(());
             loop {
                 let line = {
                     let mut guard = process.lock().await;

--- a/crates/ha-core/src/channel/imessage/mod.rs
+++ b/crates/ha-core/src/channel/imessage/mod.rs
@@ -1,3 +1,12 @@
+//! iMessage channel (macOS only, via `imsg` CLI).
+//!
+//! - **Official tool**: <https://github.com/steipete/imsg>
+//!   (要求 macOS Full Disk Access + Automation→Messages 权限)
+//! - **SDK / Reference**: imsg JSON-RPC over stdio 文档见仓库 README
+//! - **Protocol**: 子进程托管 `imsg`，stdio NDJSON JSON-RPC，watch 订阅推送
+//!   事件，send 单条命令；macOS 限定（依赖 Messages.app + chat.db）
+//! - **Last reviewed**: 2026-05-05
+
 pub mod client;
 pub mod format;
 

--- a/crates/ha-core/src/channel/imessage/mod.rs
+++ b/crates/ha-core/src/channel/imessage/mod.rs
@@ -123,6 +123,27 @@ impl ChannelPlugin for IMessagePlugin {
         // Start the RPC client
         let imsg_client = client::IMessageClient::start(&imsg_path, db_path.as_deref())?;
 
+        // 顺序至关重要：先启动 stdout 读取 loop（spawn 内 ready_tx 就绪），
+        // 再调 watch_subscribe。否则 watch_subscribe 的 RPC response 在 read
+        // loop 启动前就到了，pending oneshot 没人接 → 10s timeout 失败 →
+        // notification 订阅失败 → inbound 消息全丢。
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+        imsg_client
+            .run_notification_loop(account.id.clone(), inbound_tx, cancel, ready_tx)
+            .await;
+
+        // 等 read loop spawn 内部 ready 信号；最长 5s 兜底防止 spawn 失败时无限挂
+        if tokio::time::timeout(std::time::Duration::from_secs(5), ready_rx)
+            .await
+            .is_err()
+        {
+            app_warn!(
+                "channel",
+                "imessage",
+                "Notification loop ready signal timed out (5s); subscribe may race"
+            );
+        }
+
         // Subscribe to watch notifications
         if let Err(e) = imsg_client.watch_subscribe().await {
             app_warn!(
@@ -132,11 +153,6 @@ impl ChannelPlugin for IMessagePlugin {
                 e
             );
         }
-
-        // Start the notification listener loop
-        imsg_client
-            .run_notification_loop(account.id.clone(), inbound_tx, cancel)
-            .await;
 
         // Store the running account
         {
@@ -335,7 +351,7 @@ impl ChannelPlugin for IMessagePlugin {
         // Check binary exists
         if crate::channel::process_manager::find_binary(&imsg_path).is_none() {
             return Err(anyhow::anyhow!(
-                "imsg binary not found at '{}'. Install via: brew install openclaw/tap/imsg",
+                "imsg binary not found at '{}'. Install via: brew install steipete/tap/imsg",
                 imsg_path
             ));
         }

--- a/crates/ha-core/src/channel/irc/client.rs
+++ b/crates/ha-core/src/channel/irc/client.rs
@@ -120,17 +120,9 @@ impl IrcClient {
 
     /// Send PRIVMSG to a target (channel or nick).
     pub async fn send_privmsg(&self, target: &str, text: &str) -> Result<()> {
-        // RFC 2812 限制整行 ≤ 512 字节（含 CRLF）。服务端会在我们发出去的
-        // 消息上加 prefix `:nick!user@host PRIVMSG <target> :`，估算上限：
-        //   prefix `:nick!user@host` ≈ 60-100 bytes（保守估 100）
-        //   ` PRIVMSG ` = 9 bytes
-        //   target 长度（频道名最长 50 + 余量）
-        //   ` :` = 2 bytes
-        //   CRLF = 2 bytes
-        // 所以本地能发的 text 上限 ≈ 512 - 100 - 9 - target.len() - 2 - 2
-        //                        = 399 - target.len()
-        // 之前硬编 400 在长 host 或长频道名场景仍可能超 512；下面动态算。
-        // 最少留 64 字节兜底（CJK 21 字符 + ASCII 64 字符）。
+        // RFC 2812 整行 ≤ 512 字节（含 CRLF）。服务端附加的 prefix
+        // `:nick!user@host PRIVMSG <target> :` ≈ 100 + 9 + target.len() + 4
+        // 字节；剩下的才是 text 上限。最少留 64 字节兜底（CJK 21 字符）。
         let sanitized = text.replace(['\r', '\n'], " ");
         let overhead = 100 + 9 + target.len() + 2 + 2;
         let max_text_len = 512usize.saturating_sub(overhead).max(64);

--- a/crates/ha-core/src/channel/irc/client.rs
+++ b/crates/ha-core/src/channel/irc/client.rs
@@ -120,10 +120,20 @@ impl IrcClient {
 
     /// Send PRIVMSG to a target (channel or nick).
     pub async fn send_privmsg(&self, target: &str, text: &str) -> Result<()> {
-        // IRC messages have a max of ~512 bytes including the protocol overhead.
-        // Split long messages into chunks.
+        // RFC 2812 限制整行 ≤ 512 字节（含 CRLF）。服务端会在我们发出去的
+        // 消息上加 prefix `:nick!user@host PRIVMSG <target> :`，估算上限：
+        //   prefix `:nick!user@host` ≈ 60-100 bytes（保守估 100）
+        //   ` PRIVMSG ` = 9 bytes
+        //   target 长度（频道名最长 50 + 余量）
+        //   ` :` = 2 bytes
+        //   CRLF = 2 bytes
+        // 所以本地能发的 text 上限 ≈ 512 - 100 - 9 - target.len() - 2 - 2
+        //                        = 399 - target.len()
+        // 之前硬编 400 在长 host 或长频道名场景仍可能超 512；下面动态算。
+        // 最少留 64 字节兜底（CJK 21 字符 + ASCII 64 字符）。
         let sanitized = text.replace(['\r', '\n'], " ");
-        let max_text_len = 400; // Leave room for PRIVMSG command + target + overhead
+        let overhead = 100 + 9 + target.len() + 2 + 2;
+        let max_text_len = 512usize.saturating_sub(overhead).max(64);
         let mut remaining = sanitized.as_str();
 
         while !remaining.is_empty() {

--- a/crates/ha-core/src/channel/irc/mod.rs
+++ b/crates/ha-core/src/channel/irc/mod.rs
@@ -1,3 +1,13 @@
+//! IRC channel (RFC 2812 + IRCv3).
+//!
+//! - **Official spec**: <https://www.rfc-editor.org/rfc/rfc2812>（base IRC）+
+//!   <https://ircv3.net/specs/>（modern extensions: CAP / SASL / message-tags）
+//! - **SDK / Reference**: 无统一 SDK；参考实现
+//!   <https://ircv3.net/specs/extensions/sasl-3.1.html>
+//! - **Protocol**: TCP / TLS 直连，`\r\n` 分隔，行 ≤ 512 字节（含 CRLF），
+//!   PING/PONG 心跳，CAP LS 协商可选 SASL PLAIN
+//! - **Last reviewed**: 2026-05-05
+
 pub mod client;
 pub mod format;
 pub mod protocol;

--- a/crates/ha-core/src/channel/line/mod.rs
+++ b/crates/ha-core/src/channel/line/mod.rs
@@ -126,17 +126,13 @@ impl ChannelPlugin for LinePlugin {
             supports_unsend: false,
             supports_reply: true,
             supports_threads: false,
-            // LINE imageMessage / videoMessage / audioMessage 不需要 multipart
-            // 上传——直接以 originalContentUrl + previewImageUrl 形式声明在
-            // message object，要求公网 HTTPS URL。Document 在 LINE Messaging
-            // API 没有原生类型（必须走 Flex 或链接），暂不支持。本地 FilePath /
-            // Bytes 暂不实现，由 dispatcher 走链接文本兜底。
-            supports_media: vec![
-                MediaType::Photo,
-                MediaType::Video,
-                MediaType::Audio,
-                MediaType::Voice,
-            ],
+            // 暂不声明原生媒体能力——LINE message object 仅接收公网 HTTPS
+            // URL，但 dispatcher 的 to_outbound_media 优先给 MediaData::FilePath
+            // （hope-agent 本地缓存路径），plugin 内部会静默跳过；声明
+            // supports_media 反而让 dispatcher 不再追加链接文本兜底 → 媒体
+            // 两头不到位。媒体能力完整补完跟踪 review-followups F-057
+            // （需要本地附件中转 + 公网 HTTPS 暴露基建）
+            supports_media: Vec::new(),
             supports_typing: false,
             supports_buttons: true,
             // LINE 文本上限 5000 字符；UTF-8 字节计算 CJK 占 3 bytes，4500 字节

--- a/crates/ha-core/src/channel/line/mod.rs
+++ b/crates/ha-core/src/channel/line/mod.rs
@@ -1,3 +1,11 @@
+//! LINE Messaging API channel.
+//!
+//! - **Official API**: <https://developers.line.biz/en/reference/messaging-api/>
+//! - **SDK / Reference**: <https://github.com/line/line-bot-sdk-go>
+//! - **Protocol**: HTTPS Webhook（HMAC-SHA256 签名）+ REST Reply/Push API；
+//!   replyToken 一次性，~30s/1min 有效
+//! - **Last reviewed**: 2026-05-05
+
 pub mod api;
 pub mod format;
 pub mod webhook;

--- a/crates/ha-core/src/channel/line/mod.rs
+++ b/crates/ha-core/src/channel/line/mod.rs
@@ -278,7 +278,11 @@ impl ChannelPlugin for LinePlugin {
         if !payload.buttons.is_empty() {
             // buttons template 必须有 alt + text；text 长度上限 160（buttons
             // template 限制），caption 由外侧 text fallback。
-            let alt = if text.is_empty() { "Choose an option" } else { &text };
+            let alt = if text.is_empty() {
+                "Choose an option"
+            } else {
+                &text
+            };
             let inner_text = crate::truncate_utf8(alt, 160);
             let actions: Vec<_> = payload
                 .buttons

--- a/crates/ha-core/src/channel/line/mod.rs
+++ b/crates/ha-core/src/channel/line/mod.rs
@@ -126,13 +126,22 @@ impl ChannelPlugin for LinePlugin {
             supports_unsend: false,
             supports_reply: true,
             supports_threads: false,
-            // TODO: native LINE media (imageMessage / videoMessage)
-            // not yet implemented. Note LINE requires an HTTPS public URL —
-            // the fallback text already uses `public_base_url` from config.
-            supports_media: Vec::new(),
+            // LINE imageMessage / videoMessage / audioMessage 不需要 multipart
+            // 上传——直接以 originalContentUrl + previewImageUrl 形式声明在
+            // message object，要求公网 HTTPS URL。Document 在 LINE Messaging
+            // API 没有原生类型（必须走 Flex 或链接），暂不支持。本地 FilePath /
+            // Bytes 暂不实现，由 dispatcher 走链接文本兜底。
+            supports_media: vec![
+                MediaType::Photo,
+                MediaType::Video,
+                MediaType::Audio,
+                MediaType::Voice,
+            ],
             supports_typing: false,
             supports_buttons: true,
-            max_message_length: Some(5000),
+            // LINE 文本上限 5000 字符；UTF-8 字节计算 CJK 占 3 bytes，4500 字节
+            // 留余量
+            max_message_length: Some(4500),
         }
     }
 
@@ -219,19 +228,63 @@ impl ChannelPlugin for LinePlugin {
     ) -> Result<DeliveryResult> {
         let (api, reply_tokens) = self.get_account_state(account_id).await?;
 
-        let text = match &payload.text {
-            Some(t) if !t.is_empty() => t.clone(),
-            _ => return Ok(DeliveryResult::ok("empty")),
-        };
+        let text = payload.text.clone().unwrap_or_default();
 
-        // Build messages: use a buttons template if buttons are present,
-        // otherwise send a plain text message.
-        let messages = if !payload.buttons.is_empty() {
+        // Build messages list. Order: media first（按 LINE 习惯），text 末尾，
+        // buttons template 替代纯文本（如同时存在按钮与媒体，按钮独立成一条
+        // template 与媒体并存）。LINE 单 reply/push 支持 1-5 条 message。
+        let mut messages: Vec<serde_json::Value> = Vec::new();
+
+        for media in &payload.media {
+            let url = match &media.data {
+                MediaData::Url(u) if u.starts_with("https://") => u.clone(),
+                // FilePath / Bytes / 非 HTTPS URL 暂不支持，由 dispatcher 走
+                // 链接文本兜底
+                _ => continue,
+            };
+            match media.media_type {
+                MediaType::Photo => {
+                    messages.push(serde_json::json!({
+                        "type": "image",
+                        "originalContentUrl": &url,
+                        "previewImageUrl": &url,
+                    }));
+                }
+                MediaType::Video => {
+                    let preview = media
+                        .caption
+                        .as_deref()
+                        .filter(|s| s.starts_with("https://"))
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| url.clone());
+                    messages.push(serde_json::json!({
+                        "type": "video",
+                        "originalContentUrl": &url,
+                        "previewImageUrl": preview,
+                    }));
+                }
+                MediaType::Audio | MediaType::Voice => {
+                    // LINE 要求 audio.duration（毫秒），未知时填 1000 兜底
+                    messages.push(serde_json::json!({
+                        "type": "audio",
+                        "originalContentUrl": &url,
+                        "duration": 1000,
+                    }));
+                }
+                _ => continue,
+            }
+        }
+
+        if !payload.buttons.is_empty() {
+            // buttons template 必须有 alt + text；text 长度上限 160（buttons
+            // template 限制），caption 由外侧 text fallback。
+            let alt = if text.is_empty() { "Choose an option" } else { &text };
+            let inner_text = crate::truncate_utf8(alt, 160);
             let actions: Vec<_> = payload
                 .buttons
                 .iter()
                 .flatten()
-                .take(3) // LINE buttons template supports at most 4 actions
+                .take(3)
                 .map(|b| {
                     serde_json::json!({
                         "type": "postback",
@@ -240,29 +293,38 @@ impl ChannelPlugin for LinePlugin {
                     })
                 })
                 .collect();
-
-            vec![serde_json::json!({
+            messages.push(serde_json::json!({
                 "type": "template",
-                "altText": &text,
+                "altText": alt,
                 "template": {
                     "type": "buttons",
-                    "text": crate::truncate_utf8(&text, 160),
+                    "text": inner_text,
                     "actions": actions,
                 }
-            })]
-        } else {
-            vec![serde_json::json!({
+            }));
+        } else if !text.is_empty() {
+            messages.push(serde_json::json!({
                 "type": "text",
                 "text": text,
-            })]
-        };
+            }));
+        }
 
-        // Try to use reply token first (valid for ~1 minute)
+        if messages.is_empty() {
+            return Ok(DeliveryResult::ok("empty"));
+        }
+
+        // LINE Reply/Push 单次 ≤ 5 条 message
+        if messages.len() > 5 {
+            messages.truncate(5);
+        }
+
+        // Try to use reply token first. LINE replyToken 官方文档约定 ~1 分钟
+        // 有效；之前 50s 安全余量过激进，30-50s 区间会无谓走 push（计费 +
+        // 不计入"免费消息"配额）。改 55s 留 5s buffer 应对时钟漂移。
         let reply_token = {
             let mut tokens = reply_tokens.lock().await;
             if let Some((token, ts)) = tokens.remove(chat_id) {
-                // Only use if less than 50 seconds old
-                if ts.elapsed().as_secs() < 50 {
+                if ts.elapsed().as_secs() < 55 {
                     Some(token)
                 } else {
                     None

--- a/crates/ha-core/src/channel/line/mod.rs
+++ b/crates/ha-core/src/channel/line/mod.rs
@@ -322,9 +322,8 @@ impl ChannelPlugin for LinePlugin {
             messages.truncate(5);
         }
 
-        // Try to use reply token first. LINE replyToken 官方文档约定 ~1 分钟
-        // 有效；之前 50s 安全余量过激进，30-50s 区间会无谓走 push（计费 +
-        // 不计入"免费消息"配额）。改 55s 留 5s buffer 应对时钟漂移。
+        // LINE replyToken 官方约定 ~1 分钟有效；55s 留 5s buffer 应对时钟漂移
+        // 同时不浪费 reply 配额（reply 不计费，push 计费）
         let reply_token = {
             let mut tokens = reply_tokens.lock().await;
             if let Some((token, ts)) = tokens.remove(chat_id) {

--- a/crates/ha-core/src/channel/line/webhook.rs
+++ b/crates/ha-core/src/channel/line/webhook.rs
@@ -288,12 +288,12 @@ async fn handle_message_event(
         }
     };
 
-    // Store reply token (valid for ~1 minute)
+    // Store reply token (LINE 官方约定 ~1 分钟有效；保守 55s 留 5s buffer
+    // 应对时钟漂移；与 send_message 中 reply_token 选用窗口一致)
     if let Some(reply_token) = event.get("replyToken").and_then(|v| v.as_str()) {
         let mut tokens = reply_tokens.lock().await;
-        // Clean up expired tokens (older than 50 seconds to be safe)
         let now = std::time::Instant::now();
-        tokens.retain(|_, (_, ts)| now.duration_since(*ts).as_secs() < 50);
+        tokens.retain(|_, (_, ts)| now.duration_since(*ts).as_secs() < 55);
         tokens.insert(chat_id.clone(), (reply_token.to_string(), now));
     }
 

--- a/crates/ha-core/src/channel/mod.rs
+++ b/crates/ha-core/src/channel/mod.rs
@@ -11,6 +11,7 @@ pub mod line;
 pub mod media_helpers;
 pub mod process_manager;
 pub mod qqbot;
+pub mod rate_limit;
 pub mod registry;
 pub mod signal;
 pub mod slack;

--- a/crates/ha-core/src/channel/qqbot/api.rs
+++ b/crates/ha-core/src/channel/qqbot/api.rs
@@ -1,7 +1,10 @@
 use anyhow::{anyhow, Result};
+use lru::LruCache;
 use serde::de::DeserializeOwned;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
 
 use super::auth::{format_auth_value, QqBotAuth};
 
@@ -9,10 +12,17 @@ use super::auth::{format_auth_value, QqBotAuth};
 ///
 /// Auth scheme is documented on [`super::auth::AUTH_SCHEME`]; also sends
 /// `X-Union-Appid: {app_id}` header.
+///
+/// **`msg_seq` 状态机**：QQ Bot V2 文档明确"相同的 msg_id + msg_seq 重复发送
+/// 会失败"——同一 inbound msg_id 的多次被动回复（流式分段、逐 chunk 发送）
+/// 必须每次递增 msg_seq。`msg_seq_map` 维护 per-msg_id 的 counter，下一次
+/// 发同一 msg_id 时调 [`Self::next_msg_seq`] 拿单调递增值；LRU cap 1024 自然
+/// 驱逐过期条目（msg_id 服务端 5 分钟有效，足够）。
 pub struct QqBotApi {
     client: reqwest::Client,
     pub auth: Arc<QqBotAuth>,
     base_url: String,
+    msg_seq_map: Mutex<LruCache<String, u32>>,
 }
 
 /// Response from GET /gateway.
@@ -34,6 +44,25 @@ impl QqBotApi {
             client,
             auth,
             base_url: "https://api.sgroup.qq.com".to_string(),
+            msg_seq_map: Mutex::new(LruCache::new(
+                NonZeroUsize::new(1024).expect("1024 is non-zero"),
+            )),
+        }
+    }
+
+    /// 取下一个 `msg_seq` 值（per-msg_id 单调递增，从 1 开始）。
+    ///
+    /// 同一 msg_id 多次发送（如流式分段）必须使用不同 msg_seq；首次发送
+    /// 返回 1，下一次返回 2，依此类推。msg_id 为 None（纯主动消息）时
+    /// caller 不应调用此方法（主动消息无 msg_id）。
+    pub async fn next_msg_seq(&self, msg_id: &str) -> u32 {
+        let mut map = self.msg_seq_map.lock().await;
+        if let Some(seq) = map.get_mut(msg_id) {
+            *seq += 1;
+            *seq
+        } else {
+            map.put(msg_id.to_string(), 1);
+            1
         }
     }
 
@@ -96,6 +125,17 @@ impl QqBotApi {
         Ok(resp.url)
     }
 
+    /// 在 body 上注入 `msg_id` + 自增 `msg_seq`（per-msg_id 单调递增）。
+    /// 主动消息（msg_id=None）不注入 seq——主动消息无 msg_id 关联，QQ
+    /// 服务端不要求 seq；空 msg_id 也用同款逻辑（产生 seq=1 的兜底）。
+    async fn inject_passive_reply_meta(&self, body: &mut serde_json::Value, msg_id: Option<&str>) {
+        if let Some(id) = msg_id {
+            body["msg_id"] = serde_json::Value::String(id.to_string());
+            let seq = self.next_msg_seq(id).await;
+            body["msg_seq"] = serde_json::Value::Number(seq.into());
+        }
+    }
+
     /// Send a message to a group.
     ///
     /// POST /v2/groups/{group_openid}/messages
@@ -110,9 +150,7 @@ impl QqBotApi {
             "content": content,
             "msg_type": 0,
         });
-        if let Some(id) = msg_id {
-            body["msg_id"] = serde_json::Value::String(id.to_string());
-        }
+        self.inject_passive_reply_meta(&mut body, msg_id).await;
         self.qq_request(reqwest::Method::POST, &path, Some(body))
             .await
     }
@@ -131,9 +169,7 @@ impl QqBotApi {
             "content": content,
             "msg_type": 0,
         });
-        if let Some(id) = msg_id {
-            body["msg_id"] = serde_json::Value::String(id.to_string());
-        }
+        self.inject_passive_reply_meta(&mut body, msg_id).await;
         self.qq_request(reqwest::Method::POST, &path, Some(body))
             .await
     }
@@ -152,9 +188,7 @@ impl QqBotApi {
             "content": content,
             "msg_type": 0,
         });
-        if let Some(id) = msg_id {
-            body["msg_id"] = serde_json::Value::String(id.to_string());
-        }
+        self.inject_passive_reply_meta(&mut body, msg_id).await;
         self.qq_request(reqwest::Method::POST, &path, Some(body))
             .await
     }
@@ -173,9 +207,111 @@ impl QqBotApi {
             "content": content,
             "msg_type": 0,
         });
-        if let Some(id) = msg_id {
-            body["msg_id"] = serde_json::Value::String(id.to_string());
-        }
+        self.inject_passive_reply_meta(&mut body, msg_id).await;
+        self.qq_request(reqwest::Method::POST, &path, Some(body))
+            .await
+    }
+
+    // ── Rich Media (V2 two-step) ────────────────────────────────────
+    //
+    // QQ Bot V2 富媒体走两步流程（参考
+    // <https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/send-receive/rich-media.html>）：
+    //
+    // 1. POST `/v2/groups/{group_openid}/files` 或 `/v2/users/{openid}/files`
+    //    body: `{ file_type, url, srv_send_msg: false }` → 返回 `file_info` + `ttl`
+    // 2. 用 `msg_type=7 + media: { file_info }` 调常规 send_*_message 即可
+    //
+    // **重要约束**：file_info 上传到群文件接口 → 只能群里发；上传到 c2c
+    // 文件接口 → 只能 c2c 里发，不可跨用。
+
+    /// File type codes for `/v2/groups/.../files` and `/v2/users/.../files`.
+    /// 1=image (png/jpg)、2=video (mp4)、3=voice (silk)、4=file（暂未开放）
+    pub const FILE_TYPE_IMAGE: u32 = 1;
+    pub const FILE_TYPE_VIDEO: u32 = 2;
+    pub const FILE_TYPE_VOICE: u32 = 3;
+
+    /// Upload a media URL for use in a subsequent group message.
+    ///
+    /// Returns the `file_info` token to embed in `media` of the send message.
+    /// `file_info` 有 ttl，过期需要重新上传。
+    pub async fn post_group_files(
+        &self,
+        group_openid: &str,
+        file_type: u32,
+        url: &str,
+    ) -> Result<String> {
+        let path = format!("/v2/groups/{}/files", group_openid);
+        let body = serde_json::json!({
+            "file_type": file_type,
+            "url": url,
+            "srv_send_msg": false,
+        });
+        let resp: serde_json::Value = self
+            .qq_request(reqwest::Method::POST, &path, Some(body))
+            .await?;
+        resp.get("file_info")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow!("post_group_files response missing file_info"))
+    }
+
+    /// Upload a media URL for use in a subsequent C2C message.
+    pub async fn post_c2c_files(
+        &self,
+        openid: &str,
+        file_type: u32,
+        url: &str,
+    ) -> Result<String> {
+        let path = format!("/v2/users/{}/files", openid);
+        let body = serde_json::json!({
+            "file_type": file_type,
+            "url": url,
+            "srv_send_msg": false,
+        });
+        let resp: serde_json::Value = self
+            .qq_request(reqwest::Method::POST, &path, Some(body))
+            .await?;
+        resp.get("file_info")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow!("post_c2c_files response missing file_info"))
+    }
+
+    /// Send a media message (`msg_type=7`) to a group with a previously uploaded
+    /// `file_info` and optional caption (`content`).
+    pub async fn send_group_media(
+        &self,
+        group_openid: &str,
+        file_info: &str,
+        content: &str,
+        msg_id: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let path = format!("/v2/groups/{}/messages", group_openid);
+        let mut body = serde_json::json!({
+            "content": content,
+            "msg_type": 7,
+            "media": { "file_info": file_info },
+        });
+        self.inject_passive_reply_meta(&mut body, msg_id).await;
+        self.qq_request(reqwest::Method::POST, &path, Some(body))
+            .await
+    }
+
+    /// Send a media message (`msg_type=7`) to a C2C user.
+    pub async fn send_c2c_media(
+        &self,
+        openid: &str,
+        file_info: &str,
+        content: &str,
+        msg_id: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let path = format!("/v2/users/{}/messages", openid);
+        let mut body = serde_json::json!({
+            "content": content,
+            "msg_type": 7,
+            "media": { "file_info": file_info },
+        });
+        self.inject_passive_reply_meta(&mut body, msg_id).await;
         self.qq_request(reqwest::Method::POST, &path, Some(body))
             .await
     }
@@ -216,9 +352,7 @@ impl QqBotApi {
             ));
         };
 
-        if let Some(id) = msg_id {
-            body["msg_id"] = serde_json::Value::String(id.to_string());
-        }
+        self.inject_passive_reply_meta(&mut body, msg_id).await;
 
         self.qq_request(reqwest::Method::POST, &path, Some(body))
             .await
@@ -233,5 +367,26 @@ impl QqBotApi {
             .qq_request(reqwest::Method::POST, &path, Some(serde_json::json!({})))
             .await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn next_msg_seq_increments_per_msg_id() {
+        let auth = Arc::new(QqBotAuth::new("appid", "secret"));
+        let api = QqBotApi::new(auth);
+
+        // 同一 msg_id 多次调返回单调递增
+        assert_eq!(api.next_msg_seq("msg-1").await, 1);
+        assert_eq!(api.next_msg_seq("msg-1").await, 2);
+        assert_eq!(api.next_msg_seq("msg-1").await, 3);
+
+        // 不同 msg_id 各自独立
+        assert_eq!(api.next_msg_seq("msg-2").await, 1);
+        assert_eq!(api.next_msg_seq("msg-2").await, 2);
+        assert_eq!(api.next_msg_seq("msg-1").await, 4);
     }
 }

--- a/crates/ha-core/src/channel/qqbot/api.rs
+++ b/crates/ha-core/src/channel/qqbot/api.rs
@@ -256,12 +256,7 @@ impl QqBotApi {
     }
 
     /// Upload a media URL for use in a subsequent C2C message.
-    pub async fn post_c2c_files(
-        &self,
-        openid: &str,
-        file_type: u32,
-        url: &str,
-    ) -> Result<String> {
+    pub async fn post_c2c_files(&self, openid: &str, file_type: u32, url: &str) -> Result<String> {
         let path = format!("/v2/users/{}/files", openid);
         let body = serde_json::json!({
             "file_type": file_type,

--- a/crates/ha-core/src/channel/qqbot/api.rs
+++ b/crates/ha-core/src/channel/qqbot/api.rs
@@ -8,6 +8,51 @@ use tokio::sync::Mutex;
 
 use super::auth::{format_auth_value, QqBotAuth};
 
+/// QQ Bot V2 多端点 chat 命名空间，由 hope-agent 在 inbound MsgContext 时
+/// 把平台原始 ID 编码为 `<scope>:<id>` 字串（见 [`gateway`](super::gateway)），
+/// 出站 dispatch 时再解回选择正确的 send endpoint。
+///
+/// - `C2c` 私聊：`POST /v2/users/{openid}/messages`，仅此端点支持 keyboard
+/// - `Group` 群：`POST /v2/groups/{group_openid}/messages`，支持 keyboard 与 media
+/// - `Channel` 频道：`POST /channels/{channel_id}/messages`
+/// - `Dms` 频道私信：`POST /dms/{guild_id}/messages`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QqChatScope<'a> {
+    C2c(&'a str),
+    Group(&'a str),
+    Channel(&'a str),
+    Dms(&'a str),
+}
+
+impl<'a> QqChatScope<'a> {
+    pub fn parse(chat_id: &'a str) -> Result<Self> {
+        if let Some(id) = chat_id.strip_prefix("c2c:") {
+            Ok(QqChatScope::C2c(id))
+        } else if let Some(id) = chat_id.strip_prefix("group:") {
+            Ok(QqChatScope::Group(id))
+        } else if let Some(id) = chat_id.strip_prefix("channel:") {
+            Ok(QqChatScope::Channel(id))
+        } else if let Some(id) = chat_id.strip_prefix("dms:") {
+            Ok(QqChatScope::Dms(id))
+        } else {
+            Err(anyhow!(
+                "Unknown QQ Bot chat_id format (expected 'c2c:'/'group:'/'channel:'/'dms:' prefix): {}",
+                crate::truncate_utf8(chat_id, 100)
+            ))
+        }
+    }
+
+    /// keyboard / media 仅 c2c/group 端点 V2 接口支持；channel/dms 须降级到
+    /// 文本格式（数字回复 / 链接）。
+    pub fn supports_native_keyboard(&self) -> bool {
+        matches!(self, QqChatScope::C2c(_) | QqChatScope::Group(_))
+    }
+
+    pub fn supports_native_media(&self) -> bool {
+        matches!(self, QqChatScope::C2c(_) | QqChatScope::Group(_))
+    }
+}
+
 /// QQ Bot REST API client.
 ///
 /// Auth scheme is documented on [`super::auth::AUTH_SCHEME`]; also sends
@@ -312,43 +357,27 @@ impl QqBotApi {
     }
 
     /// Send a message with inline keyboard buttons (msg_type 2 = markdown with keyboard).
-    ///
-    /// For QQ Bot, buttons are sent as a keyboard component alongside markdown content.
-    /// Only supported for C2C and group messages (not guild channels/DMs).
+    /// Only supported for [`QqChatScope::C2c`] / [`QqChatScope::Group`].
     pub async fn send_message_with_keyboard(
         &self,
-        chat_id: &str,
+        scope: QqChatScope<'_>,
         content: &str,
         keyboard: serde_json::Value,
         msg_id: Option<&str>,
     ) -> Result<serde_json::Value> {
-        let (path, mut body) = if let Some(openid) = chat_id.strip_prefix("c2c:") {
-            (
-                format!("/v2/users/{}/messages", openid),
-                serde_json::json!({
-                    "content": content,
-                    "msg_type": 2,
-                    "keyboard": keyboard,
-                }),
-            )
-        } else if let Some(group_openid) = chat_id.strip_prefix("group:") {
-            (
-                format!("/v2/groups/{}/messages", group_openid),
-                serde_json::json!({
-                    "content": content,
-                    "msg_type": 2,
-                    "keyboard": keyboard,
-                }),
-            )
-        } else {
-            return Err(anyhow!(
-                "Keyboard buttons not supported for this QQ Bot chat type: {}",
-                crate::truncate_utf8(chat_id, 100)
-            ));
+        let path = match scope {
+            QqChatScope::C2c(openid) => format!("/v2/users/{}/messages", openid),
+            QqChatScope::Group(gid) => format!("/v2/groups/{}/messages", gid),
+            _ => {
+                return Err(anyhow!("Keyboard buttons not supported for {:?}", scope));
+            }
         };
-
+        let mut body = serde_json::json!({
+            "content": content,
+            "msg_type": 2,
+            "keyboard": keyboard,
+        });
         self.inject_passive_reply_meta(&mut body, msg_id).await;
-
         self.qq_request(reqwest::Method::POST, &path, Some(body))
             .await
     }

--- a/crates/ha-core/src/channel/qqbot/gateway.rs
+++ b/crates/ha-core/src/channel/qqbot/gateway.rs
@@ -59,6 +59,17 @@ fn save_session(account_id: &str, session_id: &str, seq: u64) {
     }
 }
 
+/// Remove the saved session file. Used when server returns INVALID_SESSION
+/// (not resumable) — leaving the stale session_id on disk would put the
+/// account into an infinite "RESUME → INVALID_SESSION → reconnect" loop after
+/// process restart.
+async fn remove_session_file(account_id: &str) {
+    if let Ok(dir) = crate::paths::channel_dir("qqbot") {
+        let path = dir.join(format!("{}.session.json", account_id));
+        let _ = tokio::fs::remove_file(&path).await;
+    }
+}
+
 /// Run the QQ Bot WebSocket gateway event loop.
 ///
 /// QQ Bot Gateway protocol (similar to Discord):
@@ -268,43 +279,16 @@ pub async fn run_qq_gateway(
         // Reset reconnect counter on successful connection
         reconnect_attempt = 0;
 
-        // 6. Start heartbeat and main event loop
-        let heartbeat_cancel = CancellationToken::new();
-        let heartbeat_token = heartbeat_cancel.clone();
-
+        // 6. Main event loop with integrated heartbeat
         // Shared seq counter for heartbeat
         let seq_holder = Arc::new(tokio::sync::Mutex::new(last_seq));
-        let _heartbeat_seq = seq_holder.clone();
 
-        // Spawn heartbeat task
-        let heartbeat_ws_url = gateway_url.clone();
-        let heartbeat_account_id = account_id.clone();
-        let main_cancel = cancel.clone();
-        tokio::spawn(async move {
-            let interval = std::time::Duration::from_millis(heartbeat_interval_ms);
-            loop {
-                tokio::select! {
-                    _ = heartbeat_cancel.cancelled() => break,
-                    _ = main_cancel.cancelled() => break,
-                    _ = tokio::time::sleep(interval) => {
-                        // Heartbeat is sent from the main loop since we can't share ws
-                        // The main loop will handle heartbeat timing
-                    }
-                }
-            }
-            app_debug!(
-                "channel",
-                "qqbot::gateway",
-                "Heartbeat task ended for account '{}' (url={})",
-                heartbeat_account_id,
-                crate::truncate_utf8(&heartbeat_ws_url, 60)
-            );
-        });
-
-        // Main event loop with integrated heartbeat
+        // 心跳定时器：tokio::time::interval 默认首 tick 立即触发，与官方
+        // botpy `gateway.py:_send_heart` 行为一致——HELLO 响应后第一次心跳
+        // 必须立即发，避免高延迟网络场景下 41s 等待窗口被服务端判超时强断。
+        // （之前的 `heartbeat_timer.tick().await; // consume immediate` 是误操作）
         let mut heartbeat_timer =
             tokio::time::interval(std::time::Duration::from_millis(heartbeat_interval_ms));
-        heartbeat_timer.tick().await; // consume the immediate first tick
 
         let mut session_active = true;
         while session_active {
@@ -316,7 +300,6 @@ pub async fn run_qq_gateway(
                         "Gateway cancelled for account '{}'",
                         account_id
                     );
-                    heartbeat_token.cancel();
                     ws.close().await;
                     // Save session before exit
                     if let Some(ref sid) = saved_session_id {
@@ -358,6 +341,11 @@ pub async fn run_qq_gateway(
                                 }
                                 GatewayAction::ReidentifyAndReconnect => {
                                     saved_session_id = None;
+                                    // 必须同步删磁盘 session 文件，否则进程重启后
+                                    // load_session 会读到过期的 session_id 又触发
+                                    // RESUME → INVALID_SESSION → reconnect 死循环
+                                    // 直到撞 MAX_RECONNECT_ATTEMPTS 才退出。
+                                    remove_session_file(&account_id).await;
                                     // Reset the sequence so the outer-loop resume check
                                     // (`saved_session_id.is_some() && last_seq > 0`) sees
                                     // a fresh-session state on the next iteration.
@@ -382,8 +370,6 @@ pub async fn run_qq_gateway(
                 }
             }
         }
-
-        heartbeat_token.cancel();
 
         // Save session state before reconnect
         {

--- a/crates/ha-core/src/channel/qqbot/mod.rs
+++ b/crates/ha-core/src/channel/qqbot/mod.rs
@@ -1,3 +1,12 @@
+//! QQ Bot V2 channel (QQ 官方机器人).
+//!
+//! - **Official API**: <https://bot.q.qq.com/wiki/develop/api-v2/>
+//! - **SDK / Reference**: <https://github.com/tencent-connect/botpy>
+//!   (官方 Python SDK，opcode 协议 + IDENTIFY/RESUME + msg_seq 参考实现)
+//! - **Protocol**: WebSocket Gateway（Discord-like opcodes）+ REST `/v2/...`，
+//!   认证头 `Authorization: QQBot {access_token}` (NOT Bearer!)
+//! - **Last reviewed**: 2026-05-05
+
 pub mod api;
 pub mod auth;
 pub mod format;

--- a/crates/ha-core/src/channel/qqbot/mod.rs
+++ b/crates/ha-core/src/channel/qqbot/mod.rs
@@ -277,9 +277,7 @@ impl ChannelPlugin for QqBotPlugin {
                     };
                     let file_type = match media.media_type {
                         MediaType::Photo => api::QqBotApi::FILE_TYPE_IMAGE,
-                        MediaType::Video | MediaType::Animation => {
-                            api::QqBotApi::FILE_TYPE_VIDEO
-                        }
+                        MediaType::Video | MediaType::Animation => api::QqBotApi::FILE_TYPE_VIDEO,
                         MediaType::Voice | MediaType::Audio => api::QqBotApi::FILE_TYPE_VOICE,
                         // Document / Sticker 暂未开放（file_type=4 需特殊审核）
                         _ => continue,
@@ -290,8 +288,7 @@ impl ChannelPlugin for QqBotPlugin {
                         api.send_c2c_media(openid, &file_info, caption, msg_id)
                             .await?
                     } else if let Some(group_openid) = chat_id.strip_prefix("group:") {
-                        let file_info =
-                            api.post_group_files(group_openid, file_type, &url).await?;
+                        let file_info = api.post_group_files(group_openid, file_type, &url).await?;
                         api.send_group_media(group_openid, &file_info, caption, msg_id)
                             .await?
                     } else {

--- a/crates/ha-core/src/channel/qqbot/mod.rs
+++ b/crates/ha-core/src/channel/qqbot/mod.rs
@@ -102,10 +102,17 @@ impl ChannelPlugin for QqBotPlugin {
             supports_polls: false,
             supports_reactions: false,
             max_message_length: Some(4096),
-            // TODO: native QQ Bot media (v2 groups/messages msg_type=7
-            // + channels multipart file_image) not yet implemented.
-            // Dispatcher falls back to a download-link text for now.
-            supports_media: Vec::new(),
+            // QQ Bot V2 c2c/group 走两步：POST /v2/{users|groups}/.../files →
+            // 拿 file_info → msg_type=7 + media。仅 url 来源（公网 HTTPS）支持
+            // 本批；Document/Sticker file_type=4 暂未开放，channel/dms 不支持，
+            // 这两类由 dispatcher 走链接文本兜底
+            supports_media: vec![
+                MediaType::Photo,
+                MediaType::Video,
+                MediaType::Voice,
+                MediaType::Audio,
+                MediaType::Animation,
+            ],
         }
     }
 
@@ -170,51 +177,142 @@ impl ChannelPlugin for QqBotPlugin {
             let text_content = payload.text.as_deref().unwrap_or("");
             let msg_id = payload.reply_to_message_id.as_deref();
 
-            let rows: Vec<_> = payload
-                .buttons
-                .iter()
-                .map(|row| {
-                    let buttons: Vec<_> = row
-                        .iter()
-                        .map(|b| {
-                            serde_json::json!({
-                                "id": b.callback_id(),
-                                "render_data": {
-                                    "label": &b.text,
-                                    "visited_label": &b.text,
-                                },
-                                "action": {
-                                    "type": 2,
-                                    "data": b.callback_id(),
-                                    "permission": { "type": 2 }
-                                }
+            // QQ Bot keyboard 仅 c2c/group 端点支持；channel/dms 走纯文本兜底
+            // （`[1] / [2] / [3]` 数字回复，与 IRC / 微信 / Signal 一致）。
+            // 否则审批按钮在频道里直接 send 失败 → 用户看不到按钮也看不到错误。
+            let supports_native_buttons =
+                chat_id.starts_with("c2c:") || chat_id.starts_with("group:");
+
+            if supports_native_buttons {
+                let rows: Vec<_> = payload
+                    .buttons
+                    .iter()
+                    .map(|row| {
+                        let buttons: Vec<_> = row
+                            .iter()
+                            .map(|b| {
+                                serde_json::json!({
+                                    "id": b.callback_id(),
+                                    "render_data": {
+                                        "label": &b.text,
+                                        "visited_label": &b.text,
+                                    },
+                                    "action": {
+                                        "type": 2,
+                                        "data": b.callback_id(),
+                                        "permission": { "type": 2 }
+                                    }
+                                })
                             })
-                        })
-                        .collect();
-                    serde_json::json!({ "buttons": buttons })
-                })
-                .collect();
+                            .collect();
+                        serde_json::json!({ "buttons": buttons })
+                    })
+                    .collect();
 
-            let keyboard = serde_json::json!({ "content": { "rows": rows } });
-            let result = api
-                .send_message_with_keyboard(chat_id, text_content, keyboard, msg_id)
-                .await?;
+                let keyboard = serde_json::json!({ "content": { "rows": rows } });
+                let result = api
+                    .send_message_with_keyboard(chat_id, text_content, keyboard, msg_id)
+                    .await?;
 
-            let response_msg_id = result
-                .get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("sent")
-                .to_string();
+                let response_msg_id = result
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("sent")
+                    .to_string();
 
-            return Ok(DeliveryResult::ok(response_msg_id));
+                return Ok(DeliveryResult::ok(response_msg_id));
+            } else {
+                // Channel / DMS 兜底：把按钮渲染成数字列表，用户回 1/2/3
+                let mut text_with_buttons = String::from(text_content);
+                if !text_with_buttons.is_empty() {
+                    text_with_buttons.push_str("\n\n");
+                }
+                let mut idx = 1;
+                for row in &payload.buttons {
+                    for b in row {
+                        text_with_buttons.push_str(&format!("[{}] {}\n", idx, b.text));
+                        idx += 1;
+                    }
+                }
+                text_with_buttons.push_str("\nReply with the number to choose.");
+
+                let result = if let Some(channel_id) = chat_id.strip_prefix("channel:") {
+                    api.send_channel_message(channel_id, &text_with_buttons, msg_id)
+                        .await?
+                } else if let Some(guild_id) = chat_id.strip_prefix("dms:") {
+                    api.send_dms_message(guild_id, &text_with_buttons, msg_id)
+                        .await?
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Unknown QQ Bot chat_id prefix: {}",
+                        crate::truncate_utf8(chat_id, 100)
+                    ));
+                };
+                let response_msg_id = result
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("sent")
+                    .to_string();
+                return Ok(DeliveryResult::ok(response_msg_id));
+            }
+        }
+
+        // 富媒体优先：QQ Bot V2 c2c/group 走两步上传（POST /files → 拿
+        // file_info → msg_type=7 + media）。channel/dms 暂不支持，降级到链接
+        // 文本（dispatcher 已用 supports_media 矩阵驱动，不会进到这里）。
+        let msg_id = payload.reply_to_message_id.as_deref();
+        if !payload.media.is_empty() {
+            let supports_native_media =
+                chat_id.starts_with("c2c:") || chat_id.starts_with("group:");
+            if supports_native_media {
+                let caption_root = payload.text.as_deref().unwrap_or("");
+                let mut last_msg_id = String::from("sent");
+                for media in &payload.media {
+                    let caption = media.caption.as_deref().unwrap_or(caption_root);
+                    let url = match &media.data {
+                        crate::channel::types::MediaData::Url(u) => u.clone(),
+                        // QQ Bot V2 上传只接收 url（公网 HTTPS）；本地附件交由
+                        // dispatcher 走链接文本兜底——这里 fallback 不发
+                        _ => continue,
+                    };
+                    let file_type = match media.media_type {
+                        MediaType::Photo => api::QqBotApi::FILE_TYPE_IMAGE,
+                        MediaType::Video | MediaType::Animation => {
+                            api::QqBotApi::FILE_TYPE_VIDEO
+                        }
+                        MediaType::Voice | MediaType::Audio => api::QqBotApi::FILE_TYPE_VOICE,
+                        // Document / Sticker 暂未开放（file_type=4 需特殊审核）
+                        _ => continue,
+                    };
+
+                    let result = if let Some(openid) = chat_id.strip_prefix("c2c:") {
+                        let file_info = api.post_c2c_files(openid, file_type, &url).await?;
+                        api.send_c2c_media(openid, &file_info, caption, msg_id)
+                            .await?
+                    } else if let Some(group_openid) = chat_id.strip_prefix("group:") {
+                        let file_info =
+                            api.post_group_files(group_openid, file_type, &url).await?;
+                        api.send_group_media(group_openid, &file_info, caption, msg_id)
+                            .await?
+                    } else {
+                        unreachable!("supports_native_media 已校验")
+                    };
+                    last_msg_id = result
+                        .get("id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("sent")
+                        .to_string();
+                }
+                return Ok(DeliveryResult::ok(last_msg_id));
+            }
+            // channel/dms 富媒体未实现 → 落到下面文本路径，dispatcher 此前已加
+            // 链接兜底
         }
 
         if let Some(ref text) = payload.text {
             if text.is_empty() {
                 return Ok(DeliveryResult::ok("empty"));
             }
-
-            let msg_id = payload.reply_to_message_id.as_deref();
 
             // Route to the correct endpoint based on chat_id prefix
             let result = if let Some(openid) = chat_id.strip_prefix("c2c:") {

--- a/crates/ha-core/src/channel/qqbot/mod.rs
+++ b/crates/ha-core/src/channel/qqbot/mod.rs
@@ -102,17 +102,14 @@ impl ChannelPlugin for QqBotPlugin {
             supports_polls: false,
             supports_reactions: false,
             max_message_length: Some(4096),
-            // QQ Bot V2 c2c/group 走两步：POST /v2/{users|groups}/.../files →
-            // 拿 file_info → msg_type=7 + media。仅 url 来源（公网 HTTPS）支持
-            // 本批；Document/Sticker file_type=4 暂未开放，channel/dms 不支持，
-            // 这两类由 dispatcher 走链接文本兜底
-            supports_media: vec![
-                MediaType::Photo,
-                MediaType::Video,
-                MediaType::Voice,
-                MediaType::Audio,
-                MediaType::Animation,
-            ],
+            // 暂不声明原生媒体能力——dispatcher 的 to_outbound_media 优先
+            // 给 MediaData::FilePath（hope-agent 本地缓存路径），但 QQ Bot
+            // V2 上传 API 只接收公网 HTTPS URL，FilePath 会被静默跳过；同时
+            // channel/dms 端点完全不开放媒体上传。声明 supports_media 反而
+            // 让 dispatcher 不再追加链接文本兜底 → 媒体两头不到位。媒体能力
+            // 完整补完跟踪 review-followups F-057（含本地附件中转 / channel
+            // 端点替代方案）
+            supports_media: Vec::new(),
         }
     }
 

--- a/crates/ha-core/src/channel/qqbot/mod.rs
+++ b/crates/ha-core/src/channel/qqbot/mod.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 use crate::channel::traits::ChannelPlugin;
 use crate::channel::types::*;
 
-use self::api::QqBotApi;
+use self::api::{QqBotApi, QqChatScope};
 use self::auth::QqBotAuth;
 
 /// Running account state for a single QQ Bot.
@@ -171,183 +171,27 @@ impl ChannelPlugin for QqBotPlugin {
         payload: &ReplyPayload,
     ) -> Result<DeliveryResult> {
         let api = self.get_api(account_id).await?;
-
-        // Handle messages with inline keyboard buttons (approval prompts, etc.)
-        if !payload.buttons.is_empty() {
-            let text_content = payload.text.as_deref().unwrap_or("");
-            let msg_id = payload.reply_to_message_id.as_deref();
-
-            // QQ Bot keyboard 仅 c2c/group 端点支持；channel/dms 走纯文本兜底
-            // （`[1] / [2] / [3]` 数字回复，与 IRC / 微信 / Signal 一致）。
-            // 否则审批按钮在频道里直接 send 失败 → 用户看不到按钮也看不到错误。
-            let supports_native_buttons =
-                chat_id.starts_with("c2c:") || chat_id.starts_with("group:");
-
-            if supports_native_buttons {
-                let rows: Vec<_> = payload
-                    .buttons
-                    .iter()
-                    .map(|row| {
-                        let buttons: Vec<_> = row
-                            .iter()
-                            .map(|b| {
-                                serde_json::json!({
-                                    "id": b.callback_id(),
-                                    "render_data": {
-                                        "label": &b.text,
-                                        "visited_label": &b.text,
-                                    },
-                                    "action": {
-                                        "type": 2,
-                                        "data": b.callback_id(),
-                                        "permission": { "type": 2 }
-                                    }
-                                })
-                            })
-                            .collect();
-                        serde_json::json!({ "buttons": buttons })
-                    })
-                    .collect();
-
-                let keyboard = serde_json::json!({ "content": { "rows": rows } });
-                let result = api
-                    .send_message_with_keyboard(chat_id, text_content, keyboard, msg_id)
-                    .await?;
-
-                let response_msg_id = result
-                    .get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("sent")
-                    .to_string();
-
-                return Ok(DeliveryResult::ok(response_msg_id));
-            } else {
-                // Channel / DMS 兜底：把按钮渲染成数字列表，用户回 1/2/3
-                let mut text_with_buttons = String::from(text_content);
-                if !text_with_buttons.is_empty() {
-                    text_with_buttons.push_str("\n\n");
-                }
-                let mut idx = 1;
-                for row in &payload.buttons {
-                    for b in row {
-                        text_with_buttons.push_str(&format!("[{}] {}\n", idx, b.text));
-                        idx += 1;
-                    }
-                }
-                text_with_buttons.push_str("\nReply with the number to choose.");
-
-                let result = if let Some(channel_id) = chat_id.strip_prefix("channel:") {
-                    api.send_channel_message(channel_id, &text_with_buttons, msg_id)
-                        .await?
-                } else if let Some(guild_id) = chat_id.strip_prefix("dms:") {
-                    api.send_dms_message(guild_id, &text_with_buttons, msg_id)
-                        .await?
-                } else {
-                    return Err(anyhow::anyhow!(
-                        "Unknown QQ Bot chat_id prefix: {}",
-                        crate::truncate_utf8(chat_id, 100)
-                    ));
-                };
-                let response_msg_id = result
-                    .get("id")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("sent")
-                    .to_string();
-                return Ok(DeliveryResult::ok(response_msg_id));
-            }
-        }
-
-        // 富媒体优先：QQ Bot V2 c2c/group 走两步上传（POST /files → 拿
-        // file_info → msg_type=7 + media）。channel/dms 暂不支持，降级到链接
-        // 文本（dispatcher 已用 supports_media 矩阵驱动，不会进到这里）。
+        let scope = QqChatScope::parse(chat_id)?;
         let msg_id = payload.reply_to_message_id.as_deref();
-        if !payload.media.is_empty() {
-            let supports_native_media =
-                chat_id.starts_with("c2c:") || chat_id.starts_with("group:");
-            if supports_native_media {
-                let caption_root = payload.text.as_deref().unwrap_or("");
-                let mut last_msg_id = String::from("sent");
-                for media in &payload.media {
-                    let caption = media.caption.as_deref().unwrap_or(caption_root);
-                    let url = match &media.data {
-                        crate::channel::types::MediaData::Url(u) => u.clone(),
-                        // QQ Bot V2 上传只接收 url（公网 HTTPS）；本地附件交由
-                        // dispatcher 走链接文本兜底——这里 fallback 不发
-                        _ => continue,
-                    };
-                    let file_type = match media.media_type {
-                        MediaType::Photo => api::QqBotApi::FILE_TYPE_IMAGE,
-                        MediaType::Video | MediaType::Animation => api::QqBotApi::FILE_TYPE_VIDEO,
-                        MediaType::Voice | MediaType::Audio => api::QqBotApi::FILE_TYPE_VOICE,
-                        // Document / Sticker 暂未开放（file_type=4 需特殊审核）
-                        _ => continue,
-                    };
 
-                    let result = if let Some(openid) = chat_id.strip_prefix("c2c:") {
-                        let file_info = api.post_c2c_files(openid, file_type, &url).await?;
-                        api.send_c2c_media(openid, &file_info, caption, msg_id)
-                            .await?
-                    } else if let Some(group_openid) = chat_id.strip_prefix("group:") {
-                        let file_info = api.post_group_files(group_openid, file_type, &url).await?;
-                        api.send_group_media(group_openid, &file_info, caption, msg_id)
-                            .await?
-                    } else {
-                        unreachable!("supports_native_media 已校验")
-                    };
-                    last_msg_id = result
-                        .get("id")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("sent")
-                        .to_string();
-                }
-                return Ok(DeliveryResult::ok(last_msg_id));
-            }
-            // channel/dms 富媒体未实现 → 落到下面文本路径，dispatcher 此前已加
-            // 链接兜底
+        if !payload.buttons.is_empty() {
+            return dispatch_buttons(&api, &scope, payload, msg_id).await;
         }
-
-        if let Some(ref text) = payload.text {
-            if text.is_empty() {
-                return Ok(DeliveryResult::ok("empty"));
+        if !payload.media.is_empty() && scope.supports_native_media() {
+            if let Some(result) = dispatch_media(&api, &scope, payload, msg_id).await? {
+                return Ok(result);
             }
-
-            // Route to the correct endpoint based on chat_id prefix
-            let result = if let Some(openid) = chat_id.strip_prefix("c2c:") {
-                api.send_c2c_message(openid, text, msg_id).await?
-            } else if let Some(group_openid) = chat_id.strip_prefix("group:") {
-                api.send_group_message(group_openid, text, msg_id).await?
-            } else if let Some(channel_id_str) = chat_id.strip_prefix("channel:") {
-                api.send_channel_message(channel_id_str, text, msg_id)
-                    .await?
-            } else if let Some(guild_id) = chat_id.strip_prefix("dms:") {
-                api.send_dms_message(guild_id, text, msg_id).await?
-            } else {
-                return Err(anyhow::anyhow!(
-                    "Unknown QQ Bot chat_id format: {}",
-                    crate::truncate_utf8(chat_id, 100)
-                ));
-            };
-
-            // Extract message_id from response if available
-            let response_msg_id = result
-                .get("id")
-                .and_then(|v| v.as_str())
-                .unwrap_or("sent")
-                .to_string();
-
-            return Ok(DeliveryResult::ok(response_msg_id));
+            // 没有可发的 url 媒体 → 落到下面文本路径，由 dispatcher 的链接兜底
         }
-
-        Ok(DeliveryResult::ok("no_content"))
+        dispatch_text(&api, &scope, payload, msg_id).await
     }
 
     async fn send_typing(&self, account_id: &str, chat_id: &str) -> Result<()> {
-        // Typing indicator is only supported for C2C messages
-        if let Some(openid) = chat_id.strip_prefix("c2c:") {
+        if let Ok(QqChatScope::C2c(openid)) = QqChatScope::parse(chat_id) {
             let api = self.get_api(account_id).await?;
             api.send_typing_c2c(openid).await?;
         }
-        // For group/channel, typing is not supported — silently ignore
+        // group / channel / dms typing 不支持 — silently ignore
         Ok(())
     }
 
@@ -453,5 +297,148 @@ impl ChannelPlugin for QqBotPlugin {
         let auth = Arc::new(QqBotAuth::new(&app_id, &client_secret));
         auth.get_token().await?;
         Ok(format!("QQ Bot ({})", app_id))
+    }
+}
+
+fn extract_response_id(value: &serde_json::Value) -> String {
+    value
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("sent")
+        .to_string()
+}
+
+/// keyboard 按钮：c2c/group 走 native；channel/dms 降级 `[1]/[2]/[3]` 数字回复
+/// （与 IRC / 微信 / Signal 一致）。
+async fn dispatch_buttons(
+    api: &QqBotApi,
+    scope: &QqChatScope<'_>,
+    payload: &ReplyPayload,
+    msg_id: Option<&str>,
+) -> Result<DeliveryResult> {
+    let text_content = payload.text.as_deref().unwrap_or("");
+
+    if scope.supports_native_keyboard() {
+        let rows: Vec<_> = payload
+            .buttons
+            .iter()
+            .map(|row| {
+                let buttons: Vec<_> = row
+                    .iter()
+                    .map(|b| {
+                        serde_json::json!({
+                            "id": b.callback_id(),
+                            "render_data": { "label": &b.text, "visited_label": &b.text },
+                            "action": {
+                                "type": 2,
+                                "data": b.callback_id(),
+                                "permission": { "type": 2 }
+                            }
+                        })
+                    })
+                    .collect();
+                serde_json::json!({ "buttons": buttons })
+            })
+            .collect();
+        let keyboard = serde_json::json!({ "content": { "rows": rows } });
+        let result = api
+            .send_message_with_keyboard(scope.clone(), text_content, keyboard, msg_id)
+            .await?;
+        return Ok(DeliveryResult::ok(extract_response_id(&result)));
+    }
+
+    let mut text = String::from(text_content);
+    if !text.is_empty() {
+        text.push_str("\n\n");
+    }
+    let mut idx = 1;
+    for row in &payload.buttons {
+        for b in row {
+            text.push_str(&format!("[{}] {}\n", idx, b.text));
+            idx += 1;
+        }
+    }
+    text.push_str("\nReply with the number to choose.");
+
+    let result = match scope {
+        QqChatScope::Channel(cid) => api.send_channel_message(cid, &text, msg_id).await?,
+        QqChatScope::Dms(gid) => api.send_dms_message(gid, &text, msg_id).await?,
+        // c2c / group 已在上面 supports_native_keyboard 分支处理
+        _ => unreachable!(),
+    };
+    Ok(DeliveryResult::ok(extract_response_id(&result)))
+}
+
+/// QQ Bot V2 c2c/group 富媒体两步上传（POST /files → file_info → msg_type=7）。
+/// 返回 `None` 表示 payload.media 全部不可发（无 url 来源），caller 应继续走
+/// 文本路径让 dispatcher 链接兜底。
+async fn dispatch_media(
+    api: &QqBotApi,
+    scope: &QqChatScope<'_>,
+    payload: &ReplyPayload,
+    msg_id: Option<&str>,
+) -> Result<Option<DeliveryResult>> {
+    let caption_root = payload.text.as_deref().unwrap_or("");
+    let mut last_msg_id: Option<String> = None;
+
+    for media in &payload.media {
+        let url = match &media.data {
+            MediaData::Url(u) => u.clone(),
+            // 仅 url 来源（公网 HTTPS）支持；本地 FilePath / Bytes 由 dispatcher
+            // 走链接文本兜底
+            _ => continue,
+        };
+        let Some(file_type) = qq_file_type(&media.media_type) else {
+            // Document / Sticker / 未开放类型
+            continue;
+        };
+        let caption = media.caption.as_deref().unwrap_or(caption_root);
+
+        let result = match scope {
+            QqChatScope::C2c(openid) => {
+                let file_info = api.post_c2c_files(openid, file_type, &url).await?;
+                api.send_c2c_media(openid, &file_info, caption, msg_id)
+                    .await?
+            }
+            QqChatScope::Group(gid) => {
+                let file_info = api.post_group_files(gid, file_type, &url).await?;
+                api.send_group_media(gid, &file_info, caption, msg_id)
+                    .await?
+            }
+            // caller 已校验 supports_native_media
+            _ => unreachable!(),
+        };
+        last_msg_id = Some(extract_response_id(&result));
+    }
+    Ok(last_msg_id.map(DeliveryResult::ok))
+}
+
+async fn dispatch_text(
+    api: &QqBotApi,
+    scope: &QqChatScope<'_>,
+    payload: &ReplyPayload,
+    msg_id: Option<&str>,
+) -> Result<DeliveryResult> {
+    let Some(text) = payload.text.as_deref().filter(|t| !t.is_empty()) else {
+        return Ok(DeliveryResult::ok("no_content"));
+    };
+    let result = match scope {
+        QqChatScope::C2c(openid) => api.send_c2c_message(openid, text, msg_id).await?,
+        QqChatScope::Group(gid) => api.send_group_message(gid, text, msg_id).await?,
+        QqChatScope::Channel(cid) => api.send_channel_message(cid, text, msg_id).await?,
+        QqChatScope::Dms(gid) => api.send_dms_message(gid, text, msg_id).await?,
+    };
+    Ok(DeliveryResult::ok(extract_response_id(&result)))
+}
+
+/// 把 hope-agent 的 [`MediaType`] 映射到 QQ Bot V2 wire-level file_type
+/// 数字。Document / Sticker 暂未开放（file_type=4 需特殊审核）→ None
+/// 让 caller 走链接文本兜底。
+fn qq_file_type(media_type: &MediaType) -> Option<u32> {
+    match media_type {
+        MediaType::Photo => Some(api::QqBotApi::FILE_TYPE_IMAGE),
+        MediaType::Video | MediaType::Animation => Some(api::QqBotApi::FILE_TYPE_VIDEO),
+        MediaType::Voice | MediaType::Audio => Some(api::QqBotApi::FILE_TYPE_VOICE),
+        _ => None,
     }
 }

--- a/crates/ha-core/src/channel/rate_limit.rs
+++ b/crates/ha-core/src/channel/rate_limit.rs
@@ -1,0 +1,196 @@
+//! REST 层 429 / Retry-After 统一处理 helper。
+//!
+//! 各 IM 平台 REST API 都按各自规则限流（Discord global + per-bucket、Slack
+//! tier-based、LINE 月度配额等），但都会通过 HTTP 429 + `Retry-After` header
+//! 通知客户端。本模块抽出最小公分母：
+//!
+//! - 解析 `Retry-After`（秒数 / RFC 7231 IMF-fixdate）
+//! - Discord 特有的 `X-RateLimit-Global` header + JSON body `global: true`
+//! - 暴露 `with_rate_limit_retry` 包装一次请求，命中 429 时按 retry_after
+//!   sleep 后再试，最多 N 次
+//!
+//! 使用前提：caller 的 request future 是 idempotent 的（POST /messages 在
+//! 拿到 429 *之前* 服务端没记账，所以重试安全）。
+//!
+//! 接入点：Discord (`channel/discord/api.rs`)、Slack
+//! (`channel/slack/api.rs`)、LINE (`channel/line/api.rs`)。
+
+use std::future::Future;
+use std::time::Duration;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use reqwest::Response;
+
+/// Parsed 429 metadata from a rejected response.
+#[derive(Debug, Clone)]
+pub struct RateLimitInfo {
+    /// 服务端要求等待的时长。
+    pub retry_after: Duration,
+    /// `true` = 全 bot 维度限流（Discord X-RateLimit-Global / body.global）；
+    /// caller 应阻塞所有请求而不仅限本次。
+    pub is_global: bool,
+}
+
+/// 探测一个 response 是否触发 429；返回 None 表示不是 429（caller 走正常路径）。
+///
+/// 优先级：`Retry-After` header（秒数 → date）→ JSON body 字段
+/// `retry_after`（Discord 用浮点秒）→ 兜底 1s。
+pub fn parse_rate_limit_headers(resp: &Response) -> Option<RateLimitInfo> {
+    if resp.status().as_u16() != 429 {
+        return None;
+    }
+
+    let headers = resp.headers();
+    let retry_after = headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_retry_after_value)
+        .unwrap_or_else(|| Duration::from_secs(1));
+
+    let is_global = headers
+        .get("x-ratelimit-global")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    Some(RateLimitInfo {
+        retry_after,
+        is_global,
+    })
+}
+
+/// 进一步用 response body（已读取的 JSON）补全 retry_after / is_global。
+///
+/// Discord/Slack 把这两个字段也放在 body 里（`{"retry_after": 1.234, "global":
+/// true}`），用于 header 缺失时的兜底。caller 已经把 body 读出来后，可以调
+/// 这里再 enrich 一次。
+pub fn enrich_with_body(info: &mut RateLimitInfo, body: &serde_json::Value) {
+    if let Some(secs) = body.get("retry_after").and_then(|v| v.as_f64()) {
+        if secs > 0.0 {
+            info.retry_after = Duration::from_millis((secs * 1000.0) as u64);
+        }
+    }
+    if let Some(global) = body.get("global").and_then(|v| v.as_bool()) {
+        info.is_global = info.is_global || global;
+    }
+}
+
+fn parse_retry_after_value(raw: &str) -> Option<Duration> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(secs) = trimmed.parse::<f64>() {
+        if secs >= 0.0 {
+            return Some(Duration::from_millis((secs * 1000.0) as u64));
+        }
+    }
+    if let Ok(date) = DateTime::parse_from_rfc2822(trimmed) {
+        let now = Utc::now();
+        let diff = date.with_timezone(&Utc).signed_duration_since(now);
+        if let Ok(std) = diff.to_std() {
+            return Some(std);
+        }
+        return Some(Duration::from_secs(0));
+    }
+    None
+}
+
+/// 包装一次请求 future，命中 429 时尊重 Retry-After 后重试。
+///
+/// - `max_attempts`：包含首次的总尝试次数（≥1）
+/// - `f`：每次重试调一次，须返回 `reqwest::Response`（caller 自己负责构造
+///   request；429 之外的状态码由 caller 后续处理）
+///
+/// 上限：单次 sleep 最长 60s（防止恶意 Retry-After: 86400 卡死服务）。
+pub async fn with_rate_limit_retry<F, Fut>(max_attempts: u32, mut f: F) -> Result<Response>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<Response>>,
+{
+    const MAX_SLEEP: Duration = Duration::from_secs(60);
+    let attempts = max_attempts.max(1);
+    let mut last_err: Option<anyhow::Error> = None;
+
+    for attempt in 0..attempts {
+        match f().await {
+            Ok(resp) => {
+                if let Some(info) = parse_rate_limit_headers(&resp) {
+                    if attempt + 1 >= attempts {
+                        // 最后一次仍 429，把 response 还给 caller 自己处理。
+                        return Ok(resp);
+                    }
+                    let sleep = info.retry_after.min(MAX_SLEEP);
+                    tokio::time::sleep(sleep).await;
+                    continue;
+                }
+                return Ok(resp);
+            }
+            Err(e) => {
+                last_err = Some(e);
+                // 网络层错误不视为 rate limit；直接返回让上层退避
+                break;
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("rate limit retry exhausted")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_retry_after_seconds() {
+        assert_eq!(
+            parse_retry_after_value("5"),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(
+            parse_retry_after_value("1.500"),
+            Some(Duration::from_millis(1500))
+        );
+        assert_eq!(parse_retry_after_value("0"), Some(Duration::from_secs(0)));
+    }
+
+    #[test]
+    fn parse_retry_after_imf_fixdate() {
+        // RFC 7231 IMF-fixdate 形式（HTTP-date 的子集，与 RFC 2822 兼容）
+        let val = parse_retry_after_value("Wed, 21 Oct 2099 07:28:00 GMT");
+        assert!(val.is_some());
+        // 远未来日期至少 1 天
+        assert!(val.unwrap() > Duration::from_secs(3600 * 24));
+    }
+
+    #[test]
+    fn parse_retry_after_invalid() {
+        assert!(parse_retry_after_value("").is_none());
+        assert!(parse_retry_after_value("not-a-number-or-date").is_none());
+        assert!(parse_retry_after_value("-5").is_none());
+    }
+
+    #[test]
+    fn enrich_body_overrides_header() {
+        let mut info = RateLimitInfo {
+            retry_after: Duration::from_secs(1),
+            is_global: false,
+        };
+        let body = serde_json::json!({ "retry_after": 3.5, "global": true });
+        enrich_with_body(&mut info, &body);
+        assert_eq!(info.retry_after, Duration::from_millis(3500));
+        assert!(info.is_global);
+    }
+
+    #[test]
+    fn enrich_body_skips_missing() {
+        let mut info = RateLimitInfo {
+            retry_after: Duration::from_secs(7),
+            is_global: true,
+        };
+        enrich_with_body(&mut info, &serde_json::json!({}));
+        assert_eq!(info.retry_after, Duration::from_secs(7));
+        assert!(info.is_global);
+    }
+}

--- a/crates/ha-core/src/channel/rate_limit.rs
+++ b/crates/ha-core/src/channel/rate_limit.rs
@@ -144,10 +144,7 @@ mod tests {
 
     #[test]
     fn parse_retry_after_seconds() {
-        assert_eq!(
-            parse_retry_after_value("5"),
-            Some(Duration::from_secs(5))
-        );
+        assert_eq!(parse_retry_after_value("5"), Some(Duration::from_secs(5)));
         assert_eq!(
             parse_retry_after_value("1.500"),
             Some(Duration::from_millis(1500))

--- a/crates/ha-core/src/channel/signal/client.rs
+++ b/crates/ha-core/src/channel/signal/client.rs
@@ -511,7 +511,10 @@ fn is_group_id(recipient: &str) -> bool {
     }
     // 纯 base64 形态群 ID（v1）：22 或 44 字符无破折号
     let len = recipient.len();
-    (len == 22 || len == 44) && recipient.chars().all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=')
+    (len == 22 || len == 44)
+        && recipient
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=')
 }
 
 #[cfg(test)]
@@ -544,9 +547,7 @@ mod tests {
         // 22 chars base64
         assert!(is_group_id("AbCdEfGhIjKlMnOpQrStUv"));
         // 44 chars base64
-        assert!(is_group_id(
-            "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGh"
-        ));
+        assert!(is_group_id("AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGh"));
     }
 
     #[test]

--- a/crates/ha-core/src/channel/signal/client.rs
+++ b/crates/ha-core/src/channel/signal/client.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 use reqwest::Client;
 use serde_json::Value;
@@ -11,6 +13,11 @@ pub struct SignalClient {
     client: Client,
     base_url: String,
     account: String,
+    /// `inbound_msg_id (timestamp 字串) → sender_id` 缓存，由 SSE 解析时写入；
+    /// outbound `send` 拼 `quoteAuthor` 时读取。signal-cli 要求 reply 必须同时
+    /// 提供 quoteTimestamp + quoteAuthor，缺一即被忽略发为普通消息。LRU cap
+    /// 1024 自然驱逐过期条目。
+    quote_authors: Arc<tokio::sync::Mutex<lru::LruCache<String, String>>>,
 }
 
 impl SignalClient {
@@ -21,7 +28,16 @@ impl SignalClient {
             // 与 daemon.rs 端绑定地址保持一致（127.0.0.1 而非 localhost）
             base_url: format!("http://127.0.0.1:{}", port),
             account,
+            quote_authors: Arc::new(tokio::sync::Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(1024).expect("1024 is non-zero"),
+            ))),
         }
+    }
+
+    /// 取一个 inbound message_id 对应的 sender_id（由 SSE loop 缓存）。
+    pub async fn quote_author_for(&self, message_id: &str) -> Option<String> {
+        let mut cache = self.quote_authors.lock().await;
+        cache.get(message_id).cloned()
     }
 
     /// Make a JSON-RPC 2.0 call to the signal-cli daemon.
@@ -418,6 +434,12 @@ impl SignalClient {
             raw: envelope.clone(),
         };
 
+        // 缓存 sender_id ←→ message_id 映射，供 outbound reply 拼 quoteAuthor 用
+        if !msg.message_id.is_empty() && !msg.sender_id.is_empty() {
+            let mut cache = self.quote_authors.lock().await;
+            cache.put(msg.message_id.clone(), msg.sender_id.clone());
+        }
+
         if inbound_tx.send(msg).await.is_err() {
             app_warn!(
                 "channel",
@@ -489,12 +511,9 @@ impl SignalClient {
 /// Signal recipient 形态：
 /// - `+E164` 电话号（例如 `+15551234567`）
 /// - UUID（v4，含 `-`，36 chars）—— 新版用户 identifier
-/// - `u:username` —— signal-cli 0.13+ username 形式
-/// - 群 ID v1：纯 base64 字符串，长度 22 或 44 chars，不含 `-` `:` `+` `@`
+/// - `u:username` 或 `@username` —— signal-cli 0.13+ username 形式
+/// - 群 ID v1：纯 base64 字符串（22 或 44 chars，无 `-` `:` `+` `@`）
 /// - 群 ID v2：以 `group.` 前缀（base64 字串）
-///
-/// 之前 `!starts_with('+')` 在 UUID 时代会把单聊 UUID 当作群发给 signal-cli，
-/// 直接返回 `Group with id ... not found`。
 fn is_group_id(recipient: &str) -> bool {
     if recipient.starts_with('+') {
         return false;

--- a/crates/ha-core/src/channel/signal/client.rs
+++ b/crates/ha-core/src/channel/signal/client.rs
@@ -18,7 +18,8 @@ impl SignalClient {
     pub fn new(port: u16, account: String) -> Self {
         Self {
             client: Client::new(),
-            base_url: format!("http://localhost:{}", port),
+            // 与 daemon.rs 端绑定地址保持一致（127.0.0.1 而非 localhost）
+            base_url: format!("http://127.0.0.1:{}", port),
             account,
         }
     }
@@ -86,12 +87,17 @@ impl SignalClient {
     }
 
     /// Send a text message to a recipient (phone number or group ID).
+    ///
+    /// `quote_timestamp` + `quote_author` 必须成对——signal-cli `send` 文档
+    /// 要求 reply 必须同时提供 `quoteTimestamp` + `quoteAuthor`（最少这两
+    /// 字段），缺一即被忽略，发出去就是普通消息。
     pub async fn send_message(
         &self,
         recipient: &str,
         message: &str,
         _attachments: &[String],
         quote_timestamp: Option<i64>,
+        quote_author: Option<&str>,
     ) -> Result<Value> {
         let mut params = serde_json::json!({
             "account": self.account,
@@ -105,8 +111,10 @@ impl SignalClient {
             params["recipient"] = serde_json::json!([recipient]);
         }
 
-        if let Some(ts) = quote_timestamp {
+        // signal-cli quote 必须有 timestamp + author 才生效
+        if let (Some(ts), Some(author)) = (quote_timestamp, quote_author) {
             params["quoteTimestamp"] = Value::Number(serde_json::Number::from(ts));
+            params["quoteAuthor"] = Value::String(author.to_string());
         }
 
         self.rpc("send", params).await
@@ -476,9 +484,74 @@ impl SignalClient {
     }
 }
 
-/// Check if a recipient string looks like a Signal group ID (base64).
-/// Group IDs are base64-encoded and typically longer than phone numbers.
+/// 判断 recipient 是否是 Signal 群组 ID。
+///
+/// Signal recipient 形态：
+/// - `+E164` 电话号（例如 `+15551234567`）
+/// - UUID（v4，含 `-`，36 chars）—— 新版用户 identifier
+/// - `u:username` —— signal-cli 0.13+ username 形式
+/// - 群 ID v1：纯 base64 字符串，长度 22 或 44 chars，不含 `-` `:` `+` `@`
+/// - 群 ID v2：以 `group.` 前缀（base64 字串）
+///
+/// 之前 `!starts_with('+')` 在 UUID 时代会把单聊 UUID 当作群发给 signal-cli，
+/// 直接返回 `Group with id ... not found`。
 fn is_group_id(recipient: &str) -> bool {
-    // Phone numbers start with '+', group IDs don't
-    !recipient.starts_with('+')
+    if recipient.starts_with('+') {
+        return false;
+    }
+    if recipient.starts_with("u:") || recipient.starts_with('@') {
+        return false;
+    }
+    if recipient.starts_with("group.") {
+        return true;
+    }
+    // UUID 含 `-`，例如 `a3b1f5e8-...`
+    if recipient.contains('-') {
+        return false;
+    }
+    // 纯 base64 形态群 ID（v1）：22 或 44 字符无破折号
+    let len = recipient.len();
+    (len == 22 || len == 44) && recipient.chars().all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_group_id_recognizes_phones() {
+        assert!(!is_group_id("+15551234567"));
+    }
+
+    #[test]
+    fn is_group_id_recognizes_uuid() {
+        assert!(!is_group_id("a3b1f5e8-1234-4abc-9def-0123456789ab"));
+    }
+
+    #[test]
+    fn is_group_id_recognizes_username() {
+        assert!(!is_group_id("u:alice"));
+        assert!(!is_group_id("@alice"));
+    }
+
+    #[test]
+    fn is_group_id_recognizes_group_v2() {
+        assert!(is_group_id("group.AbCdEfGh1234567890=="));
+    }
+
+    #[test]
+    fn is_group_id_recognizes_base64_v1() {
+        // 22 chars base64
+        assert!(is_group_id("AbCdEfGhIjKlMnOpQrStUv"));
+        // 44 chars base64
+        assert!(is_group_id(
+            "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGh"
+        ));
+    }
+
+    #[test]
+    fn is_group_id_rejects_random_strings() {
+        // 短而不像 group id
+        assert!(!is_group_id("short"));
+    }
 }

--- a/crates/ha-core/src/channel/signal/daemon.rs
+++ b/crates/ha-core/src/channel/signal/daemon.rs
@@ -38,14 +38,21 @@ impl SignalDaemon {
             None => find_free_port()?,
         };
 
-        let http_addr = format!("localhost:{}", port);
+        // 用 127.0.0.1 而非 localhost：避免 IPv6/IPv4 双栈解析不一致——
+        // signal-cli 内部 JVM 默认 IPv6 优先，client 侧 reqwest 也走 localhost
+        // 时大多数环境 OK，但容器内 /etc/hosts 缺 ::1 会出现 daemon 监听
+        // [::1]:port 而 client 走 127.0.0.1 失败的场景。统一 127.0.0.1。
+        let http_addr = format!("127.0.0.1:{}", port);
 
+        // signal-cli 的 --http 参数必须用 `=` 连接（picocli 框架对空格分隔
+        // 敏感，部分版本会把 host:port 当下一个独立参数）。改成 `--http=...`
+        // 单 token 形式，与 signal-cli-jsonrpc.5.adoc 文档一致。
+        let http_arg = format!("--http={}", http_addr);
         let args = vec![
             "-a",
             account,
             "daemon",
-            "--http",
-            &http_addr,
+            &http_arg,
             "--no-receive-stdout",
         ];
 

--- a/crates/ha-core/src/channel/signal/daemon.rs
+++ b/crates/ha-core/src/channel/signal/daemon.rs
@@ -48,13 +48,7 @@ impl SignalDaemon {
         // 敏感，部分版本会把 host:port 当下一个独立参数）。改成 `--http=...`
         // 单 token 形式，与 signal-cli-jsonrpc.5.adoc 文档一致。
         let http_arg = format!("--http={}", http_addr);
-        let args = vec![
-            "-a",
-            account,
-            "daemon",
-            &http_arg,
-            "--no-receive-stdout",
-        ];
+        let args = vec!["-a", account, "daemon", &http_arg, "--no-receive-stdout"];
 
         app_info!(
             "channel",

--- a/crates/ha-core/src/channel/signal/mod.rs
+++ b/crates/ha-core/src/channel/signal/mod.rs
@@ -1,3 +1,12 @@
+//! Signal channel via signal-cli daemon.
+//!
+//! - **Official tool**: <https://github.com/AsamK/signal-cli>
+//! - **JSON-RPC spec**:
+//!   <https://github.com/AsamK/signal-cli/blob/master/man/signal-cli-jsonrpc.5.adoc>
+//! - **Protocol**: 子进程托管 signal-cli `--http=<addr>`，HTTP JSON-RPC
+//!   `/api/v1/rpc` 双向 + SSE `/api/v1/events` 推送实时事件
+//! - **Last reviewed**: 2026-05-05
+
 pub mod client;
 pub mod daemon;
 pub mod format;

--- a/crates/ha-core/src/channel/signal/mod.rs
+++ b/crates/ha-core/src/channel/signal/mod.rs
@@ -30,6 +30,11 @@ struct RunningAccount {
     #[allow(dead_code)]
     account_phone: String,
     daemon: Option<SignalDaemon>,
+    /// Cache of `inbound_msg_id (timestamp 字串) → sender_id` for quoteAuthor
+    /// 拼装。signal-cli send 必须同时提供 quoteTimestamp + quoteAuthor 才会
+    /// 真正生效，缺一即被忽略。MsgContext.sender_id 在 dispatch 阶段不再可
+    /// 见，改为入站时缓存（LRU 由 cap 自然驱逐，避免无限增长）。
+    quote_authors: Arc<tokio::sync::Mutex<lru::LruCache<String, String>>>,
 }
 
 /// Signal channel plugin implementation.
@@ -161,6 +166,10 @@ impl ChannelPlugin for SignalPlugin {
         // Create the client
         let client = Arc::new(SignalClient::new(daemon_port, phone.clone()));
 
+        let quote_authors = Arc::new(tokio::sync::Mutex::new(lru::LruCache::new(
+            std::num::NonZeroUsize::new(1024).expect("1024 is non-zero"),
+        )));
+
         // Store the running account
         {
             let mut accounts = self.accounts.lock().await;
@@ -170,14 +179,31 @@ impl ChannelPlugin for SignalPlugin {
                     client: client.clone(),
                     account_phone: phone.clone(),
                     daemon: Some(daemon),
+                    quote_authors: quote_authors.clone(),
                 },
             );
         }
 
-        // Spawn the SSE event loop
+        // Spawn the SSE event loop. Wrap inbound_tx so we cache sender_id of
+        // each inbound MsgContext keyed by message_id, used later for
+        // signal-cli's quoteAuthor field on outbound replies.
         let account_id = account.id.clone();
+        let (intercept_tx, mut intercept_rx) = mpsc::channel::<MsgContext>(64);
+        let cache = quote_authors.clone();
+        let outbound_tx = inbound_tx.clone();
         tokio::spawn(async move {
-            client.run_sse_loop(account_id, inbound_tx, cancel).await;
+            while let Some(ctx) = intercept_rx.recv().await {
+                if !ctx.message_id.is_empty() && !ctx.sender_id.is_empty() {
+                    let mut map = cache.lock().await;
+                    map.put(ctx.message_id.clone(), ctx.sender_id.clone());
+                }
+                if outbound_tx.send(ctx).await.is_err() {
+                    break;
+                }
+            }
+        });
+        tokio::spawn(async move {
+            client.run_sse_loop(account_id, intercept_tx, cancel).await;
         });
 
         Ok(())
@@ -205,7 +231,13 @@ impl ChannelPlugin for SignalPlugin {
         chat_id: &str,
         payload: &ReplyPayload,
     ) -> Result<DeliveryResult> {
-        let client = self.get_client(account_id).await?;
+        let (client, quote_cache) = {
+            let accounts = self.accounts.lock().await;
+            let acc = accounts
+                .get(account_id)
+                .ok_or_else(|| anyhow::anyhow!("Signal account '{}' is not running", account_id))?;
+            (acc.client.clone(), acc.quote_authors.clone())
+        };
 
         if let Some(ref text) = payload.text {
             if text.is_empty() {
@@ -216,8 +248,18 @@ impl ChannelPlugin for SignalPlugin {
                 .reply_to_message_id
                 .as_deref()
                 .and_then(|id| id.parse::<i64>().ok());
+            // signal-cli reply 必须 timestamp + author 配对，缺一不发 quote
+            let quote_author = if let Some(reply_id) = payload.reply_to_message_id.as_deref() {
+                let mut cache = quote_cache.lock().await;
+                cache.get(reply_id).cloned()
+            } else {
+                None
+            };
 
-            match client.send_message(chat_id, text, &[], quote_ts).await {
+            match client
+                .send_message(chat_id, text, &[], quote_ts, quote_author.as_deref())
+                .await
+            {
                 Ok(result) => {
                     // signal-cli send returns the timestamp as message ID
                     let msg_id = result

--- a/crates/ha-core/src/channel/signal/mod.rs
+++ b/crates/ha-core/src/channel/signal/mod.rs
@@ -30,11 +30,6 @@ struct RunningAccount {
     #[allow(dead_code)]
     account_phone: String,
     daemon: Option<SignalDaemon>,
-    /// Cache of `inbound_msg_id (timestamp 字串) → sender_id` for quoteAuthor
-    /// 拼装。signal-cli send 必须同时提供 quoteTimestamp + quoteAuthor 才会
-    /// 真正生效，缺一即被忽略。MsgContext.sender_id 在 dispatch 阶段不再可
-    /// 见，改为入站时缓存（LRU 由 cap 自然驱逐，避免无限增长）。
-    quote_authors: Arc<tokio::sync::Mutex<lru::LruCache<String, String>>>,
 }
 
 /// Signal channel plugin implementation.
@@ -163,14 +158,11 @@ impl ChannelPlugin for SignalPlugin {
             daemon_port
         );
 
-        // Create the client
+        // Create the client. SSE loop 内部 parse_data_payload 会顺手把
+        // (message_id → sender_id) 写到 client.quote_authors 缓存，给 outbound
+        // reply 拼 quoteAuthor 用。
         let client = Arc::new(SignalClient::new(daemon_port, phone.clone()));
 
-        let quote_authors = Arc::new(tokio::sync::Mutex::new(lru::LruCache::new(
-            std::num::NonZeroUsize::new(1024).expect("1024 is non-zero"),
-        )));
-
-        // Store the running account
         {
             let mut accounts = self.accounts.lock().await;
             accounts.insert(
@@ -179,31 +171,13 @@ impl ChannelPlugin for SignalPlugin {
                     client: client.clone(),
                     account_phone: phone.clone(),
                     daemon: Some(daemon),
-                    quote_authors: quote_authors.clone(),
                 },
             );
         }
 
-        // Spawn the SSE event loop. Wrap inbound_tx so we cache sender_id of
-        // each inbound MsgContext keyed by message_id, used later for
-        // signal-cli's quoteAuthor field on outbound replies.
         let account_id = account.id.clone();
-        let (intercept_tx, mut intercept_rx) = mpsc::channel::<MsgContext>(64);
-        let cache = quote_authors.clone();
-        let outbound_tx = inbound_tx.clone();
         tokio::spawn(async move {
-            while let Some(ctx) = intercept_rx.recv().await {
-                if !ctx.message_id.is_empty() && !ctx.sender_id.is_empty() {
-                    let mut map = cache.lock().await;
-                    map.put(ctx.message_id.clone(), ctx.sender_id.clone());
-                }
-                if outbound_tx.send(ctx).await.is_err() {
-                    break;
-                }
-            }
-        });
-        tokio::spawn(async move {
-            client.run_sse_loop(account_id, intercept_tx, cancel).await;
+            client.run_sse_loop(account_id, inbound_tx, cancel).await;
         });
 
         Ok(())
@@ -231,29 +205,20 @@ impl ChannelPlugin for SignalPlugin {
         chat_id: &str,
         payload: &ReplyPayload,
     ) -> Result<DeliveryResult> {
-        let (client, quote_cache) = {
-            let accounts = self.accounts.lock().await;
-            let acc = accounts
-                .get(account_id)
-                .ok_or_else(|| anyhow::anyhow!("Signal account '{}' is not running", account_id))?;
-            (acc.client.clone(), acc.quote_authors.clone())
-        };
+        let client = self.get_client(account_id).await?;
 
         if let Some(ref text) = payload.text {
             if text.is_empty() {
                 return Ok(DeliveryResult::ok("empty"));
             }
 
-            let quote_ts = payload
-                .reply_to_message_id
-                .as_deref()
-                .and_then(|id| id.parse::<i64>().ok());
-            // signal-cli reply 必须 timestamp + author 配对，缺一不发 quote
-            let quote_author = if let Some(reply_id) = payload.reply_to_message_id.as_deref() {
-                let mut cache = quote_cache.lock().await;
-                cache.get(reply_id).cloned()
-            } else {
-                None
+            // signal-cli reply 必须 timestamp + author 配对，缺一即不发 quote
+            let (quote_ts, quote_author) = match payload.reply_to_message_id.as_deref() {
+                Some(reply_id) => (
+                    reply_id.parse::<i64>().ok(),
+                    client.quote_author_for(reply_id).await,
+                ),
+                None => (None, None),
             };
 
             match client

--- a/crates/ha-core/src/channel/slack/api.rs
+++ b/crates/ha-core/src/channel/slack/api.rs
@@ -2,6 +2,8 @@ use anyhow::{anyhow, Result};
 use serde::Deserialize;
 use std::time::Duration;
 
+use crate::channel::rate_limit::with_rate_limit_retry;
+
 /// Slack Web API client.
 ///
 /// Uses the bot token (xoxb-...) for all API calls except `connections_open`,
@@ -74,6 +76,10 @@ impl SlackApi {
     }
 
     /// Make a POST request to a Slack Web API method with a specified token.
+    ///
+    /// Slack Web API tier-based rate limits（chat.postMessage tier 4 ≈ 1
+    /// msg/sec/channel）通过 HTTP 429 + `Retry-After` header 通知；用
+    /// `with_rate_limit_retry` 自动尊重退避。
     async fn slack_post_with_token<T: serde::de::DeserializeOwned>(
         &self,
         method: &str,
@@ -81,16 +87,19 @@ impl SlackApi {
         body: serde_json::Value,
     ) -> Result<T> {
         let url = format!("https://slack.com/api/{}", method);
+        let auth_header = format!("Bearer {}", token);
 
-        let resp = self
-            .client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", token))
-            .header("Content-Type", "application/json; charset=utf-8")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| anyhow!("Slack API request failed for {}: {}", method, e))?;
+        let resp = with_rate_limit_retry(3, || async {
+            self.client
+                .post(&url)
+                .header("Authorization", &auth_header)
+                .header("Content-Type", "application/json; charset=utf-8")
+                .json(&body)
+                .send()
+                .await
+                .map_err(|e| anyhow!("Slack API request failed for {}: {}", method, e))
+        })
+        .await?;
 
         let status = resp.status();
         if !status.is_success() {

--- a/crates/ha-core/src/channel/slack/format.rs
+++ b/crates/ha-core/src/channel/slack/format.rs
@@ -8,10 +8,30 @@
 /// - Code block: ` ```text``` ` (same)
 /// - Links: `<url|text>` (not `[text](url)`)
 /// - Blockquote: `>` (same)
+///
+/// **Escape rules** (per <https://api.slack.com/reference/surfaces/formatting#escaping>):
+/// raw `<` `>` `&` in user-supplied text MUST be replaced with `&lt;` `&gt;`
+/// `&amp;` to avoid being parsed as control characters (mention/link/entity
+/// delimiters). Inside code spans / code blocks Slack treats content as
+/// preformatted but还需要转义这三字符以避免渲染异常。URL 部分（mrkdwn `<url|text>`
+/// 的 url 段）不转义 `&`（URL 通常合法保留），但仍转义 `<` `>` 防止破坏语法。
 pub fn markdown_to_mrkdwn(md: &str) -> String {
     let mut result = String::with_capacity(md.len());
     let mut in_code_block = false;
     let mut chars = md.chars().peekable();
+
+    /// Slack mrkdwn 控制字符：`<` 触发 mention/link/channel-ref 解析（`<@>`
+    /// `<#>` `<url>` `<url|text>`），`&` 触发 entity 解析。**这两个**必须转义。
+    /// `>` 仅在**行首**有 blockquote 语义；行内出现无害。如果行首 `>` 也转
+    /// 会丢失 blockquote 渲染——故 `>` 一律不转，blockquote 语义保留，业务侧
+    /// raw `>` 不存在被错误解析的风险。
+    fn push_escaped(out: &mut String, ch: char) {
+        match ch {
+            '<' => out.push_str("&lt;"),
+            '&' => out.push_str("&amp;"),
+            _ => out.push(ch),
+        }
+    }
 
     while let Some(ch) = chars.next() {
         // Handle code blocks: ``` ... ```
@@ -38,20 +58,22 @@ pub fn markdown_to_mrkdwn(md: &str) -> String {
             }
         }
 
-        // Inside code block: pass through unchanged
+        // Inside code block: 转义 `<>&` 防止 Slack mrkdwn 解析器把 `<` 当成
+        // mention 起始；其它字符按原文。
         if in_code_block {
-            result.push(ch);
+            push_escaped(&mut result, ch);
             continue;
         }
 
-        // Inline code: `code` - pass through unchanged
+        // Inline code: `code` — 同上，content 仍要转义 `<>&`
         if ch == '`' {
             result.push('`');
-            while let Some(c) = chars.next() {
-                result.push(c);
+            for c in chars.by_ref() {
                 if c == '`' {
+                    result.push('`');
                     break;
                 }
+                push_escaped(&mut result, c);
             }
             continue;
         }
@@ -101,21 +123,33 @@ pub fn markdown_to_mrkdwn(md: &str) -> String {
             if found_bracket && chars.peek() == Some(&'(') {
                 chars.next(); // consume (
                 let mut url = String::new();
-                while let Some(c) = chars.next() {
+                for c in chars.by_ref() {
                     if c == ')' {
                         break;
                     }
                     url.push(c);
                 }
+                // mrkdwn `<url|text>`: URL 段中允许 `&`（query params 常用），但
+                // `<` `>` 必须转义防止破坏语法；text 段全转
                 result.push('<');
-                result.push_str(&url);
+                for c in url.chars() {
+                    match c {
+                        '<' => result.push_str("&lt;"),
+                        '>' => result.push_str("&gt;"),
+                        _ => result.push(c),
+                    }
+                }
                 result.push('|');
-                result.push_str(&link_text);
+                for c in link_text.chars() {
+                    push_escaped(&mut result, c);
+                }
                 result.push('>');
             } else {
-                // Not a link, output as-is
+                // Not a link, output as-is — but still escape contents
                 result.push('[');
-                result.push_str(&link_text);
+                for c in link_text.chars() {
+                    push_escaped(&mut result, c);
+                }
                 if found_bracket {
                     result.push(']');
                 }
@@ -123,8 +157,8 @@ pub fn markdown_to_mrkdwn(md: &str) -> String {
             continue;
         }
 
-        // Everything else: pass through
-        result.push(ch);
+        // Everything else: 转义 `<` 与 `&` 后透传
+        push_escaped(&mut result, ch);
     }
 
     // Close any unclosed code block
@@ -238,6 +272,43 @@ mod tests {
     #[test]
     fn test_empty_string() {
         assert_eq!(markdown_to_mrkdwn(""), "");
+    }
+
+    #[test]
+    fn test_escape_lt_amp_in_plain_text() {
+        // 用户输入含 < 必须转义防止被解析为 mention/link 起始；& 转义防止
+        // entity；> 不转以保留 blockquote
+        assert_eq!(
+            markdown_to_mrkdwn("if a < b && c > d"),
+            "if a &lt; b &amp;&amp; c > d"
+        );
+    }
+
+    #[test]
+    fn test_escape_inside_code_span() {
+        assert_eq!(markdown_to_mrkdwn("`x < y`"), "`x &lt; y`");
+    }
+
+    #[test]
+    fn test_escape_inside_code_block() {
+        let input = "```\nx < y && z\n```";
+        let expected = "```\nx &lt; y &amp;&amp; z\n```";
+        assert_eq!(markdown_to_mrkdwn(input), expected);
+    }
+
+    #[test]
+    fn test_escape_link_text_keeps_url_amp() {
+        // URL 段保留 `&`（query params 常用），text 段转 `<`
+        assert_eq!(
+            markdown_to_mrkdwn("[a < b](https://x.com/?a=1&b=2)"),
+            "<https://x.com/?a=1&b=2|a &lt; b>"
+        );
+    }
+
+    #[test]
+    fn test_blockquote_preserved() {
+        // `>` 不被转义，blockquote 渲染保留
+        assert_eq!(markdown_to_mrkdwn("> quoted"), "> quoted");
     }
 
     #[test]

--- a/crates/ha-core/src/channel/slack/format.rs
+++ b/crates/ha-core/src/channel/slack/format.rs
@@ -78,7 +78,8 @@ pub fn markdown_to_mrkdwn(md: &str) -> String {
             continue;
         }
 
-        // Bold: **text** -> *text*
+        // Bold: **text** -> *text*；inner content 内的 `<` `&` 仍要 escape
+        // 防 `**<@U123> & x**` 内的 mention/entity 起始字符破坏 Slack 解析
         if ch == '*' && chars.peek() == Some(&'*') {
             chars.next(); // consume second *
             result.push('*');
@@ -87,13 +88,13 @@ pub fn markdown_to_mrkdwn(md: &str) -> String {
                     chars.next(); // consume closing **
                     break;
                 }
-                result.push(c);
+                push_escaped(&mut result, c);
             }
             result.push('*');
             continue;
         }
 
-        // Strikethrough: ~~text~~ -> ~text~
+        // Strikethrough: ~~text~~ -> ~text~；同样 escape inner content
         if ch == '~' && chars.peek() == Some(&'~') {
             chars.next(); // consume second ~
             result.push('~');
@@ -102,7 +103,7 @@ pub fn markdown_to_mrkdwn(md: &str) -> String {
                     chars.next(); // consume closing ~~
                     break;
                 }
-                result.push(c);
+                push_escaped(&mut result, c);
             }
             result.push('~');
             continue;
@@ -309,6 +310,21 @@ mod tests {
     fn test_blockquote_preserved() {
         // `>` 不被转义，blockquote 渲染保留
         assert_eq!(markdown_to_mrkdwn("> quoted"), "> quoted");
+    }
+
+    #[test]
+    fn test_escape_inside_bold() {
+        // `**<@U123> & x**` 内的 `<` `&` 必须转义，否则 mention/entity 起始
+        // 字符破坏 Slack 解析；`>` 保持原样（行内不触发 blockquote）
+        assert_eq!(
+            markdown_to_mrkdwn("**<@U123> & x**"),
+            "*&lt;@U123> &amp; x*"
+        );
+    }
+
+    #[test]
+    fn test_escape_inside_strikethrough() {
+        assert_eq!(markdown_to_mrkdwn("~~<#C1> & y~~"), "~&lt;#C1> &amp; y~");
     }
 
     #[test]

--- a/crates/ha-core/src/channel/slack/mod.rs
+++ b/crates/ha-core/src/channel/slack/mod.rs
@@ -107,7 +107,9 @@ impl ChannelPlugin for SlackPlugin {
             supports_draft: false,
             supports_polls: false,
             supports_reactions: false,
-            max_message_length: Some(4000),
+            // Slack chat.postMessage 上限 4000 字符；UTF-8 字节计算下 CJK 字符
+            // 占 3 bytes，留 20% 余量到 3200 字节避免 msg_too_long
+            max_message_length: Some(3200),
             // TODO: native Slack media (files.getUploadURLExternal +
             // files.completeUploadExternal) not yet implemented. Dispatcher
             // falls back to a download-link text for now.

--- a/crates/ha-core/src/channel/slack/mod.rs
+++ b/crates/ha-core/src/channel/slack/mod.rs
@@ -1,3 +1,11 @@
+//! Slack Bot channel.
+//!
+//! - **Official API**: <https://api.slack.com/apis/socket-mode>,
+//!   <https://api.slack.com/methods> (Web API)
+//! - **SDK / Reference**: <https://github.com/slackapi/python-slack-sdk>
+//! - **Protocol**: Socket Mode WebSocket（一次性 wss URL）+ Web API REST
+//! - **Last reviewed**: 2026-05-05
+
 pub mod api;
 pub mod format;
 pub mod socket;

--- a/crates/ha-core/src/channel/slack/socket.rs
+++ b/crates/ha-core/src/channel/slack/socket.rs
@@ -387,10 +387,8 @@ async fn handle_slash_command(
     let timestamp = chrono::Utc::now();
     let message_id = format!("slash_{}", timestamp.timestamp_millis());
 
-    // Slash command 可以在 channel/group/DM 任意位置触发；按 channel_id 前缀
-    // 路由：D=DM、C=public channel、G=private channel/multi-party DM。
-    // 之前固定 `chat_type=Dm` 会让群级安全策略被绕过（DM 与 channel 走不同的
-    // dm_policy / channels[] 配置）。
+    // Slash command 可以在 channel/group/DM 任意位置触发；必须按 channel_id
+    // 前缀分流，否则群级安全策略（channels[] / group_policy）会被 DM 策略绕过
     let chat_type = chat_type_from_slack_channel_id(channel_id);
 
     let msg_ctx = MsgContext {

--- a/crates/ha-core/src/channel/slack/socket.rs
+++ b/crates/ha-core/src/channel/slack/socket.rs
@@ -387,6 +387,12 @@ async fn handle_slash_command(
     let timestamp = chrono::Utc::now();
     let message_id = format!("slash_{}", timestamp.timestamp_millis());
 
+    // Slash command 可以在 channel/group/DM 任意位置触发；按 channel_id 前缀
+    // 路由：D=DM、C=public channel、G=private channel/multi-party DM。
+    // 之前固定 `chat_type=Dm` 会让群级安全策略被绕过（DM 与 channel 走不同的
+    // dm_policy / channels[] 配置）。
+    let chat_type = chat_type_from_slack_channel_id(channel_id);
+
     let msg_ctx = MsgContext {
         channel_id: ChannelId::Slack,
         account_id: account_id.to_string(),
@@ -394,7 +400,7 @@ async fn handle_slash_command(
         sender_name: user_name.map(|s| s.to_string()),
         sender_username: user_name.map(|s| s.to_string()),
         chat_id: channel_id.to_string(),
-        chat_type: ChatType::Dm, // Slash commands are treated as DMs
+        chat_type,
         chat_title: None,
         thread_id: None,
         message_id,
@@ -433,14 +439,15 @@ fn convert_slack_event(
     let ts = event.get("ts").and_then(|v| v.as_str())?;
     let text = event.get("text").and_then(|v| v.as_str());
 
-    // Determine chat type from channel_type field
-    let channel_type = event
-        .get("channel_type")
-        .and_then(|v| v.as_str())
-        .unwrap_or("channel");
+    // 优先按 event.channel_type（Events API 字段：im / mpim / group / channel）
+    // 映射；缺失或未知时回退到按 channel id 前缀（D/G/C）猜测——与
+    // `chat_type_from_slack_channel_id` 保持一致。
+    let channel_type = event.get("channel_type").and_then(|v| v.as_str());
     let chat_type = match channel_type {
-        "im" => ChatType::Dm,
-        _ => ChatType::Group,
+        Some("im") => ChatType::Dm,
+        Some("mpim") | Some("group") => ChatType::Group,
+        Some("channel") => ChatType::Channel,
+        _ => chat_type_from_slack_channel_id(channel),
     };
 
     // Determine thread_ts: if present and different from ts, this is a threaded reply
@@ -537,4 +544,31 @@ fn parse_slack_files(event: &serde_json::Value) -> Vec<InboundMedia> {
             })
         })
         .collect()
+}
+
+/// 按 Slack channel id 前缀猜测 ChatType。
+/// - `D...` direct message (1-on-1) → Dm
+/// - `C...` public channel → Channel
+/// - `G...` private channel / multi-party IM → Group
+/// - 其它（不该出现）→ Group 兜底
+fn chat_type_from_slack_channel_id(channel_id: &str) -> ChatType {
+    match channel_id.chars().next() {
+        Some('D') => ChatType::Dm,
+        Some('C') => ChatType::Channel,
+        Some('G') => ChatType::Group,
+        _ => ChatType::Group,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slack_channel_id_to_chat_type() {
+        assert_eq!(chat_type_from_slack_channel_id("D1234"), ChatType::Dm);
+        assert_eq!(chat_type_from_slack_channel_id("C5678"), ChatType::Channel);
+        assert_eq!(chat_type_from_slack_channel_id("G9ABC"), ChatType::Group);
+        assert_eq!(chat_type_from_slack_channel_id(""), ChatType::Group);
+    }
 }

--- a/crates/ha-core/src/channel/telegram/api.rs
+++ b/crates/ha-core/src/channel/telegram/api.rs
@@ -21,7 +21,11 @@ impl TelegramBotApi {
     ///
     /// Uses a custom reqwest client with proper timeouts to prevent long-polling
     /// requests from hanging indefinitely on network issues.
-    pub fn new(token: &str, proxy_url: Option<&str>, _api_root: Option<&str>) -> Self {
+    ///
+    /// `api_root` 让用户切到自托管 Bot API server（处理 >50MB 文件 / 内网部署）
+    /// 或区域反代。设置后所有 send_* / get_* 都走该 base URL（teloxide 内部
+    /// `bot.set_api_url(url)`），与官方注释"respects custom apiRoot"对齐。
+    pub fn new(token: &str, proxy_url: Option<&str>, api_root: Option<&str>) -> Self {
         // Build a custom reqwest client with timeouts.
         // connect_timeout: fail fast if the server is unreachable (10s)
         // timeout: overall request timeout, must be longer than long-poll timeout (30s)
@@ -39,7 +43,19 @@ impl TelegramBotApi {
         let client = client_builder
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
-        let bot = Bot::with_client(token, client);
+        let mut bot = Bot::with_client(token, client);
+        if let Some(root) = api_root {
+            match reqwest::Url::parse(root) {
+                Ok(url) => bot = bot.set_api_url(url),
+                Err(e) => app_warn!(
+                    "channel",
+                    "telegram::api",
+                    "Invalid apiRoot '{}', falling back to default api.telegram.org: {}",
+                    crate::truncate_utf8(root, 200),
+                    e
+                ),
+            }
+        }
 
         Self {
             bot,

--- a/crates/ha-core/src/channel/telegram/mod.rs
+++ b/crates/ha-core/src/channel/telegram/mod.rs
@@ -148,7 +148,10 @@ impl ChannelPlugin for TelegramPlugin {
             ],
             supports_typing: true,
             supports_buttons: true,
-            max_message_length: Some(4096),
+            // Telegram Bot API 上限 4096 UTF-16 code units；按 UTF-8 字节计算
+            // 中文 3 bytes ≈ 1365 字符，emoji surrogate 占 2 UTF-16 → 4096 字节
+            // 比 4096 字符宽松，但 emoji 多时会反向超限。3200 字节留余量。
+            max_message_length: Some(3200),
         }
     }
 

--- a/crates/ha-core/src/channel/telegram/mod.rs
+++ b/crates/ha-core/src/channel/telegram/mod.rs
@@ -1,3 +1,10 @@
+//! Telegram Bot API channel.
+//!
+//! - **Official API**: <https://core.telegram.org/bots/api>
+//! - **SDK / Reference**: teloxide 0.17 — <https://github.com/teloxide/teloxide>
+//! - **Protocol**: HTTPS long-polling (`getUpdates`) over teloxide `Bot`
+//! - **Last reviewed**: 2026-05-05
+
 pub mod api;
 pub mod format;
 pub mod media;

--- a/crates/ha-core/src/channel/telegram/polling.rs
+++ b/crates/ha-core/src/channel/telegram/polling.rs
@@ -39,7 +39,10 @@ pub async fn run_polling_loop(
             }
             result = tokio::time::timeout(
                 std::time::Duration::from_secs(poll_timeout as u64 + 15),
-                api.get_updates(offset, poll_timeout, &["message", "edited_message", "callback_query"])
+                // capabilities 声明 ChatType::Channel；getUpdates 默认不返回
+                // channel_post，必须在 allowed_updates 显式声明，否则 channel
+                // 帖子永远不进 inbound。
+                api.get_updates(offset, poll_timeout, &["message", "edited_message", "callback_query", "channel_post"])
             ) => {
                 match result {
                     Err(_timeout) => {

--- a/crates/ha-core/src/channel/telegram/polling.rs
+++ b/crates/ha-core/src/channel/telegram/polling.rs
@@ -167,12 +167,15 @@ async fn convert_message(
     bot_id: i64,
     bot_username: &str,
 ) -> Option<MsgContext> {
-    // Extract sender info
-    let from = msg.from.as_ref()?;
+    // Broadcast channel post 通常没有 msg.from（频道身份发的，无个人 sender），
+    // 普通 group/dm 必有 from。from 缺失时用 chat.id 作 sender_id（与频道
+    // 等价），sender_name 取 chat.title。bot 自己发的消息仍只能靠 from.id 过滤。
+    let from = msg.from.as_ref();
 
-    // Skip messages from the bot itself
-    if from.id.0 as i64 == bot_id {
-        return None;
+    if let Some(f) = from {
+        if f.id.0 as i64 == bot_id {
+            return None;
+        }
     }
 
     // Determine chat type
@@ -249,21 +252,31 @@ async fn convert_message(
     // Reply-to message ID
     let reply_to = msg.reply_to_message().map(|r| r.id.0.to_string());
 
-    let sender_name = {
-        let mut name = from.first_name.clone();
-        if let Some(ref last) = from.last_name {
-            name.push(' ');
-            name.push_str(last);
+    // sender_id / sender_name fallback：channel_post 没有 from，用 chat.id +
+    // chat.title 等价表达"频道身份"。普通群/私聊有 from 时用 from.id +
+    // first_name (+ last_name)
+    let (sender_id, sender_name, sender_username) = match from {
+        Some(f) => {
+            let mut name = f.first_name.clone();
+            if let Some(ref last) = f.last_name {
+                name.push(' ');
+                name.push_str(last);
+            }
+            (f.id.0.to_string(), Some(name), f.username.clone())
         }
-        name
+        None => (
+            msg.chat.id.0.to_string(),
+            msg.chat.title().map(|t| t.to_string()),
+            None,
+        ),
     };
 
     Some(MsgContext {
         channel_id: ChannelId::Telegram,
         account_id: account_id.to_string(),
-        sender_id: from.id.0.to_string(),
-        sender_name: Some(sender_name),
-        sender_username: from.username.clone(),
+        sender_id,
+        sender_name,
+        sender_username,
         chat_id: msg.chat.id.0.to_string(),
         chat_type,
         chat_title: msg.chat.title().map(|t| t.to_string()),

--- a/crates/ha-core/src/channel/telegram/polling.rs
+++ b/crates/ha-core/src/channel/telegram/polling.rs
@@ -133,6 +133,14 @@ async fn convert_update(
         UpdateKind::EditedMessage(msg) => {
             convert_message(api, msg, account_id, bot_id, bot_username).await
         }
+        // Telegram broadcast channel (ChatType::Channel) post —— polling
+        // allowed_updates 中已声明，必须在 convert 端配套，否则更新被静默丢弃
+        UpdateKind::ChannelPost(msg) => {
+            convert_message(api, msg, account_id, bot_id, bot_username).await
+        }
+        UpdateKind::EditedChannelPost(msg) => {
+            convert_message(api, msg, account_id, bot_id, bot_username).await
+        }
         UpdateKind::CallbackQuery(cb) => {
             // Handle approval / ask_user callbacks directly (don't create MsgContext)
             if let Some(data) = cb.data.as_ref() {

--- a/crates/ha-core/src/channel/traits.rs
+++ b/crates/ha-core/src/channel/traits.rs
@@ -230,7 +230,14 @@ pub fn default_check_access(
     }
 }
 
-/// Split text into chunks of at most `max_len` bytes, preferring paragraph boundaries.
+/// Split text into chunks of at most `max_len` **bytes** (UTF-8), preferring
+/// paragraph boundaries.
+///
+/// **Note**: `max_len` is byte-conservative. Most IM platforms publish their
+/// limit in characters (or UTF-16 code units for Telegram); a single CJK
+/// character is 3 bytes UTF-8, so 4096 bytes ≈ 1365 CJK chars. Channels
+/// whose official spec is in characters MUST set `max_message_length` below
+/// the spec value to leave UTF-8 headroom. See per-channel `capabilities()`.
 pub fn chunk_text(text: &str, max_len: usize) -> Vec<String> {
     if text.len() <= max_len {
         return vec![text.to_string()];

--- a/crates/ha-core/src/channel/wechat/mod.rs
+++ b/crates/ha-core/src/channel/wechat/mod.rs
@@ -1,3 +1,14 @@
+//! WeChat (微信) iLink Bot channel.
+//!
+//! - **Official API**: iLink Bot HTTP JSON API（私有协议，非微信官方公开）
+//! - **SDK / Reference**: Tencent OpenClaw plugin (TS) —
+//!   <https://github.com/Tencent/openclaw-weixin>
+//!   该仓库是当前 hope-agent 实现的权威对照来源（auth header / UIN / version
+//!   编码 / endpoint 路径全部按 OpenClaw 实装）
+//! - **Protocol**: HTTPS long-polling `ilink/bot/getupdates` + AES-128-ECB
+//!   媒体加密 + QR 码登录
+//! - **Last reviewed**: 2026-05-05
+
 pub mod api;
 pub mod login;
 pub(crate) mod media;

--- a/crates/ha-core/src/channel/wechat/mod.rs
+++ b/crates/ha-core/src/channel/wechat/mod.rs
@@ -364,7 +364,10 @@ impl ChannelPlugin for WeChatPlugin {
             ],
             supports_typing: true,
             supports_buttons: false,
-            max_message_length: Some(4000),
+            // 微信本身按字符上限较宽（旧版本 ~5000 字符），但 iLink 协议下
+            // 多次快速发消息会触发"发送频繁"风控；保守 1500 字节避免长回答
+            // 被切多条 + 多媒体共发时刷屏。
+            max_message_length: Some(1500),
         }
     }
 

--- a/crates/ha-core/src/channel/wechat/polling.rs
+++ b/crates/ha-core/src/channel/wechat/polling.rs
@@ -70,27 +70,44 @@ pub(crate) async fn run_polling_loop(
                     app_warn!(
                         "channel",
                         "wechat::polling",
-                        "WeChat getUpdates failed for '{}' (ret={:?} errcode={:?} errmsg={:?})",
+                        "WeChat getUpdates failed for '{}' (ret={:?} errcode={:?} errmsg={:?}, consec={})",
                         account_id,
                         resp.ret,
                         resp.errcode,
-                        resp.errmsg
+                        resp.errmsg,
+                        consecutive_failures,
                     );
 
+                    // OpenClaw types.ts 注释：errcode=-14 表示 session timeout。
+                    // 但网络抖动 / sync 漂移也可能让单次返回 -14；之前一次即触发
+                    // 1 小时熔断会让用户在偶发抖动后整小时收不到回复。
+                    // 改为 3 次连续 -14 才熔断；任何一次成功（is_api_error=false 后
+                    // consecutive_failures 重置）都重新计数。
                     if should_stop_for_expired_session(&resp) {
-                        app_warn!(
-                            "channel",
-                            "wechat::polling",
-                            "WeChat session expired for '{}'; pausing API calls for 1 hour",
-                            account_id
-                        );
-                        shared.pause_account(&account_id).await;
-                        if sleep_or_cancel(&cancel, Duration::from_secs(3600)).await {
-                            break;
+                        if consecutive_failures < 3 {
+                            app_warn!(
+                                "channel",
+                                "wechat::polling",
+                                "WeChat session expired marker for '{}' (consec={}); not pausing yet, retrying after backoff",
+                                account_id,
+                                consecutive_failures
+                            );
+                        } else {
+                            app_warn!(
+                                "channel",
+                                "wechat::polling",
+                                "WeChat session expired for '{}' after {} consecutive errors; pausing API calls for 1 hour",
+                                account_id,
+                                consecutive_failures
+                            );
+                            shared.pause_account(&account_id).await;
+                            if sleep_or_cancel(&cancel, Duration::from_secs(3600)).await {
+                                break;
+                            }
+                            shared.clear_pause(&account_id).await;
+                            consecutive_failures = 0;
+                            continue;
                         }
-                        shared.clear_pause(&account_id).await;
-                        consecutive_failures = 0;
-                        continue;
                     }
 
                     let delay = if consecutive_failures >= 3 {

--- a/crates/ha-core/src/channel/wechat/polling.rs
+++ b/crates/ha-core/src/channel/wechat/polling.rs
@@ -79,10 +79,9 @@ pub(crate) async fn run_polling_loop(
                     );
 
                     // OpenClaw types.ts 注释：errcode=-14 表示 session timeout。
-                    // 但网络抖动 / sync 漂移也可能让单次返回 -14；之前一次即触发
-                    // 1 小时熔断会让用户在偶发抖动后整小时收不到回复。
-                    // 改为 3 次连续 -14 才熔断；任何一次成功（is_api_error=false 后
-                    // consecutive_failures 重置）都重新计数。
+                    // 但网络抖动 / sync 漂移也可能瞬时返回 -14；要求 3 次连续才
+                    // 熔断（is_api_error=false 时 consecutive_failures 已重置）
+                    // 否则偶发抖动会让用户整小时收不到回复。
                     if should_stop_for_expired_session(&resp) {
                         if consecutive_failures < 3 {
                             app_warn!(

--- a/crates/ha-core/src/channel/whatsapp/mod.rs
+++ b/crates/ha-core/src/channel/whatsapp/mod.rs
@@ -1,3 +1,14 @@
+//! WhatsApp channel via third-party bridge (HTTP polling).
+//!
+//! - **Official API**: WhatsApp Cloud API
+//!   <https://developers.facebook.com/docs/whatsapp/cloud-api>（hope-agent 不直接对接，
+//!   需用户自部署 bridge）
+//! - **SDK / Reference**: <https://github.com/tulir/whatsmeow>（推荐 bridge 实现，
+//!   逆向 WA 协议提供 Go API），<https://github.com/WhiskeySockets/Baileys>（Node.js）
+//! - **Protocol**: 通用 bridge HTTP 长轮询 — `GET /api/messages?since={ts}` +
+//!   `POST /api/send`；timestamp 单位 = Unix 秒（UTC，bridge 实现需遵守）
+//! - **Last reviewed**: 2026-05-05
+
 pub mod api;
 pub mod format;
 pub mod polling;

--- a/crates/ha-core/src/channel/whatsapp/polling.rs
+++ b/crates/ha-core/src/channel/whatsapp/polling.rs
@@ -13,6 +13,17 @@ const POLL_INTERVAL: Duration = Duration::from_secs(2);
 const RETRY_DELAY: Duration = Duration::from_secs(2);
 const BACKOFF_DELAY: Duration = Duration::from_secs(30);
 
+/// 时间戳单位防御：bridge HTTP 协议约定 Unix 秒（UTC），但 WhatsApp 原生
+/// （whatsmeow / Baileys）用毫秒。若 ts 大于 4_000_000_000（2096 年）即
+/// 视为毫秒自动除 1000，避免 since= 串永远拿不到新消息。
+fn normalize_unix_seconds(ts: i64) -> i64 {
+    if ts > 4_000_000_000 {
+        ts / 1000
+    } else {
+        ts
+    }
+}
+
 /// Run the WhatsApp bridge polling loop.
 ///
 /// Follows the same pattern as the WeChat polling loop:
@@ -60,14 +71,8 @@ pub(crate) async fn run_whatsapp_polling(
                         continue;
                     }
 
-                    // 时间戳单位防御：bridge HTTP 协议约定 Unix 秒（UTC），但
-                    // WhatsApp 协议（whatsmeow / Baileys）原生用毫秒；若 bridge
-                    // 透传毫秒（> 4_000_000_000 = 2096 年）会让 since= 串得离谱
-                    // 大、下次轮询永远拿不到新消息。检测 + 自动除以 1000。
-                    if let Some(mut ts) = msg.timestamp {
-                        if ts > 4_000_000_000 {
-                            ts /= 1000;
-                        }
+                    if let Some(ts) = msg.timestamp {
+                        let ts = normalize_unix_seconds(ts);
                         if ts > last_timestamp {
                             last_timestamp = ts;
                         }
@@ -142,7 +147,7 @@ fn convert_bridge_message(account_id: &str, msg: BridgeMessage) -> Option<MsgCon
         .map(str::to_string);
 
     let timestamp = timestamp
-        .map(|ts| if ts > 4_000_000_000 { ts / 1000 } else { ts })
+        .map(normalize_unix_seconds)
         .and_then(|ts| Utc.timestamp_opt(ts, 0).single())
         .unwrap_or_else(Utc::now);
 

--- a/crates/ha-core/src/channel/whatsapp/polling.rs
+++ b/crates/ha-core/src/channel/whatsapp/polling.rs
@@ -60,8 +60,14 @@ pub(crate) async fn run_whatsapp_polling(
                         continue;
                     }
 
-                    // Update last_timestamp to the most recent message
-                    if let Some(ts) = msg.timestamp {
+                    // 时间戳单位防御：bridge HTTP 协议约定 Unix 秒（UTC），但
+                    // WhatsApp 协议（whatsmeow / Baileys）原生用毫秒；若 bridge
+                    // 透传毫秒（> 4_000_000_000 = 2096 年）会让 since= 串得离谱
+                    // 大、下次轮询永远拿不到新消息。检测 + 自动除以 1000。
+                    if let Some(mut ts) = msg.timestamp {
+                        if ts > 4_000_000_000 {
+                            ts /= 1000;
+                        }
                         if ts > last_timestamp {
                             last_timestamp = ts;
                         }
@@ -136,6 +142,7 @@ fn convert_bridge_message(account_id: &str, msg: BridgeMessage) -> Option<MsgCon
         .map(str::to_string);
 
     let timestamp = timestamp
+        .map(|ts| if ts > 4_000_000_000 { ts / 1000 } else { ts })
         .and_then(|ts| Utc.timestamp_opt(ts, 0).single())
         .unwrap_or_else(Utc::now);
 

--- a/crates/ha-core/src/channel/ws.rs
+++ b/crates/ha-core/src/channel/ws.rs
@@ -12,6 +12,17 @@ pub struct WsConnection {
     ws: WebSocketStream<MaybeTlsStream<TcpStream>>,
 }
 
+/// Close frame metadata exposed by [`WsConnection::recv_text_with_close`].
+#[derive(Debug, Clone)]
+pub struct WsClose {
+    /// Close code per RFC 6455 + protocol-specific extensions (Discord 4xxx,
+    /// QQ Bot 4xxx etc.). Tungstenite's `CloseCode` enum is flattened to u16
+    /// so unknown extensions can still be matched.
+    pub code: u16,
+    /// Optional reason string sent by the peer.
+    pub reason: String,
+}
+
 impl WsConnection {
     /// Connect to a WebSocket URL.
     pub async fn connect(url: &str) -> Result<Self> {
@@ -62,11 +73,51 @@ impl WsConnection {
     }
 
     /// Receive the next text message, returning None on close/error.
+    ///
+    /// Close frames are swallowed; callers that need to inspect the close code
+    /// (e.g. Discord 4xxx fatal vs. resumable) should use
+    /// [`recv_text_with_close`](Self::recv_text_with_close) instead.
     pub async fn recv_text(&mut self) -> Option<String> {
         loop {
             match self.ws.next().await {
                 Some(Ok(Message::Text(text))) => return Some(text.to_string()),
                 Some(Ok(Message::Close(_))) => return None,
+                Some(Ok(Message::Ping(data))) => {
+                    let _ = self.ws.send(Message::Pong(data)).await;
+                    continue;
+                }
+                Some(Ok(_)) => continue, // Binary, Pong, Frame — skip
+                Some(Err(_)) => return None,
+                None => return None,
+            }
+        }
+    }
+
+    /// Receive the next text message, exposing close frame metadata.
+    ///
+    /// Returns:
+    /// - `Some(Ok(text))` — normal data frame
+    /// - `Some(Err(WsClose { code, reason }))` — peer closed with a frame; caller
+    ///   uses `code` to route fatal vs. resumable (Discord 4004/4010-4014 fatal,
+    ///   4007/4009 fresh IDENTIFY, etc.)
+    /// - `None` — IO error or stream end without a close frame
+    pub async fn recv_text_with_close(&mut self) -> Option<Result<String, WsClose>> {
+        loop {
+            match self.ws.next().await {
+                Some(Ok(Message::Text(text))) => return Some(Ok(text.to_string())),
+                Some(Ok(Message::Close(frame))) => {
+                    let close = match frame {
+                        Some(f) => WsClose {
+                            code: u16::from(f.code),
+                            reason: f.reason.to_string(),
+                        },
+                        None => WsClose {
+                            code: 1005, // No Status Received
+                            reason: String::new(),
+                        },
+                    };
+                    return Some(Err(close));
+                }
                 Some(Ok(Message::Ping(data))) => {
                     let _ = self.ws.send(Message::Pong(data)).await;
                     continue;

--- a/docs/plans/review-followups.md
+++ b/docs/plans/review-followups.md
@@ -32,16 +32,18 @@
 
 ### F-057 IM channel 主动消息 / 媒体能力补完（跨 channel）
 
-- **来源**：2026-05-05 IM channel 全量审计
-- **现象**：本批补了 QQ Bot（c2c/group msg_type=7 两步上传）+ LINE（image/video/audio message object 公网 HTTPS URL）的富媒体；剩余 channel 仍降级为下载链接文本：
+- **来源**：2026-05-05 IM channel 全量审计 + 2026-05-06 codex review 回归
+- **现象**：本批**写过** QQ Bot c2c/group msg_type=7 两步上传 + LINE imageMessage/videoMessage/audioMessage HTTPS URL 路径；但 [`channel/worker/dispatcher.rs::to_outbound_media`](../../crates/ha-core/src/channel/worker/dispatcher.rs#L728) 优先给 `MediaData::FilePath`（hope-agent 本地缓存路径），而 QQ Bot V2 上传 / LINE message object 都只接收公网 HTTPS URL —— 两边在 plugin 内部 `match data { Url(_) => ..., _ => continue }` 把 FilePath 静默跳过。结果声明 `supports_media` 反而让 dispatcher 不再追 link fallback → 用户附件两头不到位。
+  - **2026-05-06 已回退**：QQ Bot + LINE `supports_media` 重新设为空，恢复 dispatcher 的链接文本兜底。两套两步上传 helper（`post_*_files` / `send_*_media` / `dispatch_media`、LINE message-object 构造）保留备用，等本地附件中转基建就绪再开
+- **剩余 channel 状态**：均降级为下载链接文本：
   - Slack — files v2 流程（`files.getUploadURLExternal` + `files.completeUploadExternal`）
   - Google Chat — `media.upload` + `attachment` resource name（需 Drive scope）
   - Signal — signal-cli `--attachment <path>`
   - iMessage — imsg `send_attachment` 子命令（待 stdio 协议字段）
   - WhatsApp — bridge `media` 字段
-  - LINE — 本地附件中转（仅支持公网 HTTPS URL，本地 FilePath/Bytes 待中转基建）
-  - QQ Bot — channel/dms 暂未开放（API V2 仅 c2c/group）
-- **为什么留**：每家上传协议形态不同，本批已修核心稳定性问题（msg_seq / 心跳 / INVALID_SESSION / 速率限制 / chat_type 等），富媒体属于体验补完，不阻塞首发
+  - LINE / QQ Bot — 待本地附件中转 + 公网 HTTPS 暴露基建（hope-agent 自托管端点 / 用户配置 `public_base_url` 转发缓存附件）
+  - QQ Bot — channel/dms 端点 V2 不开放原生媒体上传，仍要走链接
+- **为什么留**：核心是缺"本地缓存附件 → 公网 HTTPS URL"的中转基建，而不是各 channel 的协议代码；本批已修核心稳定性问题（msg_seq / 心跳 / INVALID_SESSION / 速率限制 / chat_type 等），富媒体不阻塞首发文本
 - **改的话要做什么**：参照 [`channel/worker/dispatcher.rs::partition_media_by_channel`](../../crates/ha-core/src/channel/worker/dispatcher.rs) 已有的能力声明驱动下，逐 channel 补 `*/media.rs` 模块；先做 Slack（用户最多）+ Signal（调试方便）
 - **影响面**：能力承诺 vs 实际不一致，dispatcher 自动降级为链接文本但用户视觉体验差
 - **触发时机建议**：用户报"图片发不出来"时按 channel 优先级排队；新增 OAuth scope 时同步评估

--- a/docs/plans/review-followups.md
+++ b/docs/plans/review-followups.md
@@ -30,7 +30,70 @@
 
 ## Open
 
+### F-057 IM channel 主动消息 / 媒体能力补完（跨 channel）
 
+- **来源**：2026-05-05 IM channel 全量审计
+- **现象**：本批补了 QQ Bot（c2c/group msg_type=7 两步上传）+ LINE（image/video/audio message object 公网 HTTPS URL）的富媒体；剩余 channel 仍降级为下载链接文本：
+  - Slack — files v2 流程（`files.getUploadURLExternal` + `files.completeUploadExternal`）
+  - Google Chat — `media.upload` + `attachment` resource name（需 Drive scope）
+  - Signal — signal-cli `--attachment <path>`
+  - iMessage — imsg `send_attachment` 子命令（待 stdio 协议字段）
+  - WhatsApp — bridge `media` 字段
+  - LINE — 本地附件中转（仅支持公网 HTTPS URL，本地 FilePath/Bytes 待中转基建）
+  - QQ Bot — channel/dms 暂未开放（API V2 仅 c2c/group）
+- **为什么留**：每家上传协议形态不同，本批已修核心稳定性问题（msg_seq / 心跳 / INVALID_SESSION / 速率限制 / chat_type 等），富媒体属于体验补完，不阻塞首发
+- **改的话要做什么**：参照 [`channel/worker/dispatcher.rs::partition_media_by_channel`](../../crates/ha-core/src/channel/worker/dispatcher.rs) 已有的能力声明驱动下，逐 channel 补 `*/media.rs` 模块；先做 Slack（用户最多）+ Signal（调试方便）
+- **影响面**：能力承诺 vs 实际不一致，dispatcher 自动降级为链接文本但用户视觉体验差
+- **触发时机建议**：用户报"图片发不出来"时按 channel 优先级排队；新增 OAuth scope 时同步评估
+
+### F-058 IM channel WebSocket / 长连接 + IRCv3 + chat_type 协议层细化（跨 channel）
+
+- **来源**：2026-05-05 IM channel 全量审计
+- **现象**：协议层补完短板：
+  - **Discord** HEARTBEAT 缺 jitter（[`gateway.rs:205`](../../crates/ha-core/src/channel/discord/gateway.rs#L205)）；IDENTIFY connection properties `os: "macos"` 写死无视实际平台；`MESSAGE_CREATE` thread_id 永远 None（实际 Discord forum 消息走 thread channel_id）；ChatType 只 Dm/Group 缺 Channel/Forum 细化（要求 cache `channel.type`）
+  - **Slack** disconnect 信封未触发立即重连（[`socket.rs:265`](../../crates/ha-core/src/channel/slack/socket.rs#L265)）；action_id 长度上限 ≤ 255 校验
+  - **QQ Bot** shard `[0,1]` 写死、IDENTIFY `properties` 空；sandbox endpoint 切换；event_id 主动/被动消息区分
+  - **Signal** SSE `data:` 多空格剥取不一致；daemon readiness 主动 poll `/api/v1/check` 而非 sleep 2s
+  - **IRC** IRCv3 `CAP LS 302` + SASL PLAIN 协商（不接 SASL 在 Libera 等主流网络可能强踢）；IRCv3 message-tags 解析（`@key=value` 前缀）；channel name 用户输入自动补 `#`
+  - **iMessage** RPC 方法名（`chats.list` / `watch.subscribe` / `sendTyping`）需对照 [`steipete/imsg`](https://github.com/steipete/imsg) 实际 RPC 暴露面；`is_group` 完全信赖字段而非 participants.len() fallback
+- **为什么留**：单实例不可见，规模化或边界场景才暴露；IRCv3 SASL 是单 channel 50-100 行重写，独立 PR 更清楚
+- **改的话要做什么**：jitter 用 `interval * rand::random::<f64>()`；`os: std::env::consts::OS`；shard 字段从 capabilities 推断；tungstenite Message::Close.code 路由模板已在 Discord 落地，可参考迁移 Slack/QQ；IRCv3 见 <https://ircv3.net/specs/extensions/sasl-3.1.html>
+- **影响面**：稳定性 / 服务端可观测性 / 现代 IRCd 兼容性
+- **触发时机建议**：单 channel 大流量场景报"频繁断线"时；接 Libera/OFTC 网络的 IRC 用户报告"被踢"时
+
+### F-059 IM channel 速率限制 / 幂等增强（跨 channel）
+
+- **来源**：2026-05-05 IM channel 全量审计
+- **现象**：本批用 [`channel/rate_limit.rs`](../../crates/ha-core/src/channel/rate_limit.rs) 接了 Discord/Slack 429 + Retry-After；剩余：
+  - **Telegram** teloxide `Throttle` adaptor 包装 `Bot`（自动尊重 FloodWait `RetryAfter` 错误），需要在 [`Cargo.toml`](../../crates/ha-core/Cargo.toml) telmit feature 加 `throttle`，且持有 Bot 类型从 `Bot` 改 `Throttle<Bot>`，diff 较大
+  - **LINE** push API `X-Line-Retry-Key` UUID4 幂等头（避免网络重试重复扣费）+ 429 处理
+  - **Feishu** `auth.rs` 并发首次取 token 加 `OnceCell` singleflight 锁
+  - **WhatsApp** 连续失败 ≥3 后 `consecutive_failures` 清零，无最终告警；接 [`channel/start_watchdog.rs`](../../crates/ha-core/src/channel/start_watchdog.rs) 同款指数退避
+- **为什么留**：边界并发 / 长期失败场景才暴露；teloxide Throttle 改动面较大需独立验证
+- **改的话要做什么**：Telegram 切 Throttle；LINE push 生成 UUID4 复用；Feishu auth 用 `tokio::sync::OnceCell` 单飞；WhatsApp 改用 watchdog
+- **影响面**：偶发计费重复 / token 配额浪费 / 长期挂掉无告警
+- **触发时机建议**：用户报"消息重复" / "Feishu 503" / "Telegram FloodWait 螺旋" 时
+
+### F-060 IM channel 配置 / 错误信息 / 安全细节（跨 channel）
+
+- **来源**：2026-05-05 IM channel 全量审计
+- **现象**：纯优雅性 / 非阻塞首发的细节，逐 channel 列：
+  - **Telegram** `sendMessageDraft` 4xx fallback 软降级；媒体退到 `sendDocument` 丢类型语义（应按 media_type 分发到 `send_voice` / `send_animation` / `send_sticker`）
+  - **WeChat** 长轮询 timeout 1ms 边界 clamp（`next_timeout_ms.clamp(5_000, 60_000)`）；登录 `current_api_base_url` redirect 后持久化复用
+  - **Slack** `subtype=file_share` 子类型显式处理；slash command response_action ack 带 payload
+  - **Feishu** `auth/v3/tenant_access_token/internal` trailing slash 去除；ack `biz_rt` 写实际处理耗时；ack `payload_encoding`/`payload_type` 透传源帧；`card.action.trigger` ack 带 update payload
+  - **QQ Bot** mention space 补空（`strip_mention_tags`）；event_id 主动/被动消息区分；botpy 那边的 sandbox bool 字段
+  - **LINE** webhook 失败返回 404 而非 403 oracle；postback origin 校验（chat_id 与 pending approval 比对，防群聊跨 session 伪造审批）
+  - **Google Chat** `webhook_server` body limit 1MB → 4-8MB（多附件 message 接近）；message resource name 文档化
+  - **WhatsApp** baseUrl 缺失 + bridge HTTP 契约 README/SKILL 文档；empty text 返回 err 而非 ok
+  - **IRC** channel name 用户输入自动补 `#`；IRCv3 message-tags 解析；reconnect writer 重建用 `Arc<Mutex<Option<...>>>` 一次替换更直观
+  - **Signal** localhost vs 127.0.0.1（**已在本批修**）；readiness `/api/v1/check` 探活；username `u:` / `@` recipient form 完整支持
+  - **iMessage** `is_group` 完全信赖字段；JSON-RPC 帧协议探测（NDJSON vs Content-Length）；typing 实际能力验证后调整 `supports_typing`
+  - **跨 channel** approval callback `try_dispatch_interactive_callback(data, source)` 应加 `source_chat_id` 参数与 worker pending map chat_id 比对（LINE postback / 群聊场景跨用户伪造审批的根本防御）
+- **为什么留**：每条独立改动小（≤10 行），按 channel 维度逐个收效率最高
+- **改的话要做什么**：每个 bullet 独立改；可分多次小 PR 收
+- **影响面**：用户体验 / 调试体验 / 极端边界 + LINE postback 是潜在安全洞
+- **触发时机建议**：下一次动到对应 channel 文件时顺手收
 
 ### F-051 `currentSessionMeta` + `incognitoEnabled` 三处复制可推进 `useQuickChatSession` / `useChatSession`
 

--- a/src/components/settings/channel-panel/AddAccountDialog.tsx
+++ b/src/components/settings/channel-panel/AddAccountDialog.tsx
@@ -95,6 +95,7 @@ export default function AddAccountDialog({
   // Google Chat-specific
   const [gchatCredentialsJson, setGchatCredentialsJson] = useState("")
   const [gchatWebhookUrl, setGchatWebhookUrl] = useState("")
+  const [gchatProjectNumber, setGchatProjectNumber] = useState("")
   // LINE-specific
   const [lineAccessToken, setLineAccessToken] = useState("")
   const [lineChannelSecret, setLineChannelSecret] = useState("")
@@ -150,7 +151,11 @@ export default function AddAccountDialog({
       case "whatsapp":
         return { baseUrl: whatsappBaseUrl.trim(), token: whatsappToken.trim() || null }
       case "googlechat":
-        return { credentialsJson: gchatCredentialsJson.trim(), webhookBaseUrl: gchatWebhookUrl.trim() || null }
+        return {
+          credentialsJson: gchatCredentialsJson.trim(),
+          webhookBaseUrl: gchatWebhookUrl.trim() || null,
+          projectNumber: gchatProjectNumber.trim(),
+        }
       case "line":
         return { channelAccessToken: lineAccessToken.trim(), channelSecret: lineChannelSecret.trim(), webhookBaseUrl: lineWebhookUrl.trim() || null }
       default:
@@ -168,7 +173,7 @@ export default function AddAccountDialog({
       case "signal": return !!signalAccount.trim()
       case "imessage": return true
       case "whatsapp": return !!whatsappBaseUrl.trim()
-      case "googlechat": return !!gchatCredentialsJson.trim()
+      case "googlechat": return !!gchatCredentialsJson.trim() && !!gchatProjectNumber.trim()
       case "line": return !!lineAccessToken.trim() && !!lineChannelSecret.trim()
       default: return !!token.trim()
     }
@@ -185,7 +190,7 @@ export default function AddAccountDialog({
       case "signal": return !!signalAccount.trim()
       case "imessage": return true
       case "whatsapp": return !!whatsappBaseUrl.trim()
-      case "googlechat": return !!gchatCredentialsJson.trim()
+      case "googlechat": return !!gchatCredentialsJson.trim() && !!gchatProjectNumber.trim()
       case "line": return !!lineAccessToken.trim() && !!lineChannelSecret.trim()
       default: return !!token.trim()
     }
@@ -664,6 +669,15 @@ export default function AddAccountDialog({
                       onChange={(e) => { setGchatCredentialsJson(e.target.value); setValidationResult(null); setValidationError(null) }}
                       className="font-mono text-xs"
                     />
+                  </div>
+                  <div className="space-y-2">
+                    <Label>{t("channels.gchatProjectNumber", "Google Cloud Project Number")}</Label>
+                    <Input
+                      placeholder="123456789012"
+                      value={gchatProjectNumber}
+                      onChange={(e) => setGchatProjectNumber(e.target.value)}
+                    />
+                    <p className="text-xs text-muted-foreground">{t("channels.gchatProjectNumberHint", "Required to verify Google-signed JWT on incoming webhooks")}</p>
                   </div>
                   <div className="space-y-2">
                     <Label>{t("channels.webhookUrl", "Public Webhook URL")}</Label>

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "رمز المصادقة (اختياري)",
     "whatsappHint": "يتطلب خدمة WhatsApp bridge قيد التشغيل. وجّه إلى URL HTTP API الخاص بها.",
     "gchatCredentials": "JSON Service Account",
+    "gchatProjectNumber": "رقم مشروع Google Cloud",
+    "gchatProjectNumberHint": "مطلوب للتحقق من JWT الموقع من Google على webhook الواردة",
     "gchatHint": "يتطلب Service Account من Google Workspace مع تفعيل Chat API",
     "webhookUrl": "URL Webhook العام",
     "webhookUrlHint": "تطبيقات سطح المكتب تحتاج URL عام (مثل ngrok) لاستقبال webhooks",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "Auth Token (optional)",
     "whatsappHint": "Requires a WhatsApp bridge service running. Point to its HTTP API URL.",
     "gchatCredentials": "Service Account JSON",
+    "gchatProjectNumber": "Google Cloud Project Number",
+    "gchatProjectNumberHint": "Required to verify Google-signed JWT on incoming webhooks",
     "gchatHint": "Requires a Google Workspace service account with Chat API enabled",
     "webhookUrl": "Public Webhook URL",
     "webhookUrlHint": "Desktop apps need a public URL (e.g. ngrok) to receive webhooks",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "Token de autenticación (opcional)",
     "whatsappHint": "Requiere un servicio puente de WhatsApp en ejecución. Apunta a su URL de API HTTP.",
     "gchatCredentials": "JSON de la Service Account",
+    "gchatProjectNumber": "Número de proyecto de Google Cloud",
+    "gchatProjectNumberHint": "Necesario para verificar el JWT firmado por Google en los webhooks entrantes",
     "gchatHint": "Requiere una Service Account de Google Workspace con la API de Chat activada",
     "webhookUrl": "URL pública del Webhook",
     "webhookUrlHint": "Las apps de escritorio necesitan una URL pública (p. ej. ngrok) para recibir webhooks",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "認証トークン（任意）",
     "whatsappHint": "WhatsApp ブリッジサービスの実行が必要です。HTTP API URL を指定してください。",
     "gchatCredentials": "サービスアカウント JSON",
+    "gchatProjectNumber": "Google Cloud プロジェクト番号",
+    "gchatProjectNumberHint": "受信 webhook の Google 署名 JWT 検証に必要",
     "gchatHint": "Chat API を有効にした Google Workspace サービスアカウントが必要です",
     "webhookUrl": "公開 Webhook URL",
     "webhookUrlHint": "デスクトップアプリは Webhook を受信するために公開 URL（ngrok など）が必要です",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "인증 토큰 (선택)",
     "whatsappHint": "WhatsApp 브리지 서비스가 실행 중이어야 합니다. HTTP API URL 을 지정하세요.",
     "gchatCredentials": "서비스 계정 JSON",
+    "gchatProjectNumber": "Google Cloud 프로젝트 번호",
+    "gchatProjectNumberHint": "수신 webhook의 Google 서명 JWT 검증에 필요",
     "gchatHint": "Chat API 가 활성화된 Google Workspace 서비스 계정이 필요합니다",
     "webhookUrl": "공개 Webhook URL",
     "webhookUrlHint": "데스크톱 앱은 Webhook 수신을 위해 공개 URL (예: ngrok) 이 필요합니다",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "Token pengesahan (pilihan)",
     "whatsappHint": "Memerlukan perkhidmatan bridge WhatsApp berjalan. Tunjuk ke URL HTTP API-nya.",
     "gchatCredentials": "JSON Service Account",
+    "gchatProjectNumber": "Nombor Projek Google Cloud",
+    "gchatProjectNumberHint": "Diperlukan untuk mengesahkan JWT yang ditandatangani Google pada webhook masuk",
     "gchatHint": "Memerlukan Service Account Google Workspace dengan Chat API didayakan",
     "webhookUrl": "URL Webhook awam",
     "webhookUrlHint": "Aplikasi desktop memerlukan URL awam (cth. ngrok) untuk menerima webhook",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "Token de autenticação (opcional)",
     "whatsappHint": "Requer um serviço bridge do WhatsApp em execução. Aponte para sua URL HTTP API.",
     "gchatCredentials": "JSON da Service Account",
+    "gchatProjectNumber": "Número do projeto do Google Cloud",
+    "gchatProjectNumberHint": "Necessário para verificar o JWT assinado pelo Google nos webhooks de entrada",
     "gchatHint": "Requer uma Service Account do Google Workspace com a Chat API ativada",
     "webhookUrl": "URL pública do Webhook",
     "webhookUrlHint": "Apps de desktop precisam de uma URL pública (ex.: ngrok) para receber webhooks",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "Токен авторизации (опционально)",
     "whatsappHint": "Требуется работающий WhatsApp bridge-сервис. Укажите URL его HTTP API.",
     "gchatCredentials": "JSON Service Account",
+    "gchatProjectNumber": "Номер проекта Google Cloud",
+    "gchatProjectNumberHint": "Требуется для проверки JWT, подписанного Google, во входящих webhook",
     "gchatHint": "Требуется Service Account Google Workspace с включённым Chat API",
     "webhookUrl": "Публичный Webhook URL",
     "webhookUrlHint": "Десктопным приложениям нужен публичный URL (например, ngrok) для приёма webhooks",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "Kimlik doğrulama tokenı (isteğe bağlı)",
     "whatsappHint": "Çalışan bir WhatsApp bridge servisi gerektirir. HTTP API URL'sini gösterin.",
     "gchatCredentials": "Service Account JSON",
+    "gchatProjectNumber": "Google Cloud Proje Numarası",
+    "gchatProjectNumberHint": "Gelen webhook için Google tarafından imzalanan JWT'yi doğrulamak için gerekli",
     "gchatHint": "Chat API etkinleştirilmiş bir Google Workspace service account gerektirir",
     "webhookUrl": "Genel Webhook URL",
     "webhookUrlHint": "Masaüstü uygulamaların webhook almak için genel bir URL'ye (örn. ngrok) ihtiyacı vardır",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "Token xác thực (tùy chọn)",
     "whatsappHint": "Yêu cầu dịch vụ bridge WhatsApp đang chạy. Trỏ đến URL HTTP API của nó.",
     "gchatCredentials": "JSON Service Account",
+    "gchatProjectNumber": "Số dự án Google Cloud",
+    "gchatProjectNumberHint": "Cần để xác minh JWT được Google ký trên webhook đến",
     "gchatHint": "Yêu cầu Service Account Google Workspace với Chat API được bật",
     "webhookUrl": "URL Webhook công khai",
     "webhookUrlHint": "Ứng dụng desktop cần URL công khai (ví dụ ngrok) để nhận webhook",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "認證令牌（可選）",
     "whatsappHint": "需要運行 WhatsApp 橋接服務，填寫其 HTTP API 地址",
     "gchatCredentials": "Service Account JSON",
+    "gchatProjectNumber": "Google Cloud 專案編號",
+    "gchatProjectNumberHint": "用於驗證入站 webhook 的 Google 簽發 JWT",
     "gchatHint": "需要 Google Workspace 服務賬號并啟用 Chat API",
     "webhookUrl": "公網 Webhook URL",
     "webhookUrlHint": "桌面應用需要公網 URL（如 ngrok）才能接收 Webhook",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2631,6 +2631,8 @@
     "whatsappBridgeToken": "认证令牌（可选）",
     "whatsappHint": "需要运行 WhatsApp 桥接服务，填写其 HTTP API 地址",
     "gchatCredentials": "Service Account JSON",
+    "gchatProjectNumber": "Google Cloud 项目编号",
+    "gchatProjectNumberHint": "用于验证入站 webhook 的 Google 签发 JWT",
     "gchatHint": "需要 Google Workspace 服务账号并启用 Chat API",
     "webhookUrl": "公网 Webhook URL",
     "webhookUrlHint": "桌面应用需要公网 URL（如 ngrok）才能接收 Webhook",


### PR DESCRIPTION
## Summary

Comprehensive audit and stabilization of IM channel implementations across Discord, QQ Bot, LINE, Slack, Google Chat, Signal, and others. Addresses protocol compliance issues, rate limiting, message sequencing, JWT verification, and media capability declarations.

## Key Changes

### QQ Bot (V2 API)
- **Message sequencing**: Implement per-msg_id monotonic `msg_seq` counter with LRU cache (1024 entries) to handle passive reply fragmentation (streaming chunks must use different seq values per QQ Bot spec)
- **Chat scope routing**: Add `QqChatScope` enum to parse and route messages to correct endpoints (c2c/group/channel/dms) with capability detection (keyboard/media support varies by endpoint)
- **Media support**: Declare native media types (Photo, Video, Voice, Audio, Animation) for c2c/group endpoints via two-step upload (POST /files → msg_type=7)
- **Gateway stability**: Add `remove_session_file()` to clear stale sessions on INVALID_SESSION (prevents infinite resume loop after restart)

### Discord
- **Rate limit handling**: Integrate `with_rate_limit_retry` helper for automatic 429 retry with Retry-After backoff (max 3 attempts, 60s cap per sleep)
- **Close frame inspection**: Add `recv_text_with_close()` to distinguish fatal close codes (4004 auth failed, 4010 invalid shard) from resumable ones (4007 invalid seq, 4009 timeout)
- **API consolidation**: Refactor request methods to use shared `auth_request()` wrapper with automatic retry

### LINE
- **Media support**: Declare native media types (Photo, Video, Audio, Voice) using public HTTPS URLs (LINE requires public URLs, not multipart upload)
- **Message composition**: Refactor dispatch to build ordered message list (media first, text last, buttons as separate template)
- **Character limit**: Adjust max_message_length from 5000 to 4500 bytes (UTF-8, CJK chars = 3 bytes each, leave buffer)

### Google Chat
- **JWT verification**: Add `GoogleChatJwtVerifier` with public key caching (1h TTL) to validate Bearer tokens signed by `chat@system.gserviceaccount.com`
- **Project number validation**: Require Google Cloud project number in webhook handler to verify JWT `aud` claim (prevents request forgery)
- **Webhook security**: Enforce JWT verification before processing MESSAGE/CARD_CLICKED events

### Signal
- **Quote author tracking**: Add LRU cache (1024 entries) to map inbound msg_id → sender_id for reply quoting (signal-cli requires both quoteTimestamp + quoteAuthor)
- **Daemon binding**: Use 127.0.0.1 instead of localhost to avoid IPv6/IPv4 dual-stack resolution inconsistencies

### Slack
- **Rate limit handling**: Integrate `with_rate_limit_retry` for tier-based rate limits (chat.postMessage tier 4 ≈ 1 msg/sec/channel)
- **Markdown escaping**: Add proper escape rules for `<` `&` in mrkdwn (control characters for mention/link/entity parsing); preserve `>` for blockquote semantics
- **Slash command routing**: Fix chat_type detection to route slash commands by channel_id prefix (prevents DM policy bypass)

### Cross-channel
- **Rate limit module**: New `rate_limit.rs` helper for parsing HTTP 429 + Retry-After (seconds/RFC 7231 date), Discord X-RateLimit-Global header, with configurable max attempts
- **Module documentation**: Add standardized header comments to all channel modules with official API links, SDK references, protocol summary, and last review date
- **Media capability declarations**: Update `supports_media` vectors to reflect actual implementation status (not just empty placeholders)

### WebSocket improvements
- **WsConnection**: Add `WsClose` struct to expose close code (u16) and reason for protocol-specific handling (Discord 4xxx codes, QQ Bot 4xxx codes)
- **Close frame inspection**: New `recv_text_with_

https://claude.ai/code/session_01Xjzc7txK6bnuMpoen3Mgnc