### PR TITLE
fix(release): 临时移除 macos-x64 lane,救 v0.2.0 发版

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,17 +31,13 @@ jobs:
             os: macos-14
             rust_target: aarch64-apple-darwin
             args: "--target aarch64-apple-darwin"
-          # macOS x64 — Intel DMG, native build on the last Intel-hosted
-          # GitHub runner (macos-13). Without this lane Intel Macs would
-          # have to run the arm64 bundle through Rosetta 2 — it works,
-          # but startup is slower and memory / battery worse. macos-13
-          # is the only GitHub-hosted Intel macOS image as of 2026; when
-          # it is eventually deprecated we will need a self-hosted runner
-          # or a paid alternative.
-          - platform: macos-x64
-            os: macos-13
-            rust_target: x86_64-apple-darwin
-            args: "--target x86_64-apple-darwin"
+          # macOS x64 lane temporarily disabled: GitHub-hosted macos-13
+          # Intel runner pool is heavily congested as of 2026-05; v0.2.0
+          # release blocked >1h with this job stuck in queue while every
+          # other platform finished. Intel Mac users continue to run the
+          # arm64 bundle through Rosetta 2 (same as v0.1.x). Re-enable
+          # in v0.2.1 once we have either a fallback to cross-compile on
+          # macos-14 or a self-hosted runner.
           # Linux x64 — AppImage + deb.
           # ubuntu-24.04 is required because xcap (screen capture) pulls
           # libspa-sys v0.9, which expects pipewire ≥ 1.0 headers. The

--- a/docs/release-notes/v0.2.0.en.md
+++ b/docs/release-notes/v0.2.0.en.md
@@ -10,7 +10,6 @@ This is the first feature release after the v0.1 line. Three themes: minimize th
 
 ## Distribution coverage filled in
 
