### PR TITLE
release: v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.2] - 2026-05-10
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3189,7 +3189,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/docs/release-notes/v0.1.2.en.md
+++ b/docs/release-notes/v0.1.2.en.md
@@ -1,0 +1,45 @@
+# Hope Agent 0.1.2 — Maintenance Release
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.1.2/docs/release-notes/v0.1.2.md) · **English**
+
+> Release date: 2026-05-10
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.1.2/CHANGELOG.md#012---2026-05-10) for the full list.
+
+A maintenance release. The headline fix restores the in-app auto-updater pipeline broken in v0.1.1, alongside a "Check for Updates" macOS menu entry, an updater-failure diagnostics panel, and the removal of a dev-only settings section that leaked into release builds. No new features.
+
+## Important Upgrade Notice
+
+**v0.1.1 users cannot receive this fix via in-app auto-update.** The updater public key compiled into the v0.1.1 binary does not match the key actually used by plugin-updater (which reads from `tauri.conf.json`); downloads succeed, but signature verification at install time always fails. v0.1.0 users and fresh installs are unaffected.
+
+**v0.1.1 users must download and install v0.1.2 manually** (install over the existing app; config and data are fully compatible):
+
+- macOS: grab the appropriate DMG from [GitHub Releases](https://github.com/shiwenwen/hope-agent/releases/latest)
+- Windows: download the NSIS installer
+- Linux: download the AppImage or DEB
+
+After upgrading to v0.1.2, the in-app auto-update pipeline resumes normal operation for subsequent versions.
+
+## Headline Fixes
+
+- **Auto-update signature verification failure** — v0.1.1 compiled an updater public key into the binary via `include_str!` that did not match the key configured in `tauri.conf.json` (which plugin-updater actually consumes). Downloads completed, signature verification at install time always failed, and the UI only showed "Failed to download or install update". Fixed by making `tauri.conf.json` the single source of truth and deleting the stale `updater.pub.pem` — no more drift.
+- **Lost update-check event race** — Clicking the macOS "Check for Updates" menu item from the chat page (or any panel other than About) emitted the request event before the About panel had mounted its listener, dropping the request silently. The request is now queued in the store and replayed once the panel subscribes.
+- **No UI feedback after download completes** — Calling relaunch immediately after install meant users never saw the "Installed" status; we now wait 1.5 s for the text to render before relaunch, with a fallback "please quit and reopen manually" if relaunch fails.
+- **"Developer Mode" leaked into release builds** — The Settings panel's "Developer Mode" section (one-click wipe of sessions / cron / memory / config / all data) was visible in release builds, posing an accidental-data-loss risk. It is now visible only in dev builds and tree-shaken out of the release bundle.
+
+## Experience Improvements
+
+- **"Check for Updates..." in the macOS menu bar** — A new entry between "About" and "Settings", available in all 12 languages; clicking opens the About panel and triggers a manual check.
+- **About-panel "Check for Updates" button always visible** — Previously hidden once a new version was detected (only "Download and install vX.Y.Z" remained); both buttons now coexist so users can re-check at any time.
+- **Updater-failure diagnostics panel** — On auto-update failure the UI now shows a collapsible "Error details" panel; the full stack trace is written to `~/.hope-agent/logs.db` (category=updater) for easy retrieval via `/ha-logs` or for attachment to a bug report.
+- **Update prompts now show per-version notes** — GitHub Release body and `latest.json#notes` are auto-injected from `docs/release-notes/<tag>.md`; the in-app "new version available" dialog now shows the actual release notes instead of the generic fallback text.
+
+## Upgrading
+
+- **Desktop (v0.1.0 / fresh install)**: install over the existing app; no breaking changes
+- **Desktop (v0.1.1)**: must download the installer manually (see "Important Upgrade Notice" above)
+- **Server / Web mode**: replace the binary and restart
+- **Config / data**: compatible, no breaking changes
+
+## Known Limitations
+
+Same as v0.1.0 — see the [v0.1.0 release notes](https://github.com/shiwenwen/hope-agent/blob/v0.1.2/docs/release-notes/v0.1.0.en.md#known-limitations).

--- a/docs/release-notes/v0.1.2.md
+++ b/docs/release-notes/v0.1.2.md
@@ -1,0 +1,46 @@
+# Hope Agent 0.1.2 — 维护版本
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.1.2/docs/release-notes/v0.1.2.en.md)
+
+> 发布日期：2026-05-10
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.1.2/CHANGELOG.md#012---2026-05-10)。
+
+本次为维护版本，核心是修复 v0.1.1 自动更新链路无法工作的问题，并补齐 macOS 菜单的「检查更新」入口、更新失败的诊断面板，以及一处仅 dev 可见的设置项误暴露在 release 包中的隐患。无新功能。
+
+## 重要升级提示
+
+**v0.1.1 用户的应用内自动更新无法拉到本次修复**：v0.1.1 编入二进制的 updater 公钥与 GitHub Release 资产的实际签名公钥不是同一把，下载阶段成功、安装阶段必抛签名验证错误。v0.1.0 用户、全新安装用户均不受影响。
+
+**v0.1.1 用户升级到 v0.1.2 必须手动下载安装包**（覆盖安装即可，配置与数据兼容）：
+
+- macOS：从 [GitHub Releases](https://github.com/shiwenwen/hope-agent/releases/latest) 下载对应架构 DMG
+- Windows：下载 NSIS installer
+- Linux：下载 AppImage 或 DEB
+
+升级到 v0.1.2 后，后续版本的应用内自动更新链路恢复正常。
+
+## 核心修复
+
+- **自动更新签名验证失败** — v0.1.1 通过 `include_str!` 编入二进制的 updater 公钥与 `tauri.conf.json` 里 plugin-updater 实际使用的公钥不是同一把，导致下载完成后签名验证必失败，UI 仅显示「下载或安装更新失败」。改为 `tauri.conf.json` 作为单一真相源，删除遗留的 `updater.pub.pem`，永不漂移。
+- **更新事件丢失 race** — 从聊天页或非「关于」面板点 macOS 菜单「检查更新」时，事件先于「关于」面板挂载发出，订阅者尚未注册导致请求被丢弃。改为把请求 queue 在 store 里，等面板挂载后重放。
+- **下载完成后 UI 无反馈** — 安装完成后立刻 relaunch 导致用户看不到「已安装」文案；改为等 1.5 秒让文案显示再 relaunch；relaunch 失败兜底显示「请手动退出后重新打开」。
+- **「开发者模式」误暴露在 release 包** — 设置面板「开发者模式」段（一键清空 sessions / cron / memory / config / 全部数据）出现在 release 包，普通用户存在误触风险。改为仅 dev 构建可见，模块从 release bundle tree-shake 剥离。
+
+## 体验增强
+
+- **macOS 顶部菜单栏新增「检查更新...」入口** — 在「关于」与「设置」之间，12 语言齐全；点击直接打开「关于」面板并发起一次手动检查。
+- **「关于」面板「检查更新」按钮始终可见** — 之前发现新版后按钮被隐藏（只显示「下载并安装 vX.Y.Z」），无法重新检查；现在两个按钮并存。
+- **更新失败诊断面板** — 自动更新失败时 UI 多出折叠「错误详情」面板，完整堆栈写入 `~/.hope-agent/logs.db`（category=updater），便于用 `/ha-logs` 自查或反馈时附带。
+- **更新提示弹窗显示版本说明** — GitHub Release body 与 `latest.json#notes` 自动从 `docs/release-notes/<tag>.md` 注入，应用内「发现新版」弹窗显示当版具体说明，而非通用 fallback 文字。
+
+## 升级
+
+- **桌面（v0.1.0 / 全新安装）**：直接覆盖安装，无破坏性变更
+- **桌面（v0.1.1）**：必须手动下载安装包（见上方「重要升级提示」）
+- **Server / Web 模式**：替换二进制后重启服务
+- **配置 / 数据**：兼容，无破坏性变更
+
+## 已知限制
+
+与 v0.1.0 一致，详见 [v0.1.0 release notes](https://github.com/shiwenwen/hope-agent/blob/v0.1.2/docs/release-notes/v0.1.0.md#已知限制)。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.1.1"
+version = "0.1.2"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",
@@ -16,7 +16,10 @@
         "title": "Hope Agent",
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 8, "y": 18 },
+        "trafficLightPosition": {
+          "x": 8,
+          "y": 18
+        },
         "width": 1200,
         "height": 800,
         "minWidth": 840,
@@ -30,7 +33,10 @@
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' ipc: http://ipc.localhost; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost data: blob: https: http:; font-src 'self' data:; media-src 'self' asset: http://asset.localhost data: blob:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:* wss://localhost:* http://localhost:* http://127.0.0.1:* https://127.0.0.1:* https:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'",
       "assetProtocol": {
         "enable": true,
-        "scope": ["$RESOURCE/**", "$HOME/.hope-agent/**"]
+        "scope": [
+          "$RESOURCE/**",
+          "$HOME/.hope-agent/**"
+        ]
       }
     }
   },
