### PR TITLE
fix(release): F-088 + F-089 macos-x64 lane 恢复 + Homebrew tap 双架构容错

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,22 @@ jobs:
             os: macos-14
             rust_target: aarch64-apple-darwin
             args: "--target aarch64-apple-darwin"
-          # macOS x64 lane temporarily disabled: GitHub-hosted macos-13
-          # Intel runner pool is heavily congested as of 2026-05; v0.2.0
-          # release blocked >1h with this job stuck in queue while every
-          # other platform finished. Intel Mac users continue to run the
-          # arm64 bundle through Rosetta 2 (same as v0.1.x). Re-enable
-          # in v0.2.1 once we have either a fallback to cross-compile on
-          # macos-14 or a self-hosted runner.
+          # macOS x64 — Intel DMG, native build on macos-13. Re-enabled
+          # in v0.2.1 after the temporary v0.2.0 removal, this time wired
+          # as a "best-effort" lane: GitHub-hosted macos-13 runners are
+          # capacity-constrained and intermittently see >1h queue times
+          # (the v0.2.0 incident). `continue_on_error: true` lets the
+          # lane fail/timeout without blocking the rest of the release;
+          # the patch-manifest job below uses `!cancelled()` so
+          # latest.json + downstream package-manager workflows still run
+          # off the platforms that did succeed. Cross-compile on macos-14
+          # or a self-hosted Intel runner remains a longer-term option
+          # (F-088 follow-up).
+          - platform: macos-x64
+            os: macos-13
+            rust_target: x86_64-apple-darwin
+            args: "--target x86_64-apple-darwin"
+            continue_on_error: true
           # Linux x64 — AppImage + deb.
           # ubuntu-24.04 is required because xcap (screen capture) pulls
           # libspa-sys v0.9, which expects pipewire ≥ 1.0 headers. The
@@ -71,6 +80,9 @@ jobs:
             args: ""
 
     runs-on: ${{ matrix.os }}
+    # `continue_on_error` is set per-platform in the matrix (currently
+    # only macos-x64). Default false for every other lane.
+    continue-on-error: ${{ matrix.continue_on_error == true }}
     steps:
       - uses: actions/checkout@v6
 
@@ -280,10 +292,14 @@ jobs:
   patch-manifest:
     name: patch latest.json
     needs: build
-    # Skip in dry-run — no draft Release exists to patch, and latest.json
-    # rewriting is exactly what we want to validate without polluting the
-    # real release stream.
-    if: github.event.inputs.dry_run != 'true'
+    # `!cancelled()` lets the manifest patch run even when a best-effort
+    # build job (e.g. macos-x64) fails or times out — the latest.json
+    # rewrite is keyed off whichever bare-binary artifacts uploaded
+    # successfully, and `patch-latest-json.mjs` already warns-and-skips
+    # missing platforms. Without this guard, a single macos-x64 timeout
+    # would block the entire release from publishing.
+    # Also skip in dry-run — no draft Release exists to patch.
+    if: ${{ !cancelled() && github.event.inputs.dry_run != 'true' }}
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -58,7 +58,13 @@ jobs:
           echo "dmg_arm=Hope.Agent_${version}_aarch64.dmg" >> "$GITHUB_OUTPUT"
           echo "dmg_intel=Hope.Agent_${version}_x64.dmg" >> "$GITHUB_OUTPUT"
 
-      - name: Download both DMGs from release
+      # Download arm64 DMG (required) and Intel DMG (best-effort). The
+      # Intel lane in release.yml is best-effort (continue_on_error) and
+      # can fail when macos-13 runners are congested — in that case the
+      # release ships arm64-only and we render the single-arch cask
+      # template below.
+      - name: Download DMGs from release
+        id: download
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -66,47 +72,78 @@ jobs:
           gh release download "$TAG" \
             --repo "${{ github.repository }}" \
             --pattern "${{ steps.ver.outputs.dmg_arm }}" \
-            --pattern "${{ steps.ver.outputs.dmg_intel }}" \
             --dir .
-          ls -la "${{ steps.ver.outputs.dmg_arm }}" "${{ steps.ver.outputs.dmg_intel }}"
+          if [[ ! -f "${{ steps.ver.outputs.dmg_arm }}" ]]; then
+            echo "::error::arm64 DMG is mandatory but was not found in release $TAG"
+            exit 1
+          fi
+          ls -la "${{ steps.ver.outputs.dmg_arm }}"
 
