### PR TITLE
fix(release): 救火 — 撤销 PR #175 引入的 F-088 best-effort lane + 修 patch-manifest gating + Rosetta 文案

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,22 +36,15 @@ jobs:
             os: macos-14
             rust_target: aarch64-apple-darwin
             args: "--target aarch64-apple-darwin"
-          # macOS x64 — Intel DMG, native build on macos-13. Re-enabled
-          # in v0.2.1 after the temporary v0.2.0 removal, this time wired
-          # as a "best-effort" lane: GitHub-hosted macos-13 runners are
-          # capacity-constrained and intermittently see >1h queue times
-          # (the v0.2.0 incident). `continue_on_error: true` lets the
-          # lane fail/timeout without blocking the rest of the release;
-          # the patch-manifest job below uses `!cancelled()` so
-          # latest.json + downstream package-manager workflows still run
-          # off the platforms that did succeed. Cross-compile on macos-14
-          # or a self-hosted Intel runner remains a longer-term option
-          # (F-088 follow-up).
-          - platform: macos-x64
-            os: macos-13
-            rust_target: x86_64-apple-darwin
-            args: "--target x86_64-apple-darwin"
-            continue_on_error: true
+          # macOS x64 lane remains disabled (since v0.2.0). GitHub-hosted
+          # macos-13 Intel runners are capacity-constrained and frequently
+          # queue >1h. An earlier v0.2.1 attempt to re-add this lane with
+          # `continue-on-error: true` did not help — Actions `needs:` waits
+          # for queued/running jobs regardless of `continue-on-error`, so
+          # patch-manifest still blocked on macos-x64. Long-term recovery
+          # (cross-compile on macos-14 or a self-hosted Intel runner)
+          # tracked as F-088. Intel Mac users continue to run the arm64
+          # bundle through Rosetta 2 (same as v0.1.x).
           # Linux x64 — AppImage + deb.
           # ubuntu-24.04 is required because xcap (screen capture) pulls
           # libspa-sys v0.9, which expects pipewire ≥ 1.0 headers. The
@@ -80,9 +73,6 @@ jobs:
             args: ""
 
     runs-on: ${{ matrix.os }}
-    # `continue_on_error` is set per-platform in the matrix (currently
-    # only macos-x64). Default false for every other lane.
-    continue-on-error: ${{ matrix.continue_on_error == true }}
     steps:
       - uses: actions/checkout@v6
 
@@ -292,14 +282,13 @@ jobs:
   patch-manifest:
     name: patch latest.json
     needs: build
-    # `!cancelled()` lets the manifest patch run even when a best-effort
-    # build job (e.g. macos-x64) fails or times out — the latest.json
-    # rewrite is keyed off whichever bare-binary artifacts uploaded
-    # successfully, and `patch-latest-json.mjs` already warns-and-skips
-    # missing platforms. Without this guard, a single macos-x64 timeout
-    # would block the entire release from publishing.
-    # Also skip in dry-run — no draft Release exists to patch.
-    if: ${{ !cancelled() && github.event.inputs.dry_run != 'true' }}
+    # Default `needs:` gating already requires every build matrix entry
+    # to succeed — that's exactly what we want. If any platform fails
+    # we *do not* want to write out a half-populated latest.json (then
+    # the operator can `Re-run failed jobs` and the original
+    # patch-manifest job stays unchanged). Only carve-out: skip in
+    # dry-run since no draft Release exists to patch.
+    if: ${{ github.event.inputs.dry_run != 'true' }}
     runs-on: ubuntu-latest
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}

--- a/homebrew/hope-agent-arm-only.rb.tmpl
+++ b/homebrew/hope-agent-arm-only.rb.tmpl
@@ -15,9 +15,9 @@ cask "hope-agent" do
   auto_updates true
   # Apple Silicon only — this release skipped the macOS Intel build lane
   # (macos-13 runner capacity constraints in upstream release.yml).
-  # Intel Mac users should stay on the prior dual-arch release until the
-  # next version that ships an x64 DMG, or run this build through
-  # Rosetta 2 (same behavior as v0.1.x).
+  # Intel Mac users have no installable arm64 path (Rosetta 2 translates
+  # Intel → Apple Silicon, not the reverse) and should stay on the prior
+  # dual-arch release until the next version that ships an x64 DMG.
   depends_on macos: ">= :big_sur", arch: :arm64
 
   app "Hope Agent.app"
