### PR TITLE
fix(release): F-090 PR 阶段验证 release.yml 改动(Layer 1 + Layer 2)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,6 +39,14 @@ jobs:
       - name: Updater pubkey sync check
         run: node scripts/verify-updater-pubkey.mjs
 
+      # Catch release.yml / update-*.yml path bugs at PR time instead of
+      # at tag-push time. Covers the workspace target/ vs src-tauri/target/
+      # mismatch that took down v0.2.0 release three times in a row, plus
+      # cross-workflow artifact-name consistency (e.g. update-homebrew-tap
+      # still trying to download a DMG that release.yml stopped producing).
+      - name: Release workflow path consistency
+        run: node scripts/check-release-paths.mjs
+
       # Informational only for now: the repo carries ~3.3k historical missing
       # keys across the 10 non-baseline locales (en/zh are the source of truth).
       # Once that backlog is paid down, drop `continue-on-error` to make this

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
         description: Release tag to build (for example v0.1.1)
         required: true
         type: string
+      dry_run:
+        description: "Validate release.yml changes — build the matrix and skip every publish step (no draft Release, no asset upload, no latest.json patch). Use when modifying this workflow."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -118,6 +123,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Verify tag matches app version
+        # Dry-runs may use a fake tag input (e.g. v9.9.9) that intentionally
+        # does not match the source-tree version — skip this gate so an
+        # in-progress version bump can still run the validation matrix.
+        if: github.event.inputs.dry_run != 'true'
         run: pnpm release:verify -- --tag "${{ env.RELEASE_TAG }}"
 
       # Refuse to ship if the desktop bundle (`tauri-plugin-updater`) and
@@ -169,6 +178,7 @@ jobs:
           Write-Host "vc_redist.x64.exe Authenticode signature OK ($subject)"
 
       - name: Build & draft release
+        if: github.event.inputs.dry_run != 'true'
         uses: tauri-apps/tauri-action@v0.5.14
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -182,6 +192,22 @@ jobs:
           prerelease: false
           includeUpdaterJson: true
           args: ${{ matrix.args }}
+
+      # Dry-run replacement for tauri-action above: build the desktop
+      # bundle locally without creating a draft Release or uploading
+      # assets. Produces the same target/<triple>/release/hope-agent[.exe]
+      # path so the bare-binary step below can validate it. Same
+      # secrets passed through so signer-sign mismatches surface here
+      # too. (`pnpm tauri build` is what tauri-action invokes internally.)
+      - name: Dry-run build (skip publish)
+        if: github.event.inputs.dry_run == 'true'
+        shell: bash
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          pnpm tauri build ${{ matrix.args }}
 
       # ── Bare-binary artifact for headless self-update ─────────
       # The desktop installers above cover GUI users; `hope-agent server`
@@ -230,6 +256,7 @@ jobs:
           echo "sig=$archive.sig" >> "$GITHUB_OUTPUT"
 
       - name: Upload bare binary to release
+        if: github.event.inputs.dry_run != 'true'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -253,6 +280,10 @@ jobs:
   patch-manifest:
     name: patch latest.json
     needs: build
+    # Skip in dry-run — no draft Release exists to patch, and latest.json
+    # rewriting is exactly what we want to validate without polluting the
+    # real release stream.
+    if: github.event.inputs.dry_run != 'true'
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -324,6 +324,46 @@ git cherry-pick -x <sha>     # 加 (cherry picked from commit <sha>)
 | 误用 `git merge release/X.Y → main` | 把维护分支历史污染进 main，AGENTS.md 红线违反 | 只 cherry-pick |
 | 新 minor 发版前忘了切 `release/X.Y` 分支 | patch 修复无处落，紧急修复需要回退 main 历史 | §2.3 minor 发布后立即切维护分支 |
 | 改 workflow job 名后没同步 ruleset | PR 卡在 status check 等待已不存在的 job | 见 AGENTS.md "## 分支与发布" 末尾 |
