### PR TITLE
fix(homebrew-tap): 首次同步空 tap repo 时 cask 没推上去

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -118,12 +118,15 @@ jobs:
           git config user.name  "hope-agent-bot"
           git config user.email "hope-agent-bot@users.noreply.github.com"
 
-          if git diff --quiet Casks/hope-agent.rb; then
+          # Stage first so the diff check sees both new and modified files.
+          # `git diff` alone ignores untracked paths, which made the first
+          # sync (when Casks/hope-agent.rb did not exist yet) silently skip.
+          git add Casks/hope-agent.rb
+          if git diff --cached --quiet; then
             echo "No cask changes for $TAG; skipping push."
             exit 0
           fi
 
-          git add Casks/hope-agent.rb
           git commit -m "hope-agent ${{ steps.ver.outputs.version }}
 
           DMG sha256: ${{ steps.sha.outputs.sha256 }}


### PR DESCRIPTION
## Summary

PR #147 引入的 `update-homebrew-tap.yml` 在首次跑（tap repo 还没有 `Casks/` 目录）时静默 skip 没推 cask。

根因：`git diff --quiet Casks/hope-agent.rb` 只看 tracked 文件，对未跟踪的新文件返回"无差异"——cp 出来的新文件被当成"无变化"直接 exit。

修法：先 `git add`，再用 `git diff --cached --quiet` 判断 staging 区是否有变化，新文件与修改文件都能正确触发 commit。

## Test plan

- [ ] CI 通过 8 项 status check
- [ ] merge 后再跑 `gh workflow run update-homebrew-tap.yml -f tag=v0.1.2`，这次应该真把 cask 推到 [shiwenwen/homebrew-hope-agent](https://github.com/shiwenwen/homebrew-hope-agent) `Casks/hope-agent.rb`
- [ ] 验证 sha256 = `ff65dc3bf03b4958671b8309de1ce9a76cbb658afc67997d1a5f535e9f28169f`（workflow 日志已算出）