### PR TITLE
docs(release): 新增完整发版流程手册

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,8 @@ pnpm test                                                                    # C
 
 ## 分支与发布
 
+> 实操流程（PR 工作流、tag 推送、cherry-pick backport、避坑速查）见 [`docs/release-process.md`](docs/release-process.md)。本节仅列契约面。
+
 `main` 承载下一个 minor 版本的开发，已发布的 minor 版本对应一条 `release/X.Y` 维护分支用于 patch 修复。两条分支之间**只允许 cherry-pick，不允许 merge**——`merge main → release/X.Y` 会把未发布功能拖入维护分支。
 
 ### 工作流

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Hope Agent 技术文档索引
 
-> 项目开发指南见 [AGENTS.md](../AGENTS.md) | 更新日志见 [CHANGELOG.md](../CHANGELOG.md)
+> 项目开发指南见 [AGENTS.md](../AGENTS.md) | 更新日志见 [CHANGELOG.md](../CHANGELOG.md) | 发版流程见 [release-process.md](release-process.md)
 
 ---
 
@@ -106,7 +106,7 @@
 | --- | --- | --- |
 | v0.1.0 | [v0.1.0.md](release-notes/v0.1.0.md) | [v0.1.0.en.md](release-notes/v0.1.0.en.md) |
 
