### PR TITLE
fix(release): bare-binary 路径走 workspace target/ 而非 src-tauri/target/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,11 +204,11 @@ jobs:
         run: |
           set -euo pipefail
           case "${{ matrix.platform }}" in
-            macos-arm64) target_dir=src-tauri/target/aarch64-apple-darwin/release; plat=darwin-aarch64; ext="";;
-            macos-x64)   target_dir=src-tauri/target/x86_64-apple-darwin/release; plat=darwin-x86_64; ext="";;
-            linux-x64)   target_dir=src-tauri/target/release; plat=linux-x86_64;  ext="";;
-            linux-arm64) target_dir=src-tauri/target/release; plat=linux-aarch64; ext="";;
-            windows-x64) target_dir=src-tauri/target/release; plat=windows-x86_64; ext=".exe";;
+            macos-arm64) target_dir=target/aarch64-apple-darwin/release; plat=darwin-aarch64; ext="";;
+            macos-x64)   target_dir=target/x86_64-apple-darwin/release; plat=darwin-x86_64; ext="";;
+            linux-x64)   target_dir=target/release; plat=linux-x86_64;  ext="";;
+            linux-arm64) target_dir=target/release; plat=linux-aarch64; ext="";;
+            windows-x64) target_dir=target/release; plat=windows-x86_64; ext=".exe";;
             *) echo "unknown matrix platform ${{ matrix.platform }}"; exit 1;;
           esac
           bin_path="$target_dir/hope-agent$ext"


### PR DESCRIPTION
## Summary

Hope Agent 是 Cargo workspace([Cargo.toml](Cargo.toml) members: crates/ha-core, crates/ha-server, src-tauri),tauri build 输出的 binary 落在 workspace 根 target/<triple>/release/,不在 src-tauri/target/.

[release.yml](.github/workflows/release.yml) 第 207-211 行的 5 个 \`target_dir\` 全部写错前缀,v0.2.0 第一次实战 bare-binary step 在 macOS arm64 直接 fail:

\`\`\`
Bare binary not found at src-tauri/target/aarch64-apple-darwin/release/hope-agent
ls: src-tauri/target/aarch64-apple-darwin/release: No such file or directory
\`\`\`

修复:5 个 target_dir 路径都去掉 \`src-tauri/\` 前缀。

## Test plan

- [x] 本地 grep 确认无残留 \`src-tauri/target\` 引用
- [ ] CI 8 项 status check 全绿
- [ ] merge 后处理 v0.2.0 release(删旧 tag + 重打 tag)