### PR TITLE
feat(aur): 新增 Arch Linux AUR 安装路径（hope-agent-bin + CI 自动同步）

### DIFF
--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -1,0 +1,173 @@
+name: Update AUR
+
+# Sync the PKGBUILD + .SRCINFO templates in `aur/hope-agent-bin/` into
+# the AUR git repo (ssh://aur@aur.archlinux.org/hope-agent-bin.git)
+# whenever a release is published.
+#
+# Triggers:
+#   - release.published — auto-fires after a draft Release is manually
+#     published (see docs/release-process.md §1.4).
+#   - workflow_dispatch — manual re-run against an existing tag, for when
+#     the PKGBUILD template itself changes and you want to backfill an
+#     already-published release without cutting a new version.
+#
+# Required repo secrets:
+#   AUR_SSH_PRIVATE_KEY — ed25519 private key whose public half is
+#                         registered on the maintainer's AUR account.
+#                         Setup steps live in aur/README.md.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to sync (for example v0.1.2)
+        required: true
+        type: string
+
+concurrency:
+  group: update-aur
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  update-aur:
+    runs-on: ubuntu-latest
+    env:
+      AUR_PKG: hope-agent-bin
+      TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v6
+
+      - name: Resolve version from tag
+        id: ver
+        run: |
+          tag="${TAG}"
+          version="${tag#v}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::tag '$tag' does not look like a release tag (expected vX.Y.Z[-pre])"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "deb_name=Hope.Agent_${version}_amd64.deb" >> "$GITHUB_OUTPUT"
+
+      - name: Download .deb from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "${{ steps.ver.outputs.deb_name }}" \
+            --dir .
+          ls -la "${{ steps.ver.outputs.deb_name }}"
+
+      - name: Compute SHA256
+        id: sha
+        run: |
+          set -euo pipefail
+          sum=$(sha256sum "${{ steps.ver.outputs.deb_name }}" | awk '{print $1}')
+          if [[ -z "$sum" || ${#sum} -ne 64 ]]; then
+            echo "::error::sha256sum returned unexpected output: $sum"
+            exit 1
+          fi
+          echo "sha256=$sum" >> "$GITHUB_OUTPUT"
+
+      - name: Render PKGBUILD + .SRCINFO from templates
+        run: |
+          set -euo pipefail
+          mkdir -p rendered
+          sed -e "s/__PKGVER__/${{ steps.ver.outputs.version }}/g" \
+              -e "s/__SHA256__/${{ steps.sha.outputs.sha256 }}/g" \
+              aur/hope-agent-bin/PKGBUILD.tmpl > rendered/PKGBUILD
+          sed -e "s/__PKGVER__/${{ steps.ver.outputs.version }}/g" \
+              -e "s/__SHA256__/${{ steps.sha.outputs.sha256 }}/g" \
+              aur/hope-agent-bin/.SRCINFO.tmpl > rendered/.SRCINFO
+
+          # Refuse to push if any placeholder leaked through.
+          for f in rendered/PKGBUILD rendered/.SRCINFO; do
+            if grep -qE '__PKGVER__|__SHA256__' "$f"; then
+              echo "::error::$f still contains template placeholders"
+              cat "$f"
+              exit 1
+            fi
+          done
+
+          echo "--- rendered PKGBUILD ---"
+          cat rendered/PKGBUILD
+          echo "--- rendered .SRCINFO ---"
+          cat rendered/.SRCINFO
+
+      - name: Install AUR SSH key
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$AUR_SSH_PRIVATE_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+
+          # Pin AUR host key to known_hosts (avoid TOFU prompt on first
+          # clone). `ssh-keyscan -t ed25519,rsa` covers both modern and
+          # legacy host keys aur.archlinux.org publishes.
+          ssh-keyscan -t ed25519,rsa aur.archlinux.org > ~/.ssh/known_hosts 2>/dev/null
+          chmod 600 ~/.ssh/known_hosts
+
+          cat > ~/.ssh/config <<EOF
+          Host aur.archlinux.org
+              HostName aur.archlinux.org
+              User aur
+              IdentityFile ~/.ssh/aur
+              IdentitiesOnly yes
+              StrictHostKeyChecking yes
+          EOF
+          chmod 600 ~/.ssh/config
+
+      - name: Clone AUR repo (or init if first push)
+        id: clone
+        run: |
+          set -euo pipefail
+          # `git clone` against an empty/uninitialized AUR package succeeds
+          # with an empty working tree; pushing back will then create the
+          # package server-side. If the package does not exist at all yet,
+          # the SSH server returns "fatal: ... does not appear to be a git
+          # repository" — fall back to `git init` + remote add.
+          if git clone "ssh://aur@aur.archlinux.org/${AUR_PKG}.git" aur-repo 2>clone.err; then
+            echo "cloned existing AUR repo"
+          else
+            echo "clone failed, treating as first push:"
+            cat clone.err
+            mkdir -p aur-repo
+            cd aur-repo
+            git init -b master
+            git remote add origin "ssh://aur@aur.archlinux.org/${AUR_PKG}.git"
+          fi
+
+      - name: Copy renders + commit + push
+        working-directory: aur-repo
+        run: |
+          set -euo pipefail
+          git config user.name  "hope-agent-bot"
+          git config user.email "hope-agent-bot@users.noreply.github.com"
+
+          cp ../rendered/PKGBUILD .
+          cp ../rendered/.SRCINFO .
+
+          git add PKGBUILD .SRCINFO
+          if git diff --cached --quiet; then
+            echo "No PKGBUILD changes for $TAG; skipping push."
+            exit 0
+          fi
+
+          git commit -m "hope-agent-bin ${{ steps.ver.outputs.version }}
+
+          deb sha256: ${{ steps.sha.outputs.sha256 }}
+          Source: ${{ github.repository }}@$TAG
+          "
+          git push origin HEAD:master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Arch Linux AUR 安装**：新增 `yay -S hope-agent-bin`（或 paru / 任意 AUR helper）安装路径；PKGBUILD / .SRCINFO 单一真相源在 [`aur/hope-agent-bin/`](aur/hope-agent-bin/)，release publish 后由 [`update-aur.yml`](.github/workflows/update-aur.yml) 自动渲染并推到 AUR `hope-agent-bin` 仓库。当前仅 x86_64，沿用 release `.deb` 重打。
 - **Web Search 新增博查 AI Search provider**：设置 → Tools → Web Search 可配置 Bocha API Key，并参与现有 provider 排序 / fallback 链路；`web_search` 工具会把通用 freshness 映射到博查时间过滤，解析 `webPages.value[]` 为统一的 title / URL / snippet 结果，出站请求继续走统一 SSRF policy gate。
 - **macOS Homebrew Cask 安装**：新增 `brew tap shiwenwen/hope-agent && brew install --cask hope-agent` 安装路径，cask 同时建立 `hope-agent` 命令行软链方便 `server` / `acp` 子命令调用；release publish 后由 [`update-homebrew-tap.yml`](.github/workflows/update-homebrew-tap.yml) 自动渲染 [`homebrew/hope-agent.rb.tmpl`](homebrew/hope-agent.rb.tmpl) 并推到 [shiwenwen/homebrew-hope-agent](https://github.com/shiwenwen/homebrew-hope-agent) tap repo。当前仅提供 Apple Silicon 构建，Intel Mac 走 Rosetta 2。
 - **服务启动 / 重启在 IM 通道感知**：所有运行模式（桌面 / `hope-agent server` / `hope-agent acp`）冷启 / 升级 / 主动重启 / 崩溃恢复时，向最近 72 小时活跃过的 IM 聊天发送一条简短系统消息「Hope Agent is back online」。每个聊天 30 min cooldown 防重复，全局 30 条上限防极端 fan-out，`HOPE_AGENT_CRASH_COUNT ≥ 3` 自动静音避免 crash-loop 刷屏。多进程通过 `runtime_lock` 防双发。GUI 入口：通知设置面板的"重启提醒"开关 + 每个 IM 账号设置里的"服务重启提醒"开关（账号级默认开启）。

--- a/README.en.md
+++ b/README.en.md
@@ -109,6 +109,14 @@ After install:
 
 Apple Silicon only; Intel Macs run under Rosetta 2.
 
+**Arch Linux / Manjaro (AUR):**
+
+```bash
+yay -S hope-agent-bin   # or paru / any AUR helper
+```
+
+Pre-built binary package (repackaged from the GitHub Release `.deb`) — no source compilation.
+
 **Other platforms / manual download:**
 
 1. Download the installer for your platform from [Releases](https://github.com/shiwenwen/hope-agent/releases):

--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ brew install --cask hope-agent
 
 当前仅 Apple Silicon 构建，Intel Mac 走 Rosetta 2 自动兼容。
 
+**Arch Linux / Manjaro（AUR）：**
+
+```bash
+yay -S hope-agent-bin   # 或 paru / 任意 AUR helper
+```
+
+预编译二进制版（沿用 GitHub Release 的 `.deb`），不从源码编译。
+
 **其他平台 / 手动下载：**
 
 1. 到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载对应平台安装包

--- a/aur/README.md
+++ b/aur/README.md
@@ -1,0 +1,59 @@
+# AUR 包模板
+
+此目录是 AUR `hope-agent-bin` 包的**单一真相源**。AUR 仓库（`ssh://aur@aur.archlinux.org/hope-agent-bin.git`）由 CI 自动从这里同步——**不要在 AUR 仓库里直接 push**，下次发版会被覆盖。
+
+## 文件
+
+- [`hope-agent-bin/PKGBUILD.tmpl`](hope-agent-bin/PKGBUILD.tmpl) — Arch 包构建脚本。`__PKGVER__` / `__SHA256__` 是 CI 占位符
+- [`hope-agent-bin/.SRCINFO.tmpl`](hope-agent-bin/.SRCINFO.tmpl) — AUR Web UI 元数据；字段必须与 PKGBUILD 严格对应，**改 PKGBUILD 时必须同步改 .SRCINFO**
+- [`../.github/workflows/update-aur.yml`](../.github/workflows/update-aur.yml) — release publish 后自动渲染推送
+
+## AUR 账号 + SSH key 配置（一次性）
+
+### 1. 注册 AUR 账号
+
+打开 https://aur.archlinux.org/register，填用户名（建议 `shiwenwen` 保持一致）+ 邮箱即可。
+
+### 2. 生成 CI 专用 SSH key
+
+**不要复用你的个人 SSH key**——CI 应该用专门的 deploy key：
+
+```bash
+ssh-keygen -t ed25519 -C "hope-agent-aur-ci" -f ~/.ssh/hope-agent-aur-ci -N ""
+```
+
+### 3. 把公钥加到 AUR 账号
+
+```bash
+cat ~/.ssh/hope-agent-aur-ci.pub
+```
+
+复制输出，到 https://aur.archlinux.org/account/<你的用户名>/edit 的 `SSH Public Key` 字段粘贴 → Save。
+
+### 4. 把私钥存到主仓 secret
+
+```bash
+gh secret set AUR_SSH_PRIVATE_KEY --repo shiwenwen/hope-agent < ~/.ssh/hope-agent-aur-ci
+```
+
+完事后删本地私钥（CI 里已存安全副本，本地不再需要）：
+
+```bash
+shred -u ~/.ssh/hope-agent-aur-ci ~/.ssh/hope-agent-aur-ci.pub  # 或 rm -P / rm
+```
+
+### 5. 第一次手动 push（可选，CI 也能自动建包）
+
+AUR 的"package 创建"就是第一次 `git push` 到 `ssh://aur@aur.archlinux.org/hope-agent-bin.git` 时 server 端自动建 repo。CI 第一次跑会完成这一步；无需任何手动操作。
+
+## 修改模板后
+
+直接改 `PKGBUILD.tmpl` / `.SRCINFO.tmpl`，下次发版 CI 会带到 AUR。要立即生效不等下次发版：
+
+```bash
+gh workflow run update-aur.yml -f tag=vX.Y.Z
+```
+
+## 详细发版流程
+
+见 [`../docs/release-process.md`](../docs/release-process.md) §1.7「AUR 自动同步」。

--- a/aur/hope-agent-bin/.SRCINFO.tmpl
+++ b/aur/hope-agent-bin/.SRCINFO.tmpl
@@ -1,0 +1,18 @@
+pkgbase = hope-agent-bin
+	pkgdesc = Local-first AI assistant desktop app — cross-device sessions, IM channel routing
+	pkgver = __PKGVER__
+	pkgrel = 1
+	url = https://github.com/shiwenwen/hope-agent
+	arch = x86_64
+	license = MIT
+	depends = webkit2gtk-4.1
+	depends = gtk3
+	depends = libayatana-appindicator
+	provides = hope-agent
+	conflicts = hope-agent
+	options = !strip
+	options = !debug
+	source = hope-agent-__PKGVER__.deb::https://github.com/shiwenwen/hope-agent/releases/download/v__PKGVER__/Hope.Agent___PKGVER___amd64.deb
+	sha256sums = __SHA256__
+
+pkgname = hope-agent-bin

--- a/aur/hope-agent-bin/PKGBUILD.tmpl
+++ b/aur/hope-agent-bin/PKGBUILD.tmpl
@@ -1,0 +1,20 @@
+# Maintainer: shiwenwen <shiwenwendevelopment@gmail.com>
+
+pkgname=hope-agent-bin
+pkgver=__PKGVER__
+pkgrel=1
+pkgdesc='Local-first AI assistant desktop app — cross-device sessions, IM channel routing'
+arch=('x86_64')
+url='https://github.com/shiwenwen/hope-agent'
+license=('MIT')
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator')
+provides=('hope-agent')
+conflicts=('hope-agent')
+options=('!strip' '!debug')
+source=("hope-agent-${pkgver}.deb::${url}/releases/download/v${pkgver}/Hope.Agent_${pkgver}_amd64.deb")
+sha256sums=('__SHA256__')
+
+package() {
+    bsdtar -xf "${srcdir}/hope-agent-${pkgver}.deb" -C "${srcdir}"
+    bsdtar -xf "${srcdir}/data.tar.gz" -C "${pkgdir}"
+}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -146,6 +146,24 @@ Publish Release 后 [`.github/workflows/update-homebrew-tap.yml`](../.github/wor
 
 **cask 模板单一真相源在主仓 [`homebrew/hope-agent.rb.tmpl`](../homebrew/hope-agent.rb.tmpl)**。不要在 tap repo 里直接改 `Casks/hope-agent.rb`——下次发版会被 CI 覆盖。
 
+### 1.7 AUR 自动同步
+
+与 §1.6 Homebrew tap 同模式，Release publish 后 [`.github/workflows/update-aur.yml`](../.github/workflows/update-aur.yml) 由 `release.published` 自动触发：
+
+1. `gh release download` 拉本次 release 的 `Hope.Agent_<version>_amd64.deb`
+2. `sha256sum` 算 deb 摘要
+3. `sed` 渲染 [`aur/hope-agent-bin/PKGBUILD.tmpl`](../aur/hope-agent-bin/PKGBUILD.tmpl) + [`.SRCINFO.tmpl`](../aur/hope-agent-bin/.SRCINFO.tmpl)
+4. 用 `AUR_SSH_PRIVATE_KEY`（专用 ed25519 deploy key，公钥已绑到 maintainer 的 AUR 账号）SSH push 到 `ssh://aur@aur.archlinux.org/hope-agent-bin.git`
+
+正常路径**不需要任何人工操作**。下列情况需要手动 `gh workflow run update-aur.yml -f tag=vX.Y.Z`：
+
+- PKGBUILD / .SRCINFO 模板本身改了（如改 deps / 改 pkgdesc），想立即对已发布版本生效
+- workflow 因为 SSH key / AUR 账号变化等原因失败过，修复后重跑
+
+**AUR 账号 + SSH key 初始化（一次性）**：详见 [`aur/README.md`](../aur/README.md)。
+
+**模板单一真相源在主仓 [`aur/hope-agent-bin/`](../aur/hope-agent-bin/)**。不要直接 push AUR 仓库——下次发版会被 CI 覆盖。**改 PKGBUILD 字段时必须同步改 .SRCINFO** 字段（两个文件结构是平行的），否则 AUR Web UI 元数据会与 PKGBUILD 不一致。
+
 ---
 
 ## 2. 新 minor 发版差异


### PR DESCRIPTION
## Summary

继 PR #147 macOS Homebrew Cask 之后，第二条 Linux 包管理器集成：Arch / Manjaro 用户 `yay -S hope-agent-bin` 一键装。

- **PKGBUILD 走预编译二进制路径**：从 GitHub Release 的 `Hope.Agent_<ver>_amd64.deb` 重打（用 `bsdtar` 解压 deb 直接铺到 `$pkgdir`），不从源码编译，对用户来说装得最快
- **模板单一真相源** 在 [`aur/hope-agent-bin/`](aur/hope-agent-bin/)（PKGBUILD + .SRCINFO 两份），CI 在 release publish 后渲染推送，**不允许在 AUR 仓库直接 push**
- **认证**：[`update-aur.yml`](.github/workflows/update-aur.yml) 用专用 ed25519 deploy key (`AUR_SSH_PRIVATE_KEY` secret) 推 `ssh://aur@aur.archlinux.org/hope-agent-bin.git`；公钥已绑到 maintainer 的 AUR 账号
- **首次配置说明** 在 [`aur/README.md`](aur/README.md)（注册 AUR、生成专用 SSH key、绑 key、存 secret）
- depends 对齐 deb 的 runtime deps：`webkit2gtk-4.1 / gtk3 / libayatana-appindicator`
- `provides=('hope-agent') + conflicts=('hope-agent')` —— 给未来可能的源码包 `hope-agent`（无 -bin 后缀）留位置
- 当前仅 x86_64

## Test plan

- [ ] CI 通过 8 项 status check
- [ ] merge 后跑 `gh workflow run update-aur.yml -f tag=v0.1.2` 灌一次现有 release
- [ ] 验证 AUR `hope-agent-bin` 仓库出现首条 commit，且 PKGBUILD / .SRCINFO 字段一致
- [ ] sha256 与本地 `sha256sum Hope.Agent_0.1.2_amd64.deb` 计算一致
- [ ] Arch 用户实测 `yay -S hope-agent-bin` 能装（或在 archlinux 容器里 `makepkg -si` 走通）