-> 任一改动需在同次提交内中英双份同步（AGENTS.md 强制约定）。
+> 任一改动需在同次提交内中英双份同步（AGENTS.md 强制约定）。完整发版流程（PR 工作流、tag 推送、cherry-pick backport、避坑速查）见 [release-process.md](release-process.md)。
 
 ---
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,304 @@
+# Hope Agent 发版流程
+
+> 分支模型与跨分支红线（`main` / `release/X.Y`、只 cherry-pick 不 merge）见 [AGENTS.md "## 分支与发布"](../AGENTS.md#分支与发布)。本文档是配套实操手册，覆盖在 branch protection 启用下的完整命令流程、避坑要点与速查表。
+
+---
+
+## 0. 心智模型
+
+### 0.1 五个角色
+
+| 角色 | 形态 | 由谁产出 |
+| --- | --- | --- |
+| 维护分支 `release/X.Y` | git branch | 新 minor 发版后由人工切出，长期存在 |
+| Tag `vX.Y.Z` | git tag | 人工在维护分支 HEAD 打，推送后触发 CI |
+| GitHub Release | GitHub 资源 | [release.yml](../.github/workflows/release.yml) 自动创建 draft，人工 publish |
+| 安装包 | 多平台二进制（DMG / NSIS / DEB / AppImage） | tauri-action 在 CI 中构建并上传到 Release |
+| `latest.json` | Tauri updater 清单 | tauri-action 自动生成并上传到 Release，客户端从此拉更新元数据 |
+
+### 0.2 一次发版的全链路
+
+```
+PR (含 release notes + CHANGELOG + version bump)
+  → 合并到 release/X.Y
+  → 在 release/X.Y HEAD 打 tag vX.Y.Z
+  → push tag 到 origin
+  → release.yml 触发：构建 macOS/Windows/Linux 产物 + latest.json
+  → 自动创建 draft GitHub Release，资产齐全
+  → 人工审阅 → publish
+  → updater endpoint（latest published release/download/latest.json）开始对外服务
+  → 已安装客户端"检查更新"拉到新版
+```
+
+### 0.3 Tauri updater 拉取链路
+
+客户端配置在 [src-tauri/tauri.conf.json](../src-tauri/tauri.conf.json) `plugins.updater.endpoints`，固定指向 `https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json`。GitHub 对 `releases/latest` 的解析规则：**只看已 published（非 draft）且非 prerelease 的最新 Release**。因此 draft 状态客户端拉不到，必须人工 publish 后才生效。
+
+### 0.4 版本号单一来源
+
+`package.json` 是版本号唯一真相源，[scripts/sync-version.mjs](../scripts/sync-version.mjs) 把它同步到 [src-tauri/Cargo.toml](../src-tauri/Cargo.toml) 与 [src-tauri/tauri.conf.json](../src-tauri/tauri.conf.json)。CI 入口 [scripts/verify-release-version.mjs](../scripts/verify-release-version.mjs) 在 tag 触发后校验三处一致且与 tag 名匹配。
+
+---
+
+## 1. patch 发版完整步骤
+
+以从 `release/0.1` 发 `v0.1.2` 为例。
+
+### 1.1 准备发版 PR
+
+从目标维护分支切发版 PR 分支：
+
+```bash
+git checkout release/0.1 && git pull
+git checkout -b release/v0.1.2
+```
+
+在 PR 分支上完成三件事（必须同 PR 合并）：
+
+**(a) 写双语 release notes**
+
+新增两份文件：
+- [docs/release-notes/v0.1.2.md](release-notes/) — 中文
+- [docs/release-notes/v0.1.2.en.md](release-notes/) — 英文
+
+顶部互加 `简体中文 · English` 切换链接（AGENTS.md 强制约定）。文件名必须与 tag 严格对应（带 `v` 前缀），CI 据此填充 `latest.json#notes`。
+
+**(b) 更新 CHANGELOG**
+
+[CHANGELOG.md](../CHANGELOG.md) 顶部新增 `## [0.1.2]` 段，每条 entry 单行 + `(#PR)` 引用，面向用户视角。具体规范见 AGENTS.md "## 文档维护"。
+
+**(c) 同步版本号**
+
+```bash
+pnpm version 0.1.2 --no-git-tag-version
+```
+
+`--no-git-tag-version` 关键：只改文件、不创建 commit、不打 tag。该命令会触发 `package.json` 中的 `version` script ([sync-version.mjs](../scripts/sync-version.mjs)) 同步 `src-tauri/Cargo.toml` 与 `src-tauri/tauri.conf.json` 三处版本号。
+
+提交 PR：
+
+```bash
+git add CHANGELOG.md \
+        docs/release-notes/v0.1.2.md docs/release-notes/v0.1.2.en.md \
+        package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
+git commit -m "release: v0.1.2"
+git push -u origin release/v0.1.2
+gh pr create --base release/0.1 --title "release: v0.1.2" \
+  --body "release notes 见 docs/release-notes/v0.1.2.md"
+```
+
+### 1.2 合并 PR
+
+走完 8 项 status check（CI 必须全绿），由 reviewer 合并到 `release/0.1`。merge / squash / rebase 任选，hash 漂移不影响后续 tag。
+
+### 1.3 打 tag 推 tag 触发 CI
+
+PR 合并后，本地：
+
+```bash
+git checkout release/0.1 && git pull
+git tag v0.1.2
+git push origin v0.1.2
+```
+
+`git push origin v0.1.2` 推送的是 tag ref，**不在 branch protection 管辖内**（仓库未配置 tag protection rule），可直推。tag 一旦上 origin，[release.yml](../.github/workflows/release.yml) 立即触发：
+
+1. `release:verify` 校验 `package.json` 版本与 tag 名一致
+2. `Extract release notes` 步骤读取 `docs/release-notes/v0.1.2.md`，缺失则 fallback 为 `See CHANGELOG.md for details.`
+3. `tauri-action` 在 macOS / Windows / Linux 三个 runner 上构建产物
+4. 自动创建 draft Release `Hope Agent v0.1.2`，上传所有产物 + `latest.json`
+
+### 1.4 审阅 draft Release 并 publish
+
+GitHub Releases 页找到 `Hope Agent v0.1.2` draft，确认：
+
+- macOS x64 / arm64 DMG 齐全
+- Windows NSIS installer 齐全
+- Linux AppImage / DEB 齐全
+- `latest.json` 在资产列表中
+- Release body 显示的是 v0.1.2 release notes 内容（不是 fallback 的 `See CHANGELOG.md for details.`）
+
+确认无误后点 **Publish release**。draft 状态 updater endpoint 抓不到 `latest.json`，**必须 publish 才会推送给已安装客户端**。
+
+### 1.5 backport 到 main
+
+详见 [§3 backport 策略](#3-backport-策略)。
+
+---
+
+## 2. 新 minor 发版差异
+
+从 `main` 发 `v0.2.0` 为例，与 patch 流程的差异：
+
+### 2.1 PR base 改为 main
+
+§1.1 的 PR base 从 `release/0.1` 换成 `main`。
+
+### 2.2 tag 在 main HEAD 打
+
+§1.3 的 `git checkout release/0.1` 改为 `git checkout main`。
+
+### 2.3 发版后切维护分支
+
+tag 推送 + Release publish 完成后，**额外**切一条新维护分支并推送：
+
+```bash
+git branch release/0.2 v0.2.0
+git push -u origin release/0.2
+```
+
+CI 触发条件 ([lint.yml](../.github/workflows/lint.yml) / [rust.yml](../.github/workflows/rust.yml) 的 `branches: [main, "release/**"]`) 与 GitHub ruleset `main-branch-protection` 的 `refs/heads/release/**` 通配符自动覆盖新分支，不需要手配。
+
+后续 `v0.2.x` 系列 patch 在 `release/0.2` 上发，按 §1 流程走。
+
+---
+
+## 3. backport 策略
+
+`release/X.Y` 上的修复**必须 cherry-pick 回 main**，否则下个 minor 发版会丢失这些修复（用户感知为"修过的 bug 又出现"经典回归）。AGENTS.md 红线：**只 cherry-pick 不 merge**。
+
+### 3.1 推荐节奏：按版本批量
+
+每发一版 patch 后立刻批量 cherry-pick 该版本所有 commit 到 main：
+
+```bash
+# 列出 v0.1.1 → v0.1.2 之间 release/0.1 上的所有 commit
+git log v0.1.1..v0.1.2 --oneline
+
+# 切 backport 分支并一次性 cherry-pick 整段
+git checkout main && git pull
+git checkout -b backport/v0.1.2-to-main
+git cherry-pick v0.1.1..v0.1.2
+
+# 解冲突（如有）后开 PR
+git push -u origin backport/v0.1.2-to-main
+gh pr create --base main \
+  --title "backport: v0.1.2 fixes to main" \
+  --body "cherry-pick 自 release/0.1, 含 v0.1.1..v0.1.2 全部 commit"
+```
+
+N 个 fix 只开一个 backport PR，节奏可控。
+
+### 3.2 跳过等价 commit
+
+某些 commit 在 main 上已经独立存在（如 CI workflow 调整两边各做一次）。`git cherry-pick` 检测到等价改动会冲突或 no-op，遇到时手动跳过：
+
+```bash
+git cherry-pick --skip
+```
+
+判断方法：commit message 与 diff 跟 main 上某个 commit 完全等价的可跳。
+
+### 3.3 评估"是否需要 backport"
+
+并非所有 patch commit 都需要回种 main：
+
+| 情形 | 处理 |
+|---|---|
+| main 已重构掉这段代码，bug 只在老分支 | 不 backport |
+| main 与 release 都有同样代码 | 必须 backport |
+| 只 main 有（新功能引入） | 不在 release 修，只在 main 修 |
+| 文档改动只针对老版本 | 不 backport |
+
+仔细评估能砍掉相当比例的 backport 工作量。
+
+### 3.4 cherry-pick 命令速查
+
+```bash
+# 单个 commit
+git cherry-pick <sha>
+
+# 一段连续 commit（含两端）
+git cherry-pick A^..B
+
+# 多个不连续 commit
+git cherry-pick sha1 sha2 sha3
+
+# 冲突中
+git cherry-pick --continue   # 解完冲突后继续
+git cherry-pick --skip       # 跳过当前
+git cherry-pick --abort      # 整段放弃
+
+# 自动在 commit message 末尾追加来源链接
+git cherry-pick -x <sha>     # 加 (cherry picked from commit <sha>)
+```
+
+---
+
+## 4. 关键避坑
+
+| 坑 | 后果 | 规避 |
+|---|---|---|
+| `pnpm version X.Y.Z` 不带 `--no-git-tag-version` | 本地直接产 commit + tag，但 branch protection 不让推到 `main` / `release/**`，发版卡死 | 一律 `--no-git-tag-version`，version commit 走 PR |
+| release notes 文件名错（如 `0.1.2.md` 缺 `v` 前缀，或拼写错误） | `latest.json#notes` 落 fallback 文字 `See CHANGELOG.md for details.`，客户端弹窗看到通用文字 | 文件名严格匹配 tag：`docs/release-notes/v<X>.<Y>.<Z>.md` |
+| 忘记同 PR 合双语 release notes | 中英任一缺失，AGENTS.md 文档约定违例 | 一个发版 PR 必有 4 个文件改动：CHANGELOG + 中文 notes + 英文 notes + 三个 version 文件 |
+| draft Release 不 publish | updater endpoint 抓不到，已发布版本对客户端不可见 | §1.4 必须人工 publish |
+| 在功能分支 `pnpm version` 带 commit/tag | squash merge 后本地 tag 指向不在 main 上的死 commit，需要重打 | 始终 `--no-git-tag-version`，tag 在 PR 合并后的目标分支 HEAD 上重新打 |
+| 跳过 backport 到 main | 下个 minor 丢失所有 patch 修复，回归风险高 | §3.1 每版发完立刻 backport |
+| 误用 `git merge release/X.Y → main` | 把维护分支历史污染进 main，AGENTS.md 红线违反 | 只 cherry-pick |
+| 新 minor 发版前忘了切 `release/X.Y` 分支 | patch 修复无处落，紧急修复需要回退 main 历史 | §2.3 minor 发布后立即切维护分支 |
+| 改 workflow job 名后没同步 ruleset | PR 卡在 status check 等待已不存在的 job | 见 AGENTS.md "## 分支与发布" 末尾 |
+
+---
+
+## 5. 命令 / 文件速查
+
+### 5.1 关键脚本
+
+| 命令 | 作用 | 入口 |
+|---|---|---|
+| `pnpm version X.Y.Z --no-git-tag-version` | 同步版本号到三处文件，不创建 commit/tag | [package.json](../package.json) `scripts.version` → [scripts/sync-version.mjs](../scripts/sync-version.mjs) |
+| `pnpm sync:version` | 手动重新同步（一般不用，version 命令自动调） | 同上 |
+| `pnpm release:verify -- --tag vX.Y.Z` | 校验三处版本号一致 + 与 tag 名匹配 | [scripts/verify-release-version.mjs](../scripts/verify-release-version.mjs) |
+
+### 5.2 关键文件
+
+| 文件 | 作用 |
+|---|---|
+| [package.json](../package.json) | 版本号单一真相源 |
+| [src-tauri/Cargo.toml](../src-tauri/Cargo.toml) | Rust crate 版本，由 sync-version 同步 |
+| [src-tauri/tauri.conf.json](../src-tauri/tauri.conf.json) | Tauri app 版本 + updater endpoint 配置 |
+| [.github/workflows/release.yml](../.github/workflows/release.yml) | tag push 触发的发版 workflow，含 release notes 提取逻辑 |
+| [docs/release-notes/](release-notes/) | 双语 release notes，文件名 `vX.Y.Z[.en].md` |
+| [CHANGELOG.md](../CHANGELOG.md) | 用户视角变更日志，单行 entry + PR 引用 |
+
+### 5.3 常用 git 命令
+
+```bash
+# 看 release/0.1 上 main 没有的 commit（待 backport 候选）
+git log origin/main..origin/release/0.1 --oneline
+
+# 看两版之间的 commit（构造 backport 范围）
+git log v0.1.1..v0.1.2 --oneline
+
+# 检查某 commit 是否已在 HEAD
+git merge-base --is-ancestor <sha> HEAD && echo "in HEAD" || echo "not in HEAD"
+
+# 查 commit 在哪些分支
+git branch --contains <sha>
+```
+
+### 5.4 GitHub CLI 速查
+
+```bash
+# 看最近的 release
+gh release list --limit 5
+
+# 看某 tag 触发的 workflow run
+gh run list --workflow release.yml --limit 5
+
+# 查 latest.json 内容（验证发版后 notes 字段填得对不对）
+gh release view v0.1.2 --json assets --jq '.assets[] | select(.name=="latest.json") | .url' \
+  | xargs curl -sL | jq .
+```
+
+---
+
+## 附录：术语对照
+
+- **patch / minor / major**：semver 三段含义，`X.Y.Z` 中的 Z / Y / X
+- **维护分支**：`release/X.Y`，长期存在，承载该 minor 的所有 patch
+- **PR 临时分支**：每次发版用一次性的 PR 工作分支（命名随意，如 `release/v0.1.2`），合并后删除
+- **backport**：把维护分支上的修复 cherry-pick 回 main 的动作
+- **draft Release**：CI 创建但未公开的 GitHub Release，updater 不可见
+- **updater endpoint**：客户端拉 `latest.json` 的固定 URL，配置在 `tauri.conf.json`


### PR DESCRIPTION
## Summary

- 新增 [`docs/release-process.md`](https://github.com/shiwenwen/hope-agent/blob/docs/release-process/docs/release-process.md) 完整发版流程手册，覆盖：
  - 心智模型（5 角色、全链路图、updater 拉取链路、版本号单一来源）
  - patch 发版完整 4 步（PR → 合并 → tag → publish）
  - 新 minor 发版差异 + 维护分支切出
  - backport 策略（按版本批量 cherry-pick + 跳过等价 commit + 取舍判断）
  - 关键避坑表（9 个高频陷阱）
  - 命令 / 文件速查 + 术语对照
- AGENTS.md `## 分支与发布` 顶部加索引链接，契约面保留不变
- docs/README.md 顶部 quote 行 + Release Notes 段加链接，提升发现性

## 背景

之前 [AGENTS.md "## 分支与发布"](https://github.com/shiwenwen/hope-agent/blob/main/AGENTS.md#分支与发布)（commit 04e17e84）只登记了分支模型契约面，实操细节散落在不同文档与对话中，几个高频卡点没文档化：

- branch protection 启用下，`pnpm version` 默认会产 commit + tag 直推维护分支，被 protection 拒——必须用 `--no-git-tag-version` + PR 流程
- `latest.json#notes` 字段由 [release.yml](https://github.com/shiwenwen/hope-agent/blob/main/.github/workflows/release.yml) `Extract release notes` 步骤从 `docs/release-notes/v<X>.<Y>.<Z>.md` 读取，文件名错就落 fallback 文字
- draft → publish 必须人工，否则 updater endpoint 抓不到
- backport 不做 → 下个 minor 丢失所有 patch 修复

新文档把这些都系统化登记。

## Test plan

- [ ] reviewer 走读文档，对照实际发版流程验证步骤无歧义
- [ ] 检查 docs/README.md 索引链接可点
- [ ] 检查 AGENTS.md 加的索引行指向正确锚点