-- **macOS Intel native DMG + dual-arch Homebrew Cask**: the release pipeline now has an Intel macOS build lane and ships both `aarch64.dmg` and `x64.dmg`, so Intel Macs no longer go through Rosetta 2. The Homebrew tap [`shiwenwen/hope-agent`](https://github.com/shiwenwen/homebrew-hope-agent) picks the right binary by host architecture — install via `brew install --cask shiwenwen/hope-agent/hope-agent`.
 - **Windows Scoop install**: `scoop bucket add hope-agent https://github.com/shiwenwen/scoop-hope-agent && scoop install hope-agent`. Scoop unpacks the NSIS installer with 7zip to obtain a single-file binary; both the GUI launcher and the `hope-agent` command line are wired up afterward.
 - **Arch Linux AUR install**: `yay -S hope-agent-bin` (or paru / any AUR helper). Both x86_64 and aarch64 are supported (Asahi Linux benefits).
 - **Self-hosted Debian / Ubuntu / Fedora / RHEL repos**: `apt install hope-agent` / `dnf install hope-agent` in one line. Hosted on GitHub Pages with metadata signed by a dedicated ed25519 GPG key. Setup steps are documented in [`README.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/README.en.md) under the end-user section.
@@ -75,6 +74,7 @@ iMessage and IRC don't carry media at the protocol level — not in scope.
 
 Same as v0.1.0 — see the [v0.1.0 release notes](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/docs/release-notes/v0.1.0.en.md#known-limitations). Additional notes for this release:
 
+- **macOS Intel native DMG not shipped this release**: GitHub-hosted `macos-13` Intel runners were congested when v0.2.0 was cut, so this release only ships the macOS arm64 DMG. Intel Mac users continue to run the arm64 bundle through Rosetta 2 (same as v0.1.x); the Homebrew tap stays single-arch for now. v0.2.1 will bring back the Intel native build and the dual-arch cask.
 - **Feishu Hire module is enterprise-only**: tenants without it see error code `1061004` when calling `feishu_hire_*`.
 - **Feishu Drive upload caps single-file uploads at ≤ 20 MB**: anything larger needs segmented upload v2, deferred to v0.3+.
 - **In-app auto-update on package-manager installs nudges you to use the package manager**: avoids drifting from the system package database.

--- a/docs/release-notes/v0.2.0.md
+++ b/docs/release-notes/v0.2.0.md
@@ -10,7 +10,6 @@
 
 ## 安装与分发全面铺设
 
-- **macOS Intel 原生 DMG + Homebrew Cask 双架构**：发版流水线新增 Intel macOS 构建线，同时产出 `aarch64.dmg` 与 `x64.dmg`，Intel Mac 不再走 Rosetta 2；Homebrew tap [`shiwenwen/hope-agent`](https://github.com/shiwenwen/homebrew-hope-agent) 改为按硬件自动选对版本，命令 `brew install --cask shiwenwen/hope-agent/hope-agent`
 - **Windows Scoop 安装**：`scoop bucket add hope-agent https://github.com/shiwenwen/scoop-hope-agent && scoop install hope-agent`，Scoop 用 7zip 解压 NSIS installer 得到单文件 binary，安装后 GUI 启动器与 `hope-agent` 命令行均可用
 - **Arch Linux AUR 安装**：`yay -S hope-agent-bin`（或 paru / 任意 AUR helper），同时支持 x86_64 与 aarch64（Asahi Linux 受益）
 - **Debian / Ubuntu / Fedora / RHEL 自建软件源**：`apt install hope-agent` / `dnf install hope-agent` 一行装好。源托管在 GitHub Pages，metadata 由专用 ed25519 GPG 密钥签名，安装步骤见 [`README.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/README.md) 普通用户段
@@ -75,6 +74,7 @@ iMessage 与 IRC 协议本身不传媒体，未涉及。
 
 与 v0.1.0 一致，详见 [v0.1.0 release notes](https://github.com/shiwenwen/hope-agent/blob/v0.2.0/docs/release-notes/v0.1.0.md#已知限制)。本版本额外补充：
 
+- **macOS Intel 原生 DMG 本版未产出**：GitHub macos-13 Intel runner 池排队拥堵导致 v0.2.0 发版被卡，本版 Release 仅产出 macOS arm64 DMG；Intel Mac 用户继续通过 Rosetta 2 跑 arm64 DMG（与 v0.1.x 体验一致），Homebrew tap 也临时保持单架构。v0.2.1 补齐 Intel 原生构建与双架构 cask
 - **飞书招聘模块需企业版开通**：未开通的租户调 `feishu_hire_*` 会返回 `1061004`
 - **飞书云盘上传单文件 ≤ 20 MB**：>20 MB 需走分片上传 v2，留待 v0.3+
 - **包管理器路径下的应用内自动更新会提示先用包管理器升级**：避免与系统包数据库脱节


### PR DESCRIPTION
## 紧急 fix

GitHub macos-13 Intel runner 池排队拥堵,v0.2.0 release 连续两次被这个 job 卡 >70 分钟仍未分到 runner. 其他 4 个平台都已跑完且 [patch-manifest](.github/workflows/release.yml#L257-L259) 必须等所有 build 完成(\`needs: build\`),整个发版死锁.

## 改动

- [release.yml:30-44](.github/workflows/release.yml#L30): 删 \`macos-x64\` build entry,留注释说明 v0.2.1 恢复
- [v0.2.0.md](docs/release-notes/v0.2.0.md) + [v0.2.0.en.md](docs/release-notes/v0.2.0.en.md): 删「macOS Intel 原生 DMG + Homebrew Cask 双架构」段,加「已知限制」一条说明本版未产出,后续 v0.2.1 补齐

## 影响

- v0.2.0 仅产出 macOS arm64 DMG + Linux x64/arm64 + Windows x64
- Intel Mac 用户继续走 Rosetta 2(与 v0.1.x 体验一致)
- [update-homebrew-tap.yml:69](.github/workflows/update-homebrew-tap.yml#L69) 拉 x64.dmg 会 fail → tap repo 本版不更新,brew 用户继续看到 v0.1.2 cask 直到 v0.2.1 修复(release notes 已声明)

## v0.2.1 follow-up

- 评估 macos-x64 lane 恢复方案:cross-compile on macos-14 / self-hosted Intel runner
- 修复 update-homebrew-tap.yml 双架构渲染逻辑
- 修复 cask 模板

## Test plan

- [x] 本地 grep 确认 release.yml 无残留 \`macos-x64\` matrix entry
- [ ] CI 8 项 status check 全绿
- [ ] merge 后处理 v0.2.0 release(删旧 tag + 重打 tag → 仅 4 个 build job 跑)