### PR TITLE
chore(release): sync-version 自动同步 Cargo.lock + verify 校验 lock 版本

### DIFF
--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -30,6 +30,20 @@ if (nextCargoToml === cargoToml) {
 
 writeFileSync(cargoTomlPath, nextCargoToml)
 
+// hope-agent 是 workspace package，cargo update 只 bump Cargo.lock 里的 workspace 版本，
+// --offline 避免查 registry。漏掉这步会让 CI 的 `cargo clippy --locked` 卡住。
+try {
+  execSync("cargo update -p hope-agent --offline --quiet", {
+    cwd: rootDir,
+    stdio: "inherit",
+  })
+} catch {
+  console.error(
+    "[sync-version] failed to sync Cargo.lock; ensure Rust toolchain is installed, or run `cargo update -p hope-agent` manually",
+  )
+  process.exit(1)
+}
+
 if (process.env.npm_lifecycle_event === "version") {
   try {
     execSync("git rev-parse --is-inside-work-tree", {
@@ -37,7 +51,7 @@ if (process.env.npm_lifecycle_event === "version") {
       stdio: "ignore",
     })
     execSync(
-      "git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json",
+      "git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json Cargo.lock",
       {
         cwd: rootDir,
         stdio: "ignore",
@@ -49,4 +63,4 @@ if (process.env.npm_lifecycle_event === "version") {
 }
 
 console.log(`[sync-version] synced desktop version to ${version}`)
-console.log("[sync-version] updated: src-tauri/Cargo.toml, src-tauri/tauri.conf.json")
+console.log("[sync-version] updated: src-tauri/Cargo.toml, src-tauri/tauri.conf.json, Cargo.lock")

--- a/scripts/verify-release-version.mjs
+++ b/scripts/verify-release-version.mjs
@@ -6,6 +6,7 @@ const rootDir = process.cwd()
 const packageJsonPath = path.join(rootDir, "package.json")
 const cargoTomlPath = path.join(rootDir, "src-tauri", "Cargo.toml")
 const tauriConfigPath = path.join(rootDir, "src-tauri", "tauri.conf.json")
+const cargoLockPath = path.join(rootDir, "Cargo.lock")
 
 const args = process.argv.slice(2)
 let expectedTag = null
@@ -27,14 +28,24 @@ if (!cargoVersionMatch) {
   process.exit(1)
 }
 
+const cargoLock = readFileSync(cargoLockPath, "utf8")
+const cargoLockHopeAgentMatch = cargoLock.match(/name = "hope-agent"\nversion = "(.*)"/)
+
+if (!cargoLockHopeAgentMatch) {
+  console.error("[release:verify] could not find hope-agent version in Cargo.lock")
+  process.exit(1)
+}
+
 const packageVersion = packageJson.version
 const tauriVersion = tauriConfig.version
 const cargoVersion = cargoVersionMatch[1]
+const cargoLockVersion = cargoLockHopeAgentMatch[1]
 
 const mismatches = [
   ["package.json", packageVersion],
   ["src-tauri/tauri.conf.json", tauriVersion],
   ["src-tauri/Cargo.toml", cargoVersion],
+  ["Cargo.lock (hope-agent)", cargoLockVersion],
 ].filter(([, value], _, all) => value !== all[0][1])
 
 if (mismatches.length > 0) {
@@ -42,6 +53,7 @@ if (mismatches.length > 0) {
   console.error(`  package.json: ${packageVersion}`)
   console.error(`  src-tauri/tauri.conf.json: ${tauriVersion}`)
   console.error(`  src-tauri/Cargo.toml: ${cargoVersion}`)
+  console.error(`  Cargo.lock (hope-agent): ${cargoLockVersion}`)
   process.exit(1)
 }
 


### PR DESCRIPTION
## Summary

`pnpm version X.Y.Z` 钩子之前漏更 `Cargo.lock` 里 hope-agent 的版本号，导致 CI 的 `cargo clippy --locked` 必须手补 lock 才能过。v0.1.0 / v0.1.1 / v0.1.2 三次发版都撞过这个坑（v0.1.2 在 #136 里手工补 lock 的 commit 才让 CI 转绿）。

**改动**：

- [scripts/sync-version.mjs](scripts/sync-version.mjs)：写完 `src-tauri/Cargo.toml` 后自动跑 `cargo update -p hope-agent --offline --quiet` 同步 lock；`Cargo.lock` 一并加入 `git add` 列表
- [scripts/verify-release-version.mjs](scripts/verify-release-version.mjs)：`pnpm release:verify` 增加 `Cargo.lock` 里 hope-agent 版本一致性校验，CI tag 触发时即使 sync 漏了也能拦住

`--offline` 选择理由：hope-agent 是 workspace package，cargo 不需要查 registry 就能 bump lock；强制 offline 避免 CI 网络抖动影响发版。

## Test plan

- [x] `pnpm release:verify` 在 main 当前状态 (0.1.1) 通过新 lock 校验
- [x] CI lint workflow 全绿
- [x] 后续 0.1.x patch 或 0.2.0 发版验证 `pnpm version` 钩子自动产出齐全 lock 改动（不再需要手补）