### PR TITLE
feat(scoop): 新增 Windows Scoop 安装路径 + README 普通用户段重组

### DIFF
--- a/.github/workflows/update-scoop-bucket.yml
+++ b/.github/workflows/update-scoop-bucket.yml
@@ -1,0 +1,134 @@
+name: Update Scoop Bucket
+
+# Sync the manifest template in `scoop/hope-agent.json.tmpl` into the
+# bucket repo (shiwenwen/scoop-hope-agent → bucket/hope-agent.json)
+# whenever a release is published.
+#
+# Triggers:
+#   - release.published — auto-fires after a draft Release is manually
+#     published (see docs/release-process.md §1.4).
+#   - workflow_dispatch — manual re-run against an existing tag, for when
+#     the manifest template itself changes and you want to backfill an
+#     already-published release without cutting a new version.
+#
+# Required repo secrets:
+#   SCOOP_BUCKET_TOKEN — fine-grained PAT with `Contents: Read and write`
+#                        on shiwenwen/scoop-hope-agent only.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to sync (for example v0.1.2)
+        required: true
+        type: string
+
+concurrency:
+  group: update-scoop-bucket
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  update-bucket:
+    runs-on: ubuntu-latest
+    env:
+      BUCKET_REPO: shiwenwen/scoop-hope-agent
+      TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v6
+
+      - name: Resolve version from tag
+        id: ver
+        run: |
+          tag="${TAG}"
+          version="${tag#v}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::tag '$tag' does not look like a release tag (expected vX.Y.Z[-pre])"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "exe_name=Hope.Agent_${version}_x64-setup.exe" >> "$GITHUB_OUTPUT"
+
+      - name: Download setup.exe from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            --pattern "${{ steps.ver.outputs.exe_name }}" \
+            --dir .
+          ls -la "${{ steps.ver.outputs.exe_name }}"
+
+      - name: Compute SHA256
+        id: sha
+        run: |
+          set -euo pipefail
+          sum=$(sha256sum "${{ steps.ver.outputs.exe_name }}" | awk '{print $1}')
+          if [[ -z "$sum" || ${#sum} -ne 64 ]]; then
+            echo "::error::sha256sum returned unexpected output: $sum"
+            exit 1
+          fi
+          echo "sha256=$sum" >> "$GITHUB_OUTPUT"
+
+      - name: Render manifest from template
+        run: |
+          set -euo pipefail
+          mkdir -p rendered/bucket
+          sed -e "s/__PKGVER__/${{ steps.ver.outputs.version }}/g" \
+              -e "s/__SHA256__/${{ steps.sha.outputs.sha256 }}/g" \
+              scoop/hope-agent.json.tmpl > rendered/bucket/hope-agent.json
+
+          if grep -qE '__PKGVER__|__SHA256__' rendered/bucket/hope-agent.json; then
+            echo "::error::rendered manifest still contains template placeholders"
+            cat rendered/bucket/hope-agent.json
+            exit 1
+          fi
+
+          # Validate JSON syntax.
+          python3 -c "import json,sys; json.load(open('rendered/bucket/hope-agent.json'))"
+
+          echo "--- rendered bucket/hope-agent.json ---"
+          cat rendered/bucket/hope-agent.json
+
+      - name: Checkout bucket repo
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ env.BUCKET_REPO }}
+          token: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          path: bucket
+
+      - name: Copy rendered manifest into bucket repo
+        run: |
+          set -euo pipefail
+          mkdir -p bucket/bucket
+          cp rendered/bucket/hope-agent.json bucket/bucket/hope-agent.json
+
+      - name: Commit and push if changed
+        working-directory: bucket
+        run: |
+          set -euo pipefail
+          git config user.name  "hope-agent-bot"
+          git config user.email "hope-agent-bot@users.noreply.github.com"
+
+          # Stage first so the diff check covers new and modified files
+          # (git diff alone ignores untracked paths; same gotcha we hit
+          # with the Homebrew tap on first sync).
+          git add bucket/hope-agent.json
+          if git diff --cached --quiet; then
+            echo "No manifest changes for $TAG; skipping push."
+            exit 0
+          fi
+
+          git commit -m "hope-agent ${{ steps.ver.outputs.version }}
+
+          setup.exe sha256: ${{ steps.sha.outputs.sha256 }}
+          Source: ${{ github.repository }}@$TAG
+          "
+          git push origin HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Windows Scoop 安装**：新增 `scoop bucket add hope-agent https://github.com/shiwenwen/scoop-hope-agent && scoop install hope-agent` 安装路径；manifest 单一真相源在 [`scoop/hope-agent.json.tmpl`](scoop/hope-agent.json.tmpl)，release publish 后由 [`update-scoop-bucket.yml`](.github/workflows/update-scoop-bucket.yml) 自动渲染并推到 [shiwenwen/scoop-hope-agent](https://github.com/shiwenwen/scoop-hope-agent) bucket repo。Scoop 用 7zip 解压 NSIS installer 拿到 `hope-agent.exe` 单文件 binary（不跑 setup.exe），install 后既有 GUI 启动器也有 `hope-agent` PowerShell shim。当前仅 x64。
+- **README 普通用户段重组**：从"按包管理器/手动混排"重排为"平台 → 装法"两层（macOS / Windows / Linux 各自分 "包管理器（推荐）" + "手动安装"），每个平台底下自包含启动方式（桌面 GUI / 后台服务 / ACP）；"首次启动 & 自动更新" 单独成段不再每平台重复。中英双语同步。
 - **Arch Linux AUR 安装**：新增 `yay -S hope-agent-bin`（或 paru / 任意 AUR helper）安装路径；PKGBUILD / .SRCINFO 单一真相源在 [`aur/hope-agent-bin/`](aur/hope-agent-bin/)，release publish 后由 [`update-aur.yml`](.github/workflows/update-aur.yml) 自动渲染并推到 AUR `hope-agent-bin` 仓库。当前仅 x86_64，沿用 release `.deb` 重打。
 - **Web Search 新增博查 AI Search provider**：设置 → Tools → Web Search 可配置 Bocha API Key，并参与现有 provider 排序 / fallback 链路；`web_search` 工具会把通用 freshness 映射到博查时间过滤，解析 `webPages.value[]` 为统一的 title / URL / snippet 结果，出站请求继续走统一 SSRF policy gate。
 - **macOS Homebrew Cask 安装**：新增 `brew tap shiwenwen/hope-agent && brew install --cask hope-agent` 安装路径，cask 同时建立 `hope-agent` 命令行软链方便 `server` / `acp` 子命令调用；release publish 后由 [`update-homebrew-tap.yml`](.github/workflows/update-homebrew-tap.yml) 自动渲染 [`homebrew/hope-agent.rb.tmpl`](homebrew/hope-agent.rb.tmpl) 并推到 [shiwenwen/homebrew-hope-agent](https://github.com/shiwenwen/homebrew-hope-agent) tap repo。当前仅提供 Apple Silicon 构建，Intel Mac 走 Rosetta 2。

--- a/README.en.md
+++ b/README.en.md
@@ -90,9 +90,11 @@ Ordinary people deserve an AI assistant that just **opens and works** — downlo
 
 ### For users
 
-> 📦 Installers: [Releases](https://github.com/shiwenwen/hope-agent/releases)
+> 📦 Full installer list across platforms: [Releases](https://github.com/shiwenwen/hope-agent/releases)
 
-**macOS (Homebrew, recommended):**
+#### macOS
+
+##### Homebrew (recommended)
 
 ```bash
 brew tap shiwenwen/hope-agent
@@ -101,15 +103,51 @@ brew install --cask hope-agent
 
 > Already have `Hope Agent.app` installed manually? Append `--adopt` to let the cask take over your existing same-version app without re-downloading, or `--force` to overwrite.
 
-After install:
+##### Manual install (DMG)
 
-- Desktop GUI: Launchpad / Applications folder (click the Hope Agent icon), or `open -a "Hope Agent"` from a terminal
-- Headless server: `hope-agent server start`
-- ACP (IDE integration): `hope-agent acp`
+Download `Hope.Agent_*.dmg` from [Releases](https://github.com/shiwenwen/hope-agent/releases) and drag into Applications.
+
+> If macOS reports "damaged" or "cannot verify the developer" on first launch, run in Terminal:
+>
+> ```bash
+> sudo xattr -cr /Applications/Hope\ Agent.app
+> sudo codesign --force --deep --sign - /Applications/Hope\ Agent.app
+> ```
 
 Apple Silicon only; Intel Macs run under Rosetta 2.
 
-**Arch Linux / Manjaro (AUR):**
+##### Launch modes
+
+- **Desktop GUI**: Launchpad / Applications folder (click the Hope Agent icon), or `open -a "Hope Agent"` / `hope-agent` from a terminal
+- **Headless server (HTTP/WS daemon)**: `hope-agent server start`
+- **ACP (IDE integration)**: `hope-agent acp`
+
+#### Windows
+
+##### Scoop (recommended)
+
+```powershell
+scoop bucket add hope-agent https://github.com/shiwenwen/scoop-hope-agent
+scoop install hope-agent
+```
+
+##### Manual install (installer)
+
+Download `Hope.Agent_*-setup.exe` from [Releases](https://github.com/shiwenwen/hope-agent/releases) and double-click. **Windows is not yet fully tested** — please file issues if anything breaks.
+
+> If Windows reports "MSVCP140_1.dll was not found" or a similar missing `VCRUNTIME140.dll` / `MSVCP140.dll` error on launch, install the [Microsoft Visual C++ 2015–2022 Redistributable (x64)](https://aka.ms/vs/17/release/vc_redist.x64.exe) and relaunch.
+
+x64 only.
+
+##### Launch modes
+
+- **Desktop GUI**: click "Hope Agent" in the Start menu, or `hope-agent` from PowerShell
+- **Headless server (HTTP/WS daemon)**: `hope-agent server start` (PowerShell / cmd)
+- **ACP (IDE integration)**: `hope-agent acp`
+
+#### Linux
+
+##### Arch Linux / Manjaro (AUR)
 
 ```bash
 yay -S hope-agent-bin   # or paru / any AUR helper
@@ -117,23 +155,27 @@ yay -S hope-agent-bin   # or paru / any AUR helper
 
 Pre-built binary package (repackaged from the GitHub Release `.deb`) — no source compilation.
 
-**Other platforms / manual download:**
+##### Manual install (AppImage / deb / rpm)
 
-1. Download the installer for your platform from [Releases](https://github.com/shiwenwen/hope-agent/releases):
-   - macOS: `Hope.Agent_*.dmg`
-   - Linux: `Hope.Agent_*.AppImage` / `Hope.Agent_*.deb` / `Hope.Agent_*.rpm`
-   - Windows: `Hope.Agent_*-setup.exe` (not yet fully tested)
-2. First launch: **pick a provider template → paste API key / sign in with Codex OAuth → chat.**
-3. Desktop installers ship with GitHub Releases auto-update; inside the app you can go to **Settings → About** to check and install updates
+From [Releases](https://github.com/shiwenwen/hope-agent/releases):
 
-> If macOS reports "damaged" or "cannot verify the developer" on first launch, execute the following commands in Terminal:
->
-> ```bash
-> sudo xattr -cr /Applications/Hope\ Agent.app
-> sudo codesign --force --deep --sign - /Applications/Hope\ Agent.app
-> ```
+- AppImage: `Hope.Agent_*.AppImage` — `chmod +x` and run
+- Debian / Ubuntu: `Hope.Agent_*.deb` — `sudo dpkg -i Hope.Agent_*.deb`
+- Fedora / RHEL: `Hope.Agent_*.rpm` — `sudo rpm -i Hope.Agent_*.rpm`
 
-> If Windows reports "MSVCP140_1.dll was not found" or a similar missing `VCRUNTIME140.dll` / `MSVCP140.dll` error on launch, install the [Microsoft Visual C++ 2015–2022 Redistributable (x64)](https://aka.ms/vs/17/release/vc_redist.x64.exe) and relaunch the application.
+x86_64 only.
+
+##### Launch modes
+
+- **Desktop GUI**: click "Hope Agent" in your app menu, or `hope-agent` from a terminal
+- **Headless server (HTTP/WS daemon)**: `hope-agent server start`
+- **ACP (IDE integration)**: `hope-agent acp`
+
+#### First launch & auto-update
+
+1. First launch wizard: **pick a provider template → paste API key / sign in with Codex OAuth → chat.**
+2. Desktop builds ship with the GitHub Releases auto-updater. Go to **Settings → About** in-app to check for and install updates.
+3. Versions installed via Homebrew / AUR / Scoop also receive updates through the built-in updater; the package manager's recorded version stays pinned to the initial install version and does not affect functionality.
 
 ### For developers
 

--- a/README.md
+++ b/README.md
@@ -90,26 +90,64 @@
 
 ### 普通用户
 
-> 📦 安装包：[Releases](https://github.com/shiwenwen/hope-agent/releases)
+> 📦 各平台完整安装包列表：[Releases](https://github.com/shiwenwen/hope-agent/releases)
 
-**macOS（Homebrew，推荐）：**
+#### macOS
+
+##### Homebrew（推荐）
 
 ```bash
 brew tap shiwenwen/hope-agent
 brew install --cask hope-agent
 ```
 
-> 已经手动装过 `Hope Agent.app`？在 `brew install` 后面加 `--adopt`（让 cask 接管同版本的现有应用，不重新下载）或 `--force`（强制重下覆盖）。
+> 已经手动装过 `Hope Agent.app`？在 `brew install` 后面加 `--adopt`（接管同版本现有应用，不重新下载）或 `--force`（强制重下覆盖）。
 
-装完后：
+##### 手动安装（DMG）
 
-- 桌面 GUI：Launchpad / 应用程序文件夹（点 Hope Agent 图标启动），或终端 `open -a "Hope Agent"`
-- 后台服务：`hope-agent server start`
-- ACP（IDE 集成）：`hope-agent acp`
+到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载 `Hope.Agent_*.dmg`，拖到「应用程序」即可。
+
+> 若启动时提示"已损坏"或"无法验证开发者"，请在终端执行：
+>
+> ```bash
+> sudo xattr -cr /Applications/Hope\ Agent.app
+> sudo codesign --force --deep --sign - /Applications/Hope\ Agent.app
+> ```
 
 当前仅 Apple Silicon 构建，Intel Mac 走 Rosetta 2 自动兼容。
 
-**Arch Linux / Manjaro（AUR）：**
+##### 启动方式
+
+- **桌面 GUI**：Launchpad / 应用程序文件夹（点 Hope Agent 图标），或终端 `open -a "Hope Agent"` / `hope-agent`
+- **后台服务（HTTP/WS daemon）**：`hope-agent server start`
+- **ACP（IDE 集成）**：`hope-agent acp`
+
+#### Windows
+
+##### Scoop（推荐）
+
+```powershell
+scoop bucket add hope-agent https://github.com/shiwenwen/scoop-hope-agent
+scoop install hope-agent
+```
+
+##### 手动安装（installer）
+
+到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载 `Hope.Agent_*-setup.exe` 双击安装。**Windows 端尚未完成充分测试**，欢迎反馈问题。
+
+> 若启动时提示"由于找不到 MSVCP140_1.dll，无法继续执行代码"或类似缺失 `VCRUNTIME140.dll` / `MSVCP140.dll`，请安装 [Microsoft Visual C++ 2015–2022 运行库（x64）](https://aka.ms/vs/17/release/vc_redist.x64.exe)后重启应用。
+
+当前仅 x64。
+
+##### 启动方式
+
+- **桌面 GUI**：Start 菜单点「Hope Agent」启动，或 PowerShell `hope-agent`
+- **后台服务（HTTP/WS daemon）**：`hope-agent server start`（PowerShell / cmd）
+- **ACP（IDE 集成）**：`hope-agent acp`
+
+#### Linux
+
+##### Arch Linux / Manjaro（AUR）
 
 ```bash
 yay -S hope-agent-bin   # 或 paru / 任意 AUR helper
@@ -117,23 +155,27 @@ yay -S hope-agent-bin   # 或 paru / 任意 AUR helper
 
 预编译二进制版（沿用 GitHub Release 的 `.deb`），不从源码编译。
 
-**其他平台 / 手动下载：**
+##### 手动安装（AppImage / deb / rpm）
 
-1. 到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载对应平台安装包
-   - macOS：`Hope.Agent_*.dmg`
-   - Linux：`Hope.Agent_*.AppImage` / `Hope.Agent_*.deb` / `Hope.Agent_*.rpm`
-   - Windows：`Hope.Agent_*-setup.exe`（尚未完成充分测试）
-2. 首次启动向导：**选 Provider 模板 → 填 API Key / Codex OAuth 登录 → 开聊**
-3. 桌面安装包内置 GitHub Releases 自动更新；应用内可在 **设置 → 关于** 里检查更新并一键安装
+到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载：
 
-> 若 macOS 启动时提示"已损坏"或"无法验证开发者"，请在终端执行以下命令：
->
-> ```bash
-> sudo xattr -cr /Applications/Hope\ Agent.app
-> sudo codesign --force --deep --sign - /Applications/Hope\ Agent.app
-> ```
+- AppImage：`Hope.Agent_*.AppImage` —— `chmod +x` 后直接运行
+- Debian / Ubuntu：`Hope.Agent_*.deb` —— `sudo dpkg -i Hope.Agent_*.deb`
+- Fedora / RHEL：`Hope.Agent_*.rpm` —— `sudo rpm -i Hope.Agent_*.rpm`
 
-> 若 Windows 启动时提示"由于找不到 MSVCP140_1.dll，无法继续执行代码"或类似缺失 `VCRUNTIME140.dll` / `MSVCP140.dll` 的报错，请安装 [Microsoft Visual C++ 2015–2022 运行库（x64）](https://aka.ms/vs/17/release/vc_redist.x64.exe)后重启应用。
+当前仅 x86_64。
+
+##### 启动方式
+
+- **桌面 GUI**：应用菜单点「Hope Agent」启动，或终端 `hope-agent`
+- **后台服务（HTTP/WS daemon）**：`hope-agent server start`
+- **ACP（IDE 集成）**：`hope-agent acp`
+
+#### 首次启动 & 自动更新
+
+1. 首次启动向导：**选 Provider 模板 → 填 API Key / Codex OAuth 登录 → 开聊**
+2. 桌面应用内置 GitHub Releases 自动更新，应用内 **设置 → 关于** 检查更新并一键安装
+3. 通过 Homebrew / AUR / Scoop 装的版本同样走应用内置 updater；包管理器视角的版本号会保持初装时的，不影响功能
 
 ### 开发者
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -164,6 +164,24 @@ Publish Release 后 [`.github/workflows/update-homebrew-tap.yml`](../.github/wor
 
 **模板单一真相源在主仓 [`aur/hope-agent-bin/`](../aur/hope-agent-bin/)**。不要直接 push AUR 仓库——下次发版会被 CI 覆盖。**改 PKGBUILD 字段时必须同步改 .SRCINFO** 字段（两个文件结构是平行的），否则 AUR Web UI 元数据会与 PKGBUILD 不一致。
 
+### 1.8 Scoop bucket 自动同步
+
+与 §1.6 / §1.7 同模式，Release publish 后 [`.github/workflows/update-scoop-bucket.yml`](../.github/workflows/update-scoop-bucket.yml) 由 `release.published` 自动触发：
+
+1. `gh release download` 拉本次 release 的 `Hope.Agent_<version>_x64-setup.exe`
+2. `sha256sum` 算 setup.exe 摘要
+3. `sed` 渲染 [`scoop/hope-agent.json.tmpl`](../scoop/hope-agent.json.tmpl) → `bucket/hope-agent.json`
+4. JSON 语法校验
+5. 用 `SCOOP_BUCKET_TOKEN`（fine-grained PAT，仅授 `shiwenwen/scoop-hope-agent` 的 `Contents: Read and write`）push 到 bucket repo
+
+手动重跑：`gh workflow run update-scoop-bucket.yml -f tag=vX.Y.Z`。
+
+**首次配置**：详见 [`scoop/README.md`](../scoop/README.md)。
+
+**Manifest 单一真相源在主仓 [`scoop/hope-agent.json.tmpl`](../scoop/hope-agent.json.tmpl)**。不要在 bucket repo 直接改 `bucket/hope-agent.json`——下次发版会被 CI 覆盖。
+
+> Scoop 默认对 `.exe` URL 用 7zip 解压（不跑 NSIS installer），所以 manifest 不需要 `installer.script`——`hope-agent.exe` 解压出来就是直接可用的单文件 binary。
+
 ---
 
 ## 2. 新 minor 发版差异

--- a/scoop/README.md
+++ b/scoop/README.md
@@ -1,0 +1,52 @@
+# Scoop Bucket 模板
+
+此目录是 Scoop bucket（[shiwenwen/scoop-hope-agent](https://github.com/shiwenwen/scoop-hope-agent)）的**单一真相源**。Bucket 仓库由 CI 自动从这里同步——**不要直接在 bucket 仓库手改 manifest**，下次发版会被覆盖。
+
+## 文件
+
+- [`hope-agent.json.tmpl`](hope-agent.json.tmpl) — Scoop manifest 模板。`__PKGVER__` / `__SHA256__` 是 CI 占位符
+- [`../.github/workflows/update-scoop-bucket.yml`](../.github/workflows/update-scoop-bucket.yml) — release publish 后自动渲染并推送
+
+## Bucket repo 初始化（一次性）
+
+### 1. 建 bucket repo
+
+```bash
+gh repo create shiwenwen/scoop-hope-agent \
+  --public \
+  --description "🦭 Scoop bucket for Hope Agent · Hope Agent 的 Scoop bucket" \
+  --add-readme
+```
+
+仓库名约定可以是 `scoop-<name>` / `<name>-bucket` / 任意——Scoop 用户 `scoop bucket add hope-agent https://github.com/shiwenwen/scoop-hope-agent` 自定义别名即可，命名不影响功能，但跟 `homebrew-hope-agent` 同前缀风格更易识别。
+
+### 2. 建 fine-grained PAT 并存到主仓 secret
+
+跟 [`../homebrew/README.md`](../homebrew/README.md) 同样的步骤，区别只在：
+
+- **Token name**: `hope-agent scoop bucket writer`
+- **Repository access**: 选 `Only select repositories` → 勾上 `scoop-hope-agent`
+- **Repository permissions → Contents**: **`Read and write`**
+
+复制 token 后：
+
+```bash
+gh secret set SCOOP_BUCKET_TOKEN --repo shiwenwen/hope-agent
+# 回车后粘贴 token + 回车（输入隐藏）
+```
+
+## 修改 Manifest 后
+
+直接改 `hope-agent.json.tmpl`，下次发版 CI 会带到 bucket。要立即生效不等下次发版：
+
+```bash
+gh workflow run update-scoop-bucket.yml -f tag=vX.Y.Z
+```
+
+## 详细发版流程
+
+见 [`../docs/release-process.md`](../docs/release-process.md) §1.8「Scoop bucket 自动同步」。
+
+## 给 Scoop 用户的安装命令
+
+放在 bucket repo 自己的 README 里（不是这里）。本目录仅维护 manifest 模板。

--- a/scoop/hope-agent.json.tmpl
+++ b/scoop/hope-agent.json.tmpl
@@ -1,0 +1,41 @@
+{
+    "version": "__PKGVER__",
+    "description": "Local-first AI assistant desktop app — cross-device sessions, IM channel routing",
+    "homepage": "https://github.com/shiwenwen/hope-agent",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/shiwenwen/hope-agent/releases/download/v__PKGVER__/Hope.Agent___PKGVER___x64-setup.exe",
+            "hash": "sha256:__SHA256__"
+        }
+    },
+    "pre_install": [
+        "Remove-Item -Path \"$dir\\`$PLUGINSDIR\" -Recurse -Force -ErrorAction SilentlyContinue"
+    ],
+    "bin": "hope-agent.exe",
+    "shortcuts": [
+        ["hope-agent.exe", "Hope Agent"]
+    ],
+    "notes": [
+        "Hope Agent is a single-binary three-mode app:",
+        "  - Click the 'Hope Agent' shortcut in the Start menu to launch the desktop GUI",
+        "  - 'hope-agent server start' runs the HTTP/WS daemon (no GUI)",
+        "  - 'hope-agent acp' runs the ACP stdio mode for IDE integrations",
+        "",
+        "If the app fails to launch with a missing DLL error (MSVCP140.dll / VCRUNTIME140.dll),",
+        "install the Microsoft Visual C++ 2015-2022 Redistributable (x64):",
+        "  https://aka.ms/vs/17/release/vc_redist.x64.exe",
+        "or run the bundled installer in this app directory:",
+        "  $dir\\resources\\vc_redist.x64.exe"
+    ],
+    "checkver": {
+        "github": "https://github.com/shiwenwen/hope-agent"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/shiwenwen/hope-agent/releases/download/v$version/Hope.Agent_$version_x64-setup.exe"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

继 PR #147 (brew) / #151 (AUR) 之后第三条包管理器集成：Windows Scoop。**附带 README 普通用户段重组**——之前按"包管理器/手动"混排不直观，改成"平台 → 装法"两层 + 每平台自包含启动方式。

### Scoop 集成

- 跟 brew / AUR 同模式：模板单一真相源 + release.published 自动同步
- Manifest 模板在 [`scoop/hope-agent.json.tmpl`](scoop/hope-agent.json.tmpl)
- [`update-scoop-bucket.yml`](.github/workflows/update-scoop-bucket.yml) 在每次 release publish 后渲染并推到 [shiwenwen/scoop-hope-agent](https://github.com/shiwenwen/scoop-hope-agent) bucket repo
- Scoop 默认对 `.exe` URL 用 7zip 解压（不跑 NSIS installer），所以拿到的是 `hope-agent.exe` 单文件 + 一个 Start menu shortcut + `hope-agent` PowerShell shim
- `notes` 字段在缺 VC Redistributable 时引导用户跑 bundled `$dir/resources/vc_redist.x64.exe`

### README 重组（双语同步）

- 平台顺序：macOS → Windows → Linux（用户量优先）
- 每个平台两小节：「包管理器（推荐）」+「手动安装」
- 启动方式三种（GUI / server / acp）放每个平台底下自包含——不用上下来回看
- 补充：所有平台均支持终端无参 `hope-agent` 启 GUI（[src-tauri/src/main.rs:25-53](src-tauri/src/main.rs#L25-L53) 单 binary 三模式默认路径）
- 「首次启动 & 自动更新」抽到末尾不再每平台重复

### 用户需要做的一次性外部配置

1. 建 bucket repo：`gh repo create shiwenwen/scoop-hope-agent --public --description "🦭 Scoop bucket for Hope Agent · Hope Agent 的 Scoop bucket" --add-readme`
2. 建 fine-grained PAT（Resource owner: shiwenwen / Selected repos: scoop-hope-agent / Contents: Read and write / 1 年）
3. `gh secret set SCOOP_BUCKET_TOKEN --repo shiwenwen/hope-agent` 通过 stdin 喂

详见 [`scoop/README.md`](scoop/README.md)。

## Test plan

- [ ] CI 通过 8 项 status check
- [ ] merge 后跑 `gh workflow run update-scoop-bucket.yml -f tag=v0.1.2` 灌一次现有 release
- [ ] 验证 `shiwenwen/scoop-hope-agent` 出现 `bucket/hope-agent.json` 且 sha256 与本地 `sha256sum Hope.Agent_0.1.2_x64-setup.exe` 一致
- [ ] Windows 用户实测 `scoop bucket add hope-agent ... && scoop install hope-agent` + 三种启动方式
- [ ] README 渲染检查（GitHub 网页 / VSCode preview）三级标题层次正确