@@ -51,18 +57,25 @@
       },
       "digestAlgorithm": "sha256",
       "wix": {
-        "language": ["en-US", "zh-CN"]
+        "language": [
+          "en-US",
+          "zh-CN"
+        ]
       },
       "nsis": {
         "installMode": "perMachine",
-        "languages": ["English"]
+        "languages": [
+          "English"
+        ]
       }
     }
   },
   "plugins": {
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDMxNjgyN0E5ODY0MzM4RDIKUldUU09FT0dxU2RvTVRGWW5IN3lkMkE2b05mRW4wUk0wak5yUHQvMjNNaTdXYVR6RjlxbmVUcC8K",
-      "endpoints": ["https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json"],
+      "endpoints": [
+        "https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json"
+      ],
       "windows": {
         "installMode": "passive"
       }


### PR DESCRIPTION
## Summary

修复 v0.1.1 自动更新链路 + macOS 菜单加「检查更新」入口 + 更新失败诊断面板 + 「开发者模式」从 release 包剥离。无新功能。

详细 release notes：
- 中文：[v0.1.2.md](https://github.com/shiwenwen/hope-agent/blob/release/v0.1.2/docs/release-notes/v0.1.2.md)
- English：[v0.1.2.en.md](https://github.com/shiwenwen/hope-agent/blob/release/v0.1.2/docs/release-notes/v0.1.2.en.md)

## Important Upgrade Notice

**v0.1.1 用户的应用内自动更新无法拉到本次修复**——v0.1.1 编入二进制的 updater 公钥与 `tauri.conf.json` 实际使用的公钥不匹配，签名验证必失败。v0.1.1 用户必须从 GitHub Releases 手动下载安装包升级到 v0.1.2，之后自动更新链路恢复正常。v0.1.0 用户、全新安装用户不受影响。

## Test plan

- [x] `pnpm release:verify -- --tag v0.1.2` 三处版本号一致
- [ ] CI 8 项 status check 全绿
- [ ] 合并后 `git checkout release/0.1 && git pull && git tag v0.1.2 && git push origin v0.1.2` 触发 release.yml
- [ ] 审阅 draft Release：DMG / NSIS / AppImage / DEB / latest.json 齐全，body 显示 v0.1.2 release notes 内容（不是 fallback）
- [ ] Publish release
- [ ] 后续 backport 到 main（包含约定段单独 PR）