### PR TITLE
docs(homebrew): 提示 brew install 遇到现有 .app 时用 --adopt / --force

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -99,6 +99,8 @@ brew tap shiwenwen/hope-agent
 brew install --cask hope-agent
 ```
 
+> Already have `Hope Agent.app` installed manually? Append `--adopt` to let the cask take over your existing same-version app without re-downloading, or `--force` to overwrite.
+
 After install:
 
 - Desktop GUI: Launchpad / Applications folder (click the Hope Agent icon), or `open -a "Hope Agent"` from a terminal

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ brew tap shiwenwen/hope-agent
 brew install --cask hope-agent
 ```
 
+> 已经手动装过 `Hope Agent.app`？在 `brew install` 后面加 `--adopt`（让 cask 接管同版本的现有应用，不重新下载）或 `--force`（强制重下覆盖）。
+
 装完后：
 
 - 桌面 GUI：Launchpad / 应用程序文件夹（点 Hope Agent 图标启动），或终端 `open -a "Hope Agent"`


### PR DESCRIPTION
## Summary

不少用户先从 Releases 手动装过 DMG，再 `brew install --cask hope-agent` 会撞上：

```
Error: It seems there is already an App at '/Applications/Hope Agent.app'.
```

这是 Homebrew Cask 标准的保守行为（避免毁掉用户手动装的版本），但对不熟悉 cask 的用户不友好。在双语 README Homebrew 段加一行提示：`--adopt` 接管同版本现有 app，`--force` 强制重下覆盖。

## Test plan

- [ ] CI 通过 8 项 status check