-      - name: Compute SHA256 for both DMGs
+          # Intel DMG: try to fetch, tolerate absence.
+          if gh release download "$TAG" \
+              --repo "${{ github.repository }}" \
+              --pattern "${{ steps.ver.outputs.dmg_intel }}" \
+              --dir . 2>/dev/null && [[ -f "${{ steps.ver.outputs.dmg_intel }}" ]]; then
+            echo "has_intel=true" >> "$GITHUB_OUTPUT"
+            echo "Intel DMG found — will render dual-arch cask."
+            ls -la "${{ steps.ver.outputs.dmg_intel }}"
+          else
+            echo "has_intel=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Intel DMG not present in release $TAG — falling back to arm64-only cask."
+          fi
+
+      - name: Compute SHA256 for available DMGs
         id: sha
         run: |
           set -euo pipefail
-          for kind in arm intel; do
-            if [[ "$kind" == "arm" ]]; then
-              file="${{ steps.ver.outputs.dmg_arm }}"
-            else
-              file="${{ steps.ver.outputs.dmg_intel }}"
-            fi
-            sum=$(sha256sum "$file" | awk '{print $1}')
-            if [[ -z "$sum" || ${#sum} -ne 64 ]]; then
-              echo "::error::sha256sum returned unexpected output for $file: $sum"
+          arm_file="${{ steps.ver.outputs.dmg_arm }}"
+          arm_sum=$(sha256sum "$arm_file" | awk '{print $1}')
+          if [[ -z "$arm_sum" || ${#arm_sum} -ne 64 ]]; then
+            echo "::error::sha256sum returned unexpected output for $arm_file: $arm_sum"
+            exit 1
+          fi
+          echo "sha256_arm=$arm_sum" >> "$GITHUB_OUTPUT"
+          echo "$arm_file sha256: $arm_sum"
+
+          if [[ "${{ steps.download.outputs.has_intel }}" == "true" ]]; then
+            intel_file="${{ steps.ver.outputs.dmg_intel }}"
+            intel_sum=$(sha256sum "$intel_file" | awk '{print $1}')
+            if [[ -z "$intel_sum" || ${#intel_sum} -ne 64 ]]; then
+              echo "::error::sha256sum returned unexpected output for $intel_file: $intel_sum"
               exit 1
             fi
-            echo "sha256_$kind=$sum" >> "$GITHUB_OUTPUT"
-            echo "$file sha256: $sum"
-          done
+            echo "sha256_intel=$intel_sum" >> "$GITHUB_OUTPUT"
+            echo "$intel_file sha256: $intel_sum"
+          fi
 
       - name: Render cask from template
         run: |
           set -euo pipefail
           mkdir -p rendered/Casks
-          sed -e "s/__VERSION__/${{ steps.ver.outputs.version }}/g" \
-              -e "s/__SHA256_ARM__/${{ steps.sha.outputs.sha256_arm }}/g" \
-              -e "s/__SHA256_INTEL__/${{ steps.sha.outputs.sha256_intel }}/g" \
-              homebrew/hope-agent.rb.tmpl > rendered/Casks/hope-agent.rb
+          if [[ "${{ steps.download.outputs.has_intel }}" == "true" ]]; then
+            template=homebrew/hope-agent.rb.tmpl
+            sed -e "s/__VERSION__/${{ steps.ver.outputs.version }}/g" \
+                -e "s/__SHA256_ARM__/${{ steps.sha.outputs.sha256_arm }}/g" \
+                -e "s/__SHA256_INTEL__/${{ steps.sha.outputs.sha256_intel }}/g" \
+                "$template" > rendered/Casks/hope-agent.rb
+            placeholders='__VERSION__|__SHA256_ARM__|__SHA256_INTEL__'
+          else
+            template=homebrew/hope-agent-arm-only.rb.tmpl
+            sed -e "s/__VERSION__/${{ steps.ver.outputs.version }}/g" \
+                -e "s/__SHA256_ARM__/${{ steps.sha.outputs.sha256_arm }}/g" \
+                "$template" > rendered/Casks/hope-agent.rb
+            placeholders='__VERSION__|__SHA256_ARM__'
+          fi
 
           # Refuse to push if any placeholder leaked through — protects the
           # tap from a broken cask if the template ever drops the markers.
-          if grep -qE '__VERSION__|__SHA256_ARM__|__SHA256_INTEL__' rendered/Casks/hope-agent.rb; then
-            echo "::error::rendered cask still contains template placeholders"
+          if grep -qE "$placeholders" rendered/Casks/hope-agent.rb; then
+            echo "::error::rendered cask still contains template placeholders (from $template)"
             cat rendered/Casks/hope-agent.rb
             exit 1
           fi
 
-          echo "--- rendered Casks/hope-agent.rb ---"
+          echo "--- rendered Casks/hope-agent.rb (from $template) ---"
           cat rendered/Casks/hope-agent.rb
 
       - name: Checkout tap repo
@@ -138,10 +175,21 @@ jobs:
             exit 0
           fi
 
+          # Commit message reflects whether the Intel DMG was included
+          # in this sync — when arm64-only, downstream readers (and
+          # future maintainers) can grep the history to see when Intel
+          # support gapped out and came back.
+          if [[ "${{ steps.download.outputs.has_intel }}" == "true" ]]; then
+            sha_summary="arm64 DMG sha256: ${{ steps.sha.outputs.sha256_arm }}
+          x64   DMG sha256: ${{ steps.sha.outputs.sha256_intel }}"
+          else
+            sha_summary="arm64 DMG sha256: ${{ steps.sha.outputs.sha256_arm }}
+          (x64 DMG absent from this release — cask is arm64-only)"
+          fi
+
           git commit -m "hope-agent ${{ steps.ver.outputs.version }}
 
-          arm64 DMG sha256: ${{ steps.sha.outputs.sha256_arm }}
-          x64   DMG sha256: ${{ steps.sha.outputs.sha256_intel }}
+          $sha_summary
           Source: ${{ github.repository }}@$TAG
           "
           git push origin HEAD

--- a/homebrew/hope-agent-arm-only.rb.tmpl
+++ b/homebrew/hope-agent-arm-only.rb.tmpl
@@ -1,0 +1,75 @@
+cask "hope-agent" do
+  version "__VERSION__"
+  sha256 "__SHA256_ARM__"
+
+  url "https://github.com/shiwenwen/hope-agent/releases/download/v#{version}/Hope.Agent_#{version}_aarch64.dmg"
+  name "Hope Agent"
+  desc "Local-first AI assistant with cross-device sessions and IM channel routing"
+  homepage "https://github.com/shiwenwen/hope-agent"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  # Apple Silicon only — this release skipped the macOS Intel build lane
+  # (macos-13 runner capacity constraints in upstream release.yml).
+  # Intel Mac users should stay on the prior dual-arch release until the
+  # next version that ships an x64 DMG, or run this build through
+  # Rosetta 2 (same behavior as v0.1.x).
+  depends_on macos: ">= :big_sur", arch: :arm64
+
+  app "Hope Agent.app"
+
+  binary "#{appdir}/Hope Agent.app/Contents/MacOS/hope-agent"
+
+  caveats <<~EOS
+    This release ships only the Apple Silicon (arm64) DMG. Intel Macs
+    can still run it via Rosetta 2, but Homebrew will only let you
+    install this cask on Apple Silicon. To unblock Intel install,
+    download the arm64 DMG manually from
+    https://github.com/shiwenwen/hope-agent/releases.
+
+    The bundle is not yet code-signed or notarized. The installer clears
+    the macOS quarantine attribute so first launch should work without
+    extra steps, but you may still see a Gatekeeper warning. If macOS
+    refuses to open the app, run:
+
+      sudo xattr -cr "/Applications/Hope Agent.app"
+
+    Launch the desktop app from Launchpad/Spotlight, or `open -a "Hope Agent"`.
+
+    The `hope-agent` shell command is also installed for the headless modes:
+      hope-agent server start   # HTTP/WS daemon (no GUI)
+      hope-agent acp            # ACP stdio for IDE integrations
+
+    Updates are delivered by the app's built-in updater, not by Homebrew.
+    After install, `brew upgrade` will not touch this cask — the desktop
+    app prompts you when a new release is published, and the `hope-agent`
+    CLI shares the same binary so it stays in sync automatically. To force
+    a reinstall from this tap (for example to recover from a broken
+    install), run:
+
+      brew reinstall --cask hope-agent
+  EOS
+
+  postflight do
+    # Strip the quarantine xattr so first launch does not trip Gatekeeper
+    # for unsigned/un-notarized builds. Safe to ignore failures — if the
+    # xattr is already absent xattr returns non-zero.
+    system_command "/usr/bin/xattr",
+                   args: ["-rd", "com.apple.quarantine", "#{appdir}/Hope Agent.app"],
+                   sudo: false,
+                   must_succeed: false
+  end
+
+  zap trash: [
+    "~/Library/Application Support/ai.hopeagent.desktop",
+    "~/Library/Caches/ai.hopeagent.desktop",
+    "~/Library/Preferences/ai.hopeagent.desktop.plist",
+    "~/Library/Saved Application State/ai.hopeagent.desktop.savedState",
+    "~/Library/WebKit/ai.hopeagent.desktop",
+    "~/.hope-agent",
+  ]
+end


### PR DESCRIPTION
## Summary

恢复 v0.2.0 临时移除的 macos-x64 build lane(F-088),并修复 Homebrew tap 在 Intel DMG 缺失时的失败模式(F-089)。两者强耦合,在同一 PR 处理。

## F-088 — macos-x64 lane 作为 best-effort 恢复

### 策略

不在本期做 cross-compile / self-hosted runner(风险大、时间不可控)。改成「best-effort lane」:

- [release.yml:41-58](.github/workflows/release.yml#L41) 加回 \`macos-x64\` matrix entry,但加 \`continue_on_error: true\` matrix field
- build job 加 \`continue-on-error: \${{ matrix.continue_on_error == true }}\`,让该 lane 失败/超时不阻塞其他平台
- [release.yml patch-manifest](.github/workflows/release.yml) 加 \`if: !cancelled()\`,让部分 build 失败时 latest.json patch 仍能跑(patch-latest-json.mjs 已容错 missing platforms)

### 已知限制

GitHub-hosted macos-13 池资源持续紧张,排队超时可能让本 lane fail。每次 release 都跑,但不保证每次都成功。当前策略接受 Intel DMG 偶发缺失。Cross-compile / self-hosted 留作长期 F-088 follow-up。

## F-089 — Homebrew tap 双架构容错

### 新增

- [homebrew/hope-agent-arm-only.rb.tmpl](homebrew/hope-agent-arm-only.rb.tmpl) 单 arm 模板,\`depends_on arch: :arm64\`,Intel 用户引导手动下载或等下版本

### 改造 [update-homebrew-tap.yml](.github/workflows/update-homebrew-tap.yml)

- **arm64 DMG 强制**(没有就 fail——这是 macOS 主要受众,缺失视为 bug)
- **Intel DMG 容错下载**(缺失就 warn,转 arm-only 模板)
- sha256 计算按存在情况
- 渲染时根据 \`has_intel\` flag 选模板
- commit message 反映是否含 Intel(便于历史 grep)

## 跟 F-090 dogfooding

本 PR 不改 [scripts/check-release-paths.mjs](scripts/check-release-paths.mjs),但 PR CI 会自动跑该静态校验。验证 5 platforms 都在 + 0 warnings:

\`\`\`
[check-release-paths] OK — 5 platforms (macos-arm64, macos-x64, linux-x64, linux-arm64, windows-x64), 0 warning(s).
\`\`\`

如需进一步信心,可在 PR 分支上手动 trigger workflow_dispatch + dry_run=true 跑一次全 5 平台 dry-run([docs/release-process.md §4.1](docs/release-process.md))。

## Test plan

- [x] 本地 \`pnpm check:release-paths\` 通过(5 platforms,0 warnings)
- [x] pre-push 六项检查全绿
- [ ] PR CI 8 项 status check 全绿
- [ ] (可选)dry-run 验证 macos-x64 真能拉到 runner 跑通

## 关闭 follow-up

- Closes [F-088](docs/plans/review-followups.md)(best-effort 策略;cross-compile / self-hosted 作为后续 follow-up 单独记)
- Closes [F-089](docs/plans/review-followups.md)