### PR TITLE
feat(dashboard): 新增「本地模型」面板,展示 Ollama 运行态与本地模型用量

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Dashboard 新增「本地模型」面板**：一眼看清 Ollama 运行态、当前加载的模型与 VRAM 占用、硬件预算余量、本地模型在所选时间窗内的调用次数 / Token / 平均 TTFT / 错误率，以及在跑的安装 / 拉取 / 预热后台任务；面板只读，模型管理仍走「设置 → 本地 LLM 助手」单一入口。
+
 ## [0.2.0] - 2026-05-13
 
 ### Changed

--- a/crates/ha-core/src/dashboard/local_models.rs
+++ b/crates/ha-core/src/dashboard/local_models.rs
@@ -142,18 +142,15 @@ pub fn query_local_model_usage(
          JOIN sessions s ON s.id = m.session_id
          {where_sql}",
     );
-    let (total_calls, total_input_tokens, total_output_tokens, avg_ttft_ms) = conn.query_row(
-        &totals_sql,
-        params_ref(&totals_params).as_slice(),
-        |r| {
+    let (total_calls, total_input_tokens, total_output_tokens, avg_ttft_ms) =
+        conn.query_row(&totals_sql, params_ref(&totals_params).as_slice(), |r| {
             Ok((
                 crate::sql_u64(r, 0)?,
                 crate::sql_u64(r, 1)?,
                 crate::sql_u64(r, 2)?,
                 r.get::<_, Option<f64>>(3)?,
             ))
-        },
-    )?;
+        })?;
 
     Ok(LocalModelUsage {
         local_provider_names: local_provider_names.to_vec(),
@@ -205,7 +202,11 @@ mod tests {
     #[test]
     fn names_helper_picks_only_local_providers() {
         let providers = vec![
-            make_provider("Ollama (local)", "http://127.0.0.1:11434", ApiType::OpenaiChat),
+            make_provider(
+                "Ollama (local)",
+                "http://127.0.0.1:11434",
+                ApiType::OpenaiChat,
+            ),
             make_provider(
                 "Anthropic",
                 "https://api.anthropic.com/v1",

--- a/crates/ha-core/src/dashboard/local_models.rs
+++ b/crates/ha-core/src/dashboard/local_models.rs
@@ -1,0 +1,455 @@
+// ── Local Models dashboard query ────────────────────────────────
+//
+// Aggregates token usage / TTFT / error counts for sessions whose
+// `provider_name` matches a configured local backend (Ollama / LiteLLM /
+// vLLM / LM Studio / SGLang). The "is this provider local?" judgement is
+// the single source of truth in [`provider::local::known_local_backends`]
+// — the frontend never has to hardcode local hostnames or ports.
+
+use anyhow::Result;
+use rusqlite::types::ToSql;
+use std::sync::Arc;
+
+use crate::provider::{known_local_backend_matches, known_local_backends, ProviderConfig};
+use crate::session::SessionDB;
+
+use super::filters::{build_session_filter, params_ref, FilterClause};
+use super::types::*;
+
+/// Walk configured providers and return display names whose `(api_type,
+/// base_url)` matches a known local backend. Order follows config order so
+/// the UI display is stable across reloads.
+pub fn local_provider_names_from(providers: &[ProviderConfig]) -> Vec<String> {
+    let backends = known_local_backends();
+    providers
+        .iter()
+        .filter(|p| {
+            backends
+                .iter()
+                .any(|b| known_local_backend_matches(b, &p.api_type, &p.base_url))
+        })
+        .map(|p| p.name.clone())
+        .collect()
+}
+
+/// Same as `local_provider_names_from` but reads the live `cached_config()`
+/// snapshot. Use this from Tauri / HTTP entry points; the test-friendly form
+/// above lets unit tests bypass the global config singleton.
+pub fn local_provider_names() -> Vec<String> {
+    let cfg = crate::config::cached_config();
+    local_provider_names_from(&cfg.providers)
+}
+
+/// Aggregate usage for sessions whose `provider_name` is in
+/// `local_provider_names`. An empty list short-circuits to all-zero with
+/// `local_provider_names = []` so the UI can render an "configure a local
+/// backend first" empty state without spurious queries.
+pub fn query_local_model_usage(
+    session_db: &Arc<SessionDB>,
+    filter: &DashboardFilter,
+    local_provider_names: &[String],
+) -> Result<LocalModelUsage> {
+    if local_provider_names.is_empty() {
+        return Ok(LocalModelUsage {
+            local_provider_names: Vec::new(),
+            total_calls: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            avg_ttft_ms: None,
+            trend: Vec::new(),
+            by_model: Vec::new(),
+        });
+    }
+
+    let conn = session_db
+        .conn
+        .lock()
+        .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+
+    let in_placeholders = vec!["?"; local_provider_names.len()].join(", ");
+    let in_clause = format!("s.provider_name IN ({in_placeholders})");
+
+    // ── Daily trend ──
+    let (trend_sql, trend_params) = build_query(
+        filter,
+        &in_clause,
+        local_provider_names,
+        "SELECT DATE(m.timestamp) as d,
+                COALESCE(SUM(m.tokens_in), 0),
+                COALESCE(SUM(m.tokens_out), 0),
+                AVG(CASE WHEN m.ttft_ms IS NOT NULL AND m.role = 'assistant' THEN m.ttft_ms END)
+         FROM messages m
+         JOIN sessions s ON s.id = m.session_id
+         {where_sql}
+         GROUP BY d
+         ORDER BY d ASC",
+    );
+    let mut stmt = conn.prepare(&trend_sql)?;
+    let rows = stmt.query_map(params_ref(&trend_params).as_slice(), |r| {
+        Ok(TokenUsageTrend {
+            date: r.get(0)?,
+            input_tokens: crate::sql_u64(r, 1)?,
+            output_tokens: crate::sql_u64(r, 2)?,
+            avg_ttft_ms: r.get(3)?,
+        })
+    })?;
+    let trend: Vec<TokenUsageTrend> = rows.collect::<std::result::Result<_, _>>()?;
+    drop(stmt);
+
+    // ── By model ──
+    let (by_model_sql, by_model_params) = build_query(
+        filter,
+        &in_clause,
+        local_provider_names,
+        "SELECT COALESCE(s.model_id, 'unknown'),
+                COALESCE(s.provider_name, 'unknown'),
+                COUNT(DISTINCT CASE WHEN m.role = 'assistant' THEN m.id END),
+                COALESCE(SUM(m.tokens_in), 0),
+                COALESCE(SUM(m.tokens_out), 0),
+                AVG(CASE WHEN m.ttft_ms IS NOT NULL AND m.role = 'assistant' THEN m.ttft_ms END),
+                COALESCE(SUM(CASE WHEN m.is_error = 1 THEN 1 ELSE 0 END), 0)
+         FROM messages m
+         JOIN sessions s ON s.id = m.session_id
+         {where_sql}
+         GROUP BY s.model_id, s.provider_name
+         ORDER BY SUM(m.tokens_in) + SUM(m.tokens_out) DESC",
+    );
+    let mut stmt = conn.prepare(&by_model_sql)?;
+    let rows = stmt.query_map(params_ref(&by_model_params).as_slice(), |r| {
+        Ok(LocalModelUsageRow {
+            model_id: r.get(0)?,
+            provider_name: r.get(1)?,
+            call_count: crate::sql_u64(r, 2)?,
+            input_tokens: crate::sql_u64(r, 3)?,
+            output_tokens: crate::sql_u64(r, 4)?,
+            avg_ttft_ms: r.get(5)?,
+            error_count: crate::sql_u64(r, 6)?,
+        })
+    })?;
+    let by_model: Vec<LocalModelUsageRow> = rows.collect::<std::result::Result<_, _>>()?;
+    drop(stmt);
+
+    // ── Totals (single row) ──
+    let (totals_sql, totals_params) = build_query(
+        filter,
+        &in_clause,
+        local_provider_names,
+        "SELECT COUNT(DISTINCT CASE WHEN m.role = 'assistant' THEN m.id END),
+                COALESCE(SUM(m.tokens_in), 0),
+                COALESCE(SUM(m.tokens_out), 0),
+                AVG(CASE WHEN m.ttft_ms IS NOT NULL AND m.role = 'assistant' THEN m.ttft_ms END)
+         FROM messages m
+         JOIN sessions s ON s.id = m.session_id
+         {where_sql}",
+    );
+    let (total_calls, total_input_tokens, total_output_tokens, avg_ttft_ms) = conn.query_row(
+        &totals_sql,
+        params_ref(&totals_params).as_slice(),
+        |r| {
+            Ok((
+                crate::sql_u64(r, 0)?,
+                crate::sql_u64(r, 1)?,
+                crate::sql_u64(r, 2)?,
+                r.get::<_, Option<f64>>(3)?,
+            ))
+        },
+    )?;
+
+    Ok(LocalModelUsage {
+        local_provider_names: local_provider_names.to_vec(),
+        total_calls,
+        total_input_tokens,
+        total_output_tokens,
+        avg_ttft_ms,
+        trend,
+        by_model,
+    })
+}
+
+/// Build the (sql, params) pair for a local-model query by appending the
+/// IN-clause to whatever `build_session_filter` produces. The template is
+/// expected to contain the literal `{where_sql}` placeholder.
+fn build_query(
+    filter: &DashboardFilter,
+    in_clause: &str,
+    local_provider_names: &[String],
+    template: &str,
+) -> (String, Vec<Box<dyn ToSql>>) {
+    let FilterClause {
+        where_sql: base_where,
+        mut params,
+    } = build_session_filter(filter, "s", Some("m"));
+    let where_sql = if base_where.is_empty() {
+        format!("WHERE {in_clause}")
+    } else {
+        format!("{base_where} AND {in_clause}")
+    };
+    for name in local_provider_names {
+        params.push(Box::new(name.clone()) as Box<dyn ToSql>);
+    }
+    (template.replace("{where_sql}", &where_sql), params)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::{ApiType, ProviderConfig};
+    use crate::session::SessionDB;
+    use chrono::Utc;
+    use rusqlite::params;
+
+    fn make_provider(name: &str, base_url: &str, api: ApiType) -> ProviderConfig {
+        ProviderConfig::new(name.into(), api, base_url.into(), String::new())
+    }
+
+    #[test]
+    fn names_helper_picks_only_local_providers() {
+        let providers = vec![
+            make_provider("Ollama (local)", "http://127.0.0.1:11434", ApiType::OpenaiChat),
+            make_provider(
+                "Anthropic",
+                "https://api.anthropic.com/v1",
+                ApiType::Anthropic,
+            ),
+            make_provider("LM Studio", "http://localhost:1234", ApiType::OpenaiChat),
+            // wrong api type → not local even on loopback
+            make_provider("Fake", "http://127.0.0.1:1234", ApiType::OpenaiResponses),
+        ];
+        let names = local_provider_names_from(&providers);
+        assert_eq!(
+            names,
+            vec!["Ollama (local)".to_string(), "LM Studio".into()]
+        );
+    }
+
+    #[test]
+    fn names_helper_returns_empty_when_no_local() {
+        let providers = vec![make_provider(
+            "Anthropic",
+            "https://api.anthropic.com/v1",
+            ApiType::Anthropic,
+        )];
+        assert!(local_provider_names_from(&providers).is_empty());
+    }
+
+    fn temp_db_path(name: &str) -> std::path::PathBuf {
+        let unique = format!(
+            "{}-{}-{}.sqlite3",
+            name,
+            std::process::id(),
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or_default()
+        );
+        std::env::temp_dir().join(unique)
+    }
+
+    fn insert_session(
+        db: &SessionDB,
+        id: &str,
+        provider_name: Option<&str>,
+        model_id: Option<&str>,
+    ) {
+        let conn = db.conn.lock().expect("lock");
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO sessions (id, title, agent_id, provider_id, provider_name, model_id, created_at, updated_at, is_cron, parent_session_id, incognito, title_source)
+             VALUES (?1, NULL, 'ha-main', NULL, ?2, ?3, ?4, ?4, 0, NULL, 0, 'manual')",
+            params![id, provider_name, model_id, now],
+        )
+        .expect("insert session");
+    }
+
+    fn insert_message(
+        db: &SessionDB,
+        session_id: &str,
+        role: &str,
+        tokens_in: Option<u64>,
+        tokens_out: Option<u64>,
+        ttft_ms: Option<u64>,
+        is_error: bool,
+    ) {
+        let conn = db.conn.lock().expect("lock");
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp, tokens_in, tokens_out, ttft_ms, is_error)
+             VALUES (?1, ?2, '', ?3, ?4, ?5, ?6, ?7)",
+            params![
+                session_id,
+                role,
+                now,
+                tokens_in.map(|v| v as i64),
+                tokens_out.map(|v| v as i64),
+                ttft_ms.map(|v| v as i64),
+                if is_error { 1 } else { 0 }
+            ],
+        )
+        .expect("insert message");
+    }
+
+    #[test]
+    fn empty_local_names_short_circuits_to_zeros() {
+        let path = temp_db_path("local-models-empty");
+        let db = Arc::new(SessionDB::open(&path).expect("open"));
+        let filter = DashboardFilter::default();
+        let usage = query_local_model_usage(&db, &filter, &[]).expect("query");
+        assert_eq!(usage.local_provider_names.len(), 0);
+        assert_eq!(usage.total_calls, 0);
+        assert!(usage.trend.is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn aggregates_only_local_provider_sessions() {
+        let path = temp_db_path("local-models-aggregate");
+        let db = Arc::new(SessionDB::open(&path).expect("open"));
+
+        // Local provider sessions
+        insert_session(&db, "s-local-1", Some("Ollama (local)"), Some("qwen3:8b"));
+        insert_message(&db, "s-local-1", "user", Some(0), Some(0), None, false);
+        insert_message(
+            &db,
+            "s-local-1",
+            "assistant",
+            Some(100),
+            Some(50),
+            Some(120),
+            false,
+        );
+        insert_message(
+            &db,
+            "s-local-1",
+            "assistant",
+            Some(80),
+            Some(40),
+            Some(80),
+            true,
+        );
+
+        insert_session(&db, "s-local-2", Some("LM Studio"), Some("gemma4:e4b"));
+        insert_message(
+            &db,
+            "s-local-2",
+            "assistant",
+            Some(200),
+            Some(120),
+            Some(200),
+            false,
+        );
+
+        // Non-local session that should NOT show up
+        insert_session(&db, "s-remote", Some("Anthropic"), Some("claude-opus-4-7"));
+        insert_message(
+            &db,
+            "s-remote",
+            "assistant",
+            Some(1_000),
+            Some(500),
+            Some(800),
+            false,
+        );
+
+        let names = vec!["Ollama (local)".to_string(), "LM Studio".to_string()];
+        let usage =
+            query_local_model_usage(&db, &DashboardFilter::default(), &names).expect("query");
+
+        assert_eq!(usage.local_provider_names, names);
+        assert_eq!(usage.total_calls, 3, "3 assistant rows from local sessions");
+        assert_eq!(usage.total_input_tokens, 100 + 80 + 200);
+        assert_eq!(usage.total_output_tokens, 50 + 40 + 120);
+        assert_eq!(usage.by_model.len(), 2);
+
+        // gemma4 first (highest tokens 200+120=320), then qwen3 (270)
+        assert_eq!(usage.by_model[0].model_id, "gemma4:e4b");
+        assert_eq!(usage.by_model[0].provider_name, "LM Studio");
+        assert_eq!(usage.by_model[0].call_count, 1);
+        assert_eq!(usage.by_model[0].error_count, 0);
+
+        assert_eq!(usage.by_model[1].model_id, "qwen3:8b");
+        assert_eq!(usage.by_model[1].provider_name, "Ollama (local)");
+        assert_eq!(usage.by_model[1].call_count, 2);
+        assert_eq!(usage.by_model[1].error_count, 1);
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn excludes_incognito_cron_and_subagent_sessions() {
+        let path = temp_db_path("local-models-excludes");
+        let db = Arc::new(SessionDB::open(&path).expect("open"));
+
+        // A normal local session we expect to count
+        insert_session(&db, "s-ok", Some("Ollama (local)"), Some("qwen3:8b"));
+        insert_message(
+            &db,
+            "s-ok",
+            "assistant",
+            Some(100),
+            Some(50),
+            Some(100),
+            false,
+        );
+
+        // is_cron = 1 — excluded
+        {
+            let conn = db.conn.lock().expect("lock");
+            let now = Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT INTO sessions (id, title, agent_id, provider_id, provider_name, model_id, created_at, updated_at, is_cron, parent_session_id, incognito, title_source)
+                 VALUES ('s-cron', NULL, 'ha-main', NULL, 'Ollama (local)', 'qwen3:8b', ?1, ?1, 1, NULL, 0, 'manual')",
+                params![now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp, tokens_in, tokens_out)
+                 VALUES ('s-cron', 'assistant', '', ?1, 999, 999)",
+                params![now],
+            )
+            .unwrap();
+        }
+
+        // parent_session_id set — subagent, excluded
+        {
+            let conn = db.conn.lock().expect("lock");
+            let now = Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT INTO sessions (id, title, agent_id, provider_id, provider_name, model_id, created_at, updated_at, is_cron, parent_session_id, incognito, title_source)
+                 VALUES ('s-sub', NULL, 'ha-main', NULL, 'Ollama (local)', 'qwen3:8b', ?1, ?1, 0, 's-ok', 0, 'manual')",
+                params![now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp, tokens_in, tokens_out)
+                 VALUES ('s-sub', 'assistant', '', ?1, 777, 777)",
+                params![now],
+            )
+            .unwrap();
+        }
+
+        // incognito = 1 — excluded
+        {
+            let conn = db.conn.lock().expect("lock");
+            let now = Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT INTO sessions (id, title, agent_id, provider_id, provider_name, model_id, created_at, updated_at, is_cron, parent_session_id, incognito, title_source)
+                 VALUES ('s-incog', NULL, 'ha-main', NULL, 'Ollama (local)', 'qwen3:8b', ?1, ?1, 0, NULL, 1, 'manual')",
+                params![now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp, tokens_in, tokens_out)
+                 VALUES ('s-incog', 'assistant', '', ?1, 555, 555)",
+                params![now],
+            )
+            .unwrap();
+        }
+
+        let names = vec!["Ollama (local)".to_string()];
+        let usage =
+            query_local_model_usage(&db, &DashboardFilter::default(), &names).expect("query");
+
+        assert_eq!(usage.total_calls, 1);
+        assert_eq!(usage.total_input_tokens, 100);
+        assert_eq!(usage.total_output_tokens, 50);
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/ha-core/src/dashboard/mod.rs
+++ b/crates/ha-core/src/dashboard/mod.rs
@@ -22,9 +22,7 @@ pub use learning::{
     EVT_RECALL_SUMMARY_USED, EVT_SKILL_ACTIVATED, EVT_SKILL_CREATED, EVT_SKILL_DISCARDED,
     EVT_SKILL_PATCHED, EVT_SKILL_USED,
 };
-pub use local_models::{
-    local_provider_names, local_provider_names_from, query_local_model_usage,
-};
+pub use local_models::{local_provider_names, local_provider_names_from, query_local_model_usage};
 pub use plan_stats::query_plan_stats;
 pub use queries::*;
 pub use types::*;

--- a/crates/ha-core/src/dashboard/mod.rs
+++ b/crates/ha-core/src/dashboard/mod.rs
@@ -9,6 +9,7 @@ mod detail_queries;
 mod filters;
 mod insights;
 pub mod learning;
+mod local_models;
 mod plan_stats;
 mod queries;
 mod types;
@@ -20,6 +21,9 @@ pub use learning::{
     query_top_skills, LearningOverview, RecallStats, SkillUsage, TimelinePoint, EVT_RECALL_HIT,
     EVT_RECALL_SUMMARY_USED, EVT_SKILL_ACTIVATED, EVT_SKILL_CREATED, EVT_SKILL_DISCARDED,
     EVT_SKILL_PATCHED, EVT_SKILL_USED,
+};
+pub use local_models::{
+    local_provider_names, local_provider_names_from, query_local_model_usage,
 };
 pub use plan_stats::query_plan_stats;
 pub use queries::*;

--- a/crates/ha-core/src/dashboard/types.rs
+++ b/crates/ha-core/src/dashboard/types.rs
@@ -367,6 +367,38 @@ pub struct DashboardInsights {
     pub model_efficiency: Vec<ModelEfficiency>,
 }
 
+// ── Local Models Tab Types ──────────────────────────────────────
+
+/// Per-model usage row for the local-models dashboard tab. Mirrors `TokenByModel`
+/// but adds error count so the UI can flag unhealthy local models.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalModelUsageRow {
+    pub model_id: String,
+    pub provider_name: String,
+    pub call_count: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub avg_ttft_ms: Option<f64>,
+    pub error_count: u64,
+}
+
+/// Aggregate usage stats for sessions whose provider is a known local backend
+/// (Ollama / LiteLLM / vLLM / LM Studio / SGLang). Empty `local_provider_names`
+/// signals "user has not configured any local provider yet" — the UI renders
+/// an onboarding hint instead of zeroed charts.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalModelUsage {
+    pub local_provider_names: Vec<String>,
+    pub total_calls: u64,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub avg_ttft_ms: Option<f64>,
+    pub trend: Vec<TokenUsageTrend>,
+    pub by_model: Vec<LocalModelUsageRow>,
+}
+
 // ── Plan Statistics Types ───────────────────────────────────────
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]

--- a/crates/ha-server/src/lib.rs
+++ b/crates/ha-server/src/lib.rs
@@ -920,6 +920,10 @@ fn build_router_with_cors(
             post(routes::dashboard::recall_stats),
         )
         .route("/dashboard/plan-stats", post(routes::dashboard::plan_stats))
+        .route(
+            "/dashboard/local-model-usage",
+            post(routes::dashboard::local_model_usage),
+        )
         // Recap
         .route("/recap/generate", post(routes::recap::generate))
         .route("/recap/reports", post(routes::recap::list_reports))
@@ -1318,6 +1322,10 @@ fn build_router_with_cors(
         .route(
             "/local-llm/ollama-status",
             get(routes::local_llm::get_ollama_status),
+        )
+        .route(
+            "/local-llm/ollama-version",
+            get(routes::local_llm::get_ollama_version),
         )
         .route(
             "/local-llm/known-backends",

--- a/crates/ha-server/src/routes/dashboard.rs
+++ b/crates/ha-server/src/routes/dashboard.rs
@@ -181,3 +181,14 @@ pub async fn plan_stats(
 ) -> Result<Json<dashboard::PlanStats>, AppError> {
     Ok(Json(dashboard::query_plan_stats(&body.filter)?))
 }
+
+pub async fn local_model_usage(
+    Json(body): Json<FilterBody>,
+) -> Result<Json<dashboard::LocalModelUsage>, AppError> {
+    let names = dashboard::local_provider_names();
+    Ok(Json(dashboard::query_local_model_usage(
+        session_db()?,
+        &body.filter,
+        &names,
+    )?))
+}

--- a/crates/ha-server/src/routes/local_llm.rs
+++ b/crates/ha-server/src/routes/local_llm.rs
@@ -11,9 +11,9 @@ use serde_json::{json, Value};
 
 use ha_core::local_llm::{
     add_ollama_model_as_embedding_config, delete_ollama_model, detect_hardware, detect_ollama,
-    get_ollama_library_model, list_local_ollama_models, model_catalog, preload_ollama_model,
-    recommend_model, register_ollama_model_as_provider, search_ollama_library, start_ollama,
-    stop_ollama_model,
+    detect_ollama_version, get_ollama_library_model, list_local_ollama_models, model_catalog,
+    preload_ollama_model, recommend_model, register_ollama_model_as_provider,
+    search_ollama_library, start_ollama, stop_ollama_model,
 };
 use ha_core::provider::known_local_backends;
 
@@ -39,6 +39,11 @@ pub async fn get_chat_catalog() -> Json<Value> {
 /// `GET /api/local-llm/ollama-status` — installed / running probe.
 pub async fn get_ollama_status() -> Json<Value> {
     Json(json!(detect_ollama().await))
+}
+
+/// `GET /api/local-llm/ollama-version` — daemon version when reachable.
+pub async fn get_ollama_version() -> Result<Json<Value>, AppError> {
+    Ok(Json(json!({ "version": detect_ollama_version().await? })))
 }
 
 /// `GET /api/local-llm/known-backends` — static local backend catalog.

--- a/docs/architecture/api-reference.md
+++ b/docs/architecture/api-reference.md
@@ -466,6 +466,7 @@ Tauri ↔ COMMAND_MAP 差集为 7 条合法非 REST 命令（4 条 Desktop-only 
 | `dashboard_tool_call_list` | `POST /api/dashboard/tool-call-list` | ✅ |
 | `dashboard_error_list` | `POST /api/dashboard/error-list` | ✅ |
 | `dashboard_agent_list` | `POST /api/dashboard/agent-list` | ✅ |
+| `dashboard_local_model_usage` | `POST /api/dashboard/local-model-usage` | ✅ |
 
 #### Dashboard Learning
 
@@ -581,6 +582,7 @@ Tauri ↔ COMMAND_MAP 差集为 7 条合法非 REST 命令（4 条 Desktop-only 
 | `local_llm_recommend_model` | `GET /api/local-llm/recommendation` | ✅ |
 | `local_llm_chat_catalog` | `GET /api/local-llm/chat-catalog` | ✅ |
 | `local_llm_detect_ollama` | `GET /api/local-llm/ollama-status` | ✅ |
+| `local_llm_detect_ollama_version` | `GET /api/local-llm/ollama-version` | ✅ |
 | `local_llm_known_backends` | `GET /api/local-llm/known-backends` | ✅ |
 | `local_llm_start_ollama` | `POST /api/local-llm/start` | ✅ |
 | `local_llm_list_models` | `GET /api/local-llm/models` | ✅ |

--- a/docs/architecture/dashboard.md
+++ b/docs/architecture/dashboard.md
@@ -23,6 +23,7 @@ Dashboard 模块提供跨三个 SQLite 数据库（SessionDB、LogDB、CronDB）
 | `cost.rs` | 模型定价表与成本计算引擎 |
 | `insights.rs` | 8 个深度洞察查询（同环比 / 趋势 / 热力图 / 健康度 / orchestrator） |
 | `learning.rs` | Learning Tracker 4 个查询 + 12 个事件常量（埋点写入 `session.db.learning_events`） |
+| `local_models.rs` | 本地模型 Tab 专属聚合：按 `provider::local::known_local_backends` 反查"本地"provider name 列表后对 sessions / messages 表做 token / 调用次数 / TTFT / 错误率统计；前端 `LocalModelsSection` 消费 |
 
 ## 数据源架构
 

--- a/scripts/i18n-translations.json
+++ b/scripts/i18n-translations.json
@@ -596,7 +596,8 @@
     "dashboard": {
       "tabs": {
         "learning": "学習",
-        "dreaming": "ドリーム"
+        "dreaming": "ドリーム",
+        "localModels": "ローカルモデル"
       },
       "learning": {
         "title": "学習トラッカー",
@@ -641,6 +642,73 @@
           "idle": "アイドル",
           "cron": "cron",
           "manual": "手動"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "Ollama 状態",
+        "ollamaPhases": {
+          "running": "実行中",
+          "installed": "インストール済（停止中）",
+          "not-installed": "未インストール"
+        },
+        "openInSettings": "設定で管理",
+        "hardware": {
+          "totalMemory": "総メモリ",
+          "available": "利用可能",
+          "gpu": "GPU",
+          "integratedGpu": "統合 GPU / ユニファイドメモリ",
+          "vram": "VRAM",
+          "budget": "推奨予算",
+          "budgetSource": {
+            "unified-memory": "ユニファイドメモリ (macOS)",
+            "dedicated-vram": "専用 VRAM",
+            "system-memory": "システムメモリ"
+          }
+        },
+        "running": {
+          "title": "実行中のモデル",
+          "empty": "現在ロードされているモデルはありません",
+          "vramUsed": "VRAM",
+          "context": "コンテキスト",
+          "expiresIn": "{{duration}} 後にアンロード",
+          "unloadingSoon": "まもなくアンロード",
+          "summary": "{{count}} 件実行中"
+        },
+        "installed": {
+          "title": "インストール済モデル",
+          "unknownFamily": "不明なファミリー",
+          "badges": {
+            "active": "アクティブ",
+            "fallback": "フォールバック",
+            "provider": "Provider モデル",
+            "embedding": "埋め込み",
+            "running": "実行中"
+          }
+        },
+        "usage": {
+          "title": "ローカルモデルの使用状況",
+          "totalCalls": "総呼び出し回数",
+          "totalTokens": "総トークン数",
+          "avgTtft": "平均 TTFT",
+          "trend": "日次トークン推移",
+          "byModel": "モデル別トークン",
+          "empty": "選択期間内にローカルモデルの呼び出しはありません",
+          "errorBadge": "{{model}}: エラー率 {{rate}}% ({{errors}}/{{calls}})"
+        },
+        "empty": {
+          "noProvider": "ローカルバックエンドが未設定です",
+          "goToSettings": "設定を開いて追加"
+        },
+        "jobs": {
+          "title": "バックグラウンドタスク",
+          "kind": {
+            "chat_model": "チャットモデルのインストール",
+            "embedding_model": "埋め込みモデルのインストール",
+            "ollama_install": "Ollama のインストール",
+            "ollama_pull": "Ollama プル",
+            "ollama_preload": "プリロード",
+            "memory_reembed": "メモリ再埋め込み"
+          }
         }
       }
     },
@@ -1367,7 +1435,8 @@
     "dashboard": {
       "tabs": {
         "learning": "학습",
-        "dreaming": "드림"
+        "dreaming": "드림",
+        "localModels": "로컬 모델"
       },
       "learning": {
         "title": "학습 트래커",
@@ -1412,6 +1481,73 @@
           "idle": "유휴",
           "cron": "cron",
           "manual": "수동"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "Ollama 상태",
+        "ollamaPhases": {
+          "running": "실행 중",
+          "installed": "설치됨 (유휴)",
+          "not-installed": "설치되지 않음"
+        },
+        "openInSettings": "설정에서 관리",
+        "hardware": {
+          "totalMemory": "총 메모리",
+          "available": "사용 가능",
+          "gpu": "GPU",
+          "integratedGpu": "내장 GPU / 통합 메모리",
+          "vram": "VRAM",
+          "budget": "권장 예산",
+          "budgetSource": {
+            "unified-memory": "통합 메모리 (macOS)",
+            "dedicated-vram": "전용 VRAM",
+            "system-memory": "시스템 메모리"
+          }
+        },
+        "running": {
+          "title": "실행 중인 모델",
+          "empty": "현재 로드된 모델이 없습니다",
+          "vramUsed": "VRAM",
+          "context": "컨텍스트",
+          "expiresIn": "{{duration}} 후 언로드",
+          "unloadingSoon": "곧 언로드",
+          "summary": "{{count}}개 실행 중"
+        },
+        "installed": {
+          "title": "설치된 모델",
+          "unknownFamily": "알 수 없는 패밀리",
+          "badges": {
+            "active": "활성",
+            "fallback": "폴백",
+            "provider": "Provider 모델",
+            "embedding": "임베딩",
+            "running": "실행 중"
+          }
+        },
+        "usage": {
+          "title": "로컬 모델 사용량",
+          "totalCalls": "총 호출 수",
+          "totalTokens": "총 토큰",
+          "avgTtft": "평균 TTFT",
+          "trend": "일별 토큰 추세",
+          "byModel": "모델별 토큰",
+          "empty": "선택한 범위에 로컬 모델 호출이 없습니다",
+          "errorBadge": "{{model}}: 오류율 {{rate}}% ({{errors}}/{{calls}})"
+        },
+        "empty": {
+          "noProvider": "로컬 백엔드가 아직 설정되지 않았습니다",
+          "goToSettings": "설정을 열어 추가"
+        },
+        "jobs": {
+          "title": "백그라운드 작업",
+          "kind": {
+            "chat_model": "채팅 모델 설치",
+            "embedding_model": "임베딩 모델 설치",
+            "ollama_install": "Ollama 설치",
+            "ollama_pull": "Ollama 풀",
+            "ollama_preload": "프리로드",
+            "memory_reembed": "메모리 재임베딩"
+          }
         }
       }
     },
@@ -2138,7 +2274,8 @@
     "dashboard": {
       "tabs": {
         "learning": "學習追蹤",
-        "dreaming": "記憶夢境"
+        "dreaming": "記憶夢境",
+        "localModels": "本地模型"
       },
       "learning": {
         "title": "學習追蹤",
@@ -2183,6 +2320,73 @@
           "idle": "閒置觸發",
           "cron": "定時觸發",
           "manual": "手動觸發"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "Ollama 狀態",
+        "ollamaPhases": {
+          "running": "執行中",
+          "installed": "已安裝（未啟動）",
+          "not-installed": "未安裝"
+        },
+        "openInSettings": "在設定中管理",
+        "hardware": {
+          "totalMemory": "總記憶體",
+          "available": "可用",
+          "gpu": "顯示卡",
+          "integratedGpu": "內建 GPU / 統一記憶體",
+          "vram": "顯示記憶體",
+          "budget": "建議預算",
+          "budgetSource": {
+            "unified-memory": "統一記憶體（macOS）",
+            "dedicated-vram": "獨立顯示記憶體",
+            "system-memory": "系統記憶體"
+          }
+        },
+        "running": {
+          "title": "執行中的模型",
+          "empty": "目前沒有模型載入",
+          "vramUsed": "顯示記憶體",
+          "context": "上下文",
+          "expiresIn": "{{duration}} 後卸載",
+          "unloadingSoon": "即將卸載",
+          "summary": "{{count}} 個執行中"
+        },
+        "installed": {
+          "title": "已安裝模型",
+          "unknownFamily": "未識別系列",
+          "badges": {
+            "active": "目前對話",
+            "fallback": "降級模型",
+            "provider": "Provider 模型",
+            "embedding": "向量模型",
+            "running": "執行中"
+          }
+        },
+        "usage": {
+          "title": "本地模型使用統計",
+          "totalCalls": "總呼叫次數",
+          "totalTokens": "總 Token",
+          "avgTtft": "平均 TTFT",
+          "trend": "每日 Token 趨勢",
+          "byModel": "依模型分布 Token",
+          "empty": "所選時間範圍內未呼叫本地模型",
+          "errorBadge": "{{model}}：錯誤率 {{rate}}%（{{errors}}/{{calls}}）"
+        },
+        "empty": {
+          "noProvider": "尚未設定任何本地後端",
+          "goToSettings": "前往設定新增"
+        },
+        "jobs": {
+          "title": "背景任務",
+          "kind": {
+            "chat_model": "安裝對話模型",
+            "embedding_model": "安裝向量模型",
+            "ollama_install": "安裝 Ollama",
+            "ollama_pull": "拉取模型",
+            "ollama_preload": "預載入模型",
+            "memory_reembed": "記憶重嵌入"
+          }
         }
       }
     },
@@ -2909,7 +3113,8 @@
     "dashboard": {
       "tabs": {
         "learning": "Öğrenme",
-        "dreaming": "Rüyalar"
+        "dreaming": "Rüyalar",
+        "localModels": "Yerel Modeller"
       },
       "learning": {
         "title": "Öğrenme Takibi",
@@ -2954,6 +3159,73 @@
           "idle": "boşta",
           "cron": "cron",
           "manual": "el ile"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "Ollama durumu",
+        "ollamaPhases": {
+          "running": "Çalışıyor",
+          "installed": "Yüklü (boşta)",
+          "not-installed": "Yüklü değil"
+        },
+        "openInSettings": "Ayarlarda yönet",
+        "hardware": {
+          "totalMemory": "Toplam bellek",
+          "available": "Kullanılabilir",
+          "gpu": "GPU",
+          "integratedGpu": "Entegre GPU / birleşik bellek",
+          "vram": "VRAM",
+          "budget": "Önerilen bütçe",
+          "budgetSource": {
+            "unified-memory": "Birleşik bellek (macOS)",
+            "dedicated-vram": "Özel VRAM",
+            "system-memory": "Sistem belleği"
+          }
+        },
+        "running": {
+          "title": "Şu anda çalışan",
+          "empty": "Şu an yüklü model yok",
+          "vramUsed": "VRAM",
+          "context": "Bağlam",
+          "expiresIn": "{{duration}} içinde boşaltılacak",
+          "unloadingSoon": "Yakında boşaltılacak",
+          "summary": "{{count}} çalışıyor"
+        },
+        "installed": {
+          "title": "Yüklü modeller",
+          "unknownFamily": "Bilinmeyen aile",
+          "badges": {
+            "active": "Etkin",
+            "fallback": "Yedek",
+            "provider": "Provider modeli",
+            "embedding": "Embedding",
+            "running": "Çalışıyor"
+          }
+        },
+        "usage": {
+          "title": "Yerel model kullanımı",
+          "totalCalls": "Toplam çağrı",
+          "totalTokens": "Toplam token",
+          "avgTtft": "Ortalama TTFT",
+          "trend": "Günlük token eğilimi",
+          "byModel": "Modele göre token",
+          "empty": "Seçilen aralıkta yerel model çağrısı yok",
+          "errorBadge": "{{model}}: hata oranı {{rate}}% ({{errors}}/{{calls}})"
+        },
+        "empty": {
+          "noProvider": "Henüz yerel backend yapılandırılmadı",
+          "goToSettings": "Eklemek için Ayarları açın"
+        },
+        "jobs": {
+          "title": "Arka plan görevleri",
+          "kind": {
+            "chat_model": "Sohbet modeli kurulumu",
+            "embedding_model": "Embedding modeli kurulumu",
+            "ollama_install": "Ollama kurulumu",
+            "ollama_pull": "Ollama indirme",
+            "ollama_preload": "Ön yükleme",
+            "memory_reembed": "Bellek yeniden embedding"
+          }
         }
       }
     },
@@ -3680,7 +3952,8 @@
     "dashboard": {
       "tabs": {
         "learning": "Học tập",
-        "dreaming": "Giấc mơ"
+        "dreaming": "Giấc mơ",
+        "localModels": "Mô hình cục bộ"
       },
       "learning": {
         "title": "Theo dõi Học tập",
@@ -3725,6 +3998,73 @@
           "idle": "nhàn rỗi",
           "cron": "cron",
           "manual": "thủ công"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "Trạng thái Ollama",
+        "ollamaPhases": {
+          "running": "Đang chạy",
+          "installed": "Đã cài (rảnh)",
+          "not-installed": "Chưa cài"
+        },
+        "openInSettings": "Quản lý trong Cài đặt",
+        "hardware": {
+          "totalMemory": "Tổng bộ nhớ",
+          "available": "Khả dụng",
+          "gpu": "GPU",
+          "integratedGpu": "GPU tích hợp / bộ nhớ thống nhất",
+          "vram": "VRAM",
+          "budget": "Ngân sách đề xuất",
+          "budgetSource": {
+            "unified-memory": "Bộ nhớ thống nhất (macOS)",
+            "dedicated-vram": "VRAM riêng",
+            "system-memory": "Bộ nhớ hệ thống"
+          }
+        },
+        "running": {
+          "title": "Đang chạy",
+          "empty": "Hiện không có mô hình nào được nạp",
+          "vramUsed": "VRAM",
+          "context": "Ngữ cảnh",
+          "expiresIn": "Sẽ gỡ tải trong {{duration}}",
+          "unloadingSoon": "Sắp gỡ tải",
+          "summary": "{{count}} đang chạy"
+        },
+        "installed": {
+          "title": "Mô hình đã cài",
+          "unknownFamily": "Họ không xác định",
+          "badges": {
+            "active": "Đang dùng",
+            "fallback": "Dự phòng",
+            "provider": "Mô hình Provider",
+            "embedding": "Embedding",
+            "running": "Đang chạy"
+          }
+        },
+        "usage": {
+          "title": "Sử dụng mô hình cục bộ",
+          "totalCalls": "Tổng lượt gọi",
+          "totalTokens": "Tổng token",
+          "avgTtft": "TTFT trung bình",
+          "trend": "Xu hướng token theo ngày",
+          "byModel": "Token theo mô hình",
+          "empty": "Không có lượt gọi mô hình cục bộ trong khoảng đã chọn",
+          "errorBadge": "{{model}}: tỉ lệ lỗi {{rate}}% ({{errors}}/{{calls}})"
+        },
+        "empty": {
+          "noProvider": "Chưa cấu hình backend cục bộ",
+          "goToSettings": "Mở Cài đặt để thêm"
+        },
+        "jobs": {
+          "title": "Tác vụ nền",
+          "kind": {
+            "chat_model": "Cài đặt mô hình chat",
+            "embedding_model": "Cài đặt mô hình embedding",
+            "ollama_install": "Cài đặt Ollama",
+            "ollama_pull": "Tải Ollama",
+            "ollama_preload": "Nạp trước",
+            "memory_reembed": "Re-embedding bộ nhớ"
+          }
         }
       }
     },
@@ -4451,7 +4791,8 @@
     "dashboard": {
       "tabs": {
         "learning": "Aprendizado",
-        "dreaming": "Sonhos"
+        "dreaming": "Sonhos",
+        "localModels": "Modelos locais"
       },
       "learning": {
         "title": "Rastreador de Aprendizado",
@@ -4496,6 +4837,73 @@
           "idle": "ocioso",
           "cron": "cron",
           "manual": "manual"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "Status do Ollama",
+        "ollamaPhases": {
+          "running": "Em execução",
+          "installed": "Instalado (parado)",
+          "not-installed": "Não instalado"
+        },
+        "openInSettings": "Gerenciar nas Configurações",
+        "hardware": {
+          "totalMemory": "Memória total",
+          "available": "Disponível",
+          "gpu": "GPU",
+          "integratedGpu": "GPU integrada / memória unificada",
+          "vram": "VRAM",
+          "budget": "Orçamento recomendado",
+          "budgetSource": {
+            "unified-memory": "Memória unificada (macOS)",
+            "dedicated-vram": "VRAM dedicada",
+            "system-memory": "Memória do sistema"
+          }
+        },
+        "running": {
+          "title": "Em execução agora",
+          "empty": "Nenhum modelo carregado no momento",
+          "vramUsed": "VRAM",
+          "context": "Contexto",
+          "expiresIn": "Será descarregado em {{duration}}",
+          "unloadingSoon": "Descarregando em breve",
+          "summary": "{{count}} em execução"
+        },
+        "installed": {
+          "title": "Modelos instalados",
+          "unknownFamily": "Família desconhecida",
+          "badges": {
+            "active": "Ativo",
+            "fallback": "Reserva",
+            "provider": "Modelo do Provider",
+            "embedding": "Embedding",
+            "running": "Em execução"
+          }
+        },
+        "usage": {
+          "title": "Uso de modelos locais",
+          "totalCalls": "Total de chamadas",
+          "totalTokens": "Total de tokens",
+          "avgTtft": "TTFT médio",
+          "trend": "Tendência diária de tokens",
+          "byModel": "Tokens por modelo",
+          "empty": "Sem chamadas a modelos locais no período selecionado",
+          "errorBadge": "{{model}}: taxa de erro {{rate}}% ({{errors}}/{{calls}})"
+        },
+        "empty": {
+          "noProvider": "Nenhum backend local configurado ainda",
+          "goToSettings": "Abra Configurações para adicionar"
+        },
+        "jobs": {
+          "title": "Tarefas em segundo plano",
+          "kind": {
+            "chat_model": "Instalação de modelo de chat",
+            "embedding_model": "Instalação de modelo de embedding",
+            "ollama_install": "Instalação do Ollama",
+            "ollama_pull": "Download do Ollama",
+            "ollama_preload": "Pré-carregamento",
+            "memory_reembed": "Re-embedding de memória"
+          }
         }
       }
     },
@@ -5222,7 +5630,8 @@
     "dashboard": {
       "tabs": {
         "learning": "Обучение",
-        "dreaming": "Сновидения"
+        "dreaming": "Сновидения",
+        "localModels": "Локальные модели"
       },
       "learning": {
         "title": "Трекер обучения",
@@ -5267,6 +5676,73 @@
           "idle": "простой",
           "cron": "cron",
           "manual": "вручную"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "Статус Ollama",
+        "ollamaPhases": {
+          "running": "Запущена",
+          "installed": "Установлена (простаивает)",
+          "not-installed": "Не установлена"
+        },
+        "openInSettings": "Управление в настройках",
+        "hardware": {
+          "totalMemory": "Всего памяти",
+          "available": "Доступно",
+          "gpu": "GPU",
+          "integratedGpu": "Встроенный GPU / единая память",
+          "vram": "VRAM",
+          "budget": "Рекомендуемый бюджет",
+          "budgetSource": {
+            "unified-memory": "Единая память (macOS)",
+            "dedicated-vram": "Выделенный VRAM",
+            "system-memory": "Системная память"
+          }
+        },
+        "running": {
+          "title": "Сейчас запущены",
+          "empty": "Ни одна модель не загружена",
+          "vramUsed": "VRAM",
+          "context": "Контекст",
+          "expiresIn": "Выгрузка через {{duration}}",
+          "unloadingSoon": "Скоро выгрузится",
+          "summary": "{{count}} запущено"
+        },
+        "installed": {
+          "title": "Установленные модели",
+          "unknownFamily": "Неизвестное семейство",
+          "badges": {
+            "active": "Активна",
+            "fallback": "Резерв",
+            "provider": "Модель Provider",
+            "embedding": "Embedding",
+            "running": "Запущена"
+          }
+        },
+        "usage": {
+          "title": "Использование локальных моделей",
+          "totalCalls": "Всего вызовов",
+          "totalTokens": "Всего токенов",
+          "avgTtft": "Среднее TTFT",
+          "trend": "Дневная динамика токенов",
+          "byModel": "Токены по моделям",
+          "empty": "В выбранном диапазоне нет вызовов локальных моделей",
+          "errorBadge": "{{model}}: уровень ошибок {{rate}}% ({{errors}}/{{calls}})"
+        },
+        "empty": {
+          "noProvider": "Локальный backend ещё не настроен",
+          "goToSettings": "Открыть настройки для добавления"
+        },
+        "jobs": {
+          "title": "Фоновые задачи",
+          "kind": {
+            "chat_model": "Установка модели чата",
+            "embedding_model": "Установка модели embedding",
+            "ollama_install": "Установка Ollama",
+            "ollama_pull": "Загрузка Ollama",
+            "ollama_preload": "Предзагрузка",
+            "memory_reembed": "Переиндексация памяти"
+          }
         }
       }
     },
@@ -5993,7 +6469,8 @@
     "dashboard": {
       "tabs": {
         "learning": "التعلّم",
-        "dreaming": "الأحلام"
+        "dreaming": "الأحلام",
+        "localModels": "النماذج المحلية"
       },
       "learning": {
         "title": "متتبع التعلّم",
@@ -6038,6 +6515,73 @@
           "idle": "خامل",
           "cron": "cron",
           "manual": "يدوي"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "حالة Ollama",
+        "ollamaPhases": {
+          "running": "قيد التشغيل",
+          "installed": "مثبت (خامل)",
+          "not-installed": "غير مثبت"
+        },
+        "openInSettings": "الإدارة من الإعدادات",
+        "hardware": {
+          "totalMemory": "إجمالي الذاكرة",
+          "available": "متاح",
+          "gpu": "GPU",
+          "integratedGpu": "GPU مدمج / ذاكرة موحدة",
+          "vram": "VRAM",
+          "budget": "الميزانية الموصى بها",
+          "budgetSource": {
+            "unified-memory": "ذاكرة موحدة (macOS)",
+            "dedicated-vram": "VRAM مخصص",
+            "system-memory": "ذاكرة النظام"
+          }
+        },
+        "running": {
+          "title": "النماذج النشطة حالياً",
+          "empty": "لا يوجد نموذج محمل حالياً",
+          "vramUsed": "VRAM",
+          "context": "السياق",
+          "expiresIn": "سيُلغى التحميل خلال {{duration}}",
+          "unloadingSoon": "سيُلغى التحميل قريباً",
+          "summary": "{{count}} قيد التشغيل"
+        },
+        "installed": {
+          "title": "النماذج المثبتة",
+          "unknownFamily": "عائلة غير معروفة",
+          "badges": {
+            "active": "النشط الآن",
+            "fallback": "احتياطي",
+            "provider": "نموذج Provider",
+            "embedding": "تضمين",
+            "running": "قيد التشغيل"
+          }
+        },
+        "usage": {
+          "title": "استخدام النماذج المحلية",
+          "totalCalls": "إجمالي الاستدعاءات",
+          "totalTokens": "إجمالي الـ Tokens",
+          "avgTtft": "متوسط TTFT",
+          "trend": "اتجاه الـ Tokens اليومي",
+          "byModel": "الـ Tokens حسب النموذج",
+          "empty": "لا توجد استدعاءات للنماذج المحلية في النطاق المحدد",
+          "errorBadge": "{{model}}: معدل خطأ {{rate}}% ({{errors}}/{{calls}})"
+        },
+        "empty": {
+          "noProvider": "لم يتم إعداد أي backend محلي بعد",
+          "goToSettings": "افتح الإعدادات لإضافة واحد"
+        },
+        "jobs": {
+          "title": "المهام الخلفية",
+          "kind": {
+            "chat_model": "تثبيت نموذج الدردشة",
+            "embedding_model": "تثبيت نموذج التضمين",
+            "ollama_install": "تثبيت Ollama",
+            "ollama_pull": "سحب من Ollama",
+            "ollama_preload": "تحميل مسبق",
+            "memory_reembed": "إعادة تضمين الذاكرة"
+          }
         }
       }
     },
@@ -6764,7 +7308,8 @@
     "dashboard": {
       "tabs": {
         "learning": "Aprendizaje",
-        "dreaming": "Sueños"
+        "dreaming": "Sueños",
+        "localModels": "Modelos locales"
       },
       "learning": {
         "title": "Tracker de aprendizaje",
@@ -6809,6 +7354,73 @@
           "idle": "inactivo",
           "cron": "cron",
           "manual": "manual"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "Estado de Ollama",
+        "ollamaPhases": {
+          "running": "En ejecución",
+          "installed": "Instalado (inactivo)",
+          "not-installed": "No instalado"
+        },
+        "openInSettings": "Gestionar en Ajustes",
+        "hardware": {
+          "totalMemory": "Memoria total",
+          "available": "Disponible",
+          "gpu": "GPU",
+          "integratedGpu": "GPU integrada / memoria unificada",
+          "vram": "VRAM",
+          "budget": "Presupuesto recomendado",
+          "budgetSource": {
+            "unified-memory": "Memoria unificada (macOS)",
+            "dedicated-vram": "VRAM dedicada",
+            "system-memory": "Memoria del sistema"
+          }
+        },
+        "running": {
+          "title": "En ejecución ahora",
+          "empty": "Ningún modelo cargado actualmente",
+          "vramUsed": "VRAM",
+          "context": "Contexto",
+          "expiresIn": "Se descargará en {{duration}}",
+          "unloadingSoon": "Descargándose pronto",
+          "summary": "{{count}} en ejecución"
+        },
+        "installed": {
+          "title": "Modelos instalados",
+          "unknownFamily": "Familia desconocida",
+          "badges": {
+            "active": "Activo",
+            "fallback": "Respaldo",
+            "provider": "Modelo de Provider",
+            "embedding": "Embedding",
+            "running": "En ejecución"
+          }
+        },
+        "usage": {
+          "title": "Uso de modelos locales",
+          "totalCalls": "Llamadas totales",
+          "totalTokens": "Tokens totales",
+          "avgTtft": "TTFT medio",
+          "trend": "Tendencia diaria de tokens",
+          "byModel": "Tokens por modelo",
+          "empty": "No hay llamadas a modelos locales en el rango seleccionado",
+          "errorBadge": "{{model}}: tasa de error {{rate}}% ({{errors}}/{{calls}})"
+        },
+        "empty": {
+          "noProvider": "Aún no hay backend local configurado",
+          "goToSettings": "Abre Ajustes para añadir uno"
+        },
+        "jobs": {
+          "title": "Tareas en segundo plano",
+          "kind": {
+            "chat_model": "Instalación de modelo de chat",
+            "embedding_model": "Instalación de modelo de embedding",
+            "ollama_install": "Instalación de Ollama",
+            "ollama_pull": "Descarga de Ollama",
+            "ollama_preload": "Precarga",
+            "memory_reembed": "Re-embedding de memoria"
+          }
         }
       }
     },
@@ -7535,7 +8147,8 @@
     "dashboard": {
       "tabs": {
         "learning": "Pembelajaran",
-        "dreaming": "Mimpi"
+        "dreaming": "Mimpi",
+        "localModels": "Model Tempatan"
       },
       "learning": {
         "title": "Pengesan Pembelajaran",
@@ -7580,6 +8193,73 @@
           "idle": "terbiar",
           "cron": "cron",
           "manual": "manual"
+        }
+      },
+      "localModels": {
+        "ollamaStatus": "Status Ollama",
+        "ollamaPhases": {
+          "running": "Berjalan",
+          "installed": "Dipasang (melahu)",
+          "not-installed": "Belum dipasang"
+        },
+        "openInSettings": "Urus dalam Tetapan",
+        "hardware": {
+          "totalMemory": "Jumlah memori",
+          "available": "Tersedia",
+          "gpu": "GPU",
+          "integratedGpu": "GPU bersepadu / memori bersatu",
+          "vram": "VRAM",
+          "budget": "Bajet disyorkan",
+          "budgetSource": {
+            "unified-memory": "Memori bersatu (macOS)",
+            "dedicated-vram": "VRAM khusus",
+            "system-memory": "Memori sistem"
+          }
+        },
+        "running": {
+          "title": "Sedang berjalan",
+          "empty": "Tiada model dimuatkan",
+          "vramUsed": "VRAM",
+          "context": "Konteks",
+          "expiresIn": "Dinyahmuat dalam {{duration}}",
+          "unloadingSoon": "Akan dinyahmuat",
+          "summary": "{{count}} berjalan"
+        },
+        "installed": {
+          "title": "Model dipasang",
+          "unknownFamily": "Keluarga tidak diketahui",
+          "badges": {
+            "active": "Aktif",
+            "fallback": "Sandaran",
+            "provider": "Model Provider",
+            "embedding": "Embedding",
+            "running": "Berjalan"
+          }
+        },
+        "usage": {
+          "title": "Penggunaan model tempatan",
+          "totalCalls": "Jumlah panggilan",
+          "totalTokens": "Jumlah token",
+          "avgTtft": "Purata TTFT",
+          "trend": "Trend token harian",
+          "byModel": "Token mengikut model",
+          "empty": "Tiada panggilan model tempatan dalam julat yang dipilih",
+          "errorBadge": "{{model}}: kadar ralat {{rate}}% ({{errors}}/{{calls}})"
+        },
+        "empty": {
+          "noProvider": "Belum ada backend tempatan dikonfigurasikan",
+          "goToSettings": "Buka Tetapan untuk menambah"
+        },
+        "jobs": {
+          "title": "Tugas latar belakang",
+          "kind": {
+            "chat_model": "Pemasangan model sembang",
+            "embedding_model": "Pemasangan model embedding",
+            "ollama_install": "Pemasangan Ollama",
+            "ollama_pull": "Muat turun Ollama",
+            "ollama_preload": "Pra-muat",
+            "memory_reembed": "Embed semula memori"
+          }
         }
       }
     },

--- a/src-tauri/src/commands/dashboard.rs
+++ b/src-tauri/src/commands/dashboard.rs
@@ -159,3 +159,12 @@ pub async fn dashboard_plan_stats(
 ) -> Result<dashboard::PlanStats, CmdError> {
     dashboard::query_plan_stats(&filter).map_err(Into::into)
 }
+
+#[tauri::command]
+pub async fn dashboard_local_model_usage(
+    filter: DashboardFilter,
+    state: State<'_, AppState>,
+) -> Result<dashboard::LocalModelUsage, CmdError> {
+    let names = dashboard::local_provider_names();
+    dashboard::query_local_model_usage(&state.session_db, &filter, &names).map_err(Into::into)
+}

--- a/src-tauri/src/commands/local_llm.rs
+++ b/src-tauri/src/commands/local_llm.rs
@@ -2,11 +2,11 @@ use crate::commands::CmdError;
 use crate::AppState;
 use ha_core::local_llm::{
     add_ollama_model_as_embedding_config, delete_ollama_model, detect_hardware, detect_ollama,
-    get_ollama_library_model, list_local_ollama_models, model_catalog, preload_ollama_model,
-    recommend_model, register_ollama_model_as_provider, search_ollama_library, start_ollama,
-    stop_ollama_model, HardwareInfo, LocalModelDeleteResult, LocalOllamaModel, ModelCandidate,
-    ModelRecommendation, OllamaLibraryModelDetail, OllamaLibrarySearchResponse,
-    OllamaModelActionResult, OllamaModelRegistration, OllamaStatus,
+    detect_ollama_version, get_ollama_library_model, list_local_ollama_models, model_catalog,
+    preload_ollama_model, recommend_model, register_ollama_model_as_provider,
+    search_ollama_library, start_ollama, stop_ollama_model, HardwareInfo, LocalModelDeleteResult,
+    LocalOllamaModel, ModelCandidate, ModelRecommendation, OllamaLibraryModelDetail,
+    OllamaLibrarySearchResponse, OllamaModelActionResult, OllamaModelRegistration, OllamaStatus,
 };
 use ha_core::memory::EmbeddingModelConfig;
 use ha_core::provider::{known_local_backends, KnownLocalBackend};
@@ -36,6 +36,11 @@ pub async fn local_llm_chat_catalog() -> Result<Vec<ModelCandidate>, CmdError> {
 #[tauri::command]
 pub async fn local_llm_detect_ollama() -> Result<OllamaStatus, CmdError> {
     Ok(detect_ollama().await)
+}
+
+#[tauri::command]
+pub async fn local_llm_detect_ollama_version() -> Result<Option<String>, CmdError> {
+    detect_ollama_version().await.map_err(Into::into)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -299,6 +299,7 @@ pub fn run() {
             commands::local_llm::local_llm_recommend_model,
             commands::local_llm::local_llm_chat_catalog,
             commands::local_llm::local_llm_detect_ollama,
+            commands::local_llm::local_llm_detect_ollama_version,
             commands::local_llm::local_llm_known_backends,
             commands::local_llm::local_llm_start_ollama,
             commands::local_llm::local_llm_list_models,
@@ -574,6 +575,7 @@ pub fn run() {
             commands::dashboard::dashboard_top_skills,
             commands::dashboard::dashboard_recall_stats,
             commands::dashboard::dashboard_plan_stats,
+            commands::dashboard::dashboard_local_model_usage,
             // Recap (deep analysis reports)
             commands::recap::recap_generate,
             commands::recap::recap_list_reports,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -516,7 +516,10 @@ export default function App() {
                     </div>
                   }
                 >
-                  <DashboardView onBack={() => setView("chat")} />
+                  <DashboardView
+                    onBack={() => setView("chat")}
+                    onOpenSettings={handleOpenSettings}
+                  />
                 </Suspense>
               )}
               {view === "plans" && (

--- a/src/components/dashboard/DashboardView.tsx
+++ b/src/components/dashboard/DashboardView.tsx
@@ -25,6 +25,7 @@ import SessionSection from "./SessionSection"
 import ErrorSection from "./ErrorSection"
 import TaskSection from "./TaskSection"
 import SystemMetricsSection from "./SystemMetricsSection"
+import LocalModelsSection from "./LocalModelsSection"
 import RecapTab from "./recap/RecapTab"
 import DreamingTab from "./dreaming/DreamingTab"
 import LearningTab from "./learning/LearningTab"
@@ -43,8 +44,16 @@ import type {
   DetailListType,
   AutoRefreshInterval,
   PlanStats,
+  DashboardLocalModelUsage,
 } from "./types"
 import { autoRefreshMs } from "./types"
+import type {
+  HardwareInfo,
+  LocalOllamaModel,
+  OllamaStatus,
+} from "@/types/local-llm"
+import type { LocalModelJobSnapshot } from "@/types/local-model-jobs"
+import type { SettingsSection } from "@/components/settings/types"
 
 function defaultFilter(): DashboardFilterState {
   const now = new Date()
@@ -97,7 +106,21 @@ function downloadCsv(filename: string, rows: Record<string, unknown>[]) {
   URL.revokeObjectURL(url)
 }
 
-export default function DashboardView({ onBack }: { onBack: () => void }) {
+interface LocalModelsTabData {
+  ollama: OllamaStatus | null
+  ollamaVersion: string | null
+  hardware: HardwareInfo | null
+  models: LocalOllamaModel[] | null
+  usage: DashboardLocalModelUsage | null
+  jobs: LocalModelJobSnapshot[] | null
+}
+
+interface DashboardViewProps {
+  onBack: () => void
+  onOpenSettings?: (section?: SettingsSection) => void
+}
+
+export default function DashboardView({ onBack, onOpenSettings }: DashboardViewProps) {
   const { t } = useTranslation()
   const [filter, setFilter] = useState<DashboardFilterState>(defaultFilter)
   const [activeTab, setActiveTab] = useState("insights")
@@ -113,6 +136,14 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
   const [systemMetrics, setSystemMetrics] = useState<SystemMetrics | null>(null)
   const [systemHistory, setSystemHistory] = useState<SystemHistoryPoint[]>([])
   const [planStats, setPlanStats] = useState<PlanStats | null>(null)
+  const [localModelsData, setLocalModelsData] = useState<LocalModelsTabData>({
+    ollama: null,
+    ollamaVersion: null,
+    hardware: null,
+    models: null,
+    usage: null,
+    jobs: null,
+  })
   const [granularity, setGranularity] = useState<Granularity>("day")
   const [autoRefresh, setAutoRefresh] = useState<AutoRefreshInterval>("off")
   const [lastRefreshAt, setLastRefreshAt] = useState<Date | null>(null)
@@ -205,6 +236,42 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
                 next.splice(0, next.length - SYSTEM_HISTORY_LIMIT)
               }
               return next
+            })
+            break
+          }
+          case "local-models": {
+            // Tolerate per-probe failures (e.g. Ollama unreachable) without
+            // breaking the whole tab — each settled result becomes null if
+            // the call rejects.
+            const settled = await Promise.allSettled([
+              getTransport().call<OllamaStatus>("local_llm_detect_ollama"),
+              getTransport().call<HardwareInfo>("local_llm_detect_hardware"),
+              getTransport().call<{ version: string | null } | string | null>(
+                "local_llm_detect_ollama_version",
+              ),
+              getTransport().call<LocalOllamaModel[]>("local_llm_list_models"),
+              getTransport().call<DashboardLocalModelUsage>(
+                "dashboard_local_model_usage",
+                { filter },
+              ),
+              getTransport().call<LocalModelJobSnapshot[]>("local_model_job_list"),
+            ])
+            const pick = <T,>(r: PromiseSettledResult<T>): T | null =>
+              r.status === "fulfilled" ? r.value : null
+            const versionResp = pick(settled[2])
+            const version =
+              typeof versionResp === "string"
+                ? versionResp
+                : versionResp && typeof versionResp === "object"
+                  ? (versionResp.version ?? null)
+                  : null
+            setLocalModelsData({
+              ollama: pick(settled[0]),
+              hardware: pick(settled[1]),
+              ollamaVersion: version,
+              models: pick(settled[3]),
+              usage: pick(settled[4]),
+              jobs: pick(settled[5]),
             })
             break
           }
@@ -455,6 +522,9 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
               <TabsTrigger value="tasks">{t("dashboard.tabs.tasks")}</TabsTrigger>
               <TabsTrigger value="plans">{t("dashboard.tabs.plans")}</TabsTrigger>
               <TabsTrigger value="system">{t("dashboard.tabs.system")}</TabsTrigger>
+              <TabsTrigger value="local-models">
+                {t("dashboard.tabs.localModels")}
+              </TabsTrigger>
               <TabsTrigger value="recap">{t("dashboard.tabs.recap")}</TabsTrigger>
               <TabsTrigger value="learning">{t("dashboard.tabs.learning")}</TabsTrigger>
               <TabsTrigger value="dreaming">{t("dashboard.tabs.dreaming")}</TabsTrigger>
@@ -517,6 +587,18 @@ export default function DashboardView({ onBack }: { onBack: () => void }) {
           </TabsContent>
           <TabsContent value="system">
             <SystemMetricsSection data={systemMetrics} history={systemHistory} loading={loading} />
+          </TabsContent>
+          <TabsContent value="local-models">
+            <LocalModelsSection
+              loading={loading}
+              ollama={localModelsData.ollama}
+              ollamaVersion={localModelsData.ollamaVersion}
+              hardware={localModelsData.hardware}
+              models={localModelsData.models}
+              usage={localModelsData.usage}
+              jobs={localModelsData.jobs}
+              onOpenSettings={onOpenSettings}
+            />
           </TabsContent>
           <TabsContent value="recap">
             <RecapTab />

--- a/src/components/dashboard/LocalModelsSection.tsx
+++ b/src/components/dashboard/LocalModelsSection.tsx
@@ -1,0 +1,674 @@
+import React, { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import {
+  AreaChart,
+  Area,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip as RechartsTooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts"
+import {
+  Activity,
+  AlertCircle,
+  Cpu,
+  Gauge,
+  HardDrive,
+  Layers,
+  MemoryStick,
+  Monitor,
+  PackageOpen,
+  Server,
+  Timer,
+  Zap,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
+import { cn } from "@/lib/utils"
+import MetricCard from "@/components/common/MetricCard"
+import { formatBytes as formatRawBytes } from "@/lib/format"
+import type { SettingsSection } from "@/components/settings/types"
+import type {
+  HardwareInfo,
+  LocalOllamaModel,
+  OllamaStatus,
+} from "@/types/local-llm"
+import type { LocalModelJobSnapshot } from "@/types/local-model-jobs"
+import {
+  isLocalModelJobActive,
+  isLocalModelJobVisible,
+  localModelJobPercent,
+} from "@/types/local-model-jobs"
+import type { DashboardLocalModelUsage } from "./types"
+import { chartName, chartNumber, formatNumber } from "./types"
+
+interface LocalModelsSectionProps {
+  loading: boolean
+  ollama: OllamaStatus | null
+  ollamaVersion: string | null
+  hardware: HardwareInfo | null
+  models: LocalOllamaModel[] | null
+  usage: DashboardLocalModelUsage | null
+  jobs: LocalModelJobSnapshot[] | null
+  onOpenSettings?: (section?: SettingsSection) => void
+}
+
+function formatBytes(bytes: number): string {
+  return formatRawBytes(bytes, { fractionDigits: { GB: 2, TB: 2 } })
+}
+
+function mbToBytes(mb: number): number {
+  return mb * 1024 * 1024
+}
+
+function SectionSkeleton({ height }: { height: number }) {
+  return (
+    <div
+      className="w-full bg-muted animate-pulse rounded-lg"
+      style={{ height }}
+    />
+  )
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n))
+}
+
+interface BadgeProps {
+  children: React.ReactNode
+  className?: string
+}
+
+function Badge({ children, className }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-md border px-1.5 py-0.5 text-[10px] font-medium",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}
+
+/**
+ * Parse `expires_at` (RFC3339) into a human-friendly "在 5 分钟后卸载" string.
+ * Returns null when the timestamp is missing, malformed, or already past.
+ */
+function formatExpiresIn(
+  expiresAt: string | null | undefined,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): string | null {
+  if (!expiresAt) return null
+  const ts = Date.parse(expiresAt)
+  if (!Number.isFinite(ts)) return null
+  const deltaSec = Math.round((ts - Date.now()) / 1000)
+  if (deltaSec <= 0) return t("dashboard.localModels.running.unloadingSoon")
+  if (deltaSec < 60)
+    return t("dashboard.localModels.running.expiresIn", {
+      duration: `${deltaSec}s`,
+    })
+  if (deltaSec < 3600)
+    return t("dashboard.localModels.running.expiresIn", {
+      duration: `${Math.floor(deltaSec / 60)}m`,
+    })
+  return t("dashboard.localModels.running.expiresIn", {
+    duration: `${Math.floor(deltaSec / 3600)}h${Math.floor((deltaSec % 3600) / 60)}m`,
+  })
+}
+
+const PHASE_COLORS: Record<string, { text: string; bg: string }> = {
+  running: { text: "text-emerald-600", bg: "bg-emerald-500/10" },
+  installed: { text: "text-amber-600", bg: "bg-amber-500/10" },
+  "not-installed": { text: "text-red-600", bg: "bg-red-500/10" },
+}
+
+const LocalModelsSection = React.memo(function LocalModelsSection({
+  loading,
+  ollama,
+  ollamaVersion,
+  hardware,
+  models,
+  usage,
+  jobs,
+  onOpenSettings,
+}: LocalModelsSectionProps) {
+  const { t } = useTranslation()
+
+  const runningModels = useMemo(
+    () => (models ?? []).filter((m) => m.running),
+    [models],
+  )
+  const installedModels = useMemo(() => models ?? [], [models])
+  const visibleJobs = useMemo(
+    () => (jobs ?? []).filter(isLocalModelJobVisible),
+    [jobs],
+  )
+
+  const totalVramBytes = useMemo(
+    () =>
+      runningModels.reduce((sum, m) => sum + (m.sizeVramBytes ?? 0), 0),
+    [runningModels],
+  )
+  const budgetBytes = hardware ? mbToBytes(hardware.budgetMb) : 0
+  const vramPct = budgetBytes > 0
+    ? clamp((totalVramBytes / budgetBytes) * 100, 0, 100)
+    : 0
+
+  const trendData = useMemo(
+    () =>
+      (usage?.trend ?? []).map((p) => ({
+        date: p.date,
+        inputTokens: p.inputTokens,
+        outputTokens: p.outputTokens,
+      })),
+    [usage],
+  )
+
+  const byModelData = useMemo(
+    () =>
+      (usage?.byModel ?? []).map((row) => ({
+        modelId: row.modelId,
+        providerName: row.providerName,
+        totalTokens: row.inputTokens + row.outputTokens,
+        callCount: row.callCount,
+        errorRate:
+          row.callCount > 0 ? (row.errorCount / row.callCount) * 100 : 0,
+        errorCount: row.errorCount,
+        avgTtftMs: row.avgTtftMs,
+      })),
+    [usage],
+  )
+
+  if (loading && !ollama && !hardware && !models && !usage) {
+    return (
+      <div className="space-y-4 mt-4">
+        <SectionSkeleton height={64} />
+        <SectionSkeleton height={120} />
+        <SectionSkeleton height={240} />
+        <SectionSkeleton height={300} />
+      </div>
+    )
+  }
+
+  const phase = ollama?.phase ?? "not-installed"
+  const phaseColor = PHASE_COLORS[phase] ?? PHASE_COLORS["not-installed"]
+  const phaseLabel = t(`dashboard.localModels.ollamaPhases.${phase}`)
+
+  return (
+    <div className="space-y-4 mt-4">
+      {/* Block A — Ollama status bar */}
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border bg-card px-4 py-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div
+            className={`h-8 w-8 rounded-full flex items-center justify-center shrink-0 ${phaseColor.bg}`}
+          >
+            <Server className={`h-4 w-4 ${phaseColor.text}`} />
+          </div>
+          <div className="min-w-0">
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <span className="text-sm font-semibold">
+                {t("dashboard.localModels.ollamaStatus")}
+              </span>
+              <span className={`text-sm font-medium ${phaseColor.text}`}>
+                {phaseLabel}
+              </span>
+              {ollamaVersion && (
+                <span className="text-xs text-muted-foreground">
+                  v{ollamaVersion}
+                </span>
+              )}
+            </div>
+            {ollama?.baseUrl && (
+              <div className="text-[11px] text-muted-foreground truncate">
+                {ollama.baseUrl}
+              </div>
+            )}
+          </div>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onOpenSettings?.("modelConfig")}
+        >
+          {t("dashboard.localModels.openInSettings")}
+        </Button>
+      </div>
+
+      {/* Block B — Hardware budget */}
+      {hardware && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          <MetricCard
+            icon={MemoryStick}
+            label={t("dashboard.localModels.hardware.totalMemory")}
+            value={formatBytes(mbToBytes(hardware.totalMemoryMb))}
+            subValue={`${t("dashboard.localModels.hardware.available")}: ${formatBytes(
+              mbToBytes(hardware.availableMemoryMb),
+            )}`}
+            colorClass="text-purple-500"
+            bgClass="bg-purple-500/10"
+          />
+          <MetricCard
+            icon={Monitor}
+            label={t("dashboard.localModels.hardware.gpu")}
+            value={hardware.gpu?.name ?? t("dashboard.localModels.hardware.integratedGpu")}
+            subValue={
+              hardware.gpu?.vramMb != null
+                ? `${t("dashboard.localModels.hardware.vram")}: ${formatBytes(mbToBytes(hardware.gpu.vramMb))}`
+                : undefined
+            }
+            colorClass="text-blue-500"
+            bgClass="bg-blue-500/10"
+          />
+          <MetricCard
+            icon={Gauge}
+            label={t("dashboard.localModels.hardware.budget")}
+            value={formatBytes(mbToBytes(hardware.budgetMb))}
+            subValue={t(
+              `dashboard.localModels.hardware.budgetSource.${hardware.budgetSource}`,
+            )}
+            colorClass="text-emerald-500"
+            bgClass="bg-emerald-500/10"
+          />
+          <MetricCard
+            icon={Layers}
+            label={t("dashboard.localModels.installed.title")}
+            value={formatNumber(installedModels.length)}
+            subValue={
+              runningModels.length > 0
+                ? t("dashboard.localModels.running.summary", {
+                    count: runningModels.length,
+                  })
+                : undefined
+            }
+            colorClass="text-amber-500"
+            bgClass="bg-amber-500/10"
+          />
+        </div>
+      )}
+
+      {/* Block C — Running models (read-only) */}
+      <div className="rounded-xl border bg-card p-4">
+        <div className="flex items-center justify-between mb-3">
+          <h3 className="text-sm font-medium flex items-center gap-2">
+            <Cpu className="h-4 w-4 text-emerald-500" />
+            {t("dashboard.localModels.running.title")}
+          </h3>
+          {runningModels.length > 0 && budgetBytes > 0 && (
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {formatBytes(totalVramBytes)} /{" "}
+              {formatBytes(budgetBytes)}
+            </span>
+          )}
+        </div>
+
+        {runningModels.length === 0 ? (
+          <div className="py-6 flex flex-col items-center text-muted-foreground text-sm">
+            <Cpu className="h-7 w-7 mb-2 opacity-30" />
+            <span>{t("dashboard.localModels.running.empty")}</span>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {budgetBytes > 0 && (
+              <Progress value={vramPct} className="h-2" />
+            )}
+            <div className="space-y-2">
+              {runningModels.map((m) => {
+                const expires = formatExpiresIn(m.expiresAt, t)
+                return (
+                  <div
+                    key={m.id}
+                    className="flex items-center justify-between gap-3 rounded-lg bg-muted/40 px-3 py-2 text-sm"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="font-medium truncate">{m.name}</div>
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+                        {m.sizeVramBytes != null && (
+                          <span className="tabular-nums">
+                            {t("dashboard.localModels.running.vramUsed")}:{" "}
+                            {formatBytes(m.sizeVramBytes)}
+                          </span>
+                        )}
+                        {m.contextWindow != null && (
+                          <span className="tabular-nums">
+                            {t("dashboard.localModels.running.context")}:{" "}
+                            {formatNumber(m.contextWindow)}
+                          </span>
+                        )}
+                        {expires && (
+                          <span className="flex items-center gap-1">
+                            <Timer className="h-3 w-3" />
+                            {expires}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Block D — Installed models (read-only grid) */}
+      {installedModels.length > 0 && (
+        <div className="rounded-xl border bg-card p-4">
+          <h3 className="text-sm font-medium flex items-center gap-2 mb-3">
+            <PackageOpen className="h-4 w-4 text-blue-500" />
+            {t("dashboard.localModels.installed.title")}
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {installedModels.map((m) => (
+              <div
+                key={m.id}
+                className="rounded-lg border bg-background/40 p-3 space-y-2"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="font-medium text-sm truncate">{m.name}</div>
+                    <div className="text-[11px] text-muted-foreground truncate">
+                      {m.details?.family ??
+                        t("dashboard.localModels.installed.unknownFamily")}
+                      {m.sizeBytes != null
+                        ? ` · ${formatBytes(m.sizeBytes)}`
+                        : ""}
+                      {m.contextWindow != null
+                        ? ` · ctx ${formatNumber(m.contextWindow)}`
+                        : ""}
+                    </div>
+                  </div>
+                  {m.usage.running && (
+                    <Badge className="bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border-emerald-500/20">
+                      <Activity className="h-3 w-3 mr-1" />
+                      {t("dashboard.localModels.installed.badges.running")}
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {m.usage.activeModel && (
+                    <Badge className="bg-blue-500/10 text-blue-700 dark:text-blue-300 border-blue-500/20">
+                      {t("dashboard.localModels.installed.badges.active")}
+                    </Badge>
+                  )}
+                  {m.usage.fallbackModel && (
+                    <Badge className="border-border text-muted-foreground">
+                      {t("dashboard.localModels.installed.badges.fallback")}
+                    </Badge>
+                  )}
+                  {m.usage.providerModel && !m.usage.activeModel && (
+                    <Badge className="border-border text-muted-foreground">
+                      {t("dashboard.localModels.installed.badges.provider")}
+                    </Badge>
+                  )}
+                  {(m.usage.embeddingConfig || m.usage.embeddingModel) && (
+                    <Badge className="border-border text-muted-foreground">
+                      {t("dashboard.localModels.installed.badges.embedding")}
+                    </Badge>
+                  )}
+                  {m.capabilities.map((cap) => (
+                    <Badge
+                      key={cap}
+                      className="border-border text-muted-foreground"
+                    >
+                      {cap}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Block E — Usage statistics */}
+      <div className="rounded-xl border bg-card p-4 space-y-4">
+        <div className="flex items-center gap-2">
+          <Zap className="h-4 w-4 text-violet-500" />
+          <h3 className="text-sm font-medium">
+            {t("dashboard.localModels.usage.title")}
+          </h3>
+        </div>
+
+        {usage == null ? null : usage.localProviderNames.length === 0 ? (
+          <div className="py-8 flex flex-col items-center gap-2 text-muted-foreground text-sm">
+            <AlertCircle className="h-7 w-7 opacity-30" />
+            <span>{t("dashboard.localModels.empty.noProvider")}</span>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => onOpenSettings?.("modelConfig")}
+            >
+              {t("dashboard.localModels.empty.goToSettings")}
+            </Button>
+          </div>
+        ) : usage.totalCalls === 0 ? (
+          <div className="py-8 flex flex-col items-center gap-2 text-muted-foreground text-sm">
+            <Zap className="h-7 w-7 opacity-30" />
+            <span>{t("dashboard.localModels.usage.empty")}</span>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <MetricCard
+                icon={Zap}
+                label={t("dashboard.localModels.usage.totalCalls")}
+                value={formatNumber(usage.totalCalls)}
+                colorClass="text-violet-500"
+                bgClass="bg-violet-500/10"
+              />
+              <MetricCard
+                icon={HardDrive}
+                label={t("dashboard.localModels.usage.totalTokens")}
+                value={formatNumber(
+                  usage.totalInputTokens + usage.totalOutputTokens,
+                )}
+                subValue={`${formatNumber(usage.totalInputTokens)} in · ${formatNumber(usage.totalOutputTokens)} out`}
+                colorClass="text-blue-500"
+                bgClass="bg-blue-500/10"
+              />
+              <MetricCard
+                icon={Timer}
+                label={t("dashboard.localModels.usage.avgTtft")}
+                value={
+                  usage.avgTtftMs != null
+                    ? `${Math.round(usage.avgTtftMs)}ms`
+                    : "—"
+                }
+                colorClass="text-amber-500"
+                bgClass="bg-amber-500/10"
+              />
+            </div>
+
+            {trendData.length > 1 && (
+              <div>
+                <div className="text-xs text-muted-foreground mb-2">
+                  {t("dashboard.localModels.usage.trend")}
+                </div>
+                <ResponsiveContainer width="100%" height={180}>
+                  <AreaChart
+                    data={trendData}
+                    margin={{ top: 5, right: 16, left: 0, bottom: 0 }}
+                  >
+                    <defs>
+                      <linearGradient id="localInGrad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor="#3b82f6" stopOpacity={0.45} />
+                        <stop offset="100%" stopColor="#3b82f6" stopOpacity={0} />
+                      </linearGradient>
+                      <linearGradient id="localOutGrad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor="#a855f7" stopOpacity={0.45} />
+                        <stop offset="100%" stopColor="#a855f7" stopOpacity={0} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 10 }}
+                      stroke="var(--color-muted-foreground)"
+                      tickFormatter={(v: string) => v.slice(5)}
+                    />
+                    <YAxis
+                      tick={{ fontSize: 10 }}
+                      stroke="var(--color-muted-foreground)"
+                      tickFormatter={(v: number) => formatNumber(v)}
+                    />
+                    <RechartsTooltip
+                      contentStyle={{
+                        backgroundColor: "var(--color-popover)",
+                        border: "1px solid var(--color-border)",
+                        borderRadius: "8px",
+                        fontSize: "12px",
+                        color: "var(--color-popover-foreground)",
+                      }}
+                      formatter={(value, name) => [
+                        formatNumber(chartNumber(value)),
+                        chartName(name) === "inputTokens"
+                          ? t("dashboard.token.inputTokens")
+                          : t("dashboard.token.outputTokens"),
+                      ]}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="inputTokens"
+                      stroke="#3b82f6"
+                      strokeWidth={2}
+                      fill="url(#localInGrad)"
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="outputTokens"
+                      stroke="#a855f7"
+                      strokeWidth={2}
+                      fill="url(#localOutGrad)"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+
+            {byModelData.length > 0 && (
+              <div>
+                <div className="text-xs text-muted-foreground mb-2">
+                  {t("dashboard.localModels.usage.byModel")}
+                </div>
+                <ResponsiveContainer width="100%" height={Math.max(160, byModelData.length * 36)}>
+                  <BarChart
+                    data={byModelData}
+                    layout="vertical"
+                    margin={{ top: 4, right: 16, left: 16, bottom: 0 }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                    <XAxis
+                      type="number"
+                      tick={{ fontSize: 10 }}
+                      stroke="var(--color-muted-foreground)"
+                      tickFormatter={(v: number) => formatNumber(v)}
+                    />
+                    <YAxis
+                      type="category"
+                      dataKey="modelId"
+                      tick={{ fontSize: 11 }}
+                      stroke="var(--color-muted-foreground)"
+                      width={140}
+                    />
+                    <RechartsTooltip
+                      contentStyle={{
+                        backgroundColor: "var(--color-popover)",
+                        border: "1px solid var(--color-border)",
+                        borderRadius: "8px",
+                        fontSize: "12px",
+                        color: "var(--color-popover-foreground)",
+                      }}
+                      formatter={(value) => [formatNumber(chartNumber(value))]}
+                    />
+                    <Bar dataKey="totalTokens" radius={[0, 4, 4, 0]}>
+                      {byModelData.map((row, idx) => (
+                        <Cell
+                          key={`${row.modelId}-${idx}`}
+                          fill={row.errorRate > 5 ? "#ef4444" : "#8b5cf6"}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+                <div className="mt-2 space-y-1">
+                  {byModelData
+                    .filter((row) => row.errorRate > 5)
+                    .map((row) => (
+                      <div
+                        key={`err-${row.modelId}`}
+                        className="text-[11px] text-red-600 dark:text-red-400 flex items-center gap-1"
+                      >
+                        <AlertCircle className="h-3 w-3" />
+                        {t("dashboard.localModels.usage.errorBadge", {
+                          model: row.modelId,
+                          rate: row.errorRate.toFixed(1),
+                          errors: row.errorCount,
+                          calls: row.callCount,
+                        })}
+                      </div>
+                    ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Block F — Background jobs */}
+      {visibleJobs.length > 0 && (
+        <div className="rounded-xl border bg-card p-4">
+          <h3 className="text-sm font-medium flex items-center gap-2 mb-3">
+            <Activity className="h-4 w-4 text-amber-500" />
+            {t("dashboard.localModels.jobs.title")}
+          </h3>
+          <div className="space-y-2">
+            {visibleJobs.map((job) => {
+              const pct = localModelJobPercent(job)
+              const active = isLocalModelJobActive(job)
+              return (
+                <div
+                  key={job.jobId}
+                  className="rounded-lg bg-muted/40 px-3 py-2 text-sm space-y-1.5"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="font-medium truncate">
+                        {job.displayName || job.modelId}
+                      </div>
+                      <div className="text-[11px] text-muted-foreground truncate">
+                        {t(`dashboard.localModels.jobs.kind.${job.kind}`, {
+                          defaultValue: job.kind,
+                        })}
+                        {" · "}
+                        {job.phase}
+                        {!active && (
+                          <span className="ml-1">({job.status})</span>
+                        )}
+                      </div>
+                    </div>
+                    {pct != null && (
+                      <span className="text-[11px] tabular-nums text-muted-foreground shrink-0">
+                        {pct.toFixed(0)}%
+                      </span>
+                    )}
+                  </div>
+                  {pct != null && (
+                    <Progress value={pct} className="h-1.5" />
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+})
+
+export default LocalModelsSection

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -501,6 +501,28 @@ export type RecapProgress =
   | { phase: "done"; reportId: string }
   | { phase: "failed"; reportId: string; message: string }
 
+// ── Local Models Tab ────────────────────────────────────────────
+
+export interface DashboardLocalModelUsageRow {
+  modelId: string
+  providerName: string
+  callCount: number
+  inputTokens: number
+  outputTokens: number
+  avgTtftMs: number | null
+  errorCount: number
+}
+
+export interface DashboardLocalModelUsage {
+  localProviderNames: string[]
+  totalCalls: number
+  totalInputTokens: number
+  totalOutputTokens: number
+  avgTtftMs: number | null
+  trend: TokenUsageTrend[]
+  byModel: DashboardLocalModelUsageRow[]
+}
+
 // ── Plan Stats ──────────────────────────────────────────────────
 
 export interface PlanStateDistribution {

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -842,18 +842,34 @@
       "systemUptime": "وقت تشغيل النظام",
       "virtualMem": "الذاكرة الافتراضية"
     },
+    "plans": {
+      "active": "قيد التنفيذ",
+      "avgExecution": "متوسط زمن التنفيذ",
+      "byAgent": "حسب Agent",
+      "byAgentCompleted": "مكتمل",
+      "byProject": "حسب المشروع",
+      "completionRate": "نسبة الإكمال",
+      "created": "تم إنشاؤها",
+      "creationTrend": "اتجاه الإنشاء (30 يومًا)",
+      "empty": "لا توجد بيانات خطط في النافذة المختارة.",
+      "noProject": "بدون مشروع",
+      "sampleSize": "تم أخذ عينة من {{count}} مكتملة",
+      "stateDistribution": "توزيع الحالات",
+      "total": "إجمالي الخطط"
+    },
     "tabs": {
       "dreaming": "الأحلام",
       "errors": "الأخطاء",
       "insights": "رؤى",
       "learning": "التعلّم",
+      "plans": "الخطط",
       "recap": "المراجعة",
       "sessions": "الجلسات",
       "system": "النظام",
       "tasks": "المهام",
       "tokens": "استخدام الرموز",
       "tools": "استخدام الأدوات",
-      "plans": "الخطط"
+      "localModels": "النماذج المحلية"
     },
     "task": {
       "activeJobs": "النشطة",
@@ -902,20 +918,72 @@
       "name": "الاسم",
       "totalMs": "الإجمالي (ms)"
     },
-    "plans": {
-      "active": "قيد التنفيذ",
-      "avgExecution": "متوسط زمن التنفيذ",
-      "byAgent": "حسب Agent",
-      "byAgentCompleted": "مكتمل",
-      "byProject": "حسب المشروع",
-      "completionRate": "نسبة الإكمال",
-      "created": "تم إنشاؤها",
-      "creationTrend": "اتجاه الإنشاء (30 يومًا)",
-      "empty": "لا توجد بيانات خطط في النافذة المختارة.",
-      "noProject": "بدون مشروع",
-      "sampleSize": "تم أخذ عينة من {{count}} مكتملة",
-      "stateDistribution": "توزيع الحالات",
-      "total": "إجمالي الخطط"
+    "localModels": {
+      "ollamaStatus": "حالة Ollama",
+      "ollamaPhases": {
+        "running": "قيد التشغيل",
+        "installed": "مثبت (خامل)",
+        "not-installed": "غير مثبت"
+      },
+      "openInSettings": "الإدارة من الإعدادات",
+      "hardware": {
+        "totalMemory": "إجمالي الذاكرة",
+        "available": "متاح",
+        "gpu": "GPU",
+        "integratedGpu": "GPU مدمج / ذاكرة موحدة",
+        "vram": "VRAM",
+        "budget": "الميزانية الموصى بها",
+        "budgetSource": {
+          "unified-memory": "ذاكرة موحدة (macOS)",
+          "dedicated-vram": "VRAM مخصص",
+          "system-memory": "ذاكرة النظام"
+        }
+      },
+      "running": {
+        "title": "النماذج النشطة حالياً",
+        "empty": "لا يوجد نموذج محمل حالياً",
+        "vramUsed": "VRAM",
+        "context": "السياق",
+        "expiresIn": "سيُلغى التحميل خلال {{duration}}",
+        "unloadingSoon": "سيُلغى التحميل قريباً",
+        "summary": "{{count}} قيد التشغيل"
+      },
+      "installed": {
+        "title": "النماذج المثبتة",
+        "unknownFamily": "عائلة غير معروفة",
+        "badges": {
+          "active": "النشط الآن",
+          "fallback": "احتياطي",
+          "provider": "نموذج Provider",
+          "embedding": "تضمين",
+          "running": "قيد التشغيل"
+        }
+      },
+      "usage": {
+        "title": "استخدام النماذج المحلية",
+        "totalCalls": "إجمالي الاستدعاءات",
+        "totalTokens": "إجمالي الـ Tokens",
+        "avgTtft": "متوسط TTFT",
+        "trend": "اتجاه الـ Tokens اليومي",
+        "byModel": "الـ Tokens حسب النموذج",
+        "empty": "لا توجد استدعاءات للنماذج المحلية في النطاق المحدد",
+        "errorBadge": "{{model}}: معدل خطأ {{rate}}% ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "لم يتم إعداد أي backend محلي بعد",
+        "goToSettings": "افتح الإعدادات لإضافة واحد"
+      },
+      "jobs": {
+        "title": "المهام الخلفية",
+        "kind": {
+          "chat_model": "تثبيت نموذج الدردشة",
+          "embedding_model": "تثبيت نموذج التضمين",
+          "ollama_install": "تثبيت Ollama",
+          "ollama_pull": "سحب من Ollama",
+          "ollama_preload": "تحميل مسبق",
+          "memory_reembed": "إعادة تضمين الذاكرة"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "مساعد ذكاء اصطناعي يفهمك أكثر كلما استخدمته — على سطح المكتب والسحابة والمحادثات، جاهز دائمًا عند الطلب.\nفيما يلي إرشادات سريعة — يمكن تخطي جميع الخطوات باستثناء اختيار النموذج.",
       "title": "Welcome to Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "إضافة مرجع الخطة إلى المحادثة الحالية",
+    "badge": {
+      "archived": "مؤرشف",
+      "completed": "مكتمل",
+      "executing": "قيد التنفيذ",
+      "orphan": "يتيم",
+      "planning": "قيد التخطيط",
+      "review": "قيد المراجعة"
+    },
+    "count": "{{count}} خطة",
+    "empty": "لا توجد خطط بعد.",
+    "emptyPlan": "ملف الخطة فارغ.",
+    "filter": {
+      "allAgents": "كل الـ Agent",
+      "state": {
+        "all": "كل الحالات",
+        "archived": "مؤرشف (تم الخروج)",
+        "completed": "مكتمل",
+        "executing": "قيد التنفيذ",
+        "planning": "قيد التخطيط",
+        "review": "قيد المراجعة"
+      }
+    },
+    "openInSession": "الفتح في الجلسة",
+    "refresh": "تحديث",
+    "selectHint": "اختر خطة على اليسار لعرض محتواها.",
+    "sessionDeleted": "تم حذف الجلسة المالكة",
+    "title": "الخطط",
+    "untitled": "خطة بدون عنوان"
   },
   "planMode": {
     "approveAndExecute": "بدء التنفيذ",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "خدمات متوافقة مع /v1/chat/completions",
     "openaiResponsesDesc": "خدمات متوافقة مع /v1/responses",
     "selectApiType": "اختر نوع API"
-  },
-  "plans": {
-    "addToChat": "إضافة مرجع الخطة إلى المحادثة الحالية",
-    "badge": {
-      "archived": "مؤرشف",
-      "completed": "مكتمل",
-      "executing": "قيد التنفيذ",
-      "orphan": "يتيم",
-      "planning": "قيد التخطيط",
-      "review": "قيد المراجعة"
-    },
-    "count": "{{count}} خطة",
-    "empty": "لا توجد خطط بعد.",
-    "emptyPlan": "ملف الخطة فارغ.",
-    "filter": {
-      "allAgents": "كل الـ Agent",
-      "state": {
-        "all": "كل الحالات",
-        "archived": "مؤرشف (تم الخروج)",
-        "completed": "مكتمل",
-        "executing": "قيد التنفيذ",
-        "planning": "قيد التخطيط",
-        "review": "قيد المراجعة"
-      }
-    },
-    "openInSession": "الفتح في الجلسة",
-    "refresh": "تحديث",
-    "selectHint": "اختر خطة على اليسار لعرض محتواها.",
-    "sessionDeleted": "تم حذف الجلسة المالكة",
-    "title": "الخطط",
-    "untitled": "خطة بدون عنوان"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -868,7 +868,8 @@
       "system": "System",
       "tasks": "Tasks",
       "tokens": "Token Usage",
-      "tools": "Tool Usage"
+      "tools": "Tool Usage",
+      "localModels": "Local Models"
     },
     "task": {
       "activeJobs": "Active",
@@ -916,6 +917,73 @@
       "frequency": "Call Frequency",
       "name": "Tool Name",
       "totalMs": "Total (ms)"
+    },
+    "localModels": {
+      "ollamaStatus": "Ollama status",
+      "ollamaPhases": {
+        "running": "Running",
+        "installed": "Installed (idle)",
+        "not-installed": "Not installed"
+      },
+      "openInSettings": "Manage in Settings",
+      "hardware": {
+        "totalMemory": "Total memory",
+        "available": "Available",
+        "gpu": "GPU",
+        "integratedGpu": "Integrated GPU / unified memory",
+        "vram": "VRAM",
+        "budget": "Recommendation budget",
+        "budgetSource": {
+          "unified-memory": "Unified memory (macOS)",
+          "dedicated-vram": "Dedicated VRAM",
+          "system-memory": "System memory"
+        }
+      },
+      "running": {
+        "title": "Currently running",
+        "empty": "No model is currently loaded",
+        "vramUsed": "VRAM",
+        "context": "Context",
+        "expiresIn": "Unloads in {{duration}}",
+        "unloadingSoon": "Unloading shortly",
+        "summary": "{{count}} running"
+      },
+      "installed": {
+        "title": "Installed models",
+        "unknownFamily": "Unknown family",
+        "badges": {
+          "active": "Active",
+          "fallback": "Fallback",
+          "provider": "Provider model",
+          "embedding": "Embedding",
+          "running": "Running"
+        }
+      },
+      "usage": {
+        "title": "Local model usage",
+        "totalCalls": "Total calls",
+        "totalTokens": "Total tokens",
+        "avgTtft": "Avg TTFT",
+        "trend": "Daily token trend",
+        "byModel": "Tokens by model",
+        "empty": "No local-model calls in the selected range",
+        "errorBadge": "{{model}}: {{rate}}% error rate ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "No local backend configured yet",
+        "goToSettings": "Open Settings to add one"
+      },
+      "jobs": {
+        "title": "Background tasks",
+        "kind": {
+          "chat_model": "Chat model install",
+          "embedding_model": "Embedding model install",
+          "ollama_install": "Ollama install",
+          "ollama_pull": "Ollama pull",
+          "ollama_preload": "Preload",
+          "memory_reembed": "Memory re-embedding"
+        }
+      }
     }
   },
   "diffPanel": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -842,18 +842,34 @@
       "systemUptime": "Uptime del sistema",
       "virtualMem": "Memoria virtual"
     },
+    "plans": {
+      "active": "En curso",
+      "avgExecution": "Tiempo medio de ejecución",
+      "byAgent": "Por Agent",
+      "byAgentCompleted": "Completado",
+      "byProject": "Por proyecto",
+      "completionRate": "Tasa de finalización",
+      "created": "Creado",
+      "creationTrend": "Tendencia de creación (30 días)",
+      "empty": "Sin datos de Plan en la ventana seleccionada.",
+      "noProject": "Sin proyecto",
+      "sampleSize": "{{count}} ejecuciones completadas muestreadas",
+      "stateDistribution": "Distribución de estados",
+      "total": "Total de planes"
+    },
     "tabs": {
       "dreaming": "Sueños",
       "errors": "Errores",
       "insights": "Insights",
       "learning": "Aprendizaje",
+      "plans": "Planes",
       "recap": "Recap",
       "sessions": "Sesiones",
       "system": "Sistema",
       "tasks": "Tareas",
       "tokens": "Uso de tokens",
       "tools": "Uso de herramientas",
-      "plans": "Planes"
+      "localModels": "Modelos locales"
     },
     "task": {
       "activeJobs": "Activas",
@@ -902,20 +918,72 @@
       "name": "Nombre",
       "totalMs": "Total (ms)"
     },
-    "plans": {
-      "active": "En curso",
-      "avgExecution": "Tiempo medio de ejecución",
-      "byAgent": "Por Agent",
-      "byAgentCompleted": "Completado",
-      "byProject": "Por proyecto",
-      "completionRate": "Tasa de finalización",
-      "created": "Creado",
-      "creationTrend": "Tendencia de creación (30 días)",
-      "empty": "Sin datos de Plan en la ventana seleccionada.",
-      "noProject": "Sin proyecto",
-      "sampleSize": "{{count}} ejecuciones completadas muestreadas",
-      "stateDistribution": "Distribución de estados",
-      "total": "Total de planes"
+    "localModels": {
+      "ollamaStatus": "Estado de Ollama",
+      "ollamaPhases": {
+        "running": "En ejecución",
+        "installed": "Instalado (inactivo)",
+        "not-installed": "No instalado"
+      },
+      "openInSettings": "Gestionar en Ajustes",
+      "hardware": {
+        "totalMemory": "Memoria total",
+        "available": "Disponible",
+        "gpu": "GPU",
+        "integratedGpu": "GPU integrada / memoria unificada",
+        "vram": "VRAM",
+        "budget": "Presupuesto recomendado",
+        "budgetSource": {
+          "unified-memory": "Memoria unificada (macOS)",
+          "dedicated-vram": "VRAM dedicada",
+          "system-memory": "Memoria del sistema"
+        }
+      },
+      "running": {
+        "title": "En ejecución ahora",
+        "empty": "Ningún modelo cargado actualmente",
+        "vramUsed": "VRAM",
+        "context": "Contexto",
+        "expiresIn": "Se descargará en {{duration}}",
+        "unloadingSoon": "Descargándose pronto",
+        "summary": "{{count}} en ejecución"
+      },
+      "installed": {
+        "title": "Modelos instalados",
+        "unknownFamily": "Familia desconocida",
+        "badges": {
+          "active": "Activo",
+          "fallback": "Respaldo",
+          "provider": "Modelo de Provider",
+          "embedding": "Embedding",
+          "running": "En ejecución"
+        }
+      },
+      "usage": {
+        "title": "Uso de modelos locales",
+        "totalCalls": "Llamadas totales",
+        "totalTokens": "Tokens totales",
+        "avgTtft": "TTFT medio",
+        "trend": "Tendencia diaria de tokens",
+        "byModel": "Tokens por modelo",
+        "empty": "No hay llamadas a modelos locales en el rango seleccionado",
+        "errorBadge": "{{model}}: tasa de error {{rate}}% ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "Aún no hay backend local configurado",
+        "goToSettings": "Abre Ajustes para añadir uno"
+      },
+      "jobs": {
+        "title": "Tareas en segundo plano",
+        "kind": {
+          "chat_model": "Instalación de modelo de chat",
+          "embedding_model": "Instalación de modelo de embedding",
+          "ollama_install": "Instalación de Ollama",
+          "ollama_pull": "Descarga de Ollama",
+          "ollama_preload": "Precarga",
+          "memory_reembed": "Re-embedding de memoria"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "Un asistente de IA que te conoce mejor cuanto más lo usas: en el escritorio, en la nube y en la mensajería, siempre disponible.\nSigue una guía rápida: todos los pasos son opcionales salvo elegir un modelo.",
       "title": "Welcome to Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "Agregar referencia del Plan al chat actual",
+    "badge": {
+      "archived": "Archivado",
+      "completed": "Completado",
+      "executing": "Ejecutando",
+      "orphan": "Huérfano",
+      "planning": "Planificando",
+      "review": "En revisión"
+    },
+    "count": "{{count}} planes",
+    "empty": "Aún no hay planes.",
+    "emptyPlan": "Este archivo de Plan está vacío.",
+    "filter": {
+      "allAgents": "Todos los Agents",
+      "state": {
+        "all": "Todos los estados",
+        "archived": "Archivado (salida)",
+        "completed": "Completado",
+        "executing": "Ejecutando",
+        "planning": "Planificando",
+        "review": "En revisión"
+      }
+    },
+    "openInSession": "Abrir en la sesión",
+    "refresh": "Actualizar",
+    "selectHint": "Selecciona un Plan a la izquierda para ver el contenido.",
+    "sessionDeleted": "Sesión propietaria eliminada",
+    "title": "Planes",
+    "untitled": "Plan sin título"
   },
   "planMode": {
     "approveAndExecute": "Iniciar ejecución",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "Servicios compatibles con /v1/chat/completions",
     "openaiResponsesDesc": "Servicios compatibles con /v1/responses",
     "selectApiType": "Seleccione Tipo de API"
-  },
-  "plans": {
-    "addToChat": "Agregar referencia del Plan al chat actual",
-    "badge": {
-      "archived": "Archivado",
-      "completed": "Completado",
-      "executing": "Ejecutando",
-      "orphan": "Huérfano",
-      "planning": "Planificando",
-      "review": "En revisión"
-    },
-    "count": "{{count}} planes",
-    "empty": "Aún no hay planes.",
-    "emptyPlan": "Este archivo de Plan está vacío.",
-    "filter": {
-      "allAgents": "Todos los Agents",
-      "state": {
-        "all": "Todos los estados",
-        "archived": "Archivado (salida)",
-        "completed": "Completado",
-        "executing": "Ejecutando",
-        "planning": "Planificando",
-        "review": "En revisión"
-      }
-    },
-    "openInSession": "Abrir en la sesión",
-    "refresh": "Actualizar",
-    "selectHint": "Selecciona un Plan a la izquierda para ver el contenido.",
-    "sessionDeleted": "Sesión propietaria eliminada",
-    "title": "Planes",
-    "untitled": "Plan sin título"
   }
 }

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -842,18 +842,34 @@
       "systemUptime": "システム稼働時間",
       "virtualMem": "仮想メモリ"
     },
+    "plans": {
+      "active": "進行中",
+      "avgExecution": "平均実行時間",
+      "byAgent": "Agent 別",
+      "byAgentCompleted": "完了",
+      "byProject": "プロジェクト別",
+      "completionRate": "完了率",
+      "created": "作成",
+      "creationTrend": "作成トレンド (30 日)",
+      "empty": "選択した期間に Plan がありません。",
+      "noProject": "プロジェクトなし",
+      "sampleSize": "完了 {{count}} 件をサンプリング",
+      "stateDistribution": "状態分布",
+      "total": "Plan 総数"
+    },
     "tabs": {
       "dreaming": "ドリーム",
       "errors": "エラー監視",
       "insights": "インサイト",
       "learning": "学習",
+      "plans": "Plan",
       "recap": "レビュー",
       "sessions": "セッション分析",
       "system": "システム監視",
       "tasks": "タスク統計",
       "tokens": "トークン使用量",
       "tools": "ツール使用",
-      "plans": "Plan"
+      "localModels": "ローカルモデル"
     },
     "task": {
       "activeJobs": "アクティブ",
@@ -902,20 +918,72 @@
       "name": "ツール名",
       "totalMs": "合計 (ms)"
     },
-    "plans": {
-      "active": "進行中",
-      "avgExecution": "平均実行時間",
-      "byAgent": "Agent 別",
-      "byAgentCompleted": "完了",
-      "byProject": "プロジェクト別",
-      "completionRate": "完了率",
-      "created": "作成",
-      "creationTrend": "作成トレンド (30 日)",
-      "empty": "選択した期間に Plan がありません。",
-      "noProject": "プロジェクトなし",
-      "sampleSize": "完了 {{count}} 件をサンプリング",
-      "stateDistribution": "状態分布",
-      "total": "Plan 総数"
+    "localModels": {
+      "ollamaStatus": "Ollama 状態",
+      "ollamaPhases": {
+        "running": "実行中",
+        "installed": "インストール済（停止中）",
+        "not-installed": "未インストール"
+      },
+      "openInSettings": "設定で管理",
+      "hardware": {
+        "totalMemory": "総メモリ",
+        "available": "利用可能",
+        "gpu": "GPU",
+        "integratedGpu": "統合 GPU / ユニファイドメモリ",
+        "vram": "VRAM",
+        "budget": "推奨予算",
+        "budgetSource": {
+          "unified-memory": "ユニファイドメモリ (macOS)",
+          "dedicated-vram": "専用 VRAM",
+          "system-memory": "システムメモリ"
+        }
+      },
+      "running": {
+        "title": "実行中のモデル",
+        "empty": "現在ロードされているモデルはありません",
+        "vramUsed": "VRAM",
+        "context": "コンテキスト",
+        "expiresIn": "{{duration}} 後にアンロード",
+        "unloadingSoon": "まもなくアンロード",
+        "summary": "{{count}} 件実行中"
+      },
+      "installed": {
+        "title": "インストール済モデル",
+        "unknownFamily": "不明なファミリー",
+        "badges": {
+          "active": "アクティブ",
+          "fallback": "フォールバック",
+          "provider": "Provider モデル",
+          "embedding": "埋め込み",
+          "running": "実行中"
+        }
+      },
+      "usage": {
+        "title": "ローカルモデルの使用状況",
+        "totalCalls": "総呼び出し回数",
+        "totalTokens": "総トークン数",
+        "avgTtft": "平均 TTFT",
+        "trend": "日次トークン推移",
+        "byModel": "モデル別トークン",
+        "empty": "選択期間内にローカルモデルの呼び出しはありません",
+        "errorBadge": "{{model}}: エラー率 {{rate}}% ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "ローカルバックエンドが未設定です",
+        "goToSettings": "設定を開いて追加"
+      },
+      "jobs": {
+        "title": "バックグラウンドタスク",
+        "kind": {
+          "chat_model": "チャットモデルのインストール",
+          "embedding_model": "埋め込みモデルのインストール",
+          "ollama_install": "Ollama のインストール",
+          "ollama_pull": "Ollama プル",
+          "ollama_preload": "プリロード",
+          "memory_reembed": "メモリ再埋め込み"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "使うほどあなたを理解していく AI アシスタント——デスクトップ、クラウド、IM でいつでも呼び出せます。\n以下は簡単なセットアップです——モデル選択以外はすべてスキップできます。",
       "title": "Welcome to Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "現在のチャットに Plan 参照を追加",
+    "badge": {
+      "archived": "アーカイブ済み",
+      "completed": "完了",
+      "executing": "実行中",
+      "orphan": "孤立",
+      "planning": "計画中",
+      "review": "レビュー中"
+    },
+    "count": "Plan: {{count}} 件",
+    "empty": "Plan はありません。",
+    "emptyPlan": "この Plan ファイルは空です。",
+    "filter": {
+      "allAgents": "すべての Agent",
+      "state": {
+        "all": "すべての状態",
+        "archived": "アーカイブ (終了済み)",
+        "completed": "完了",
+        "executing": "実行中",
+        "planning": "計画中",
+        "review": "レビュー中"
+      }
+    },
+    "openInSession": "所属セッションへ移動",
+    "refresh": "更新",
+    "selectHint": "左側で Plan を選択してください。",
+    "sessionDeleted": "所属セッションは削除されました",
+    "title": "Plan 履歴",
+    "untitled": "無題の Plan"
   },
   "planMode": {
     "approveAndExecute": "実行開始",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "/v1/chat/completions 互換サービス",
     "openaiResponsesDesc": "/v1/responses 互換サービス",
     "selectApiType": "API タイプを選択"
-  },
-  "plans": {
-    "addToChat": "現在のチャットに Plan 参照を追加",
-    "badge": {
-      "archived": "アーカイブ済み",
-      "completed": "完了",
-      "executing": "実行中",
-      "orphan": "孤立",
-      "planning": "計画中",
-      "review": "レビュー中"
-    },
-    "count": "Plan: {{count}} 件",
-    "empty": "Plan はありません。",
-    "emptyPlan": "この Plan ファイルは空です。",
-    "filter": {
-      "allAgents": "すべての Agent",
-      "state": {
-        "all": "すべての状態",
-        "archived": "アーカイブ (終了済み)",
-        "completed": "完了",
-        "executing": "実行中",
-        "planning": "計画中",
-        "review": "レビュー中"
-      }
-    },
-    "openInSession": "所属セッションへ移動",
-    "refresh": "更新",
-    "selectHint": "左側で Plan を選択してください。",
-    "sessionDeleted": "所属セッションは削除されました",
-    "title": "Plan 履歴",
-    "untitled": "無題の Plan"
   }
 }

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -842,18 +842,34 @@
       "systemUptime": "시스템 가동",
       "virtualMem": "가상 메모리"
     },
+    "plans": {
+      "active": "진행 중",
+      "avgExecution": "평균 실행 시간",
+      "byAgent": "Agent별",
+      "byAgentCompleted": "완료",
+      "byProject": "프로젝트별",
+      "completionRate": "완료율",
+      "created": "생성",
+      "creationTrend": "생성 추이 (30일)",
+      "empty": "선택한 기간 내 Plan 데이터가 없습니다.",
+      "noProject": "프로젝트 없음",
+      "sampleSize": "{{count}}개 완료 표본",
+      "stateDistribution": "상태 분포",
+      "total": "총 Plan 수"
+    },
     "tabs": {
       "dreaming": "드림",
       "errors": "오류",
       "insights": "인사이트",
       "learning": "학습",
+      "plans": "Plan",
       "recap": "회고",
       "sessions": "세션",
       "system": "시스템",
       "tasks": "작업",
       "tokens": "토큰 사용량",
       "tools": "도구 사용",
-      "plans": "Plan"
+      "localModels": "로컬 모델"
     },
     "task": {
       "activeJobs": "활성",
@@ -902,20 +918,72 @@
       "name": "도구 이름",
       "totalMs": "합계 (ms)"
     },
-    "plans": {
-      "active": "진행 중",
-      "avgExecution": "평균 실행 시간",
-      "byAgent": "Agent별",
-      "byAgentCompleted": "완료",
-      "byProject": "프로젝트별",
-      "completionRate": "완료율",
-      "created": "생성",
-      "creationTrend": "생성 추이 (30일)",
-      "empty": "선택한 기간 내 Plan 데이터가 없습니다.",
-      "noProject": "프로젝트 없음",
-      "sampleSize": "{{count}}개 완료 표본",
-      "stateDistribution": "상태 분포",
-      "total": "총 Plan 수"
+    "localModels": {
+      "ollamaStatus": "Ollama 상태",
+      "ollamaPhases": {
+        "running": "실행 중",
+        "installed": "설치됨 (유휴)",
+        "not-installed": "설치되지 않음"
+      },
+      "openInSettings": "설정에서 관리",
+      "hardware": {
+        "totalMemory": "총 메모리",
+        "available": "사용 가능",
+        "gpu": "GPU",
+        "integratedGpu": "내장 GPU / 통합 메모리",
+        "vram": "VRAM",
+        "budget": "권장 예산",
+        "budgetSource": {
+          "unified-memory": "통합 메모리 (macOS)",
+          "dedicated-vram": "전용 VRAM",
+          "system-memory": "시스템 메모리"
+        }
+      },
+      "running": {
+        "title": "실행 중인 모델",
+        "empty": "현재 로드된 모델이 없습니다",
+        "vramUsed": "VRAM",
+        "context": "컨텍스트",
+        "expiresIn": "{{duration}} 후 언로드",
+        "unloadingSoon": "곧 언로드",
+        "summary": "{{count}}개 실행 중"
+      },
+      "installed": {
+        "title": "설치된 모델",
+        "unknownFamily": "알 수 없는 패밀리",
+        "badges": {
+          "active": "활성",
+          "fallback": "폴백",
+          "provider": "Provider 모델",
+          "embedding": "임베딩",
+          "running": "실행 중"
+        }
+      },
+      "usage": {
+        "title": "로컬 모델 사용량",
+        "totalCalls": "총 호출 수",
+        "totalTokens": "총 토큰",
+        "avgTtft": "평균 TTFT",
+        "trend": "일별 토큰 추세",
+        "byModel": "모델별 토큰",
+        "empty": "선택한 범위에 로컬 모델 호출이 없습니다",
+        "errorBadge": "{{model}}: 오류율 {{rate}}% ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "로컬 백엔드가 아직 설정되지 않았습니다",
+        "goToSettings": "설정을 열어 추가"
+      },
+      "jobs": {
+        "title": "백그라운드 작업",
+        "kind": {
+          "chat_model": "채팅 모델 설치",
+          "embedding_model": "임베딩 모델 설치",
+          "ollama_install": "Ollama 설치",
+          "ollama_pull": "Ollama 풀",
+          "ollama_preload": "프리로드",
+          "memory_reembed": "메모리 재임베딩"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "사용할수록 당신을 더 잘 이해하는 AI 어시스턴트 — 데스크톱, 클라우드, IM 어디서든 언제든 호출할 수 있습니다.\n아래는 간단한 안내입니다 — 모델 선택을 제외한 모든 단계는 건너뛸 수 있습니다.",
       "title": "Welcome to Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "현재 채팅에 Plan 참조 추가",
+    "badge": {
+      "archived": "보관됨",
+      "completed": "완료",
+      "executing": "실행 중",
+      "orphan": "고아",
+      "planning": "계획 중",
+      "review": "검토 중"
+    },
+    "count": "Plan {{count}}개",
+    "empty": "아직 Plan이 없습니다.",
+    "emptyPlan": "이 Plan 파일은 비어 있습니다.",
+    "filter": {
+      "allAgents": "모든 Agent",
+      "state": {
+        "all": "모든 상태",
+        "archived": "보관됨 (종료)",
+        "completed": "완료",
+        "executing": "실행 중",
+        "planning": "계획 중",
+        "review": "검토 중"
+      }
+    },
+    "openInSession": "해당 세션 열기",
+    "refresh": "새로 고침",
+    "selectHint": "왼쪽에서 Plan을 선택하세요.",
+    "sessionDeleted": "소유 세션이 삭제됨",
+    "title": "Plan 기록",
+    "untitled": "이름 없는 Plan"
   },
   "planMode": {
     "approveAndExecute": "실행 시작",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "/v1/chat/completions 호환 서비스",
     "openaiResponsesDesc": "/v1/responses 호환 서비스",
     "selectApiType": "API 유형 선택"
-  },
-  "plans": {
-    "addToChat": "현재 채팅에 Plan 참조 추가",
-    "badge": {
-      "archived": "보관됨",
-      "completed": "완료",
-      "executing": "실행 중",
-      "orphan": "고아",
-      "planning": "계획 중",
-      "review": "검토 중"
-    },
-    "count": "Plan {{count}}개",
-    "empty": "아직 Plan이 없습니다.",
-    "emptyPlan": "이 Plan 파일은 비어 있습니다.",
-    "filter": {
-      "allAgents": "모든 Agent",
-      "state": {
-        "all": "모든 상태",
-        "archived": "보관됨 (종료)",
-        "completed": "완료",
-        "executing": "실행 중",
-        "planning": "계획 중",
-        "review": "검토 중"
-      }
-    },
-    "openInSession": "해당 세션 열기",
-    "refresh": "새로 고침",
-    "selectHint": "왼쪽에서 Plan을 선택하세요.",
-    "sessionDeleted": "소유 세션이 삭제됨",
-    "title": "Plan 기록",
-    "untitled": "이름 없는 Plan"
   }
 }

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -842,18 +842,34 @@
       "systemUptime": "Masa berjalan sistem",
       "virtualMem": "Memori maya"
     },
+    "plans": {
+      "active": "Sedang berlangsung",
+      "avgExecution": "Tempoh perlaksanaan purata",
+      "byAgent": "Mengikut Agent",
+      "byAgentCompleted": "Selesai",
+      "byProject": "Mengikut projek",
+      "completionRate": "Kadar penyelesaian",
+      "created": "Dicipta",
+      "creationTrend": "Trend penciptaan (30 hari)",
+      "empty": "Tiada data Plan dalam tempoh dipilih.",
+      "noProject": "Tanpa projek",
+      "sampleSize": "Disampel {{count}} larian selesai",
+      "stateDistribution": "Taburan keadaan",
+      "total": "Jumlah Plan"
+    },
     "tabs": {
       "dreaming": "Mimpi",
       "errors": "Ralat",
       "insights": "Cerapan",
       "learning": "Pembelajaran",
+      "plans": "Plan",
       "recap": "Tinjauan",
       "sessions": "Sesi",
       "system": "Sistem",
       "tasks": "Tugasan",
       "tokens": "Penggunaan Token",
       "tools": "Penggunaan Alat",
-      "plans": "Plan"
+      "localModels": "Model Tempatan"
     },
     "task": {
       "activeJobs": "Aktif",
@@ -902,20 +918,72 @@
       "name": "Nama",
       "totalMs": "Jumlah (ms)"
     },
-    "plans": {
-      "active": "Sedang berlangsung",
-      "avgExecution": "Tempoh perlaksanaan purata",
-      "byAgent": "Mengikut Agent",
-      "byAgentCompleted": "Selesai",
-      "byProject": "Mengikut projek",
-      "completionRate": "Kadar penyelesaian",
-      "created": "Dicipta",
-      "creationTrend": "Trend penciptaan (30 hari)",
-      "empty": "Tiada data Plan dalam tempoh dipilih.",
-      "noProject": "Tanpa projek",
-      "sampleSize": "Disampel {{count}} larian selesai",
-      "stateDistribution": "Taburan keadaan",
-      "total": "Jumlah Plan"
+    "localModels": {
+      "ollamaStatus": "Status Ollama",
+      "ollamaPhases": {
+        "running": "Berjalan",
+        "installed": "Dipasang (melahu)",
+        "not-installed": "Belum dipasang"
+      },
+      "openInSettings": "Urus dalam Tetapan",
+      "hardware": {
+        "totalMemory": "Jumlah memori",
+        "available": "Tersedia",
+        "gpu": "GPU",
+        "integratedGpu": "GPU bersepadu / memori bersatu",
+        "vram": "VRAM",
+        "budget": "Bajet disyorkan",
+        "budgetSource": {
+          "unified-memory": "Memori bersatu (macOS)",
+          "dedicated-vram": "VRAM khusus",
+          "system-memory": "Memori sistem"
+        }
+      },
+      "running": {
+        "title": "Sedang berjalan",
+        "empty": "Tiada model dimuatkan",
+        "vramUsed": "VRAM",
+        "context": "Konteks",
+        "expiresIn": "Dinyahmuat dalam {{duration}}",
+        "unloadingSoon": "Akan dinyahmuat",
+        "summary": "{{count}} berjalan"
+      },
+      "installed": {
+        "title": "Model dipasang",
+        "unknownFamily": "Keluarga tidak diketahui",
+        "badges": {
+          "active": "Aktif",
+          "fallback": "Sandaran",
+          "provider": "Model Provider",
+          "embedding": "Embedding",
+          "running": "Berjalan"
+        }
+      },
+      "usage": {
+        "title": "Penggunaan model tempatan",
+        "totalCalls": "Jumlah panggilan",
+        "totalTokens": "Jumlah token",
+        "avgTtft": "Purata TTFT",
+        "trend": "Trend token harian",
+        "byModel": "Token mengikut model",
+        "empty": "Tiada panggilan model tempatan dalam julat yang dipilih",
+        "errorBadge": "{{model}}: kadar ralat {{rate}}% ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "Belum ada backend tempatan dikonfigurasikan",
+        "goToSettings": "Buka Tetapan untuk menambah"
+      },
+      "jobs": {
+        "title": "Tugas latar belakang",
+        "kind": {
+          "chat_model": "Pemasangan model sembang",
+          "embedding_model": "Pemasangan model embedding",
+          "ollama_install": "Pemasangan Ollama",
+          "ollama_pull": "Muat turun Ollama",
+          "ollama_preload": "Pra-muat",
+          "memory_reembed": "Embed semula memori"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "Pembantu AI yang semakin mengenali anda setiap kali digunakan — di desktop, di awan dan di IM, sentiasa bersedia.\nDi bawah ialah panduan ringkas — semua langkah boleh dilangkau kecuali memilih model.",
       "title": "Welcome to Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "Tambah rujukan Plan ke perbualan semasa",
+    "badge": {
+      "archived": "Diarkibkan",
+      "completed": "Selesai",
+      "executing": "Sedang dijalankan",
+      "orphan": "Yatim",
+      "planning": "Sedang merancang",
+      "review": "Dalam semakan"
+    },
+    "count": "{{count}} Plan",
+    "empty": "Tiada Plan lagi.",
+    "emptyPlan": "Fail Plan ini kosong.",
+    "filter": {
+      "allAgents": "Semua Agent",
+      "state": {
+        "all": "Semua keadaan",
+        "archived": "Diarkibkan (keluar)",
+        "completed": "Selesai",
+        "executing": "Sedang dijalankan",
+        "planning": "Sedang merancang",
+        "review": "Dalam semakan"
+      }
+    },
+    "openInSession": "Buka dalam sesi",
+    "refresh": "Muat semula",
+    "selectHint": "Pilih satu Plan di sebelah kiri untuk melihat kandungannya.",
+    "sessionDeleted": "Sesi pemilik telah dipadam",
+    "title": "Plan",
+    "untitled": "Plan tanpa tajuk"
   },
   "planMode": {
     "approveAndExecute": "Mula pelaksanaan",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "Perkhidmatan serasi dengan /v1/chat/completions",
     "openaiResponsesDesc": "Perkhidmatan serasi dengan /v1/responses",
     "selectApiType": "Pilih Jenis API"
-  },
-  "plans": {
-    "addToChat": "Tambah rujukan Plan ke perbualan semasa",
-    "badge": {
-      "archived": "Diarkibkan",
-      "completed": "Selesai",
-      "executing": "Sedang dijalankan",
-      "orphan": "Yatim",
-      "planning": "Sedang merancang",
-      "review": "Dalam semakan"
-    },
-    "count": "{{count}} Plan",
-    "empty": "Tiada Plan lagi.",
-    "emptyPlan": "Fail Plan ini kosong.",
-    "filter": {
-      "allAgents": "Semua Agent",
-      "state": {
-        "all": "Semua keadaan",
-        "archived": "Diarkibkan (keluar)",
-        "completed": "Selesai",
-        "executing": "Sedang dijalankan",
-        "planning": "Sedang merancang",
-        "review": "Dalam semakan"
-      }
-    },
-    "openInSession": "Buka dalam sesi",
-    "refresh": "Muat semula",
-    "selectHint": "Pilih satu Plan di sebelah kiri untuk melihat kandungannya.",
-    "sessionDeleted": "Sesi pemilik telah dipadam",
-    "title": "Plan",
-    "untitled": "Plan tanpa tajuk"
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -842,18 +842,34 @@
       "systemUptime": "Uptime do sistema",
       "virtualMem": "Memória virtual"
     },
+    "plans": {
+      "active": "Em andamento",
+      "avgExecution": "Tempo médio de execução",
+      "byAgent": "Por Agent",
+      "byAgentCompleted": "Concluídos",
+      "byProject": "Por projeto",
+      "completionRate": "Taxa de conclusão",
+      "created": "Criados",
+      "creationTrend": "Tendência de criação (30 dias)",
+      "empty": "Sem dados de Plan na janela selecionada.",
+      "noProject": "Sem projeto",
+      "sampleSize": "{{count}} execuções concluídas amostradas",
+      "stateDistribution": "Distribuição de estados",
+      "total": "Total de planos"
+    },
     "tabs": {
       "dreaming": "Sonhos",
       "errors": "Erros",
       "insights": "Insights",
       "learning": "Aprendizado",
+      "plans": "Planos",
       "recap": "Recap",
       "sessions": "Sessões",
       "system": "Sistema",
       "tasks": "Tarefas",
       "tokens": "Uso de tokens",
       "tools": "Uso de ferramentas",
-      "plans": "Planos"
+      "localModels": "Modelos locais"
     },
     "task": {
       "activeJobs": "Ativas",
@@ -902,20 +918,72 @@
       "name": "Nome",
       "totalMs": "Total (ms)"
     },
-    "plans": {
-      "active": "Em andamento",
-      "avgExecution": "Tempo médio de execução",
-      "byAgent": "Por Agent",
-      "byAgentCompleted": "Concluídos",
-      "byProject": "Por projeto",
-      "completionRate": "Taxa de conclusão",
-      "created": "Criados",
-      "creationTrend": "Tendência de criação (30 dias)",
-      "empty": "Sem dados de Plan na janela selecionada.",
-      "noProject": "Sem projeto",
-      "sampleSize": "{{count}} execuções concluídas amostradas",
-      "stateDistribution": "Distribuição de estados",
-      "total": "Total de planos"
+    "localModels": {
+      "ollamaStatus": "Status do Ollama",
+      "ollamaPhases": {
+        "running": "Em execução",
+        "installed": "Instalado (parado)",
+        "not-installed": "Não instalado"
+      },
+      "openInSettings": "Gerenciar nas Configurações",
+      "hardware": {
+        "totalMemory": "Memória total",
+        "available": "Disponível",
+        "gpu": "GPU",
+        "integratedGpu": "GPU integrada / memória unificada",
+        "vram": "VRAM",
+        "budget": "Orçamento recomendado",
+        "budgetSource": {
+          "unified-memory": "Memória unificada (macOS)",
+          "dedicated-vram": "VRAM dedicada",
+          "system-memory": "Memória do sistema"
+        }
+      },
+      "running": {
+        "title": "Em execução agora",
+        "empty": "Nenhum modelo carregado no momento",
+        "vramUsed": "VRAM",
+        "context": "Contexto",
+        "expiresIn": "Será descarregado em {{duration}}",
+        "unloadingSoon": "Descarregando em breve",
+        "summary": "{{count}} em execução"
+      },
+      "installed": {
+        "title": "Modelos instalados",
+        "unknownFamily": "Família desconhecida",
+        "badges": {
+          "active": "Ativo",
+          "fallback": "Reserva",
+          "provider": "Modelo do Provider",
+          "embedding": "Embedding",
+          "running": "Em execução"
+        }
+      },
+      "usage": {
+        "title": "Uso de modelos locais",
+        "totalCalls": "Total de chamadas",
+        "totalTokens": "Total de tokens",
+        "avgTtft": "TTFT médio",
+        "trend": "Tendência diária de tokens",
+        "byModel": "Tokens por modelo",
+        "empty": "Sem chamadas a modelos locais no período selecionado",
+        "errorBadge": "{{model}}: taxa de erro {{rate}}% ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "Nenhum backend local configurado ainda",
+        "goToSettings": "Abra Configurações para adicionar"
+      },
+      "jobs": {
+        "title": "Tarefas em segundo plano",
+        "kind": {
+          "chat_model": "Instalação de modelo de chat",
+          "embedding_model": "Instalação de modelo de embedding",
+          "ollama_install": "Instalação do Ollama",
+          "ollama_pull": "Download do Ollama",
+          "ollama_preload": "Pré-carregamento",
+          "memory_reembed": "Re-embedding de memória"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "Um assistente de IA que te conhece melhor a cada uso — no desktop, na nuvem e na mensageria, sempre pronto.\nSegue um guia rápido — todas as etapas são opcionais, exceto escolher um modelo.",
       "title": "Welcome to Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "Adicionar referência do Plan ao chat atual",
+    "badge": {
+      "archived": "Arquivado",
+      "completed": "Concluído",
+      "executing": "Executando",
+      "orphan": "Órfão",
+      "planning": "Planejando",
+      "review": "Em revisão"
+    },
+    "count": "{{count}} planos",
+    "empty": "Sem planos ainda.",
+    "emptyPlan": "Este arquivo de Plan está vazio.",
+    "filter": {
+      "allAgents": "Todos os Agents",
+      "state": {
+        "all": "Todos os estados",
+        "archived": "Arquivado (saída)",
+        "completed": "Concluído",
+        "executing": "Executando",
+        "planning": "Planejando",
+        "review": "Em revisão"
+      }
+    },
+    "openInSession": "Abrir na sessão",
+    "refresh": "Atualizar",
+    "selectHint": "Selecione um Plan à esquerda para ver o conteúdo.",
+    "sessionDeleted": "Sessão proprietária excluída",
+    "title": "Planos",
+    "untitled": "Plan sem título"
   },
   "planMode": {
     "approveAndExecute": "Iniciar execução",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "Serviços compatíveis com /v1/chat/completions",
     "openaiResponsesDesc": "Serviços compatíveis com /v1/responses",
     "selectApiType": "Selecione o Tipo de API"
-  },
-  "plans": {
-    "addToChat": "Adicionar referência do Plan ao chat atual",
-    "badge": {
-      "archived": "Arquivado",
-      "completed": "Concluído",
-      "executing": "Executando",
-      "orphan": "Órfão",
-      "planning": "Planejando",
-      "review": "Em revisão"
-    },
-    "count": "{{count}} planos",
-    "empty": "Sem planos ainda.",
-    "emptyPlan": "Este arquivo de Plan está vazio.",
-    "filter": {
-      "allAgents": "Todos os Agents",
-      "state": {
-        "all": "Todos os estados",
-        "archived": "Arquivado (saída)",
-        "completed": "Concluído",
-        "executing": "Executando",
-        "planning": "Planejando",
-        "review": "Em revisão"
-      }
-    },
-    "openInSession": "Abrir na sessão",
-    "refresh": "Atualizar",
-    "selectHint": "Selecione um Plan à esquerda para ver o conteúdo.",
-    "sessionDeleted": "Sessão proprietária excluída",
-    "title": "Planos",
-    "untitled": "Plan sem título"
   }
 }

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -842,18 +842,34 @@
       "systemUptime": "Время работы системы",
       "virtualMem": "Виртуальная память"
     },
+    "plans": {
+      "active": "В работе",
+      "avgExecution": "Среднее время выполнения",
+      "byAgent": "По Agent",
+      "byAgentCompleted": "Завершено",
+      "byProject": "По проектам",
+      "completionRate": "Доля завершённых",
+      "created": "Создано",
+      "creationTrend": "Тренд создания (30 дней)",
+      "empty": "Нет данных Plan в выбранном окне.",
+      "noProject": "Без проекта",
+      "sampleSize": "Выборка из {{count}} завершённых",
+      "stateDistribution": "Распределение по состояниям",
+      "total": "Всего планов"
+    },
     "tabs": {
       "dreaming": "Сновидения",
       "errors": "Ошибки",
       "insights": "Инсайты",
       "learning": "Обучение",
+      "plans": "Планы",
       "recap": "Разбор",
       "sessions": "Сессии",
       "system": "Система",
       "tasks": "Задачи",
       "tokens": "Использование токенов",
       "tools": "Использование инструментов",
-      "plans": "Планы"
+      "localModels": "Локальные модели"
     },
     "task": {
       "activeJobs": "Активные",
@@ -902,20 +918,72 @@
       "name": "Название",
       "totalMs": "Всего (мс)"
     },
-    "plans": {
-      "active": "В работе",
-      "avgExecution": "Среднее время выполнения",
-      "byAgent": "По Agent",
-      "byAgentCompleted": "Завершено",
-      "byProject": "По проектам",
-      "completionRate": "Доля завершённых",
-      "created": "Создано",
-      "creationTrend": "Тренд создания (30 дней)",
-      "empty": "Нет данных Plan в выбранном окне.",
-      "noProject": "Без проекта",
-      "sampleSize": "Выборка из {{count}} завершённых",
-      "stateDistribution": "Распределение по состояниям",
-      "total": "Всего планов"
+    "localModels": {
+      "ollamaStatus": "Статус Ollama",
+      "ollamaPhases": {
+        "running": "Запущена",
+        "installed": "Установлена (простаивает)",
+        "not-installed": "Не установлена"
+      },
+      "openInSettings": "Управление в настройках",
+      "hardware": {
+        "totalMemory": "Всего памяти",
+        "available": "Доступно",
+        "gpu": "GPU",
+        "integratedGpu": "Встроенный GPU / единая память",
+        "vram": "VRAM",
+        "budget": "Рекомендуемый бюджет",
+        "budgetSource": {
+          "unified-memory": "Единая память (macOS)",
+          "dedicated-vram": "Выделенный VRAM",
+          "system-memory": "Системная память"
+        }
+      },
+      "running": {
+        "title": "Сейчас запущены",
+        "empty": "Ни одна модель не загружена",
+        "vramUsed": "VRAM",
+        "context": "Контекст",
+        "expiresIn": "Выгрузка через {{duration}}",
+        "unloadingSoon": "Скоро выгрузится",
+        "summary": "{{count}} запущено"
+      },
+      "installed": {
+        "title": "Установленные модели",
+        "unknownFamily": "Неизвестное семейство",
+        "badges": {
+          "active": "Активна",
+          "fallback": "Резерв",
+          "provider": "Модель Provider",
+          "embedding": "Embedding",
+          "running": "Запущена"
+        }
+      },
+      "usage": {
+        "title": "Использование локальных моделей",
+        "totalCalls": "Всего вызовов",
+        "totalTokens": "Всего токенов",
+        "avgTtft": "Среднее TTFT",
+        "trend": "Дневная динамика токенов",
+        "byModel": "Токены по моделям",
+        "empty": "В выбранном диапазоне нет вызовов локальных моделей",
+        "errorBadge": "{{model}}: уровень ошибок {{rate}}% ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "Локальный backend ещё не настроен",
+        "goToSettings": "Открыть настройки для добавления"
+      },
+      "jobs": {
+        "title": "Фоновые задачи",
+        "kind": {
+          "chat_model": "Установка модели чата",
+          "embedding_model": "Установка модели embedding",
+          "ollama_install": "Установка Ollama",
+          "ollama_pull": "Загрузка Ollama",
+          "ollama_preload": "Предзагрузка",
+          "memory_reembed": "Переиндексация памяти"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "ИИ-ассистент, который узнаёт вас всё лучше с каждым использованием — на рабочем столе, в облаке и в мессенджерах, всегда на связи.\nДалее — краткое знакомство: пропустить можно любой шаг, кроме выбора модели.",
       "title": "Welcome to Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "Добавить ссылку на Plan в текущий чат",
+    "badge": {
+      "archived": "Архивировано",
+      "completed": "Завершено",
+      "executing": "Выполняется",
+      "orphan": "Сирота",
+      "planning": "Планирование",
+      "review": "На проверке"
+    },
+    "count": "Планов: {{count}}",
+    "empty": "Планов пока нет.",
+    "emptyPlan": "Файл Plan пуст.",
+    "filter": {
+      "allAgents": "Все Agent",
+      "state": {
+        "all": "Все состояния",
+        "archived": "Архив (выход)",
+        "completed": "Завершено",
+        "executing": "Выполняется",
+        "planning": "Планирование",
+        "review": "На проверке"
+      }
+    },
+    "openInSession": "Открыть в сессии",
+    "refresh": "Обновить",
+    "selectHint": "Выберите Plan слева, чтобы посмотреть содержимое.",
+    "sessionDeleted": "Сессия-владелец удалена",
+    "title": "Планы",
+    "untitled": "Plan без названия"
   },
   "planMode": {
     "approveAndExecute": "Начать выполнение",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "Сервисы, совместимые с /v1/chat/completions",
     "openaiResponsesDesc": "Сервисы, совместимые с /v1/responses",
     "selectApiType": "Выберите тип API"
-  },
-  "plans": {
-    "addToChat": "Добавить ссылку на Plan в текущий чат",
-    "badge": {
-      "archived": "Архивировано",
-      "completed": "Завершено",
-      "executing": "Выполняется",
-      "orphan": "Сирота",
-      "planning": "Планирование",
-      "review": "На проверке"
-    },
-    "count": "Планов: {{count}}",
-    "empty": "Планов пока нет.",
-    "emptyPlan": "Файл Plan пуст.",
-    "filter": {
-      "allAgents": "Все Agent",
-      "state": {
-        "all": "Все состояния",
-        "archived": "Архив (выход)",
-        "completed": "Завершено",
-        "executing": "Выполняется",
-        "planning": "Планирование",
-        "review": "На проверке"
-      }
-    },
-    "openInSession": "Открыть в сессии",
-    "refresh": "Обновить",
-    "selectHint": "Выберите Plan слева, чтобы посмотреть содержимое.",
-    "sessionDeleted": "Сессия-владелец удалена",
-    "title": "Планы",
-    "untitled": "Plan без названия"
   }
 }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -842,18 +842,34 @@
       "systemUptime": "Sistem çalışma süresi",
       "virtualMem": "Sanal bellek"
     },
+    "plans": {
+      "active": "Devam ediyor",
+      "avgExecution": "Ortalama yürütme süresi",
+      "byAgent": "Agent bazında",
+      "byAgentCompleted": "Tamamlanan",
+      "byProject": "Proje bazında",
+      "completionRate": "Tamamlanma oranı",
+      "created": "Oluşturulan",
+      "creationTrend": "Oluşturma trendi (30 gün)",
+      "empty": "Seçili pencerede Plan verisi yok.",
+      "noProject": "Proje yok",
+      "sampleSize": "{{count}} tamamlanmış örnek",
+      "stateDistribution": "Durum dağılımı",
+      "total": "Toplam Plan"
+    },
     "tabs": {
       "dreaming": "Rüyalar",
       "errors": "Hatalar",
       "insights": "İçgörüler",
       "learning": "Öğrenme",
+      "plans": "Planlar",
       "recap": "Özet",
       "sessions": "Oturumlar",
       "system": "Sistem",
       "tasks": "Görevler",
       "tokens": "Token kullanımı",
       "tools": "Araç kullanımı",
-      "plans": "Planlar"
+      "localModels": "Yerel Modeller"
     },
     "task": {
       "activeJobs": "Aktif",
@@ -902,20 +918,72 @@
       "name": "Ad",
       "totalMs": "Toplam (ms)"
     },
-    "plans": {
-      "active": "Devam ediyor",
-      "avgExecution": "Ortalama yürütme süresi",
-      "byAgent": "Agent bazında",
-      "byAgentCompleted": "Tamamlanan",
-      "byProject": "Proje bazında",
-      "completionRate": "Tamamlanma oranı",
-      "created": "Oluşturulan",
-      "creationTrend": "Oluşturma trendi (30 gün)",
-      "empty": "Seçili pencerede Plan verisi yok.",
-      "noProject": "Proje yok",
-      "sampleSize": "{{count}} tamamlanmış örnek",
-      "stateDistribution": "Durum dağılımı",
-      "total": "Toplam Plan"
+    "localModels": {
+      "ollamaStatus": "Ollama durumu",
+      "ollamaPhases": {
+        "running": "Çalışıyor",
+        "installed": "Yüklü (boşta)",
+        "not-installed": "Yüklü değil"
+      },
+      "openInSettings": "Ayarlarda yönet",
+      "hardware": {
+        "totalMemory": "Toplam bellek",
+        "available": "Kullanılabilir",
+        "gpu": "GPU",
+        "integratedGpu": "Entegre GPU / birleşik bellek",
+        "vram": "VRAM",
+        "budget": "Önerilen bütçe",
+        "budgetSource": {
+          "unified-memory": "Birleşik bellek (macOS)",
+          "dedicated-vram": "Özel VRAM",
+          "system-memory": "Sistem belleği"
+        }
+      },
+      "running": {
+        "title": "Şu anda çalışan",
+        "empty": "Şu an yüklü model yok",
+        "vramUsed": "VRAM",
+        "context": "Bağlam",
+        "expiresIn": "{{duration}} içinde boşaltılacak",
+        "unloadingSoon": "Yakında boşaltılacak",
+        "summary": "{{count}} çalışıyor"
+      },
+      "installed": {
+        "title": "Yüklü modeller",
+        "unknownFamily": "Bilinmeyen aile",
+        "badges": {
+          "active": "Etkin",
+          "fallback": "Yedek",
+          "provider": "Provider modeli",
+          "embedding": "Embedding",
+          "running": "Çalışıyor"
+        }
+      },
+      "usage": {
+        "title": "Yerel model kullanımı",
+        "totalCalls": "Toplam çağrı",
+        "totalTokens": "Toplam token",
+        "avgTtft": "Ortalama TTFT",
+        "trend": "Günlük token eğilimi",
+        "byModel": "Modele göre token",
+        "empty": "Seçilen aralıkta yerel model çağrısı yok",
+        "errorBadge": "{{model}}: hata oranı {{rate}}% ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "Henüz yerel backend yapılandırılmadı",
+        "goToSettings": "Eklemek için Ayarları açın"
+      },
+      "jobs": {
+        "title": "Arka plan görevleri",
+        "kind": {
+          "chat_model": "Sohbet modeli kurulumu",
+          "embedding_model": "Embedding modeli kurulumu",
+          "ollama_install": "Ollama kurulumu",
+          "ollama_pull": "Ollama indirme",
+          "ollama_preload": "Ön yükleme",
+          "memory_reembed": "Bellek yeniden embedding"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "Kullandıkça seni daha iyi tanıyan bir AI asistanı — masaüstü, bulut ve IM; her an hazır.\nAşağıda kısa bir kurulum var — model seçimi dışındaki tüm adımlar atlanabilir.",
       "title": "Welcome to Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "Plan referansını mevcut sohbete ekle",
+    "badge": {
+      "archived": "Arşivlenmiş",
+      "completed": "Tamamlandı",
+      "executing": "Yürütülüyor",
+      "orphan": "Sahipsiz",
+      "planning": "Planlanıyor",
+      "review": "İnceleme"
+    },
+    "count": "{{count}} Plan",
+    "empty": "Henüz Plan yok.",
+    "emptyPlan": "Bu Plan dosyası boş.",
+    "filter": {
+      "allAgents": "Tüm Agent'lar",
+      "state": {
+        "all": "Tüm durumlar",
+        "archived": "Arşivlenmiş (çıkış)",
+        "completed": "Tamamlandı",
+        "executing": "Yürütülüyor",
+        "planning": "Planlanıyor",
+        "review": "İnceleme"
+      }
+    },
+    "openInSession": "Oturumda aç",
+    "refresh": "Yenile",
+    "selectHint": "Sol taraftan bir Plan seçin.",
+    "sessionDeleted": "Sahip oturum silinmiş",
+    "title": "Planlar",
+    "untitled": "İsimsiz plan"
   },
   "planMode": {
     "approveAndExecute": "Yürütmeyi başlat",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "/v1/chat/completions uyumlu servisler",
     "openaiResponsesDesc": "/v1/responses uyumlu servisler",
     "selectApiType": "API Türü Seçin"
-  },
-  "plans": {
-    "addToChat": "Plan referansını mevcut sohbete ekle",
-    "badge": {
-      "archived": "Arşivlenmiş",
-      "completed": "Tamamlandı",
-      "executing": "Yürütülüyor",
-      "orphan": "Sahipsiz",
-      "planning": "Planlanıyor",
-      "review": "İnceleme"
-    },
-    "count": "{{count}} Plan",
-    "empty": "Henüz Plan yok.",
-    "emptyPlan": "Bu Plan dosyası boş.",
-    "filter": {
-      "allAgents": "Tüm Agent'lar",
-      "state": {
-        "all": "Tüm durumlar",
-        "archived": "Arşivlenmiş (çıkış)",
-        "completed": "Tamamlandı",
-        "executing": "Yürütülüyor",
-        "planning": "Planlanıyor",
-        "review": "İnceleme"
-      }
-    },
-    "openInSession": "Oturumda aç",
-    "refresh": "Yenile",
-    "selectHint": "Sol taraftan bir Plan seçin.",
-    "sessionDeleted": "Sahip oturum silinmiş",
-    "title": "Planlar",
-    "untitled": "İsimsiz plan"
   }
 }

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -842,18 +842,34 @@
       "systemUptime": "Thời gian hoạt động hệ thống",
       "virtualMem": "Bộ nhớ ảo"
     },
+    "plans": {
+      "active": "Đang tiến hành",
+      "avgExecution": "Thời gian thực thi trung bình",
+      "byAgent": "Theo Agent",
+      "byAgentCompleted": "Hoàn tất",
+      "byProject": "Theo dự án",
+      "completionRate": "Tỷ lệ hoàn tất",
+      "created": "Tạo",
+      "creationTrend": "Xu hướng tạo (30 ngày)",
+      "empty": "Không có dữ liệu Plan trong khoảng đã chọn.",
+      "noProject": "Không có dự án",
+      "sampleSize": "Đã lấy mẫu {{count}} lần hoàn tất",
+      "stateDistribution": "Phân bố trạng thái",
+      "total": "Tổng số Plan"
+    },
     "tabs": {
       "dreaming": "Giấc mơ",
       "errors": "Lỗi",
       "insights": "Insights",
       "learning": "Học tập",
+      "plans": "Plan",
       "recap": "Đánh giá",
       "sessions": "Phiên",
       "system": "Hệ thống",
       "tasks": "Tác vụ",
       "tokens": "Sử dụng token",
       "tools": "Sử dụng công cụ",
-      "plans": "Plan"
+      "localModels": "Mô hình cục bộ"
     },
     "task": {
       "activeJobs": "Hoạt động",
@@ -902,20 +918,72 @@
       "name": "Tên",
       "totalMs": "Tổng (ms)"
     },
-    "plans": {
-      "active": "Đang tiến hành",
-      "avgExecution": "Thời gian thực thi trung bình",
-      "byAgent": "Theo Agent",
-      "byAgentCompleted": "Hoàn tất",
-      "byProject": "Theo dự án",
-      "completionRate": "Tỷ lệ hoàn tất",
-      "created": "Tạo",
-      "creationTrend": "Xu hướng tạo (30 ngày)",
-      "empty": "Không có dữ liệu Plan trong khoảng đã chọn.",
-      "noProject": "Không có dự án",
-      "sampleSize": "Đã lấy mẫu {{count}} lần hoàn tất",
-      "stateDistribution": "Phân bố trạng thái",
-      "total": "Tổng số Plan"
+    "localModels": {
+      "ollamaStatus": "Trạng thái Ollama",
+      "ollamaPhases": {
+        "running": "Đang chạy",
+        "installed": "Đã cài (rảnh)",
+        "not-installed": "Chưa cài"
+      },
+      "openInSettings": "Quản lý trong Cài đặt",
+      "hardware": {
+        "totalMemory": "Tổng bộ nhớ",
+        "available": "Khả dụng",
+        "gpu": "GPU",
+        "integratedGpu": "GPU tích hợp / bộ nhớ thống nhất",
+        "vram": "VRAM",
+        "budget": "Ngân sách đề xuất",
+        "budgetSource": {
+          "unified-memory": "Bộ nhớ thống nhất (macOS)",
+          "dedicated-vram": "VRAM riêng",
+          "system-memory": "Bộ nhớ hệ thống"
+        }
+      },
+      "running": {
+        "title": "Đang chạy",
+        "empty": "Hiện không có mô hình nào được nạp",
+        "vramUsed": "VRAM",
+        "context": "Ngữ cảnh",
+        "expiresIn": "Sẽ gỡ tải trong {{duration}}",
+        "unloadingSoon": "Sắp gỡ tải",
+        "summary": "{{count}} đang chạy"
+      },
+      "installed": {
+        "title": "Mô hình đã cài",
+        "unknownFamily": "Họ không xác định",
+        "badges": {
+          "active": "Đang dùng",
+          "fallback": "Dự phòng",
+          "provider": "Mô hình Provider",
+          "embedding": "Embedding",
+          "running": "Đang chạy"
+        }
+      },
+      "usage": {
+        "title": "Sử dụng mô hình cục bộ",
+        "totalCalls": "Tổng lượt gọi",
+        "totalTokens": "Tổng token",
+        "avgTtft": "TTFT trung bình",
+        "trend": "Xu hướng token theo ngày",
+        "byModel": "Token theo mô hình",
+        "empty": "Không có lượt gọi mô hình cục bộ trong khoảng đã chọn",
+        "errorBadge": "{{model}}: tỉ lệ lỗi {{rate}}% ({{errors}}/{{calls}})"
+      },
+      "empty": {
+        "noProvider": "Chưa cấu hình backend cục bộ",
+        "goToSettings": "Mở Cài đặt để thêm"
+      },
+      "jobs": {
+        "title": "Tác vụ nền",
+        "kind": {
+          "chat_model": "Cài đặt mô hình chat",
+          "embedding_model": "Cài đặt mô hình embedding",
+          "ollama_install": "Cài đặt Ollama",
+          "ollama_pull": "Tải Ollama",
+          "ollama_preload": "Nạp trước",
+          "memory_reembed": "Re-embedding bộ nhớ"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "Một trợ lý AI càng dùng càng hiểu bạn — trên máy tính, trên đám mây và trong IM, luôn sẵn sàng.\nDưới đây là hướng dẫn nhanh — ngoại trừ chọn mô hình, mọi bước đều có thể bỏ qua.",
       "title": "Welcome to Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "Thêm tham chiếu Plan vào cuộc trò chuyện hiện tại",
+    "badge": {
+      "archived": "Đã lưu trữ",
+      "completed": "Hoàn tất",
+      "executing": "Đang thực thi",
+      "orphan": "Mồ côi",
+      "planning": "Đang lên kế hoạch",
+      "review": "Đang xét duyệt"
+    },
+    "count": "{{count}} Plan",
+    "empty": "Chưa có Plan nào.",
+    "emptyPlan": "Tệp Plan này trống.",
+    "filter": {
+      "allAgents": "Tất cả Agent",
+      "state": {
+        "all": "Tất cả trạng thái",
+        "archived": "Đã lưu trữ (đã thoát)",
+        "completed": "Hoàn tất",
+        "executing": "Đang thực thi",
+        "planning": "Đang lên kế hoạch",
+        "review": "Đang xét duyệt"
+      }
+    },
+    "openInSession": "Mở trong phiên",
+    "refresh": "Làm mới",
+    "selectHint": "Chọn một Plan ở bên trái để xem nội dung.",
+    "sessionDeleted": "Phiên sở hữu đã bị xoá",
+    "title": "Lịch sử Plan",
+    "untitled": "Plan chưa đặt tên"
   },
   "planMode": {
     "approveAndExecute": "Bắt đầu thực thi",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "Dịch vụ tương thích /v1/chat/completions",
     "openaiResponsesDesc": "Dịch vụ tương thích /v1/responses",
     "selectApiType": "Chọn loại API"
-  },
-  "plans": {
-    "addToChat": "Thêm tham chiếu Plan vào cuộc trò chuyện hiện tại",
-    "badge": {
-      "archived": "Đã lưu trữ",
-      "completed": "Hoàn tất",
-      "executing": "Đang thực thi",
-      "orphan": "Mồ côi",
-      "planning": "Đang lên kế hoạch",
-      "review": "Đang xét duyệt"
-    },
-    "count": "{{count}} Plan",
-    "empty": "Chưa có Plan nào.",
-    "emptyPlan": "Tệp Plan này trống.",
-    "filter": {
-      "allAgents": "Tất cả Agent",
-      "state": {
-        "all": "Tất cả trạng thái",
-        "archived": "Đã lưu trữ (đã thoát)",
-        "completed": "Hoàn tất",
-        "executing": "Đang thực thi",
-        "planning": "Đang lên kế hoạch",
-        "review": "Đang xét duyệt"
-      }
-    },
-    "openInSession": "Mở trong phiên",
-    "refresh": "Làm mới",
-    "selectHint": "Chọn một Plan ở bên trái để xem nội dung.",
-    "sessionDeleted": "Phiên sở hữu đã bị xoá",
-    "title": "Lịch sử Plan",
-    "untitled": "Plan chưa đặt tên"
   }
 }

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -842,18 +842,34 @@
       "systemUptime": "系統運行",
       "virtualMem": "虛擬內存"
     },
+    "plans": {
+      "active": "進行中",
+      "avgExecution": "平均執行時間",
+      "byAgent": "依 Agent 分組",
+      "byAgentCompleted": "已完成",
+      "byProject": "依專案分組",
+      "completionRate": "完成率",
+      "created": "新建",
+      "creationTrend": "30 天建立趨勢",
+      "empty": "所選時間範圍內無 Plan 資料。",
+      "noProject": "未歸屬專案",
+      "sampleSize": "已取樣 {{count}} 個完成的 Plan",
+      "stateDistribution": "狀態分佈",
+      "total": "Plan 總數"
+    },
     "tabs": {
       "dreaming": "記憶夢境",
       "errors": "異常監控",
       "insights": "綜合概覽",
       "learning": "學習追蹤",
+      "plans": "Plan",
       "recap": "複盤",
       "sessions": "會話分析",
       "system": "系統監控",
       "tasks": "任務統計",
       "tokens": "Token 用量",
       "tools": "工具使用",
-      "plans": "Plan"
+      "localModels": "本地模型"
     },
     "task": {
       "activeJobs": "活躍任務",
@@ -902,20 +918,72 @@
       "name": "工具名稱",
       "totalMs": "總耗時(ms)"
     },
-    "plans": {
-      "active": "進行中",
-      "avgExecution": "平均執行時間",
-      "byAgent": "依 Agent 分組",
-      "byAgentCompleted": "已完成",
-      "byProject": "依專案分組",
-      "completionRate": "完成率",
-      "created": "新建",
-      "creationTrend": "30 天建立趨勢",
-      "empty": "所選時間範圍內無 Plan 資料。",
-      "noProject": "未歸屬專案",
-      "sampleSize": "已取樣 {{count}} 個完成的 Plan",
-      "stateDistribution": "狀態分佈",
-      "total": "Plan 總數"
+    "localModels": {
+      "ollamaStatus": "Ollama 狀態",
+      "ollamaPhases": {
+        "running": "執行中",
+        "installed": "已安裝（未啟動）",
+        "not-installed": "未安裝"
+      },
+      "openInSettings": "在設定中管理",
+      "hardware": {
+        "totalMemory": "總記憶體",
+        "available": "可用",
+        "gpu": "顯示卡",
+        "integratedGpu": "內建 GPU / 統一記憶體",
+        "vram": "顯示記憶體",
+        "budget": "建議預算",
+        "budgetSource": {
+          "unified-memory": "統一記憶體（macOS）",
+          "dedicated-vram": "獨立顯示記憶體",
+          "system-memory": "系統記憶體"
+        }
+      },
+      "running": {
+        "title": "執行中的模型",
+        "empty": "目前沒有模型載入",
+        "vramUsed": "顯示記憶體",
+        "context": "上下文",
+        "expiresIn": "{{duration}} 後卸載",
+        "unloadingSoon": "即將卸載",
+        "summary": "{{count}} 個執行中"
+      },
+      "installed": {
+        "title": "已安裝模型",
+        "unknownFamily": "未識別系列",
+        "badges": {
+          "active": "目前對話",
+          "fallback": "降級模型",
+          "provider": "Provider 模型",
+          "embedding": "向量模型",
+          "running": "執行中"
+        }
+      },
+      "usage": {
+        "title": "本地模型使用統計",
+        "totalCalls": "總呼叫次數",
+        "totalTokens": "總 Token",
+        "avgTtft": "平均 TTFT",
+        "trend": "每日 Token 趨勢",
+        "byModel": "依模型分布 Token",
+        "empty": "所選時間範圍內未呼叫本地模型",
+        "errorBadge": "{{model}}：錯誤率 {{rate}}%（{{errors}}/{{calls}}）"
+      },
+      "empty": {
+        "noProvider": "尚未設定任何本地後端",
+        "goToSettings": "前往設定新增"
+      },
+      "jobs": {
+        "title": "背景任務",
+        "kind": {
+          "chat_model": "安裝對話模型",
+          "embedding_model": "安裝向量模型",
+          "ollama_install": "安裝 Ollama",
+          "ollama_pull": "拉取模型",
+          "ollama_preload": "預載入模型",
+          "memory_reembed": "記憶重嵌入"
+        }
+      }
     }
   },
   "diffPanel": {
@@ -1611,6 +1679,37 @@
       "subtitle": "越用越懂你的 AI 助手——桌面、雲端、IM，隨叫隨到。\n下面是一段簡短的引導——除了選擇模型，其它每一步都可以跳過。",
       "title": "欢迎使用 Hope Agent"
     }
+  },
+  "plans": {
+    "addToChat": "將該 Plan 加入目前對話",
+    "badge": {
+      "archived": "已封存",
+      "completed": "已完成",
+      "executing": "執行中",
+      "orphan": "孤立檔案",
+      "planning": "規劃中",
+      "review": "審核中"
+    },
+    "count": "共 {{count}} 個 Plan",
+    "empty": "尚無 Plan。",
+    "emptyPlan": "此 Plan 檔案為空。",
+    "filter": {
+      "allAgents": "全部 Agent",
+      "state": {
+        "all": "全部狀態",
+        "archived": "已封存 (已離開)",
+        "completed": "已完成",
+        "executing": "執行中",
+        "planning": "規劃中",
+        "review": "審核中"
+      }
+    },
+    "openInSession": "前往所屬會話",
+    "refresh": "重新整理",
+    "selectHint": "請在左側選擇一個 Plan 以檢視內容。",
+    "sessionDeleted": "所屬會話已刪除",
+    "title": "Plan 歷史",
+    "untitled": "未命名 Plan"
   },
   "planMode": {
     "approveAndExecute": "開始執行",
@@ -3971,36 +4070,5 @@
     "openaiChatDesc": "兼容 /v1/chat/completions 的服務",
     "openaiResponsesDesc": "兼容 /v1/responses 的服務",
     "selectApiType": "選擇 API 類型"
-  },
-  "plans": {
-    "addToChat": "將該 Plan 加入目前對話",
-    "badge": {
-      "archived": "已封存",
-      "completed": "已完成",
-      "executing": "執行中",
-      "orphan": "孤立檔案",
-      "planning": "規劃中",
-      "review": "審核中"
-    },
-    "count": "共 {{count}} 個 Plan",
-    "empty": "尚無 Plan。",
-    "emptyPlan": "此 Plan 檔案為空。",
-    "filter": {
-      "allAgents": "全部 Agent",
-      "state": {
-        "all": "全部狀態",
-        "archived": "已封存 (已離開)",
-        "completed": "已完成",
-        "executing": "執行中",
-        "planning": "規劃中",
-        "review": "審核中"
-      }
-    },
-    "openInSession": "前往所屬會話",
-    "refresh": "重新整理",
-    "selectHint": "請在左側選擇一個 Plan 以檢視內容。",
-    "sessionDeleted": "所屬會話已刪除",
-    "title": "Plan 歷史",
-    "untitled": "未命名 Plan"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -868,7 +868,8 @@
       "system": "系统监控",
       "tasks": "任务统计",
       "tokens": "Token 用量",
-      "tools": "工具使用"
+      "tools": "工具使用",
+      "localModels": "本地模型"
     },
     "task": {
       "activeJobs": "活跃任务",
@@ -916,6 +917,73 @@
       "frequency": "调用频次",
       "name": "工具名称",
       "totalMs": "总耗时(ms)"
+    },
+    "localModels": {
+      "ollamaStatus": "Ollama 状态",
+      "ollamaPhases": {
+        "running": "运行中",
+        "installed": "已安装（未启动）",
+        "not-installed": "未安装"
+      },
+      "openInSettings": "在设置中管理",
+      "hardware": {
+        "totalMemory": "总内存",
+        "available": "可用",
+        "gpu": "显卡",
+        "integratedGpu": "集显 / 统一内存",
+        "vram": "显存",
+        "budget": "推荐预算",
+        "budgetSource": {
+          "unified-memory": "统一内存（macOS）",
+          "dedicated-vram": "独立显存",
+          "system-memory": "系统内存"
+        }
+      },
+      "running": {
+        "title": "运行中的模型",
+        "empty": "当前没有模型加载中",
+        "vramUsed": "显存",
+        "context": "上下文",
+        "expiresIn": "{{duration}} 后卸载",
+        "unloadingSoon": "即将卸载",
+        "summary": "{{count}} 个运行中"
+      },
+      "installed": {
+        "title": "已安装模型",
+        "unknownFamily": "未识别系列",
+        "badges": {
+          "active": "当前对话",
+          "fallback": "降级模型",
+          "provider": "Provider 模型",
+          "embedding": "向量模型",
+          "running": "运行中"
+        }
+      },
+      "usage": {
+        "title": "本地模型使用统计",
+        "totalCalls": "总调用次数",
+        "totalTokens": "总 Token",
+        "avgTtft": "平均 TTFT",
+        "trend": "每日 Token 趋势",
+        "byModel": "按模型 Token 分布",
+        "empty": "所选时间范围内未调用本地模型",
+        "errorBadge": "{{model}}：错误率 {{rate}}%（{{errors}}/{{calls}}）"
+      },
+      "empty": {
+        "noProvider": "尚未配置任何本地后端",
+        "goToSettings": "前往设置添加"
+      },
+      "jobs": {
+        "title": "后台任务",
+        "kind": {
+          "chat_model": "安装对话模型",
+          "embedding_model": "安装向量模型",
+          "ollama_install": "安装 Ollama",
+          "ollama_pull": "拉取模型",
+          "ollama_preload": "预热模型",
+          "memory_reembed": "记忆重嵌入"
+        }
+      }
     }
   },
   "diffPanel": {

--- a/src/lib/transport-http.ts
+++ b/src/lib/transport-http.ts
@@ -375,6 +375,7 @@ const COMMAND_MAP: Record<string, EndpointDef> = {
   local_llm_detect_hardware:       { method: "GET",    path: "/api/local-llm/hardware" },
   local_llm_recommend_model:       { method: "GET",    path: "/api/local-llm/recommendation" },
   local_llm_detect_ollama:         { method: "GET",    path: "/api/local-llm/ollama-status" },
+  local_llm_detect_ollama_version: { method: "GET",    path: "/api/local-llm/ollama-version" },
   local_llm_known_backends:        { method: "GET",    path: "/api/local-llm/known-backends" },
   local_llm_chat_catalog:          { method: "GET",    path: "/api/local-llm/chat-catalog" },
   local_llm_start_ollama:          { method: "POST",   path: "/api/local-llm/start" },
@@ -436,6 +437,7 @@ const COMMAND_MAP: Record<string, EndpointDef> = {
   dashboard_top_skills:            { method: "POST",   path: "/api/dashboard/learning/top-skills" },
   dashboard_recall_stats:          { method: "POST",   path: "/api/dashboard/learning/recall-stats" },
   dashboard_plan_stats:            { method: "POST",   path: "/api/dashboard/plan-stats" },
+  dashboard_local_model_usage:     { method: "POST",   path: "/api/dashboard/local-model-usage" },
 
   // -- Slash commands --
   list_slash_commands:             { method: "GET",    path: "/api/slash-commands" },


### PR DESCRIPTION
## Summary

- Dashboard 新增独立 Tab「本地模型」,聚合展示 Ollama 状态、硬件预算、运行中模型 VRAM 占用、已安装模型清单、本地模型在所选时间窗内的调用次数 / Token / TTFT / 错误率,以及在跑的安装 / 拉取 / 预热后台任务。
- 面板只读,模型管理仍走「设置 → 本地 LLM 助手」单一入口,避免维护两套确认弹窗。
- "本地"判定在后端 `provider::local::known_local_backends` 单一真相源,前端零硬编码。

## 新增 API

| Tauri Command | HTTP |
|---|---|
| `dashboard_local_model_usage` | `POST /api/dashboard/local-model-usage` |
| `local_llm_detect_ollama_version` | `GET /api/local-llm/ollama-version` |

## 后端改动

- 新文件 [`crates/ha-core/src/dashboard/local_models.rs`](crates/ha-core/src/dashboard/local_models.rs)
  - `local_provider_names_from(&[ProviderConfig]) -> Vec<String>`:纯函数 helper,便于无 config singleton 测试
  - `query_local_model_usage(session_db, filter, &[String]) -> LocalModelUsage`:复用 `build_session_filter` 自动排除 cron / subagent / incognito,在其上 AND 一个 `s.provider_name IN (?, ?, ...)` 过滤
  - 5 单测覆盖:helper 选本地 / helper 空返 / 空 names 短路 / 多本地后端聚合排名正确 / cron+subagent+incognito 全部正确排除

## 前端改动

- 新组件 [`src/components/dashboard/LocalModelsSection.tsx`](src/components/dashboard/LocalModelsSection.tsx) 6 个 Block
  - Block A — Ollama 状态条:phase 配色 badge + 版本 + base_url + 「在设置中管理」按钮
  - Block B — 硬件预算:总内存 / GPU + VRAM / 推荐预算 / 已装模型数 共 4 张 MetricCard
  - Block C — 运行中模型(只读):VRAM 总占用 + 相对 budget 的进度条 + 每模型 `expires_at` 倒计时
  - Block D — 已安装模型清单(只读):active / fallback / provider / embedding / running 徽章 + capabilities chips
  - Block E — 使用统计:总调用 / Token / TTFT 3 张卡 + 每日趋势 AreaChart + 按模型柱图(错误率 > 5% 红色高亮 + 红色警告行)
  - Block F — 后台任务:进行中的 ollama-pull / chat_model / embedding_model / preload / memory_reembed 进度条
- [`DashboardView.tsx`](src/components/dashboard/DashboardView.tsx) 注册新 Tab,`Promise.allSettled` 并发拉 6 个数据源(Ollama 不可达时单源降级,不黑整个 Tab)
- i18n 12 语言齐全(46 新 key,`pnpm i18n:check` 全绿)

## 不做的(YAGNI)

- 不采集 GPU 利用率 / 温度 / 功耗(platform 模块只有静态 `detect_dedicated_gpu`,无运行时指标)
- 不动 `query_token_usage`,全模型混合视图保留,新 query 旁路
- 不重构 SystemMetricsSection,VRAM 不是系统全局指标,专属本地模型 Tab
- 不在大盘里放模型管理按钮(预热 / 停止 / 删除),避免与 Settings → 本地 LLM 助手 维护两套确认弹窗

## Test plan

- [x] 后端 `cargo test -p ha-core --lib dashboard::local_models` 5/5
- [x] 后端 `cargo check -p ha-core -p ha-server`
- [x] 前端 `pnpm typecheck`
- [x] `node scripts/sync-i18n.mjs --check` 12 语言全齐
- [x] `pre-push` 全套 6 项绿
- [ ] CI 8 项 status check 全绿
- [ ] **本地手测(merge 前补):**
  - [ ] 未装 Ollama:Block A 显示「未安装」,B 显示硬件,C/D/E/F 空态合理
  - [ ] 装好 Ollama + 拉一个 `gemma4:e2b`:已安装列表出现,徽章正确
  - [ ] 预热后等 10s:运行中 Block 出现 VRAM 占用 + 倒计时
  - [ ] 跑 3 轮对话:使用统计三张 MetricCard 数字合理,by_model 柱图按 token 排序
  - [ ] DashboardFilter 时间窗切换:统计随之刷新,硬件 / 运行态 Block 不受影响
  - [ ] HTTP 模式 `hope-agent server start`:新两个 endpoint 返回 200