### PR TITLE
fix(linux-repo): deb 缺 Section 字段双层修复（tauri.conf.json 治本 + workflow 兜底）

### DIFF
--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -137,7 +137,13 @@ jobs:
           # very first run when the package is not yet in db/.
           reprepro -b apt remove stable hope-agent || true
 
-          reprepro -b apt includedeb stable "$GITHUB_WORKSPACE/artifacts/$DEB_NAME"
+          # `-S utils -P optional` provides default Section + Priority for
+          # the deb. Tauri's bundler currently does not emit a Section
+          # field in the .deb control file, and reprepro refuses to
+          # publish a package without one. `utils` is the Debian default
+          # for misc-purpose command-line / desktop tools.
+          reprepro -b apt -S utils -P optional \
+            includedeb stable "$GITHUB_WORKSPACE/artifacts/$DEB_NAME"
 
           echo "--- apt index ---"
           ls -la apt/dists/stable/

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -57,6 +57,12 @@
         "installMode": "perMachine",
         "languages": ["English"]
       }
+    },
+    "linux": {
+      "deb": {
+        "section": "utils",
+        "priority": "optional"
+      }
     }
   },
   "plugins": {


### PR DESCRIPTION
## Summary

PR #154 引入的 `update-linux-repo.yml` 第一次跑就栽在 reprepro 上：

```
Not removed as not found: hope-agent
Exporting indices...
No section given for 'hope-agent', skipping.
There have been errors!
```

根因：Tauri 的 deb bundler 默认不写 `Section:` / `Priority:` 字段。reprepro 在 export indices 时拒绝发布缺 Section 的包。

## 双层修复

1. **治本** ([src-tauri/tauri.conf.json](src-tauri/tauri.conf.json))：加 `bundle.linux.deb.section = "utils"` + `priority = "optional"`，v0.1.3+ 的 .deb 自带字段，符合 Debian Policy
2. **兜底** ([.github/workflows/update-linux-repo.yml](.github/workflows/update-linux-repo.yml))：`reprepro includedeb` 加 `-S utils -P optional`——给已发布的 v0.1.0/v0.1.1/v0.1.2 老 .deb 回灌时不挂，也防未来 Tauri 升级行为变化时再次踩坑

`utils` 是 Debian 推荐给 "misc-purpose CLI / desktop tools" 的标准 section；`priority: optional` 适用于非必需但常用的桌面应用。

## Test plan

- [ ] CI 通过 8 项 status check
- [ ] merge 后再跑 `gh workflow run update-linux-repo.yml -f tag=v0.1.2`，应走通整条链路
- [ ] 验证 bucket repo 出现 `apt/dists/stable/InRelease` + `apt/pool/main/h/hope-agent/hope-agent_0.1.2_amd64.deb`
- [ ] 验证 `rpm/stable/x86_64/repodata/repomd.xml.asc` 存在
- [ ] 在 docker `debian:12-slim` 容器里实测 `apt install hope-agent` 完整链路
- [ ] v0.1.3 发布后 `dpkg -I Hope.Agent_0.1.3_amd64.deb | grep Section` 应见 `Section: utils`