### PR TITLE
fix(release): rust-cache workspaces 走 workspace 根而非 src-tauri/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: "./src-tauri -> target"
+          workspaces: ". -> target"
 
       # Windows MSVC + vendored OpenSSL needs NASM. Use Chocolatey
       # instead of ilammy/setup-nasm (upstream still on Node 20, see


### PR DESCRIPTION
## Summary

[release.yml:90](.github/workflows/release.yml#L90) 的 rust-cache 配置:

\`\`\`yaml
workspaces: \"./src-tauri -> target\"  # 错: src-tauri 不是 workspace 根
\`\`\`

Hope Agent 是 Cargo workspace,真实 cargo target 在仓库根 \`./target/\`,不在 \`src-tauri/target/\`. 这与 #169 修的 bare-binary 路径是同根问题(workspace target 路径在 release.yml 写错). 这条 cache 配置从未真的命中过——副作用是每次 release CI 都从零编译(~40 min/run).

改为 \`\". -> target\"\`. [ha-server build.rs](crates/ha-server/build.rs) 已声明 \`cargo:rerun-if-changed=dist\`,Vite 产出新 \`./dist/\` 仍会触发 ha-server 重编 + rust-embed 重嵌入,**web GUI 新鲜度不受影响**.

## 关于 PR #169

本 commit 原本是 PR #169 的第二个 commit,push 后 GitHub PR API head_sha 同步延迟,merge 时该 commit 还没反映在 PR 上,实际只合入了第一个 commit. 这里单开 PR 把它带回来.

## Test plan

- [x] 本地确认 \`rust.yml\` / \`lint.yml\` 默认 workspace 配置已经对
- [x] CI 8 项 status check 全绿
- [x] merge 后处理 v0.2.0 release(删旧 tag + 重打 tag,在含两次修复的 main HEAD 上)