### PR TITLE
feat(homebrew): 新增 macOS Homebrew Cask 安装路径（自建 tap + CI 自动同步）

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,0 +1,132 @@
+name: Update Homebrew Tap
+
+# Sync the cask template in `homebrew/hope-agent.rb.tmpl` into the public
+# tap repo (shiwenwen/homebrew-hope-agent → Casks/hope-agent.rb) whenever
+# a release is published.
+#
+# Triggers:
+#   - release.published — auto-fires after a draft Release is manually
+#     published (see docs/release-process.md §1.4).
+#   - workflow_dispatch — manual re-run against an existing tag, for when
+#     the cask template itself changes and you want to backfill an
+#     already-published release without cutting a new version.
+#
+# Required repo secrets:
+#   HOMEBREW_TAP_TOKEN — fine-grained PAT with `Contents: Read and write`
+#                       on shiwenwen/homebrew-hope-agent only.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to sync (for example v0.1.2)
+        required: true
+        type: string
+
+concurrency:
+  group: update-homebrew-tap
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  update-tap:
+    runs-on: ubuntu-latest
+    env:
+      TAP_REPO: shiwenwen/homebrew-hope-agent
+      TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v6
+
+      - name: Resolve version from tag
+        id: ver
+        run: |
+          tag="${TAG}"
+          # Strip leading "v"; reject anything that is not a valid SemVer-ish
+          # release tag so we never push a broken cask to the tap.
+          version="${tag#v}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::tag '$tag' does not look like a release tag (expected vX.Y.Z[-pre])"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "dmg_name=Hope.Agent_${version}_aarch64.dmg" >> "$GITHUB_OUTPUT"
+
+      - name: Download DMG from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "${{ steps.ver.outputs.dmg_name }}" \
+            --dir .
+          ls -la "${{ steps.ver.outputs.dmg_name }}"
+
+      - name: Compute SHA256
+        id: sha
+        run: |
+          set -euo pipefail
+          sum=$(sha256sum "${{ steps.ver.outputs.dmg_name }}" | awk '{print $1}')
+          if [[ -z "$sum" || ${#sum} -ne 64 ]]; then
+            echo "::error::sha256sum returned unexpected output: $sum"
+            exit 1
+          fi
+          echo "sha256=$sum" >> "$GITHUB_OUTPUT"
+
+      - name: Render cask from template
+        run: |
+          set -euo pipefail
+          mkdir -p rendered/Casks
+          sed -e "s/__VERSION__/${{ steps.ver.outputs.version }}/g" \
+              -e "s/__SHA256__/${{ steps.sha.outputs.sha256 }}/g" \
+              homebrew/hope-agent.rb.tmpl > rendered/Casks/hope-agent.rb
+
+          # Refuse to push if any placeholder leaked through — protects the
+          # tap from a broken cask if the template ever drops the markers.
+          if grep -qE '__VERSION__|__SHA256__' rendered/Casks/hope-agent.rb; then
+            echo "::error::rendered cask still contains template placeholders"
+            cat rendered/Casks/hope-agent.rb
+            exit 1
+          fi
+
+          echo "--- rendered Casks/hope-agent.rb ---"
+          cat rendered/Casks/hope-agent.rb
+
+      - name: Checkout tap repo
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.TAP_REPO }}
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: Copy rendered cask into tap repo
+        run: |
+          set -euo pipefail
+          mkdir -p tap/Casks
+          cp rendered/Casks/hope-agent.rb tap/Casks/hope-agent.rb
+
+      - name: Commit and push if changed
+        working-directory: tap
+        run: |
+          set -euo pipefail
+          git config user.name  "hope-agent-bot"
+          git config user.email "hope-agent-bot@users.noreply.github.com"
+
+          if git diff --quiet Casks/hope-agent.rb; then
+            echo "No cask changes for $TAG; skipping push."
+            exit 0
+          fi
+
+          git add Casks/hope-agent.rb
+          git commit -m "hope-agent ${{ steps.ver.outputs.version }}
+
+          DMG sha256: ${{ steps.sha.outputs.sha256 }}
+          Source: ${{ github.repository }}@$TAG
+          "
+          git push origin HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **macOS Homebrew Cask 安装**：新增 `brew tap shiwenwen/hope-agent && brew install --cask hope-agent` 安装路径，cask 同时建立 `hope-agent` 命令行软链方便 `server` / `acp` 子命令调用；release publish 后由 [`update-homebrew-tap.yml`](.github/workflows/update-homebrew-tap.yml) 自动渲染 [`homebrew/hope-agent.rb.tmpl`](homebrew/hope-agent.rb.tmpl) 并推到 [shiwenwen/homebrew-hope-agent](https://github.com/shiwenwen/homebrew-hope-agent) tap repo。当前仅提供 Apple Silicon 构建，Intel Mac 走 Rosetta 2。
 - **服务启动 / 重启在 IM 通道感知**：所有运行模式（桌面 / `hope-agent server` / `hope-agent acp`）冷启 / 升级 / 主动重启 / 崩溃恢复时，向最近 72 小时活跃过的 IM 聊天发送一条简短系统消息「Hope Agent is back online」。每个聊天 30 min cooldown 防重复，全局 30 条上限防极端 fan-out，`HOPE_AGENT_CRASH_COUNT ≥ 3` 自动静音避免 crash-loop 刷屏。多进程通过 `runtime_lock` 防双发。GUI 入口：通知设置面板的"重启提醒"开关 + 每个 IM 账号设置里的"服务重启提醒"开关（账号级默认开启）。
 - 新增「导出对话」功能：Sidebar 右键菜单 + 标题栏按钮均可触发，支持 Markdown / JSON / HTML 三种格式，可选包含工具调用与思考过程；桌面端走原生保存对话框，浏览器端走 Blob 下载。`/export` 斜杠命令同步升级为 `[md|json|html] [full|tools|thinking]` 位置参数（无参等价旧行为）。
 - **飞书完整对齐 v0.2.0 / Phase A 收尾 + Phase B + Phase C**（roadmap 见 `docs/plans/`）：

--- a/README.en.md
+++ b/README.en.md
@@ -92,10 +92,21 @@ Ordinary people deserve an AI assistant that just **opens and works** — downlo
 
 > 📦 Installers: [Releases](https://github.com/shiwenwen/hope-agent/releases)
 
+**macOS (Homebrew, recommended):**
+
+```bash
+brew tap shiwenwen/hope-agent
+brew install --cask hope-agent
+```
+
+After installation `hope-agent server start` / `hope-agent acp` work directly from the shell — the cask installs a symlink into your Homebrew `bin` directory. Only an Apple Silicon (arm64) build is published today; Intel Macs run it under Rosetta 2 (macOS will offer to install Rosetta on first launch if it is not already present).
+
+**Other platforms / manual download:**
+
 1. Download the installer for your platform from [Releases](https://github.com/shiwenwen/hope-agent/releases):
-   - macOS: `Hope-Agent_*.dmg`
-   - Linux: `hope-agent_*.AppImage`
-   - Windows: `Hope-Agent_*.exe` / `Hope-Agent_*.msi` (not yet fully tested)
+   - macOS: `Hope.Agent_*.dmg`
+   - Linux: `Hope.Agent_*.AppImage` / `Hope.Agent_*.deb` / `Hope.Agent_*.rpm`
+   - Windows: `Hope.Agent_*-setup.exe` (not yet fully tested)
 2. First launch: **pick a provider template → paste API key / sign in with Codex OAuth → chat.**
 3. Desktop installers ship with GitHub Releases auto-update; inside the app you can go to **Settings → About** to check and install updates
 

--- a/README.en.md
+++ b/README.en.md
@@ -99,7 +99,13 @@ brew tap shiwenwen/hope-agent
 brew install --cask hope-agent
 ```
 
-After installation `hope-agent server start` / `hope-agent acp` work directly from the shell — the cask installs a symlink into your Homebrew `bin` directory. Only an Apple Silicon (arm64) build is published today; Intel Macs run it under Rosetta 2 (macOS will offer to install Rosetta on first launch if it is not already present).
+After install:
+
+- Desktop GUI: Launchpad / Applications folder (click the Hope Agent icon), or `open -a "Hope Agent"` from a terminal
+- Headless server: `hope-agent server start`
+- ACP (IDE integration): `hope-agent acp`
+
+Apple Silicon only; Intel Macs run under Rosetta 2.
 
 **Other platforms / manual download:**
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,21 @@
 
 > 📦 安装包：[Releases](https://github.com/shiwenwen/hope-agent/releases)
 
+**macOS（Homebrew，推荐）：**
+
+```bash
+brew tap shiwenwen/hope-agent
+brew install --cask hope-agent
+```
+
+安装完毕后命令行也能直接用 `hope-agent server start` / `hope-agent acp`（cask 已自动建立软链）。当前仅提供 Apple Silicon (arm64) 构建，Intel Mac 走 Rosetta 2 自动兼容（首次启动 macOS 会引导安装 Rosetta）。
+
+**其他平台 / 手动下载：**
+
 1. 到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载对应平台安装包
-   - macOS：`Hope-Agent_*.dmg`
-   - Linux：`hope-agent_*.AppImage`
-   - Windows：`Hope-Agent_*.exe` / `Hope-Agent_*.msi`（尚未完成充分测试）
+   - macOS：`Hope.Agent_*.dmg`
+   - Linux：`Hope.Agent_*.AppImage` / `Hope.Agent_*.deb` / `Hope.Agent_*.rpm`
+   - Windows：`Hope.Agent_*-setup.exe`（尚未完成充分测试）
 2. 首次启动向导：**选 Provider 模板 → 填 API Key / Codex OAuth 登录 → 开聊**
 3. 桌面安装包内置 GitHub Releases 自动更新；应用内可在 **设置 → 关于** 里检查更新并一键安装
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,13 @@ brew tap shiwenwen/hope-agent
 brew install --cask hope-agent
 ```
 
-安装完毕后命令行也能直接用 `hope-agent server start` / `hope-agent acp`（cask 已自动建立软链）。当前仅提供 Apple Silicon (arm64) 构建，Intel Mac 走 Rosetta 2 自动兼容（首次启动 macOS 会引导安装 Rosetta）。
+装完后：
+
+- 桌面 GUI：Launchpad / 应用程序文件夹（点 Hope Agent 图标启动），或终端 `open -a "Hope Agent"`
+- 后台服务：`hope-agent server start`
+- ACP（IDE 集成）：`hope-agent acp`
+
+当前仅 Apple Silicon 构建，Intel Mac 走 Rosetta 2 自动兼容。
 
 **其他平台 / 手动下载：**
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -128,6 +128,24 @@ GitHub Releases 页找到 `Hope Agent v0.1.2` draft，确认：
 
 详见 [§3 backport 策略](#3-backport-策略)。
 
+### 1.6 Homebrew tap 自动同步
+
+Publish Release 后 [`.github/workflows/update-homebrew-tap.yml`](../.github/workflows/update-homebrew-tap.yml) 由 `release.published` 事件自动触发：
+
+1. `gh release download` 拉本次 release 的 `Hope.Agent_<version>_aarch64.dmg`
+2. `sha256sum` 算 DMG 摘要
+3. `sed` 把 [`homebrew/hope-agent.rb.tmpl`](../homebrew/hope-agent.rb.tmpl) 的 `__VERSION__` / `__SHA256__` 占位符替换，渲染为 `Casks/hope-agent.rb`
+4. 用 `HOMEBREW_TAP_TOKEN`（fine-grained PAT，仅授 `shiwenwen/homebrew-hope-agent` 的 `Contents: Read and write`）push 到 tap repo
+
+正常路径**不需要任何人工操作**。下列情况需要手动 `gh workflow run update-homebrew-tap.yml -f tag=vX.Y.Z`：
+
+- cask 模板本身改了（如新增 caveats / zap 路径），想立即对已发布版本生效，不等下个 release
+- workflow 因为 token 过期 / tap repo 不存在等原因失败过，修复后重跑
+
+**tap repo 初始化（一次性）**：详见 [`homebrew/README.md`](../homebrew/README.md)。仓库名必须是 `homebrew-hope-agent`（Homebrew 约定 `homebrew-<tapname>`），否则 `brew tap shiwenwen/hope-agent` 找不到。
+
+**cask 模板单一真相源在主仓 [`homebrew/hope-agent.rb.tmpl`](../homebrew/hope-agent.rb.tmpl)**。不要在 tap repo 里直接改 `Casks/hope-agent.rb`——下次发版会被 CI 覆盖。
+
 ---
 
 ## 2. 新 minor 发版差异

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,36 @@
+# Homebrew Cask 模板
+
+此目录是 Homebrew Cask 的**单一真相源**。Tap 仓库（[shiwenwen/homebrew-hope-agent](https://github.com/shiwenwen/homebrew-hope-agent)）由 CI 自动从这里同步——**不要在 tap repo 里手改 cask 文件**，下一次发版会被覆盖。
+
+## 文件
+
+- [`hope-agent.rb.tmpl`](hope-agent.rb.tmpl) — Cask 模板。`__VERSION__` / `__SHA256__` 是 CI 占位符，由 [`update-homebrew-tap.yml`](../.github/workflows/update-homebrew-tap.yml) 在每次 release publish 时填充并推送到 tap repo 的 `Casks/hope-agent.rb`
+
+## 修改 Cask 后
+
+直接改 `hope-agent.rb.tmpl`，下次发版 CI 会自动把改动带到 tap repo。如果想立即生效（不等下次发版），需要：
+
+1. PR 合到 `main` 或 `release/*`
+2. 手动触发 workflow：`gh workflow run update-homebrew-tap.yml -f tag=vX.Y.Z`，CI 会用指定 tag 的 DMG 重新算 sha256、渲染模板、推 tap repo
+
+## Tap repo 初始化（一次性）
+
+新建 [shiwenwen/homebrew-hope-agent](https://github.com/shiwenwen/homebrew-hope-agent)（**仓库名必须是 `homebrew-<tapname>`**，brew 才能识别 `brew tap shiwenwen/hope-agent`）。
+
+初始结构：
+
+```
+homebrew-hope-agent/
+├── README.md          # 引导用户 brew tap + brew install --cask
+└── Casks/
+    └── hope-agent.rb  # 由本仓 CI 自动维护，初次可空
+```
+
+在主仓 GitHub Settings → Secrets → Actions 加一个 `HOMEBREW_TAP_TOKEN`：
+
+- 类型：Fine-grained PAT
+- 仓库范围：仅 `shiwenwen/homebrew-hope-agent`
+- 权限：`Contents: Read and write`
+- 过期：建议 1 年，到期前提醒续期
+
+详细发版流程见 [`docs/release-process.md` §1.6 Homebrew tap 自动同步](../docs/release-process.md)。

--- a/homebrew/hope-agent.rb.tmpl
+++ b/homebrew/hope-agent.rb.tmpl
@@ -1,0 +1,68 @@
+cask "hope-agent" do
+  version "__VERSION__"
+  sha256 "__SHA256__"
+
+  url "https://github.com/shiwenwen/hope-agent/releases/download/v#{version}/Hope.Agent_#{version}_aarch64.dmg"
+  name "Hope Agent"
+  desc "Local-first AI assistant with cross-device sessions and IM channel routing"
+  homepage "https://github.com/shiwenwen/hope-agent"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: ">= :big_sur"
+
+  app "Hope Agent.app"
+
+  binary "#{appdir}/Hope Agent.app/Contents/MacOS/hope-agent"
+
+  caveats <<~EOS
+    Hope Agent is currently distributed as an Apple Silicon (arm64) build.
+    On Intel Macs it runs through Rosetta 2; macOS will prompt to install
+    Rosetta the first time you launch the app if it is not already present.
+
+    The bundle is not yet code-signed or notarized. The installer clears
+    the macOS quarantine attribute so first launch should work without
+    extra steps, but you may still see a Gatekeeper warning. If macOS
+    refuses to open the app, run:
+
+      sudo xattr -cr "/Applications/Hope Agent.app"
+
+    Launch the desktop app from Launchpad/Spotlight, or `open -a "Hope Agent"`.
+
+    The `hope-agent` shell command is also installed for the headless modes:
+      hope-agent server start   # HTTP/WS daemon (no GUI)
+      hope-agent acp            # ACP stdio for IDE integrations
+
+    Updates are delivered by the app's built-in updater, not by Homebrew.
+    After install, `brew upgrade` will not touch this cask — the desktop
+    app prompts you when a new release is published, and the `hope-agent`
+    CLI shares the same binary so it stays in sync automatically. To force
+    a reinstall from this tap (for example to recover from a broken
+    install), run:
+
+      brew reinstall --cask hope-agent
+  EOS
+
+  postflight do
+    # Strip the quarantine xattr so first launch does not trip Gatekeeper
+    # for unsigned/un-notarized builds. Safe to ignore failures — if the
+    # xattr is already absent xattr returns non-zero.
+    system_command "/usr/bin/xattr",
+                   args: ["-rd", "com.apple.quarantine", "#{appdir}/Hope Agent.app"],
+                   sudo: false,
+                   must_succeed: false
+  end
+
+  zap trash: [
+    "~/Library/Application Support/ai.hopeagent.desktop",
+    "~/Library/Caches/ai.hopeagent.desktop",
+    "~/Library/Preferences/ai.hopeagent.desktop.plist",
+    "~/Library/Saved Application State/ai.hopeagent.desktop.savedState",
+    "~/Library/WebKit/ai.hopeagent.desktop",
+    "~/.hope-agent",
+  ]
+end


### PR DESCRIPTION
## Summary

- 新增 macOS Homebrew Cask 安装路径：`brew tap shiwenwen/hope-agent && brew install --cask hope-agent`
- Cask 模板单一真相源在 [`homebrew/hope-agent.rb.tmpl`](homebrew/hope-agent.rb.tmpl)，CI 在每次 release publish 后自动渲染推送到 [shiwenwen/homebrew-hope-agent](https://github.com/shiwenwen/homebrew-hope-agent) tap repo
- 含 `hope-agent` CLI symlink（覆盖 `server` / `acp` 子命令）、`auto_updates true`（让 Tauri 内置 updater 接管更新，brew 不再过问版本同步）
- 当前仅 Apple Silicon 构建，Intel Mac 走 Rosetta 2
- 双语 README + CHANGELOG + [`docs/release-process.md §1.6`](docs/release-process.md) 同步更新

## Test plan

- [ ] CI 通过 8 项 status check
- [ ] merge 后手动跑 `gh workflow run update-homebrew-tap.yml -f tag=v0.1.2` 灌一次现有 release
- [ ] 验证 tap repo 出现 `Casks/hope-agent.rb` 且 sha256 与本地 `shasum -a 256 Hope.Agent_0.1.2_aarch64.dmg` 计算一致
- [ ] `brew tap shiwenwen/hope-agent && brew install --cask hope-agent` 实测装好可用
- [ ] 应用启动 → Launchpad / `open -a "Hope Agent"` / 终端 `hope-agent server start` 三条路径均工作