### PR TITLE
fix(chat): recover auto-follow when MessageList scroll lock gets stale

### DIFF
--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -239,6 +239,12 @@ export default function MessageList({
     }
     const el = containerRef.current
     if (!el) return
+    // Defensive unlock: stale lock can survive edge timing (gesture + stream
+    // frame ordering) even after we've effectively returned to bottom.
+    // Keeping the lock in this state disables follow-bottom permanently.
+    if (atBottomRef.current && userScrollLockRef.current) {
+      userScrollLockRef.current = false
+    }
     if (!atBottomRef.current || userScrollLockRef.current) return
     el.scrollTop = el.scrollHeight
   }, [messages, sessionKey])


### PR DESCRIPTION
### Motivation
- Recent timing between user gestures and streaming frames could leave `userScrollLockRef` stale while `atBottomRef` is true, causing the chat viewport to stop auto-following new stream output.

### Description
- Add a defensive unlock in `MessageList`'s follow-bottom `useLayoutEffect` that clears `userScrollLockRef` when `atBottomRef.current` is true before deciding to pin the viewport to bottom, preventing a permanent lock state; change concentrated in `src/components/chat/MessageList.tsx`.

### Testing
- Ran `pnpm typecheck` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd7482b0648321974b133860cae689)