### PR TITLE
[codex] Fix collapsible session sidebar UI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,6 +41,11 @@ jobs:
           rustflags: ""
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Do not restore ~/.cargo/bin after setup-rust-toolchain installs
+          # rustup shims. A stale macOS cache can replace `cargo` with the
+          # rustup installer and make `cargo test` fail before compilation.
+          cache-bin: false
 
       # Vendored OpenSSL needs NASM to build on Windows MSVC. Chocolatey
       # is pre-installed on windows-latest runners; this avoids the
@@ -94,6 +99,11 @@ jobs:
           rustflags: ""
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Do not restore ~/.cargo/bin after setup-rust-toolchain installs
+          # rustup shims. A stale macOS cache can replace `cargo` with the
+          # rustup installer and make `cargo test` fail before compilation.
+          cache-bin: false
 
       - name: Install NASM (Windows only)
         if: runner.os == 'Windows'

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -90,6 +90,15 @@ export default function ChatScreen({
 
   // Sidebar panel width
   const [panelWidth, setPanelWidth] = useState(288)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    if (typeof window === "undefined") return false
+    return window.localStorage.getItem("hope.chatSidebarCollapsed") === "true"
+  })
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    window.localStorage.setItem("hope.chatSidebarCollapsed", String(sidebarCollapsed))
+  }, [sidebarCollapsed])
 
   // Right panel widths (resizable)
   const [planPanelWidth, setPlanPanelWidth] = useState(520)
