### PR TITLE
fix(local_llm): auto-maintainer 无 Ollama 目标时静默 + 不可达只警告一次

### DIFF
--- a/crates/ha-core/src/local_llm/auto_maintainer.rs
+++ b/crates/ha-core/src/local_llm/auto_maintainer.rs
@@ -61,6 +61,11 @@ static ALERT_COOLDOWN: Lazy<Mutex<HashMap<String, Instant>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 static SESSION_SILENCED: Lazy<Mutex<HashSet<String>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 static LOOP_SPAWNED: AtomicBool = AtomicBool::new(false);
+/// Suppresses the "Ollama unreachable" warning between sweeps. We log on the
+/// transition into unreachable (once), then stay quiet until a sweep succeeds
+/// — without this gate the watchdog spams the same line every 60s on machines
+/// that have a local Ollama target configured but no Ollama installed.
+static UNREACHABLE_LOGGED: AtomicBool = AtomicBool::new(false);
 
 // ── Public types (mirrored on the TS side) ─────────────────────────
 
@@ -186,20 +191,34 @@ async fn run_one_pass() {
     if !cfg.local_llm.auto_maintenance.enabled {
         return;
     }
+    // No Ollama target configured (no Ollama-backed active model, no Ollama
+    // embedding) → nothing for the watchdog to do. Skip silently so we don't
+    // probe / warn on machines where the user never opted into local LLM.
+    if resolve_default_tag(ModelKind::Chat, &cfg).is_none()
+        && resolve_default_tag(ModelKind::Embedding, &cfg).is_none()
+    {
+        UNREACHABLE_LOGGED.store(false, Ordering::SeqCst);
+        return;
+    }
     // If the daemon is down, try to bring it up. start_ollama() is idempotent
     // (returns Ok early when ping succeeds) and will attempt to spawn ollama
     // serve when it doesn't. Failing here means Ollama isn't installed or the
     // binary is unusable — the user has to fix that themselves; nothing the
     // watchdog can do.
     if let Err(e) = super::start_ollama().await {
-        crate::app_warn!(
-            "local_llm",
-            "auto_maintainer",
-            "Skipping pass — Ollama is unreachable and could not be auto-started: {:#}",
-            e
-        );
+        // Only warn on the transition into unreachable. Subsequent ticks stay
+        // quiet until a sweep succeeds (which clears the gate below).
+        if !UNREACHABLE_LOGGED.swap(true, Ordering::SeqCst) {
+            crate::app_warn!(
+                "local_llm",
+                "auto_maintainer",
+                "Skipping pass — Ollama is unreachable and could not be auto-started (further occurrences suppressed until reachable): {:#}",
+                e
+            );
+        }
         return;
     }
+    UNREACHABLE_LOGGED.store(false, Ordering::SeqCst);
     let installed = match list_local_ollama_models().await {
         Ok(v) => v,
         Err(e) => {


### PR DESCRIPTION
## Summary

- watchdog 之前每 60s 跑一次 `start_ollama`，无论用户是否配过本地 Ollama 模型；没装 Ollama 的机器会被刷 `Skipping pass — Ollama is unreachable` 警告，全无价值。
- 入口先检查 chat / embedding 是否存在 Ollama 目标，都没有就静默 return，连 `start_ollama` 都不调。
- 真有目标但不可达时用 `AtomicBool` 状态门，仅在「转入不可达」那次警告一次（文案加 `further occurrences suppressed until reachable` 提示），sweep 成功（或目标被取消）后复位；恢复或再次失联会重新记录一条。

## Test plan

- [x] `cargo test -p ha-core --locked` 996 passed
- [x] `cargo fmt --check` / `cargo clippy -p ha-core -p ha-server` / `pnpm typecheck` / `pnpm lint` / `pnpm test` 全过（pre-push 钩子）
- [x] 手动验证：未装 Ollama + 没有本地 Ollama provider/embedding，启动后 `app.log` 不再出现该 WARN
- [x] 手动验证：有 Ollama provider 配置但 Ollama 未启动，启动后只出现一次 WARN，60s 后不再重复