@@ -26,10 +26,11 @@ cask "hope-agent" do
 
   caveats <<~EOS
     This release ships only the Apple Silicon (arm64) DMG. Intel Macs
-    can still run it via Rosetta 2, but Homebrew will only let you
-    install this cask on Apple Silicon. To unblock Intel install,
-    download the arm64 DMG manually from
-    https://github.com/shiwenwen/hope-agent/releases.
+    cannot install it — Rosetta 2 translates Intel binaries to run on
+    Apple Silicon, not the reverse. Intel Mac users should remain on
+    the prior dual-arch release (download from
+    https://github.com/shiwenwen/hope-agent/releases) until a future
+    version ships an x64 DMG again.
 
     The bundle is not yet code-signed or notarized. The installer clears
     the macOS quarantine attribute so first launch should work without

--- a/scripts/check-release-paths.mjs
+++ b/scripts/check-release-paths.mjs
@@ -148,7 +148,7 @@ for (const dep of downstreamArtifactDeps) {
   if (matrixPlatforms.has(dep.requires)) continue
   const message = `${dep.workflow} references artifact pattern "${dep.fragment}" but release.yml matrix has no platform "${dep.requires}" — downstream workflow will fail on release publish.`
   if (dep.severity === "error") errors.push(message)
-  else warnings.push(message + " (warn-only: this dependency is known-broken and tracked as a follow-up.)")
+  else warnings.push(message + " (warn-only: downstream workflow is expected to handle the missing artifact gracefully.)")
 }
 
 // ─── Check 4 ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## 紧急背景

[PR #175](https://github.com/shiwenwen/hope-agent/pull/175) (F-088 + F-089) 在合并时遇到与 [#169](https://github.com/shiwenwen/hope-agent/pull/169) 一样的 GitHub PR API head_sha 同步延迟问题:codex review 后我推 \`6780bfd3\` 修复 commit 但 GitHub UI 未刷出,user 在那之前点了 merge,**修复未进 PR**。

结果:release/v0.2 当前含 codex review 标记的 3 个问题(P1 + P2 + P3)。本 PR 把 codex review 修复 cherry-pick 进来。

## 修复(cherry-pick 自原 \`6780bfd3\`)

### [P2] 撤销 F-088 best-effort lane(根本不成立)

[release.yml](.github/workflows/release.yml) macos-x64 entry + \`continue-on-error\`:
- Actions \`needs:\` 等待 queued/running 子任务,与 success/failure 状态无关
- macos-13 排队 1h 仍然把 patch-manifest 和发布收尾卡死
- \`continue-on-error\` 只影响最终结论,不让下游跳过等待

修复:删 macos-x64 matrix entry,回到 v0.2.0 状态。F-088 保留 Open follow-up,长期通过 cross-compile 或 self-hosted runner 解决。

### [P1] 撤销 patch-manifest \`!cancelled()\` 绕过

F-088 配套加的 \`if: !cancelled()\` 让 patch-manifest 在 build job fail 时也跑:
- patch-latest-json.mjs warn+skip 缺失 platform,写出**不完整**的 latest.json
- 之后 \`Re-run failed jobs\` 不会重跑 patch-manifest,draft release 永久留 broken manifest

修复:\`if\` 改回 \`github.event.inputs.dry_run != 'true'\`,让 Actions 默认 needs success-gating 重新生效。

### [P3] arm-only cask Rosetta 文案反了

[homebrew/hope-agent-arm-only.rb.tmpl](homebrew/hope-agent-arm-only.rb.tmpl) 旧文案让 Intel Mac 用户「via Rosetta 2 装 arm64 DMG」—— Rosetta 2 是让 **Apple Silicon 跑 Intel binary**,不是反过来。

修复:comment + caveats 改正方向,引导 Intel 用户回老版本 dual-arch。

### 附带:warning 文案稳态化

\`scripts/check-release-paths.mjs\` warning 文案从「known-broken and tracked as a follow-up」改成「downstream workflow is expected to handle gracefully」—— 反映稳态行为不是临时债。

## 影响

- 关闭 PR #175 引入的 3 个 codex review 问题
- F-089(Homebrew tap 容错 + arm-only 模板)保留,价值独立
- F-088 维持 Open,需要长期方案

## Test plan

- [x] cherry-pick clean(无冲突)
- [x] \`pnpm check:release-paths\` 通过(4 platforms, 1 warning 稳态)
- [ ] CI 8 项全绿