+| 改 [`release.yml`](../.github/workflows/release.yml) 但没在 PR 阶段验证 | tag push 后跑真实 release 才 fail，删 tag 重打+又一轮 CI 等待。v0.2.0 三次因此返工 | PR CI 会跑 [`scripts/check-release-paths.mjs`](../scripts/check-release-paths.mjs) 静态校验（路径/双架构/必备 platform）；进一步可手动跑 dry-run（见 §4.1） |
+
+### 4.1 修改 release.yml 时的验证流程
+
+任何动 [`release.yml`](../.github/workflows/release.yml) 或 `update-*.yml` 的 PR，按下面两层防护：
+
+**Layer 1 — 自动静态校验**（PR CI 必跑，秒级）
+
+[`.github/workflows/lint.yml`](../.github/workflows/lint.yml) 跑 `node scripts/check-release-paths.mjs`，验证：
+
+- 每个 platform matrix 的 `target_dir=...` 不带 `src-tauri/` 前缀（Hope Agent 是 Cargo workspace，binary 在仓库根 `./target/`）
+- Swatinem/rust-cache `workspaces:` 不指向 src-tauri 子目录
+- `update-homebrew-tap.yml` / `update-aur.yml` / `update-scoop-bucket.yml` / `update-linux-repo.yml` 引用的 release artifact 文件名模式与 [release.yml](../.github/workflows/release.yml) 实际产出对得上（缺哪个 platform 就 fail / warn）
+- matrix 包含 4 个必备 platform（`macos-arm64` / `linux-x64` / `linux-arm64` / `windows-x64`）
+
+本地手动跑：`pnpm check:release-paths`。任何输出 `errors:` 段都会让 PR CI fail。
+
+**Layer 2 — 手动 dry-run**（建议但不强制，~30~40 min）
+
+不确定改动会不会 break 真实 build 时，触发一次 dry-run：
+
+1. 打开 [Actions → Release workflow](https://github.com/shiwenwen/hope-agent/actions/workflows/release.yml)
+2. 点 "Run workflow" → branch 选 PR 分支
+3. **`tag`** 填一个 sentinel 如 `v0.0.0-dryrun`（不真存在的 tag，verify 步骤自动跳过）
+4. **`dry_run`** 勾选为 `true`
+5. 跑 → 全 5 平台的 build 矩阵会跑（含 bare-binary path check + signer sign 验证），但跳过：
+   - tauri-action 的 draft Release 创建
+   - bare-binary upload to release
+   - patch-manifest job
+6. 产物可在 workflow run 的 `Artifacts` 段下载（`bare-binary-<platform>` artifact）
+
+dry-run **不**改任何 GitHub 状态：不打 tag、不创建 Release、不污染 latest.json。失败重跑无副作用。
+
+**何时必跑 dry-run**：
+
+- 改了 [release.yml](../.github/workflows/release.yml) `Bundle + sign bare binary` step 的 path/case 分支
+- 改了 matrix 配置（platform / runner / target / args）
+- 改了 [`tauri.conf.json`](../src-tauri/tauri.conf.json) 的 `beforeBuildCommand` / `frontendDist` 或 bundle config
+- 引入新的 platform-specific build deps（apt deps / NASM / 等）
+- 单纯改 release notes / version bump：不用跑
 
 ---
 
@@ -336,6 +376,7 @@ git cherry-pick -x <sha>     # 加 (cherry picked from commit <sha>)
 | `pnpm version X.Y.Z --no-git-tag-version` | 同步版本号到三处文件，不创建 commit/tag | [package.json](../package.json) `scripts.version` → [scripts/sync-version.mjs](../scripts/sync-version.mjs) |
 | `pnpm sync:version` | 手动重新同步（一般不用，version 命令自动调） | 同上 |
 | `pnpm release:verify -- --tag vX.Y.Z` | 校验三处版本号一致 + 与 tag 名匹配 | [scripts/verify-release-version.mjs](../scripts/verify-release-version.mjs) |
+| `pnpm check:release-paths` | 静态校验 release.yml / update-*.yml 路径与 platform 一致性 | [scripts/check-release-paths.mjs](../scripts/check-release-paths.mjs) |
 
 ### 5.2 关键文件
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "preview": "vite preview",
     "sync:version": "node scripts/sync-version.mjs",
     "release:verify": "node scripts/verify-release-version.mjs",
+    "check:release-paths": "node scripts/check-release-paths.mjs",
     "fetch:vcredist": "node scripts/fetch-vcredist.mjs",
     "tauri": "tauri",
     "version": "node scripts/sync-version.mjs",

--- a/scripts/check-release-paths.mjs
+++ b/scripts/check-release-paths.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+// Static validator for release-related GitHub Actions workflows.
+// Catches the classes of bugs that took down the v0.2.0 release three
+// times in a row:
+//   1. cargo target_dir written as `src-tauri/target/...` while Hope
+//      Agent is a Cargo workspace (real target lives in `./target/`).
+//   2. Swatinem/rust-cache `workspaces:` pointing at `./src-tauri ->
+//      target` for the same reason — the cache never hits.
+//   3. update-*.yml referencing release artifact filename patterns that
+//      release.yml no longer produces (e.g. `x64.dmg` after the
+//      macos-x64 lane was temporarily removed in v0.2.0).
+//
+// Runs in PR CI on any change to .github/workflows/*.yml or this
+// script. Exits non-zero on any check failure.
+
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(__dirname, "..")
+
+const errors = []
+const warnings = []
+
+function readWorkflow(name) {
+  return readFileSync(path.join(repoRoot, ".github", "workflows", name), "utf8")
+}
+
+// ─── Check 1 ─────────────────────────────────────────────────────────
+// release.yml bare-binary step: every `target_dir=...` must start with
+// `target/`, never `src-tauri/target/`. Hope Agent is a Cargo workspace
+// — cargo writes binaries to the workspace root target/, not to the
+// src-tauri member subdirectory.
+{
+  const release = readWorkflow("release.yml")
+  const targetDirMatches = [...release.matchAll(/target_dir=([^\s;)]+)/g)]
+  if (targetDirMatches.length === 0) {
+    errors.push("release.yml: expected at least one target_dir= assignment in bare-binary step, found none")
+  }
+  for (const m of targetDirMatches) {
+    const value = m[1]
+    if (value.startsWith("src-tauri/")) {
+      errors.push(
+        `release.yml: target_dir="${value}" starts with src-tauri/ — Hope Agent is a Cargo workspace, cargo writes to repo-root ./target/, not src-tauri/target/. Drop the src-tauri/ prefix.`,
+      )
+    } else if (!value.startsWith("target/") && value !== "target") {
+      errors.push(
+        `release.yml: target_dir="${value}" does not start with target/ — bare-binary step expects cargo output paths.`,
+      )
+    }
+  }
+}
+
+// ─── Check 2 ─────────────────────────────────────────────────────────
+// Swatinem/rust-cache `workspaces:` value. Should point at workspace
+// root (".") or a sibling crate path that contains a Cargo.toml with
+// `[workspace]`, never the src-tauri member by itself.
+{
+  const release = readWorkflow("release.yml")
+  const wsMatch = release.match(/Swatinem\/rust-cache[\s\S]*?workspaces:\s*"([^"]+)"/)
+  if (!wsMatch) {
+    warnings.push("release.yml: no Swatinem/rust-cache workspaces: value found (or format changed) — skip rust-cache check")
+  } else {
+    const value = wsMatch[1]
+    // Format: "<dir1> -> target<sep><dir2> -> target..." but value
+    // must reference the workspace root, not the src-tauri member.
+    if (/^\.?\/?src-tauri\b/.test(value)) {
+      errors.push(
+        `release.yml: rust-cache workspaces="${value}" points at src-tauri/ — Hope Agent is a Cargo workspace, cache target lives at repo-root ./target/. Use ". -> target".`,
+      )
+    }
+  }
+}
+
+// ─── Check 3 ─────────────────────────────────────────────────────────
+// Cross-workflow artifact-name consistency. update-homebrew-tap.yml /
+// update-aur.yml / update-scoop-bucket.yml / update-linux-repo.yml all
+// download specific filename patterns from the GitHub Release. If
+// release.yml stops producing a pattern (e.g. macos-x64 lane removed),
+// the downstream workflow will fail silently — leaving package
+// managers stuck on the prior version.
+//
+// We can't tell from release.yml *exactly* what tauri-action will name
+// the bundle, but we can detect "downstream wants pattern P, but
+// release.yml's matrix has no platform that produces P".
+
+const matrixPlatforms = (() => {
+  const release = readWorkflow("release.yml")
+  const matrixSection = release.match(/strategy:\s*\n([\s\S]*?)runs-on:/)
+  if (!matrixSection) return new Set()
+  return new Set(
+    [...matrixSection[1].matchAll(/-\s+platform:\s*(\S+)/g)].map((m) => m[1]),
+  )
+})()
+
+// Map of (filename-pattern fragment) → required platform.
+// Only catches gross mismatches; signatures-of-truth in tauri.conf.json
+// are not parsed here.
+const downstreamArtifactDeps = [
+  {
+    workflow: "update-homebrew-tap.yml",
+    fragment: "x64.dmg",
+    requires: "macos-x64",
+    severity: "warn",
+  },
+  {
+    workflow: "update-homebrew-tap.yml",
+    fragment: "aarch64.dmg",
+    requires: "macos-arm64",
+    severity: "error",
+  },
+  {
+    workflow: "update-aur.yml",
+    fragment: "amd64.deb",
+    requires: "linux-x64",
+    severity: "error",
+  },
+  {
+    workflow: "update-scoop-bucket.yml",
+    fragment: "x64-setup.exe",
+    requires: "windows-x64",
+    severity: "error",
+  },
+  {
+    workflow: "update-linux-repo.yml",
+    fragment: "amd64.deb",
+    requires: "linux-x64",
+    severity: "error",
+  },
+  {
+    workflow: "update-linux-repo.yml",
+    fragment: "x86_64.rpm",
+    requires: "linux-x64",
+    severity: "error",
+  },
+]
+
+for (const dep of downstreamArtifactDeps) {
+  let yml
+  try {
+    yml = readWorkflow(dep.workflow)
+  } catch {
+    warnings.push(`Cross-check skipped: ${dep.workflow} not found.`)
+    continue
+  }
+  if (!yml.includes(dep.fragment)) continue
+  if (matrixPlatforms.has(dep.requires)) continue
+  const message = `${dep.workflow} references artifact pattern "${dep.fragment}" but release.yml matrix has no platform "${dep.requires}" — downstream workflow will fail on release publish.`
+  if (dep.severity === "error") errors.push(message)
+  else warnings.push(message + " (warn-only: this dependency is known-broken and tracked as a follow-up.)")
+}
+
+// ─── Check 4 ─────────────────────────────────────────────────────────
+// release.yml must include at least the 4 platforms required for the
+// updater manifest's bare_binary entries to be useful: macos-arm64,
+// linux-x64, linux-arm64, windows-x64. macos-x64 is currently optional
+// (temporarily removed in v0.2.0; recovery tracked as F-088).
+const requiredPlatforms = ["macos-arm64", "linux-x64", "linux-arm64", "windows-x64"]
+for (const p of requiredPlatforms) {
+  if (!matrixPlatforms.has(p)) {
+    errors.push(`release.yml matrix is missing required platform "${p}" — releases without it ship broken bare-binary manifests for that OS/arch.`)
+  }
+}
+
+// ─── Report ──────────────────────────────────────────────────────────
+if (warnings.length > 0) {
+  console.warn("[check-release-paths] warnings:")
+  for (const w of warnings) console.warn(`  - ${w}`)
+}
+if (errors.length > 0) {
+  console.error("[check-release-paths] errors:")
+  for (const e of errors) console.error(`  - ${e}`)
+  process.exit(1)
+}
+
+console.log(`[check-release-paths] OK — ${matrixPlatforms.size} platforms (${[...matrixPlatforms].join(", ")}), ${warnings.length} warning(s).`)