@@ -1233,7 +1242,9 @@ export default function ChatScreen({
         currentSessionId={session.currentSessionId}
         loadingSessionIds={session.loadingSessionIds}
         panelWidth={panelWidth}
+        sidebarCollapsed={sidebarCollapsed}
         onPanelWidthChange={setPanelWidth}
+        onSidebarCollapsedChange={setSidebarCollapsed}
         onSwitchSession={session.handleSwitchSession}
         onNewChat={handleStartNewChat}
         onDeleteSession={session.handleDeleteSession}
@@ -1385,6 +1396,8 @@ export default function ChatScreen({
           onOpenHandover={(sid) => setHandoverSessionId(sid)}
           agents={session.agents}
           onChangeAgent={handleChangeAgent}
+          sidebarCollapsed={sidebarCollapsed}
+          onExpandSidebar={() => setSidebarCollapsed(false)}
         />
 
         <div className="flex-1 flex min-h-0 overflow-hidden">

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -20,6 +20,7 @@ import {
   Send,
   Ghost,
   Download,
+  PanelLeftOpen,
 } from "lucide-react"
 import { ExportSessionDialog } from "@/components/chat/export/ExportSessionDialog"
 import ChannelIcon from "@/components/common/ChannelIcon"
@@ -86,6 +87,10 @@ interface ChatTitleBarProps {
    * exist, the dropdown is hidden.
    */
   onChangeAgent?: (agentId: string) => void
+  /** Whether the session sidebar is currently collapsed. */
+  sidebarCollapsed?: boolean
+  /** Expands the session sidebar from the title bar. */
+  onExpandSidebar?: () => void
 }
 
 export default function ChatTitleBar({
@@ -114,6 +119,8 @@ export default function ChatTitleBar({
   onOpenHandover,
   agents = [],
   onChangeAgent,
+  sidebarCollapsed,
+  onExpandSidebar,
 }: ChatTitleBarProps) {
   const { t } = useTranslation()
   const appVersion = useAppVersion()
@@ -223,6 +230,17 @@ export default function ChatTitleBar({
       data-tauri-drag-region
     >
       <div className="flex items-end gap-2 min-w-0 pb-1.5">
+        {sidebarCollapsed && onExpandSidebar && (
+          <IconTip label={t("chat.expandSidebar")}>
+            <button
+              className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
+              aria-label={t("chat.expandSidebar")}
+              onClick={onExpandSidebar}
+            >
+              <PanelLeftOpen className="h-4 w-4" />
+            </button>
+          </IconTip>
+        )}
         {project && (
           <>
             <div className="inline-flex items-center gap-1 shrink-0 min-w-0">

--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -11,12 +11,8 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { IconTip } from "@/components/ui/tooltip"
-import {
-  Bot,
-  MessageSquarePlus,
-  PanelLeftClose,
-  PanelLeftOpen,
-} from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Bot, MessageSquarePlus, PanelLeftClose } from "lucide-react"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import type { SessionSearchResult } from "@/types/chat"
@@ -34,7 +30,9 @@ export default function ChatSidebar({
   currentSessionId,
   loadingSessionIds,
   panelWidth,
+  sidebarCollapsed,
   onPanelWidthChange,
+  onSidebarCollapsedChange,
   onSwitchSession,
   onNewChat,
   onDeleteSession,
@@ -52,10 +50,6 @@ export default function ChatSidebar({
   searchFocusSignal,
 }: ChatSidebarProps) {
   const { t } = useTranslation()
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
-    if (typeof window === "undefined") return false
-    return window.localStorage.getItem("hope.chatSidebarCollapsed") === "true"
-  })
   const [agentsExpanded, setAgentsExpanded] = useState(true)
   const [projectsExpanded, setProjectsExpanded] = useState(true)
   const [showNewChatMenu, setShowNewChatMenu] = useState(false)
@@ -100,9 +94,9 @@ export default function ChatSidebar({
   const searchTruncated = (searchResults?.length ?? 0) >= SEARCH_LIMIT
 
   useEffect(() => {
-    if (typeof window === "undefined") return
-    window.localStorage.setItem("hope.chatSidebarCollapsed", String(sidebarCollapsed))
-  }, [sidebarCollapsed])
+    if (searchFocusSignal === undefined || searchFocusSignal === 0) return
+    onSidebarCollapsedChange(false)
+  }, [searchFocusSignal, onSidebarCollapsedChange])
 
   useEffect(() => {
     const q = searchQuery.trim()
@@ -114,10 +108,11 @@ export default function ChatSidebar({
     setSearching(true)
     const timer = setTimeout(async () => {
       try {
-        const results = await getTransport().call<SessionSearchResult[]>(
-          "search_sessions_cmd",
-          { query: q, agentId: selectedAgentId ?? undefined, limit: SEARCH_LIMIT },
-        )
+        const results = await getTransport().call<SessionSearchResult[]>("search_sessions_cmd", {
+          query: q,
+          agentId: selectedAgentId ?? undefined,
+          limit: SEARCH_LIMIT,
+        })
         setSearchResults(sortSessionSearchResults(results ?? []))
       } catch (err) {
         logger.error("chat", "ChatSidebar::search", "search failed", err)
@@ -250,127 +245,159 @@ export default function ChatSidebar({
     setDeleteConfirmSessionId(null)
   }
 
-  if (sidebarCollapsed) {
-    return (
-      <div className="w-11 shrink-0 border-r border-border bg-background flex flex-col items-center">
-        <div
-          className="h-10 w-full flex items-end justify-center pb-1.5"
-          data-tauri-drag-region
-        >
-          <IconTip label={t("chat.expandSidebar")} side="right">
-            <button
-              className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
-              aria-label={t("chat.expandSidebar")}
-              onClick={() => setSidebarCollapsed(false)}
-            >
-              <PanelLeftOpen className="h-4 w-4" />
-            </button>
-          </IconTip>
-        </div>
-      </div>
-    )
-  }
-
   return (
     <>
       <div
-        style={{ width: panelWidth }}
-        className="shrink-0 border-r border-border bg-background flex flex-col"
+        style={{ width: sidebarCollapsed ? 0 : panelWidth }}
+        className="relative h-full shrink-0 transition-[width] duration-200 ease-out"
       >
-        {/* Title bar */}
-        <div className="h-10 flex items-end px-4 shrink-0" data-tauri-drag-region>
-          <h2 className="text-sm font-semibold text-foreground pb-1.5">
-            {t("chat.conversations")}
-          </h2>
-          <div className="ml-auto flex items-center gap-1 pb-1.5">
-            <IconTip label={t("chat.collapseSidebar")}>
-              <button
-                className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
-                aria-label={t("chat.collapseSidebar")}
-                onClick={() => setSidebarCollapsed(true)}
-              >
-                <PanelLeftClose className="h-4 w-4" />
-              </button>
-            </IconTip>
-            {/* New Chat button */}
-            <div className="relative" ref={newChatMenuRef}>
-              <IconTip label={t("chat.newChat")}>
-                <button
-                  className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
-                  onClick={() => {
-                    if (agents.length === 1) {
-                      onNewChat(agents[0].id)
-                    } else {
-                      setShowNewChatMenu(!showNewChatMenu)
-                    }
-                  }}
-                >
-                  <MessageSquarePlus className="h-4 w-4" />
-                </button>
-              </IconTip>
-              {/* Agent selector popup */}
-              {showNewChatMenu && (
-                <div className="absolute right-0 top-full mt-1 bg-popover/95 backdrop-blur-xl border border-border/60 rounded-xl shadow-lg z-50 min-w-[180px] p-1.5 animate-in fade-in-0 zoom-in-95 duration-150">
-                  {agents.map((agent) => (
+        <div className="h-full overflow-hidden">
+          <div
+            style={{ width: panelWidth }}
+            aria-hidden={sidebarCollapsed}
+            inert={sidebarCollapsed ? true : undefined}
+            className={cn(
+              "h-full border-r border-border bg-background flex flex-col transition-[opacity,transform] duration-200 ease-out",
+              sidebarCollapsed
+                ? "pointer-events-none -translate-x-3 opacity-0"
+                : "translate-x-0 opacity-100",
+            )}
+          >
+            {/* Title bar */}
+            <div className="h-10 flex items-end px-4 shrink-0" data-tauri-drag-region>
+              <h2 className="text-sm font-semibold text-foreground pb-1.5">
+                {t("chat.conversations")}
+              </h2>
+              <div className="ml-auto flex items-center gap-1 pb-1.5">
+                <IconTip label={t("chat.collapseSidebar")}>
+                  <button
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
+                    aria-label={t("chat.collapseSidebar")}
+                    onClick={(e) => {
+                      e.currentTarget.blur()
+                      onSidebarCollapsedChange(true)
+                    }}
+                  >
+                    <PanelLeftClose className="h-4 w-4" />
+                  </button>
+                </IconTip>
+                {/* New Chat button */}
+                <div className="relative" ref={newChatMenuRef}>
+                  <IconTip label={t("chat.newChat")}>
                     <button
-                      key={agent.id}
-                      className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[13px] rounded-md text-foreground/80 hover:bg-secondary/60 hover:text-foreground transition-colors"
+                      className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
                       onClick={() => {
-                        onNewChat(agent.id)
-                        setShowNewChatMenu(false)
+                        if (agents.length === 1) {
+                          onNewChat(agents[0].id)
+                        } else {
+                          setShowNewChatMenu(!showNewChatMenu)
+                        }
                       }}
                     >
-                      <div className="w-5 h-5 rounded-full bg-primary/15 flex items-center justify-center text-primary shrink-0 text-[10px] overflow-hidden">
-                        {agent.avatar ? (
-                          <img
-                            src={getTransport().resolveAssetUrl(agent.avatar) ?? agent.avatar}
-                            className="w-full h-full object-cover"
-                            alt=""
-                          />
-                        ) : agent.emoji ? (
-                          <span>{agent.emoji}</span>
-                        ) : (
-                          <Bot className="h-3 w-3" />
-                        )}
-                      </div>
-                      <span className="truncate">{agent.name}</span>
+                      <MessageSquarePlus className="h-4 w-4" />
                     </button>
-                  ))}
+                  </IconTip>
+                  {/* Agent selector popup */}
+                  {showNewChatMenu && (
+                    <div className="absolute right-0 top-full mt-1 bg-popover/95 backdrop-blur-xl border border-border/60 rounded-xl shadow-lg z-50 min-w-[180px] p-1.5 animate-in fade-in-0 zoom-in-95 duration-150">
+                      {agents.map((agent) => (
+                        <button
+                          key={agent.id}
+                          className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[13px] rounded-md text-foreground/80 hover:bg-secondary/60 hover:text-foreground transition-colors"
+                          onClick={() => {
+                            onNewChat(agent.id)
+                            setShowNewChatMenu(false)
+                          }}
+                        >
+                          <div className="w-5 h-5 rounded-full bg-primary/15 flex items-center justify-center text-primary shrink-0 text-[10px] overflow-hidden">
+                            {agent.avatar ? (
+                              <img
+                                src={getTransport().resolveAssetUrl(agent.avatar) ?? agent.avatar}
+                                className="w-full h-full object-cover"
+                                alt=""
+                              />
+                            ) : agent.emoji ? (
+                              <span>{agent.emoji}</span>
+                            ) : (
+                              <Bot className="h-3 w-3" />
+                            )}
+                          </div>
+                          <span className="truncate">{agent.name}</span>
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
-              )}
+              </div>
             </div>
-          </div>
-        </div>
 
-          <div
-            className="flex-1 overflow-y-auto overflow-x-hidden"
-            onScroll={(e) => {
-              if (!hasMoreSessions || loadingMoreSessions || !onLoadMoreSessions) return
-              const el = e.currentTarget
-              // Trigger when scrolled within 100px of the bottom
-              if (el.scrollHeight - el.scrollTop - el.clientHeight < 100) {
-                onLoadMoreSessions()
-              }
-            }}
-          >
-            {/* Projects section — shown above agents so users reach their
-                active workspace first. Falls back silently when no handler
-                is wired (backwards-compat). */}
-            {(projects.length > 0 || onAddProject) && (
-              <ProjectSection
-                projects={projects}
-                sessions={sessions}
+            <div
+              className="flex-1 overflow-y-auto overflow-x-hidden"
+              onScroll={(e) => {
+                if (!hasMoreSessions || loadingMoreSessions || !onLoadMoreSessions) return
+                const el = e.currentTarget
+                // Trigger when scrolled within 100px of the bottom
+                if (el.scrollHeight - el.scrollTop - el.clientHeight < 100) {
+                  onLoadMoreSessions()
+                }
+              }}
+            >
+              {/* Projects section — shown above agents so users reach their
+                  active workspace first. Falls back silently when no handler
+                  is wired (backwards-compat). */}
+              {(projects.length > 0 || onAddProject) && (
+                <ProjectSection
+                  projects={projects}
+                  sessions={sessions}
+                  agents={agents}
+                  currentSessionId={currentSessionId}
+                  loadingSessionIds={loadingSessionIds}
+                  expanded={projectsExpanded}
+                  setExpanded={setProjectsExpanded}
+                  onAddProject={() => onAddProject?.()}
+                  onOpenProjectSettings={(p) => onOpenProjectSettings?.(p)}
+                  onNewChatInProject={(pid, opts) => onNewChatInProject?.(pid, opts)}
+                  onArchiveProject={(pid, archived) => onArchiveProject?.(pid, archived)}
+                  onSwitchSession={onSwitchSession}
+                  onDeleteSession={handleDeleteClick}
+                  onMarkAllRead={onMarkAllRead}
+                  renamingSessionId={renamingSessionId}
+                  renameValue={renameValue}
+                  renameInputRef={renameInputRef}
+                  onStartRename={startRename}
+                  onRenameValueChange={setRenameValue}
+                  onCommitRename={commitRename}
+                  onCancelRename={cancelRename}
+                  onMoveSessionToProject={onMoveSessionToProject}
+                  getAgentInfo={getAgentInfo}
+                  formatRelativeTime={formatRelativeTime}
+                />
+              )}
+
+              {/* Collapsible Agents section */}
+              <AgentSection
                 agents={agents}
+                agentsExpanded={agentsExpanded}
+                setAgentsExpanded={setAgentsExpanded}
+                selectedAgentId={selectedAgentId}
+                toggleAgentFilter={toggleAgentFilter}
+                onNewChat={onNewChat}
+                onEditAgent={onEditAgent}
+                panelWidth={panelWidth}
+              />
+
+              {/* Session filter tabs + session list */}
+              <SessionList
+                sessions={sessions}
+                filteredSessions={filteredSessions}
+                sessionFilter={sessionFilter}
+                setSessionFilter={setSessionFilter}
+                selectedAgentId={selectedAgentId}
                 currentSessionId={currentSessionId}
                 loadingSessionIds={loadingSessionIds}
-                expanded={projectsExpanded}
-                setExpanded={setProjectsExpanded}
-                onAddProject={() => onAddProject?.()}
-                onOpenProjectSettings={(p) => onOpenProjectSettings?.(p)}
-                onNewChatInProject={(pid, opts) => onNewChatInProject?.(pid, opts)}
-                onArchiveProject={(pid, archived) => onArchiveProject?.(pid, archived)}
+                loadingMoreSessions={loadingMoreSessions}
                 onSwitchSession={onSwitchSession}
-                onDeleteSession={handleDeleteClick}
+                onDeleteClick={handleDeleteClick}
                 onMarkAllRead={onMarkAllRead}
                 renamingSessionId={renamingSessionId}
                 renameValue={renameValue}
@@ -379,83 +406,50 @@ export default function ChatSidebar({
                 onRenameValueChange={setRenameValue}
                 onCommitRename={commitRename}
                 onCancelRename={cancelRename}
-                onMoveSessionToProject={onMoveSessionToProject}
                 getAgentInfo={getAgentInfo}
                 formatRelativeTime={formatRelativeTime}
+                searchQuery={searchQuery}
+                onSearchQueryChange={setSearchQuery}
+                searchResults={searchResults}
+                searchTruncated={searchTruncated}
+                searching={searching}
+                agents={agents}
+                projects={projects}
+                onMoveToProject={onMoveSessionToProject}
+                searchFocusSignal={sidebarCollapsed ? 0 : searchFocusSignal}
               />
-            )}
-
-            {/* Collapsible Agents section */}
-            <AgentSection
-              agents={agents}
-              agentsExpanded={agentsExpanded}
-              setAgentsExpanded={setAgentsExpanded}
-              selectedAgentId={selectedAgentId}
-              toggleAgentFilter={toggleAgentFilter}
-              onNewChat={onNewChat}
-              onEditAgent={onEditAgent}
-              panelWidth={panelWidth}
-            />
-
-            {/* Session filter tabs + session list */}
-            <SessionList
-              sessions={sessions}
-              filteredSessions={filteredSessions}
-              sessionFilter={sessionFilter}
-              setSessionFilter={setSessionFilter}
-              selectedAgentId={selectedAgentId}
-              currentSessionId={currentSessionId}
-              loadingSessionIds={loadingSessionIds}
-              loadingMoreSessions={loadingMoreSessions}
-              onSwitchSession={onSwitchSession}
-              onDeleteClick={handleDeleteClick}
-              onMarkAllRead={onMarkAllRead}
-              renamingSessionId={renamingSessionId}
-              renameValue={renameValue}
-              renameInputRef={renameInputRef}
-              onStartRename={startRename}
-              onRenameValueChange={setRenameValue}
-              onCommitRename={commitRename}
-              onCancelRename={cancelRename}
-              getAgentInfo={getAgentInfo}
-              formatRelativeTime={formatRelativeTime}
-              searchQuery={searchQuery}
-              onSearchQueryChange={setSearchQuery}
-              searchResults={searchResults}
-              searchTruncated={searchTruncated}
-              searching={searching}
-              agents={agents}
-              projects={projects}
-              onMoveToProject={onMoveSessionToProject}
-              searchFocusSignal={searchFocusSignal}
-            />
+            </div>
           </div>
         </div>
+      </div>
 
-        {/* Delete session confirmation dialog */}
-        <AlertDialog
-          open={!!deleteConfirmSessionId}
-          onOpenChange={(open) => !open && setDeleteConfirmSessionId(null)}
-        >
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>{t("chat.deleteSessionTitle")}</AlertDialogTitle>
-              <AlertDialogDescription>{t("chat.deleteSessionWarning")}</AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
-              <AlertDialogAction
-                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                onClick={confirmDelete}
-              >
-                {t("common.delete")}
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+      {/* Delete session confirmation dialog */}
+      <AlertDialog
+        open={!!deleteConfirmSessionId}
+        onOpenChange={(open) => !open && setDeleteConfirmSessionId(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("chat.deleteSessionTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("chat.deleteSessionWarning")}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={confirmDelete}
+            >
+              {t("common.delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       {/* Drag Handle */}
       <div
-        className="w-1 shrink-0 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 transition-colors"
+        className={cn(
+          "shrink-0 cursor-col-resize transition-[width,opacity,background-color] duration-200 ease-out hover:bg-primary/30 active:bg-primary/50",
+          sidebarCollapsed ? "w-0 pointer-events-none opacity-0" : "w-1 opacity-100",
+        )}
         onMouseDown={handleDragStart}
       />
     </>

--- a/src/components/chat/sidebar/types.ts
+++ b/src/components/chat/sidebar/types.ts
@@ -9,7 +9,9 @@ export interface ChatSidebarProps {
   currentSessionId: string | null
   loadingSessionIds: Set<string>
   panelWidth: number
+  sidebarCollapsed: boolean
   onPanelWidthChange: (width: number) => void
+  onSidebarCollapsedChange: (collapsed: boolean) => void
   onSwitchSession: (
     sessionId: string,
     opts?: { targetMessageId?: number; highlightTerms?: string[] },


### PR DESCRIPTION
## Summary

Fixes the newly added session-list collapse behavior so it feels native instead of leaving layout artifacts.

- Animate the session sidebar width/opacity/position when collapsing and expanding.
- Remove the collapsed white strip by shrinking the sidebar container to zero width.
- Move the expand control into the chat title bar so it does not cover top content.
- Align the title-bar expand control with the existing agent/title elements.

## Root Cause

The collapsed state rendered a separate fixed-width mini sidebar (`w-11`), which left a visible blank strip. Moving the expand button to an absolutely positioned overlay removed the strip, but it then covered the title-bar content. The collapsed state now lives in `ChatScreen`, so `ChatTitleBar` can render the expand control in normal layout.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `cargo test  -p ha-core -p ha-server --locked`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- Local Vite preview visual check for collapsed and expanded sidebar states

Note: `pnpm test` prints the existing `Could not parse CSS stylesheet` warnings, but all Vitest files/tests pass.