### PR TITLE
docs: 维护分支命名 release/X.Y → release/vX.Y（与 tag 前缀对齐）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,13 +57,13 @@ pnpm test                                                                    # C
 
 > 实操流程（PR 工作流、tag 推送、cherry-pick backport、避坑速查）见 [`docs/release-process.md`](docs/release-process.md)。本节仅列契约面。
 
-`main` 承载下一个 minor 版本的开发，已发布的 minor 版本对应一条 `release/X.Y` 维护分支用于 patch 修复。两条分支之间**只允许 cherry-pick，不允许 merge**——`merge main → release/X.Y` 会把未发布功能拖入维护分支。
+`main` 承载下一个 minor 版本的开发，已发布的 minor 版本对应一条 `release/vX.Y` 维护分支用于 patch 修复。两条分支之间**只允许 cherry-pick，不允许 merge**——`merge main → release/vX.Y` 会把未发布功能拖入维护分支。
 
 ### 工作流
 
-- **修 bug**：从 `release/X.Y` 切 `fix/X.Y-<topic>`，PR base 选 `release/X.Y`；合并并发版后 cherry-pick 回 `main` 再单独发 PR
+- **修 bug**：从 `release/vX.Y` 切 `fix/vX.Y-<topic>`，PR base 选 `release/vX.Y`；合并并发版后 cherry-pick 回 `main` 再单独发 PR
 - **新功能**：从 `main` 切 `feat/<topic>`，PR base 选 `main`
-- **新 minor 发版**：`main` 上 `pnpm version X.Y.0` 打 tag，再 `git branch release/X.Y vX.Y.0 && git push -u origin release/X.Y`，CI 与 protection 通过 ruleset 通配符自动覆盖
+- **新 minor 发版**：`main` 上 `pnpm version X.Y.0` 打 tag，再 `git branch release/vX.Y vX.Y.0 && git push -u origin release/vX.Y`，CI 与 protection 通过 ruleset 通配符自动覆盖
 
 ### CI 与 branch protection
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -42,14 +42,14 @@ PR (含 release notes + CHANGELOG + version bump)
 
 ## 1. patch 发版完整步骤
 
-以从 `release/0.1` 发 `v0.1.2` 为例。
+以从 `release/v0.1` 发 `v0.1.2` 为例。
 
 ### 1.1 准备发版 PR
 
 从目标维护分支切发版 PR 分支：
 
 ```bash
-git checkout release/0.1 && git pull
+git checkout release/v0.1 && git pull
 git checkout -b release/v0.1.2
 ```
 
@@ -87,20 +87,20 @@ git add CHANGELOG.md \
         package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
 git commit -m "release: v0.1.2"
 git push -u origin release/v0.1.2
-gh pr create --base release/0.1 --title "release: v0.1.2" \
+gh pr create --base release/v0.1 --title "release: v0.1.2" \
   --body "release notes 见 docs/release-notes/v0.1.2.md"
 ```
 
 ### 1.2 合并 PR
 
-走完 8 项 status check（CI 必须全绿），由 reviewer 合并到 `release/0.1`。merge / squash / rebase 任选，hash 漂移不影响后续 tag。
+走完 8 项 status check（CI 必须全绿），由 reviewer 合并到 `release/v0.1`。merge / squash / rebase 任选，hash 漂移不影响后续 tag。
 
 ### 1.3 打 tag 推 tag 触发 CI
 
 PR 合并后，本地：
 
 ```bash
-git checkout release/0.1 && git pull
+git checkout release/v0.1 && git pull
 git tag v0.1.2
 git push origin v0.1.2
 ```
@@ -136,24 +136,24 @@ GitHub Releases 页找到 `Hope Agent v0.1.2` draft，确认：
 
 ### 2.1 PR base 改为 main
 
-§1.1 的 PR base 从 `release/0.1` 换成 `main`。
+§1.1 的 PR base 从 `release/v0.1` 换成 `main`。
 
 ### 2.2 tag 在 main HEAD 打
 
-§1.3 的 `git checkout release/0.1` 改为 `git checkout main`。
+§1.3 的 `git checkout release/v0.1` 改为 `git checkout main`。
 
 ### 2.3 发版后切维护分支
 
 tag 推送 + Release publish 完成后，**额外**切一条新维护分支并推送：
 
 ```bash
