### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-13
+
 ### Changed
 
 - **统一 turn 终止系统**：用户主动停止、模型链全部失败、上下文压缩失败、应用关闭 / 崩溃 / 配置缺失等所有「非自然完成」路径现在走同一条 `finalize` 管线，把发生了什么以中文「系统事件」一句话写进 `context_json`，让模型下一轮明确感知；UI 同步在会话里渲染一条系统通知条；IM 渠道也会发对应的提醒。partial 内容（已产生的文本 / 思考 / 工具调用）按各 Provider 原生格式结构化保留，不再扁平化成纯文本；被中断未返回结果的 `tool_use` 自动补合成 `tool_result` 防止下次请求被 API 拒。原「用户停止假装成功」导致模型续错话题、Crash 时 user 消息丢失这两个老问题修掉。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,7 +3221,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/docs/release-notes/v0.2.0.en.md
+++ b/docs/release-notes/v0.2.0.en.md
@@ -1,69 +1,84 @@
-# Hope Agent 0.2.0 — Full Feishu / Lark coverage
+# Hope Agent 0.2.0 — Distribution everywhere · Feishu workspace · Self-update
 
-> [简体中文](./v0.2.0.md) · **English**
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/docs/release-notes/v0.2.0.md) · **English**
 
-> See [`CHANGELOG.md`](../../CHANGELOG.md#unreleased) for the full diff.
+> Release date: 2026-05-13
 
-This release upgrades Feishu / Lark from "an IM channel" to "a full workspace target". Where v0.1.0 let an agent talk to a Feishu bot, v0.2.0 lets an agent **directly read and modify Feishu documents, multi-dimensional tables, drive files, wiki pages, approvals, calendar events, contacts, and hiring records**. 13 review-friendly PRs (A1 + B0 / B1 + C0 - C9) landed in sequence — each < 1500 lines, independently mergeable, independently revertible.
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/CHANGELOG.md#020---2026-05-13) for the full diff.
 
-## Highlights
+This is the first feature release after the v0.1 line. Three themes: minimize the cost of installing Hope Agent on any mainstream platform, upgrade Feishu / Lark from "an IM channel" to "a full workspace", and let the upgrade itself be triggered by a one-sentence conversation. We also unified how abnormal turn terminations are recorded — user stops, model chain failures, compaction failures, and app crashes now leave structured traces so the next turn can see exactly what happened.
 
-### Feishu IM channel completeness
+## Distribution coverage filled in
 
-- **Inbound media now reaches the dispatcher**. v0.1.0 silently dropped every image / file / voice / video / sticker the user sent to a Feishu bot (`ws_event.rs:699` hard-coded `media: Vec::new()` — a production bug). New module [`channel/feishu/inbound_media.rs`](../../crates/ha-core/src/channel/feishu/inbound_media.rs) parses `content` JSON by `msg_type`, extracts `image_key` / `file_key`, downloads via `GET /im/v1/messages/{id}/resources/{key}` to a local path, and exposes `InboundMedia.file_url` so downstream consumers can read it. `capabilities.supports_media` now also lists `Voice` and `Sticker`.
-- **9 new Feishu event types parsed**: `im.message.reaction.{created,deleted}_v1` / `im.message.recalled_v1` / `im.message.message_read_v1` / `im.chat.member.{user,bot}.{added,deleted}_v1` / `im.chat.{created,disbanded}_v1`. New module [`channel/feishu/inbound_events.rs`](../../crates/ha-core/src/channel/feishu/inbound_events.rs).
+- **macOS Intel native DMG + dual-arch Homebrew Cask**: the release pipeline now has an Intel macOS build lane and ships both `aarch64.dmg` and `x64.dmg`, so Intel Macs no longer go through Rosetta 2. The Homebrew tap [`shiwenwen/hope-agent`](https://github.com/shiwenwen/homebrew-hope-agent) picks the right binary by host architecture — install via `brew install --cask shiwenwen/hope-agent/hope-agent`.
+- **Windows Scoop install**: `scoop bucket add hope-agent https://github.com/shiwenwen/scoop-hope-agent && scoop install hope-agent`. Scoop unpacks the NSIS installer with 7zip to obtain a single-file binary; both the GUI launcher and the `hope-agent` command line are wired up afterward.
+- **Arch Linux AUR install**: `yay -S hope-agent-bin` (or paru / any AUR helper). Both x86_64 and aarch64 are supported (Asahi Linux benefits).
+- **Self-hosted Debian / Ubuntu / Fedora / RHEL repos**: `apt install hope-agent` / `dnf install hope-agent` in one line. Hosted on GitHub Pages with metadata signed by a dedicated ed25519 GPG key. Setup steps are documented in [`README.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/README.en.md) under the end-user section.
+- **Linux arm64 native builds**: releases now ship `arm64.deb` / `arm64.AppImage` / `aarch64.rpm` alongside their amd64 counterparts — Raspberry Pi, Asahi Linux, and AWS Graviton hosts run natively.
 
-### `InboundEvent` enum across all 12 channels
+macOS, Windows, and Linux each have an official "package-manager one-liner" install path.
 
-- `ChannelPlugin::start_account` signature is now `mpsc::Sender<InboundEvent>` instead of `mpsc::Sender<MsgContext>`. 6 variants (`Message` / `Reaction` / `MessageEdited` / `MessageRecalled` / `Membership` / `ReadReceipt`) plus shared `EventCommon` / `MembershipAction` substructures.
-- All 12 channel plugins were mechanically updated to wrap their messages with `InboundEvent::Message(...)`. Non-Message variants currently log only at the dispatcher; business behavior (sync edits to messages table, BotLeft cleanup, auto-welcome, etc.) is deferred to v0.3+ Phase B.2.
-- mpsc buffer raised 256 → 1024 so high-volume non-message events don't back-pressure real chat traffic.
+## Upgrade Hope Agent from a conversation
 
-### 40 Feishu business tools
+A new `app_update` built-in tool plus a `ha-self-update` skill let the model run check / download / verify / replace / restart end-to-end from a conversation, across three distribution paths:
 
-| Module | Tools | Capabilities |
-|--------|-------|--------------|
-| **docx** | 4 | Create empty doc, list blocks, append block, overwrite block text |
-| **bitable** | 7 | Record CRUD + batch update (≤1000) + structured search (field projection / sort / filter DSL) + list/get views + list dashboards |
-| **drive** | 3 | List folder + upload ≤20MB (paths protected via approval engine) + download to local |
-| **wiki** | 1 | Resolve wiki token → `obj_token` + `obj_type`, then drill in via `feishu_docx_get_blocks` / `feishu_bitable_*` |
-| **approval** | 5 | Create / get / cancel / list instances + subscribe to events |
-| **calendar** | 6 | List calendars + create/list/update/delete events + invite attendees |
-| **contact** | 4 | Single user lookup / batch (≤50) / department / list users by department |
-| **hire** | 5 | List jobs / get job / list talents / get talent / list applications |
+- **Desktop GUI**: routes through `tauri-plugin-updater`.
+- **Package managers** (Homebrew / Scoop / AUR / apt / dnf): the model identifies the install method and invokes the right CLI.
+- **Manual binary deployments**: downloads the bare-binary tar.gz / zip, verifies the Minisign signature, atomically replaces the running binary, and restarts.
 
-**All `feishu_*` tools share one global provisioning gate**: `tools/dispatch.rs::is_globally_configured` matches `n.starts_with("feishu_")` — once any Feishu IM channel account is configured, the gate flips green; otherwise the system prompt's `# Unconfigured Capabilities` section nudges the user.
+Every upgrade goes through an `ask_user_question` Yes/No confirmation — there is no path that skips signature verification. See [`docs/architecture/self-update.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/docs/architecture/self-update.md).
 
-**Credentials are reused**: [`tools/feishu/resolve_feishu_api`](../../crates/ha-core/src/tools/feishu/mod.rs) reads `cached_config().channels.accounts`, finds the configured Feishu account, and caches `Arc<FeishuAuth>` per account_id so the 7200-second tenant token is shared across concurrent tool calls. **Decoupled from whether the channel's WebSocket gateway is running** — users who only want docx / bitable access without a Feishu bot are first-class.
+## Feishu becomes a full workspace, not just an IM channel
 
-**Tier 3 Configured / off-by-default**: all 40 tools are off for every agent by default, avoiding a 40-entry prompt blast. Users opt in via Agent → Capabilities, or enable `deferredTools.enabled` so the LLM can find them on demand via `tool_search`.
+- **Inbound messages actually reach the dispatcher**: v0.1 silently dropped every image / file / voice / video / sticker the user sent to a Feishu bot. This release parses them and downloads them locally for the LLM to consume multimodally.
+- **9 new event types wired up**: reactions, message edits, message recalls, read receipts, group membership changes, group creation / disbanding — all flow through the dispatcher (business behavior is deferred to v0.3+; this release is log-only).
+- **40 Feishu business tools**: docx (4) / bitable (7) / drive (3) / wiki (1) / approval (5) / calendar (6) / contact (4) / hire (5) / bitable views + dashboards (3). Credentials are reused from existing Feishu IM accounts — no second configuration step. All tools are off-by-default per agent; users either opt in via Agent → Capabilities or enable deferred tool loading so the LLM can find them on demand.
+- **Companion [`feishu` skill](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/skills/feishu/SKILL.md)**: path-conditionally activated. Documents 5 common workflow scripts, an app-scope cheat sheet, an error-code translation table, and a risk-level table.
+- **Local-path Feishu tools are guarded by the protected-path engine**: `feishu_drive_upload_media` and `feishu_drive_download_media` share the same approval gate as `read` / `write`.
 
-### Companion Skill
+## 12-channel IM inbound-attachment parity
 
-New [`skills/feishu`](../../skills/feishu/SKILL.md), conditionally activated by `paths: ["**/*飞书*", "**/*feishu*", "**/*lark*"]`. Documents 5 common workflow scripts (OKR weekly report, meeting scheduling, colleague lookup, approval, wiki link resolution), an app-scope cheat sheet, an error-code translation table, and risk levels (HIGH for `approval_create/cancel` — must double-confirm; MEDIUM-sensitive for `contact_*` / `hire_*talent*` — don't echo personal data verbatim).
+The "parse a lightweight ref → defer download → stream to disk" pipeline that Feishu earned in v0.2 was extracted into channel-agnostic infrastructure, then used to fix 11 non-Feishu channels:
 
-### Path-permission protection
+- **Fixed**: Slack used to hand the LLM a `url_private` link that requires a bot token to fetch; Signal had `file_url: None`, so the LLM couldn't see attachments at all; Discord CDN URLs expire in 24 hours, producing 410s on later session references.
+- **Newly wired**: Google Chat / LINE / QQ Bot / WhatsApp previously dropped all inbound attachments — users sent images and the agent saw nothing. All four now download to local paths.
+- **Performance hardening**: Telegram and WeChat now stream large files to disk (per-file 512 MiB sanity cap), and WeChat's encrypted attachments use a two-stage on-disk AES buffer so a 100 MB file no longer needs a 200 MB+ RSS peak.
 
-`feishu_drive_upload_media` and `feishu_drive_download_media` are now recognized by [`permission::rules::extract_path_arg`](../../crates/ha-core/src/permission/rules.rs) — local `path` arguments flow through the protected-path engine, so patterns like `~/.ssh/...` / `*.pem` trigger the same approval gate as `read` / `write`.
+iMessage and IRC don't carry media at the protocol level — not in scope.
 
-## Upgrade notes
+## Sturdier conversation lifecycle
 
-- **New dev-dependency**: `wiremock = "0.6"` (test-only).
-- **Backwards compatible**: existing Feishu IM accounts work as-is for the new business tools — no second configuration step.
-- **Agent default behavior unchanged**: every Feishu tool ships `default_for_main = false`, so existing agents upgrade silently. Users must opt in per-agent.
-- **Feishu app scopes**: each tool's description names the required scope (`docx:document`, `bitable:app`, `drive:drive`, etc.). Error code `99991672` means a scope is missing — the agent points the user to the Feishu admin panel via [`skills/feishu/SKILL.md`](../../skills/feishu/SKILL.md)'s error-code table.
-- **Hire module**: Feishu Hire is enterprise-only. Tenants without it see error code `1061004`; the agent guides the user to ask their admin to enable it.
+- **Unified turn termination**: user stops, full model-chain failures, compaction failures, app shutdown / crash / missing-config — every non-natural completion path now goes through a single `finalize` pipeline. What happened is written into the conversation as a short Chinese "system event" so the next turn can see it; the UI renders a matching system notice; IM channels send the corresponding alert too.
+- **Crash vs. graceful shutdown distinguishable**: signal handlers (SIGTERM / SIGINT / Ctrl+C / Ctrl+Break) write a sentinel before exiting. On next launch, lingering turns are labeled either "Shutdown" or "Crash" based on that sentinel, with copy and behavior tuned for each.
+- **exec subprocess / grandchild leak fixed**: `exec` running `sh -c 'cmd1 & cmd2 & wait'` now cleans up grandchildren too. Tokio task panics and runtime shutdown no longer leak processes.
+- **Turn lifecycle recovery after a stop**: HTTP mode no longer synthesizes a late `turn_started` that flips a terminal state back to running; during startup, only the Primary process recovers leftover turns, so a secondary server / acp launch can't misclassify an in-flight desktop turn.
 
-## Still not done (v0.3+)
+## Productivity additions
 
-- docx block-type extension (image / table / code blocks)
-- drive segmented upload v2 (>20 MB)
-- bitable formulas / automations / view creation
-- approval template creation / approve / reject task
-- calendar meeting rooms / resource booking
-- task / email subsystems
-- Phase B.2: recall syncs to `messages` table / BotLeft cleans up sessions / auto-welcome on join
-- Phase B.3: reaction / edit / recall parsing for Telegram / Discord / Slack / etc.
-- Application-layer rate limiter (only when 99991400 storms appear in the wild)
+- **Historical Plan viewer + `@plan` references + Dashboard Plan stats**: a new Plans entry in the left sidebar lets you browse every plan across sessions read-only (including archived ones), filter by agent / state, switch versions, and jump to the owning session. The detail panel's "Add to conversation" button drops `@plan:<short_id>:v<version>` into the input — at send time, the backend resolves it into a markdown attachment injected into the LLM context. The Dashboard gains a Plans sub-tab (state distribution / completion rate / top agent / top project / 30-day creation trend / average execution duration).
+- **Export conversation**: a right-click menu in the sidebar and a button in the title bar both trigger it. Three formats — Markdown / JSON / HTML — with optional inclusion of tool calls and thinking. Desktop uses the native save dialog; browser uses Blob download. The `/export` slash command upgrades to `[md|json|html] [full|tools|thinking]` positional args.
+- **"Continue" banner when the tool-call limit is hit**: previously you had to manually type "continue" to push past `max_tool_rounds`. Now a banner lets you click once. The banner persists in conversation history, so refresh keeps the entry point.
+- **Service start / restart awareness in IM channels**: every run mode (desktop / `hope-agent server` / `hope-agent acp`) sends a brief "Hope Agent is back online" notice to IM chats active within the last 72 hours on cold start, upgrade, manual restart, or crash recovery. 30-minute per-chat cooldown, 30-message global cap, and `HOPE_AGENT_CRASH_COUNT ≥ 3` auto-mute prevent crash-loop spam. GUI offers a dedicated toggle.
+- **Bocha AI Search joins Web Search providers**: configurable alongside existing providers in the ordering and fallback chain.
+- **Onboarding adds a search-provider step**: both the desktop local-mode wizard and `hope-agent server setup` CLI pick from DuckDuckGo / SearXNG / Tavily / Bocha / Brave / Perplexity / Google / Grok / Kimi, or skip. We did not bump the onboarding version, so existing users aren't re-prompted; rerun the wizard to see the new step.
 
-See [`docs/plans/feishu-business-tools.md §9`](../plans/feishu-business-tools.md) for the full roadmap.
+## Upgrade
+
+- **Desktop (v0.1.0 / v0.1.2 users)**: install over the top, or click "Check for Updates" in the app for a one-click upgrade. Config and data are fully compatible.
+- **Desktop (v0.1.1 users)**: due to a known issue with v0.1.1's auto-update signature verification (fixed in v0.1.2), download the installer manually and install once. Auto-update works normally from then on.
+- **Package-manager users**: `brew upgrade --cask hope-agent` / `scoop update hope-agent` / `yay -Syu hope-agent-bin` / `apt update && apt install --only-upgrade hope-agent` / `dnf upgrade hope-agent`.
+- **Server / Web mode**: replace the binary and restart the service.
+- **Feishu business tools**: automatically available to configured Feishu IM accounts. Individual tools require the admin to enable the corresponding scope in the Feishu console — error code 99991672 means a scope is missing and the agent will guide the user. The hire module is enterprise-only (error code 1061004).
+- **Agent configuration**: every Feishu tool is `default_for_main = false`, so existing agents won't see the new tools by default. Opt in per agent via Capabilities, or enable deferred tool loading so the model discovers them on demand.
+
+## Known limitations
+
+Same as v0.1.0 — see the [v0.1.0 release notes](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/docs/release-notes/v0.1.0.en.md#known-limitations). Additional notes for this release:
+
+- **Feishu Hire module is enterprise-only**: tenants without it see error code `1061004` when calling `feishu_hire_*`.
+- **Feishu Drive upload caps single-file uploads at ≤ 20 MB**: anything larger needs segmented upload v2, deferred to v0.3+.
+- **In-app auto-update on package-manager installs nudges you to use the package manager**: avoids drifting from the system package database.
+
+## Full changelog
+
+See [CHANGELOG.md](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/CHANGELOG.md#020---2026-05-13).

--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -1,70 +1,84 @@
-# Hope Agent 0.2.0 — 飞书完整对齐
+# Hope Agent 0.2.0 — 安装铺设 · 飞书工作空间 · 自助升级
 
-> **简体中文** · [English](./v0.2.0.en.md)
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/docs/release-notes/v0.2.0.en.md)
 
-> 详见 [`CHANGELOG.md`](../../CHANGELOG.md#unreleased)。
+> 发布日期：2026-05-13
 
-本版主题：**让飞书从「IM 渠道」升级为「完整工作空间」**。从「桌面 / IM agent 对话飞书 bot」一路开到「agent 直接读改飞书的多维表格 / 文档 / 云盘 / 知识库 / 审批 / 日历 / 通讯录 / 招聘」。整条线 13 个独立 PR（A1 + B0 / B1 + C0 - C9）串行落地，每个 PR review-friendly < 1500 行 diff、独立可回滚。
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/CHANGELOG.md#020---2026-05-13)。
 
-## 亮点
+本版本是 v0.1 系列之后第一个功能型版本，主轴有三：把 Hope Agent 装到任何主流平台上的成本降到最低、把飞书从「IM 渠道」升级成一个完整工作空间、并让升级本身可以在对话里一句话完成。同时统一了会话异常终止的语义，从此用户主动停止、模型出错、压缩失败、应用崩溃这些路径都会留下结构化痕迹让下一轮模型明确感知。
 
-### 飞书 IM 渠道补完
+## 安装与分发全面铺设
 
-- **入站媒体真正进 dispatcher**：v0.1.0 把飞书发的图 / 文件 / 语音 / 视频 / 贴纸全部丢弃（`ws_event.rs:699` 硬编码 `media: Vec::new()`，线上 bug）。新增 [`channel/feishu/inbound_media.rs`](../../crates/ha-core/src/channel/feishu/inbound_media.rs) 按 `msg_type` 解析 `content` JSON 提取 `image_key` / `file_key`，调 `GET /im/v1/messages/{id}/resources/{key}` 下载到本地，`InboundMedia.file_url` 指本地路径下游可读。`capabilities.supports_media` 同步补 `Voice` / `Sticker`。
-- **9 种新事件解析**：`im.message.reaction.{created,deleted}_v1` / `im.message.recalled_v1` / `im.message.message_read_v1` / `im.chat.member.{user,bot}.{added,deleted}_v1` / `im.chat.{created,disbanded}_v1` 现在全部进 dispatcher。新文件 [`channel/feishu/inbound_events.rs`](../../crates/ha-core/src/channel/feishu/inbound_events.rs)。
+- **macOS Intel 原生 DMG + Homebrew Cask 双架构**：发版流水线新增 Intel macOS 构建线，同时产出 `aarch64.dmg` 与 `x64.dmg`，Intel Mac 不再走 Rosetta 2；Homebrew tap [`shiwenwen/hope-agent`](https://github.com/shiwenwen/homebrew-hope-agent) 改为按硬件自动选对版本，命令 `brew install --cask shiwenwen/hope-agent/hope-agent`
+- **Windows Scoop 安装**：`scoop bucket add hope-agent https://github.com/shiwenwen/scoop-hope-agent && scoop install hope-agent`，Scoop 用 7zip 解压 NSIS installer 得到单文件 binary，安装后 GUI 启动器与 `hope-agent` 命令行均可用
+- **Arch Linux AUR 安装**：`yay -S hope-agent-bin`（或 paru / 任意 AUR helper），同时支持 x86_64 与 aarch64（Asahi Linux 受益）
+- **Debian / Ubuntu / Fedora / RHEL 自建软件源**：`apt install hope-agent` / `dnf install hope-agent` 一行装好。源托管在 GitHub Pages，metadata 由专用 ed25519 GPG 密钥签名，安装步骤见 [`README.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/README.md) 普通用户段
+- **Linux arm64 原生构建**：发版同时产出 `arm64.deb` / `arm64.AppImage` / `aarch64.rpm`，树莓派 / Asahi Linux / AWS Graviton 服务器原生跑
 
-### `InboundEvent` 跨 12 channel 入站事件枚举
+至此 macOS / Windows / Linux 三大平台均提供「包管理器一行装」的官方路径。
 
-- `ChannelPlugin::start_account` 签名 `mpsc::Sender<MsgContext>` → `mpsc::Sender<InboundEvent>`；6 variants（Message / Reaction / MessageEdited / MessageRecalled / Membership / ReadReceipt）+ 子结构 `EventCommon` / `MembershipAction` 等
-- 12 channel 全 `inbound_tx.send(InboundEvent::Message(msg))` 机械替换；非 Message 走 dispatcher 5 分支 log-only handler
-- mpsc buffer 256 → 1024，避免高频非消息事件背压真正的对话流
-- 业务行为（撤回同步 messages 表 / BotLeft 清 session / 入群欢迎）延后 v0.3+ Phase B.2
+## 模型对话直接升级 Hope Agent
 
-### 40 个飞书业务 tool
+新增 `app_update` 内置工具与 `ha-self-update` skill，模型可以在对话里完成检查 / 下载 / 校验 / 替换 / 重启全流程，覆盖三档分发路径：
 
-| 模块 | tools 数 | 关键能力 |
-|------|---------|---------|
-| **docx 云文档** | 4 | 建空文档、列 block、追加 block、覆盖 block 文本 |
-| **bitable 多维表格** | 7 | record CRUD + 批量更新（≤1000）+ search（field projection / sort / filter DSL）+ list/get views + list dashboards |
-| **drive 云盘** | 3 | 列文件夹 + 上传（≤20MB，路径走 protected-path 审批）+ 下载到本地 |
-| **wiki 知识库** | 1 | wiki token → obj_token + obj_type，再用 docx_get_blocks / bitable_* 读真实内容 |
-| **approval 审批** | 5 | 创建 / 查询 / 撤销实例 + 列实例 + 订阅事件 |
-| **calendar 日历** | 6 | 列日历 + 建/列/改/删事件 + 邀请 attendees |
-| **contact 联系人** | 4 | 单查 / 批量（≤50）/ 部门 / 按部门列用户 |
-| **hire 招聘** | 5 | 列岗位 / 查岗位 / 列人才 / 查人才 / 列投递 |
+- **桌面 GUI**：走 `tauri-plugin-updater`
+- **包管理器**(Homebrew / Scoop / AUR / apt / dnf)：模型自动识别当前发行方式并调用对应 CLI
+- **手动 binary 部署**：下载裸 binary tar.gz / zip，Minisign 校验签名，原子替换运行中的二进制后自重启
 
-**所有 `feishu_*` tool 共享一个全局配置门**：`tools/dispatch.rs::is_globally_configured` 通配 `n.starts_with("feishu_")` —— 配过任何一个飞书 IM channel 账号即生效，未配则 system prompt `# Unconfigured Capabilities` 段引导。
+每次升级强制 `ask_user_question` 走 Yes/No 二次确认，跳过签名校验的路径不存在。详见 [`docs/architecture/self-update.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/docs/architecture/self-update.md)。
 
-**凭据复用**：[`tools/feishu/resolve_feishu_api`](../../crates/ha-core/src/tools/feishu/mod.rs) 从 `cached_config().channels.accounts` 找配置的飞书账号，按 account_id 缓存 `Arc<FeishuAuth>`，token 共享 7200s。**与 IM 渠道是否运行 WS 网关解耦**——只想用 docx / bitable 不开 bot 的场景也支持。
+## 飞书从 IM 渠道升级为完整工作空间
 
-**Tier 3 Configured / off-by-default**：飞书 tool 默认对所有 agent 关闭，避免把 40 个 tool 一次性灌进 prompt；用户在 Agent 设置里勾选启用，或 `deferredTools.enabled` 后让 LLM 通过 `tool_search` 按需发现。
+- **入站消息真正进 dispatcher**：v0.1 把飞书发的图 / 文件 / 语音 / 视频 / 贴纸全部丢弃，本版补完解析并下载到本地供 LLM 多模态读取
+- **9 种新事件接入**：reaction / message edit / message recall / read receipt / 群成员变更 / 群创建解散 全部进 dispatcher（业务行为延后 v0.3+，本版先 log-only）
+- **40 个飞书业务工具**：docx 云文档(4)/ bitable 多维表格(7)/ drive 云盘(3)/ wiki 知识库(1)/ 审批(5)/ 日历(6)/ 通讯录(4)/ 招聘(5)/ bitable 视图 + 仪表盘(3)。凭据与 IM 渠道账号共享，不需要重复配置；默认对 agent 关闭，按需在 Agent 设置里勾选或通过延迟工具加载让 LLM 自主发现
+- **配套 [`feishu` skill](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/skills/feishu/SKILL.md)**：路径条件激活，文档化 5 个常见工作流剧本、scope 速查表、错误码翻译表与风险等级表
+- **写本地路径的飞书工具受保护路径引擎护航**：`feishu_drive_upload_media` / `feishu_drive_download_media` 与 `read` / `write` 共享同一审批门
 
-### 配套 Skill
+## IM 入站附件 12 渠道一致性
 
-新增 [`skills/feishu`](../../skills/feishu/SKILL.md)，`paths: ["**/*飞书*", "**/*feishu*", "**/*lark*"]` 条件激活。文档化 5 个常见工作流剧本（OKR 周报 / 排会议 / 查同事 / 审批 / wiki 链接解析）+ scope 速查表 + 错误码翻译表 + 风险等级（HIGH `approval_create/cancel` 必须二次确认；MEDIUM-敏感 `contact_*` / `hire_*talent*` 不要原样回显个人信息）。
+把飞书在 v0.2 打磨出的「parse 轻量 ref → 延迟下载 → 流式落盘」管线抽成跨渠道公共基础设施，回头修复了 11 个非飞书渠道的入站附件问题：
 
-### 路径权限保护
+- **修复**：Slack 之前给 LLM 的 `url_private` 链接没有 token 拉不动；Signal `file_url: None` 让 LLM 完全看不到附件；Discord CDN URL 24 小时过期之后会变 410
+- **新接**：Google Chat / LINE / QQ Bot / WhatsApp 此前入站附件全 drop，用户发图 agent 完全看不到，本版全部接通本地下载
+- **性能 hardening**：Telegram / WeChat 大文件改为边收边写盘（每渠道有 512 MiB 单文件 sanity cap），WeChat 加密附件用 AES 磁盘缓冲二段法解密——100 MB 文件不再吃 200 MB+ 内存峰值
 
-`feishu_drive_upload_media` / `feishu_drive_download_media` 加入 [`permission::rules::extract_path_arg`](../../crates/ha-core/src/permission/rules.rs)——本地 `path` 走 protected-path 引擎，`~/.ssh/...` / `*.pem` 等模式与 `read` / `write` tool 共享审批门。
+iMessage 与 IRC 协议本身不传媒体，未涉及。
 
-## 升级指南
+## 更稳的会话生命周期
 
-- **新增依赖**：`wiremock = "0.6"` 进 `[dev-dependencies]`，仅测试期编译
-- **配置兼容**：完全向后兼容。已配的飞书 IM 账号自动可用于业务 tool；不需要二次配置
-- **Agent 默认行为零变化**：飞书 tool 全部 `default_for_main = false`，老 agent 升级后看不到新 tool 直到主动在 capabilities 里勾选
-- **App scope**：用户使用具体 tool 前需在飞书后台「权限管理」开通对应 scope（`docx:document` / `bitable:app` / `drive:drive` 等）。错误码 `99991672` 即 scope 缺失，agent 会按 [`skills/feishu/SKILL.md`](../../skills/feishu/SKILL.md) 错误码表引导用户去后台勾选。
-- **hire 模块**：飞书招聘是企业版才有的能力，未开通的租户调 `feishu_hire_*` 会返 `1061004`；agent 会提示「请管理员开通飞书招聘」
+- **统一 turn 终止系统**：用户主动停止、模型链全部失败、上下文压缩失败、应用关闭 / 崩溃 / 配置缺失等所有非自然完成路径现在走同一条 finalize 管线。发生了什么会以一句中文「系统事件」写进上下文让下一轮模型明确感知，UI 同步在会话里渲染一条系统通知条，IM 渠道也会发对应提醒
+- **崩溃 vs 优雅退出可区分**：信号处理器退出前写 sentinel，下次启动据此把残留 turn 标记为「Shutdown（应用已关闭）」或「Crash（进程异常退出）」，文案与行为针对性区分
+- **exec 子进程孙进程泄漏修复**：`exec` 跑 `sh -c 'cmd1 & cmd2 & wait'` 这种孙进程也会被一并清掉，tokio 任务 panic / 运行时关闭路径不再残留
+- **任务停止后 turn 生命周期恢复**：HTTP 模式不再合成 late `turn_started` 把 terminal state 改回 running；多进程启动期只由 Primary 进程恢复 leftover turn
 
-## 仍未做（v0.3+）
+## 生产力增强
 
-- docx 块类型扩展（image / table / code block）
-- drive 大文件分片上传 v2（>20MB）
-- bitable 公式 / 自动化 / 视图创建
-- approval 模板创建 / approve/reject task
-- calendar 会议室 / 资源预订
-- task / email 子系统
-- Phase B.2：撤回同步 session messages 表 / BotLeft 清 session / 入群欢迎
-- Phase B.3：Telegram / Discord / Slack 等 reaction / edit / recall 事件解析
-- 限流 RateLimiter（实战 99991400 频繁时再做）
+- **历史 Plan 查看器 + `@plan` 引用 + Dashboard 统计**：左侧栏新增 Plans 入口，跨会话只读浏览所有 plan（含已归档），支持 Agent / 状态筛选、版本切换、一键跳转所属会话；详情面板「添加到对话」按钮把 `@plan:<short_id>:v<version>` 塞进当前输入框，发送时由后端解析为 markdown attachment 注入；Dashboard 新增 Plans 子板（状态分布 / 完成率 / Top Agent / Project / 30 天创建趋势 / 平均执行时长）
+- **导出对话**：Sidebar 右键菜单 + 标题栏按钮均可触发，支持 Markdown / JSON / HTML 三种格式，可选包含工具调用与思考过程；桌面端走原生保存对话框，浏览器端走 Blob 下载；`/export` 斜杠命令同步升级为 `[md|json|html] [full|tools|thinking]` 位置参数
+- **工具调用达上限「继续」横幅**：原本只能手敲「继续」推进，现在直接点横幅即可；横幅在会话历史中持久化，刷新后入口仍在
+- **服务启动 / 重启在 IM 通道感知**：所有运行模式冷启 / 升级 / 主动重启 / 崩溃恢复时，向最近 72 小时活跃过的 IM 聊天发送「Hope Agent is back online」简短通知；30 分钟聊天级 cooldown + 全局 30 条上限 + `HOPE_AGENT_CRASH_COUNT ≥ 3` 自动静音防 crash-loop 刷屏；GUI 提供独立开关
+- **博查 AI Search 接入 Web Search**：可与现有 Provider 排序与 fallback 链路共存
+- **引导页新增搜索 Provider 配置步骤**：本地模式与 `hope-agent server setup` CLI 引导同步，可选择 DuckDuckGo / SearXNG / Tavily / Bocha / Brave / Perplexity / Google / Grok / Kimi 或跳过；本次不 bump onboarding version，存量用户不被打断
 
-详见 [`docs/plans/feishu-business-tools.md §9`](../plans/feishu-business-tools.md) 后续路线表。
+## 升级
+
+- **桌面（v0.1.0 / v0.1.2 用户）**：直接覆盖安装或在应用内点「检查更新」一键升级；配置与数据完全兼容
+- **桌面（v0.1.1 用户）**：因 v0.1.1 自动更新链路签名验证存在已知问题（已在 v0.1.2 修复），需手动下载安装包覆盖一次，之后即可正常自动升级
+- **包管理器用户**：`brew upgrade --cask hope-agent` / `scoop update hope-agent` / `yay -Syu hope-agent-bin` / `apt update && apt install --only-upgrade hope-agent` / `dnf upgrade hope-agent`
+- **Server / Web 模式**：替换二进制后重启服务
+- **飞书业务工具**：自动可用于已配置的飞书 IM 账号，但具体 tool 需要管理员在飞书后台「权限管理」开通对应 scope（错误码 99991672 即 scope 缺失，agent 会引导）；招聘模块仅企业版可用（错误码 1061004）
+- **Agent 配置**：飞书工具全部 `default_for_main = false`，老 agent 升级后默认看不到新工具，需在 Agent capabilities 里勾选或开启「延迟工具加载」让模型按需发现
+
+## 已知限制
+
+与 v0.1.0 一致，详见 [v0.1.0 release notes](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/docs/release-notes/v0.1.0.md#已知限制)。本版本额外补充：
+
+- **飞书招聘模块需企业版开通**：未开通的租户调 `feishu_hire_*` 会返回 `1061004`
+- **飞书云盘上传单文件 ≤ 20 MB**：>20 MB 需走分片上传 v2，留待 v0.3+
+- **包管理器路径下的应用内自动更新会提示先用包管理器升级**：避免与系统包数据库脱节
+
+## 完整变更日志
+
+详见 [CHANGELOG.md](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/CHANGELOG.md#020---2026-05-13)。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.1.1"
+version = "0.2.0"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",
@@ -16,7 +16,10 @@
         "title": "Hope Agent",
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 8, "y": 18 },
+        "trafficLightPosition": {
+          "x": 8,
+          "y": 18
+        },
         "width": 1200,
         "height": 800,
         "minWidth": 840,
@@ -30,7 +33,10 @@
       "csp": "default-src 'self' ipc: http://ipc.localhost; script-src 'self' ipc: http://ipc.localhost; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost data: blob: https: http:; font-src 'self' data:; media-src 'self' asset: http://asset.localhost data: blob:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:* wss://localhost:* http://localhost:* http://127.0.0.1:* https://127.0.0.1:* https:; frame-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'",
       "assetProtocol": {
         "enable": true,
-        "scope": ["$RESOURCE/**", "$HOME/.hope-agent/**"]
+        "scope": [
+          "$RESOURCE/**",
+          "$HOME/.hope-agent/**"
+        ]
       }
     }
   },
@@ -53,11 +59,16 @@
       },
       "digestAlgorithm": "sha256",
       "wix": {
-        "language": ["en-US", "zh-CN"]
+        "language": [
+          "en-US",
+          "zh-CN"
+        ]
       },
       "nsis": {
         "installMode": "perMachine",
-        "languages": ["English"]
+        "languages": [
+          "English"
+        ]
       }
     },
     "linux": {
@@ -70,7 +81,9 @@
   "plugins": {
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDMxNjgyN0E5ODY0MzM4RDIKUldUU09FT0dxU2RvTVRGWW5IN3lkMkE2b05mRW4wUk0wak5yUHQvMjNNaTdXYVR6RjlxbmVUcC8K",
-      "endpoints": ["https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json"],
+      "endpoints": [
+        "https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json"
+      ],
       "windows": {
         "installMode": "passive"
       }


### PR DESCRIPTION
## Summary

- 版本号 bump：`0.1.1` → `0.2.0`（package.json / src-tauri/Cargo.toml / src-tauri/tauri.conf.json / Cargo.lock）
- CHANGELOG `[Unreleased]` → `[0.2.0] - 2026-05-13`
- 双语 release notes 重写：[`docs/release-notes/v0.2.0.md`](docs/release-notes/v0.2.0.md) + [`v0.2.0.en.md`](docs/release-notes/v0.2.0.en.md)，按面向用户视角分六大主题（安装铺设 / 自助升级 / 飞书工作空间 / IM 入站附件 12 渠道一致性 / 会话生命周期 / 生产力增强）

## Release notes

详见 [`docs/release-notes/v0.2.0.md`](docs/release-notes/v0.2.0.md)。release.yml 在 tag 推送后会自动把这份内容注入 GitHub Release body 与 `latest.json#notes`。

## Test plan

- [x] `pnpm release:verify -- --tag v0.2.0` 通过
- [x] pre-push hook 六项检查全绿（cargo fmt / clippy / test，pnpm typecheck / lint / test）
- [ ] CI 8 项 status check 全绿
- [ ] merge 后在 main HEAD 打 `v0.2.0` tag 触发 release.yml
- [ ] 等三平台构建完成后人工审 draft Release 并 publish
- [ ] publish 后切 `release/v0.2` 长期维护分支