### PR TITLE
fix(about): F-087 更新提示用 MarkdownRenderer 渲染 release notes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { toast } from "sonner"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { LightboxProvider } from "@/components/common/ImageLightbox"
 import ErrorBoundary from "@/components/common/ErrorBoundary"
+import MarkdownRenderer from "@/components/common/MarkdownRenderer"
 import ProviderSetup from "@/components/settings/ProviderSetup"
 import SettingsView from "@/components/settings/SettingsView"
 import type { SettingsSection } from "@/components/settings/types"
@@ -660,13 +661,16 @@ export default function App() {
                               ? `发现新版本 v${globalPendingUpdate.version}`
                               : `Update v${globalPendingUpdate.version}`}
                           </p>
-                          <div className="mt-2.5 max-h-[180px] overflow-y-auto pr-2 scrollbar-thin scrollbar-thumb-muted-foreground/20 hover:scrollbar-thumb-muted-foreground/40 scrollbar-track-transparent">
-                            <p className="text-xs text-muted-foreground leading-relaxed whitespace-pre-wrap">
-                              {globalPendingUpdate.body ||
-                                t("about.updateAvailable", {
+                          <div className="mt-2.5 max-h-[180px] overflow-y-auto pr-2 text-xs leading-relaxed text-muted-foreground scrollbar-thin scrollbar-thumb-muted-foreground/20 hover:scrollbar-thumb-muted-foreground/40 scrollbar-track-transparent">
+                            {globalPendingUpdate.body ? (
+                              <MarkdownRenderer content={globalPendingUpdate.body} />
+                            ) : (
+                              <p>
+                                {t("about.updateAvailable", {
                                   version: globalPendingUpdate.version,
                                 })}
-                            </p>
+                              </p>
+                            )}
                           </div>
                           <div className="mt-4 flex justify-end">
                             <button

--- a/src/components/settings/AboutPanel.tsx
+++ b/src/components/settings/AboutPanel.tsx
@@ -4,6 +4,7 @@ import type { LucideIcon } from "lucide-react"
 import { Brain, Download, ExternalLink, Globe, Loader2, Monitor, RefreshCw } from "lucide-react"
 import alphaLogoUrl from "@/assets/alpha-logo.png"
 import { Button } from "@/components/ui/button"
+import MarkdownRenderer from "@/components/common/MarkdownRenderer"
 import { HOPE_AGENT_URLS, useAppVersion } from "@/lib/appMeta"
 import {
   checkForDesktopUpdate,
@@ -272,7 +273,7 @@ export default function AboutPanel() {
 
             {pendingUpdate && (
               <div className="mt-5 overflow-hidden rounded-2xl border border-emerald-500/20 bg-gradient-to-r from-emerald-500/8 via-emerald-500/5 to-transparent">
-                <div className="flex flex-wrap items-center gap-3 px-5 py-4">
+                <div className="flex flex-wrap items-start gap-3 px-5 py-4">
                   <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-emerald-500/12">
                     <Download className="h-4.5 w-4.5 text-emerald-600 dark:text-emerald-400" />
                   </div>
@@ -281,14 +282,14 @@ export default function AboutPanel() {
                       {updateStatus}
                     </p>
                     {pendingUpdate.body && (
-                      <p className="mt-0.5 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
-                        {pendingUpdate.body}
-                      </p>
+                      <div className="mt-1 max-h-48 overflow-auto text-xs leading-relaxed text-muted-foreground">
+                        <MarkdownRenderer content={pendingUpdate.body} />
+                      </div>
                     )}
                   </div>
                   <Button
                     size="sm"
-                    className="shrink-0 gap-1.5 rounded-full bg-emerald-600 px-4 text-white shadow-sm transition-all hover:bg-emerald-700 hover:shadow-md active:scale-[0.97] dark:bg-emerald-500 dark:hover:bg-emerald-600"
+                    className="mt-1 shrink-0 gap-1.5 rounded-full bg-emerald-600 px-4 text-white shadow-sm transition-all hover:bg-emerald-700 hover:shadow-md active:scale-[0.97] dark:bg-emerald-500 dark:hover:bg-emerald-600"
                     onClick={handleInstallUpdate}
                     disabled={installingUpdate || checkingUpdate}
                   >


### PR DESCRIPTION
## Summary

v0.1.2 加「发现新版」弹窗时偷懒,把 \`latest.json#notes\` 直接 \`<p>\` 裸文本渲染 + \`line-clamp-2\` 截 2 行。v0.1.x release notes 短没人注意,v0.2.0 长 release notes 暴露问题——标题/列表/链接/代码块全显示成裸文本(用户报告:「现在好像是纯文本」)。

## 改动

[src/components/settings/AboutPanel.tsx](src/components/settings/AboutPanel.tsx#L283):

- \`<p>{pendingUpdate.body}</p>\` → \`<MarkdownRenderer content={pendingUpdate.body} />\`
- 复用项目已有 [\`MarkdownRenderer\`](src/components/common/MarkdownRenderer.tsx)(Streamdown 包装,与聊天 / ask_user_question 共享渲染管线)
- 容器加 \`max-h-48 overflow-auto\` 让长 release notes 内部滚动,不挤压「安装」按钮
- flex 改 \`items-center\` → \`items-start\` + button \`mt-1\`,markdown 内容多时 button 不漂

## 影响

- 从 v0.2.1 开始的用户看到的「发现新版」提示能正确渲染 markdown
- v0.2.0 已安装用户看不到本修复——他们用 v0.1.x binary 看新版提示,渲染逻辑在他们的 binary 里。要看到 markdown 渲染必须先升到 v0.2.1,才能在收到 v0.2.2+ 提示时看到正确效果

## Test plan

- [x] \`pnpm typecheck\` 通过
- [x] pre-push 六项检查全绿
- [ ] PR CI 8 项 status check 全绿
- [ ] (手动)\`pnpm tauri dev\` 验证 AboutPanel 收到 mock pendingUpdate 时能正确渲染 markdown

## 关闭

Closes [F-087](docs/plans/review-followups.md).