### PR DESCRIPTION
## Summary

v0.2.0 三次发版失败的根因都是 release.yml 改动没在 PR 阶段被 catch:
1. bare-binary 路径错(src-tauri/target vs target) → [#169](https://github.com/shiwenwen/hope-agent/pull/169)
2. rust-cache workspace 路径错 → [#170](https://github.com/shiwenwen/hope-agent/pull/170)
3. macos-x64 lane runner 池假设错 → [#172](https://github.com/shiwenwen/hope-agent/pull/172)

本 PR 加两层防线一次性 close [F-090](docs/plans/review-followups.md).

## Layer 1 — 自动静态校验(PR CI,秒级)

- 新增 [scripts/check-release-paths.mjs](scripts/check-release-paths.mjs),catch 已知错误模式:
  - bare-binary step 的 \`target_dir\` 不带 \`src-tauri/\` 前缀
  - Swatinem/rust-cache \`workspaces:\` 不指向 src-tauri 子目录
  - 下游 workflow(update-homebrew-tap / aur / scoop / linux-repo)引用的 artifact 文件名模式与 release.yml matrix 实际产出对得上
  - matrix 含 4 必备 platform(macos-arm64 / linux-x64 / linux-arm64 / windows-x64),少哪个就 fail
- [lint.yml](.github/workflows/lint.yml) 加 'Release workflow path consistency' step,任何 PR 改 .github/workflows/*.yml 自动跑
- 本地手动:\`pnpm check:release-paths\`

## Layer 2 — 手动 dry-run(workflow_dispatch,~30-40 min)

- [release.yml](.github/workflows/release.yml) workflow_dispatch 加 \`dry_run: boolean\` input. dry-run 时:
  - 跳过 'Verify tag matches app version'(允许 sentinel tag 如 \`v0.0.0-dryrun\`)
  - 跳过 tauri-action(避免创建 stray draft Release)
  - 新增 'Dry-run build (skip publish)' step 直接调 \`pnpm tauri build\`(产物路径与 tauri-action 内部调用相同)
  - bare-binary path-check + sign 仍跑(验证 signing 配置)
  - 跳过 'Upload bare binary to release' + patch-manifest job
  - 'Upload bare binary as workflow artifact' 仍跑,产物可下载验证
- 不改任何 GitHub 状态:不打 tag、不创建 Release、不污染 latest.json

## 文档

- [docs/release-process.md §4.1](docs/release-process.md) 加「修改 release.yml 时的验证流程」说明两层防线 + 何时必跑 dry-run
- §4 避坑表 + §5 命令速查同步更新

## 反向测试

本地把 release.yml 的 target_dir 改回 \`src-tauri/target/...\`,Layer 1 正确 catch:
\`\`\`
[check-release-paths] errors:
  - release.yml: target_dir=\"src-tauri/target/release\" starts with src-tauri/ — Hope Agent is a Cargo workspace...
\`\`\`

当前仓库实际跑(macos-x64 lane 已临时移除):
\`\`\`
[check-release-paths] warnings:
  - update-homebrew-tap.yml references artifact pattern \"x64.dmg\" but release.yml matrix has no platform \"macos-x64\"...
[check-release-paths] OK — 4 platforms ..., 1 warning(s).
\`\`\`
准确反映 [F-089](docs/plans/review-followups.md) 状态(warn-only 不阻塞).

## Test plan

- [x] 本地 \`pnpm check:release-paths\` 通过
- [x] 反向测试 catch 真实 bug
- [x] pre-push 六项检查全绿
- [ ] PR CI 8 项 status check 全绿
- [ ] **merge 后,在新一次 release.yml 改动(F-088 / F-089)PR 上验证 Layer 1 自动生效**

## 下一个 follow-up

按 [v0.2.1 follow-up 清单](docs/plans/review-followups.md):
- F-088 + F-089(macos-x64 lane 恢复 + Homebrew 双架构容错)— 借本 PR 的 dry-run 验证
- F-087(AboutPanel markdown 渲染)— 与 release pipeline 解耦,独立 PR