### PR TITLE
fix(release): release:verify 正则兼容 CRLF 行尾

### DIFF
--- a/scripts/verify-release-version.mjs
+++ b/scripts/verify-release-version.mjs
@@ -29,7 +29,7 @@ if (!cargoVersionMatch) {
 }
 
 const cargoLock = readFileSync(cargoLockPath, "utf8")
-const cargoLockHopeAgentMatch = cargoLock.match(/name = "hope-agent"\nversion = "(.*)"/)
+const cargoLockHopeAgentMatch = cargoLock.match(/name = "hope-agent"\r?\nversion = "(.*)"/)
 
 if (!cargoLockHopeAgentMatch) {
   console.error("[release:verify] could not find hope-agent version in Cargo.lock")


### PR DESCRIPTION
## Summary

[scripts/verify-release-version.mjs](scripts/verify-release-version.mjs) 第 32 行的正则硬编码 `\n` 匹配 Cargo.lock 中 `name = "hope-agent"` 与 `version = "..."` 之间的换行,但 Windows runner 默认 git `autocrlf=true` 把文本转 CRLF,匹配失败。

v0.2.0 release.yml [Run 25780901119](https://github.com/shiwenwen/hope-agent/actions/runs/25780901119) 的 windows-x64 job 在 "Verify tag matches app version" 步骤就 fail,Linux / macOS 默认 LF 不受影响。

修复:把 `\n` 改成 `\r?\n` 兼容两种行尾。

## Test plan

- [x] 本地 macOS `pnpm release:verify -- --tag v0.2.0` 仍通过(LF)
- [ ] CI 8 项 status check 全绿
- [ ] merge 后处理 v0.2.0 release(取消旧 run + 删旧 tag + 重打 tag)