-git branch release/0.2 v0.2.0
-git push -u origin release/0.2
+git branch release/v0.2 v0.2.0
+git push -u origin release/v0.2
 ```
 
 CI 触发条件 ([lint.yml](../.github/workflows/lint.yml) / [rust.yml](../.github/workflows/rust.yml) 的 `branches: [main, "release/**"]`) 与 GitHub ruleset `main-branch-protection` 的 `refs/heads/release/**` 通配符自动覆盖新分支，不需要手配。
 
-后续 `v0.2.x` 系列 patch 在 `release/0.2` 上发，按 §1 流程走。
+后续 `v0.2.x` 系列 patch 在 `release/v0.2` 上发，按 §1 流程走。
 
 ---
 
@@ -166,7 +166,7 @@ CI 触发条件 ([lint.yml](../.github/workflows/lint.yml) / [rust.yml](../.gith
 每发一版 patch 后立刻批量 cherry-pick 该版本所有 commit 到 main：
 
 ```bash
-# 列出 v0.1.1 → v0.1.2 之间 release/0.1 上的所有 commit
+# 列出 v0.1.1 → v0.1.2 之间 release/v0.1 上的所有 commit
 git log v0.1.1..v0.1.2 --oneline
 
 # 切 backport 分支并一次性 cherry-pick 整段
@@ -178,7 +178,7 @@ git cherry-pick v0.1.1..v0.1.2
 git push -u origin backport/v0.1.2-to-main
 gh pr create --base main \
   --title "backport: v0.1.2 fixes to main" \
-  --body "cherry-pick 自 release/0.1, 含 v0.1.1..v0.1.2 全部 commit"
+  --body "cherry-pick 自 release/v0.1, 含 v0.1.1..v0.1.2 全部 commit"
 ```
 
 N 个 fix 只开一个 backport PR，节奏可控。
@@ -270,8 +270,8 @@ git cherry-pick -x <sha>     # 加 (cherry picked from commit <sha>)
 ### 5.3 常用 git 命令
 
 ```bash
-# 看 release/0.1 上 main 没有的 commit（待 backport 候选）
-git log origin/main..origin/release/0.1 --oneline
+# 看 release/v0.1 上 main 没有的 commit（待 backport 候选）
+git log origin/main..origin/release/v0.1 --oneline
 
 # 看两版之间的 commit（构造 backport 范围）
 git log v0.1.1..v0.1.2 --oneline


### PR DESCRIPTION
## Summary

GitHub 端 `release/0.1` 已 rename 为 `release/v0.1`（命名与 tag 前缀 `vX.Y.Z` 对齐）。本 PR 同步两份治理文档里的占位符与例子，仓库其它地方无引用。

**改动**：

- [AGENTS.md](AGENTS.md) §「分支与发布」：占位符 `release/X.Y` → `release/vX.Y`，影响 4 处
- [docs/release-process.md](docs/release-process.md)：13 处实例（v0.1 流程示例 + §2.3 新 minor 例子 `release/0.2` → `release/v0.2`）

## 自动跟随、不需手改

- ruleset `main-branch-protection` 的 `conditions.ref_name.include` 已是 `refs/heads/release/**` 通配符 → 新名仍覆盖
- [.github/workflows/lint.yml](.github/workflows/lint.yml) / [rust.yml](.github/workflows/rust.yml) `branches: [main, "release/**"]` → 新名仍触发
- 已合并 PR 的 base 字段、所有 `branch/release/0.1` URL → GitHub 永久 redirect

## 留意

PR 临时分支命名（如 `release/v0.1.2`）现在与维护分支命名 `release/v0.1` 是同前缀子串，可能造成视觉混淆。文档 §6 里把 PR 分支描述为「命名随意」，所以不算 hard 冲突；如果要强约定 PR 分支命名（如 `release-pr/v0.1.2` 或 `bump/v0.1.2`）请单独提，本 PR 不动。

## Test plan

- [x] CI 全绿