### PR TITLE
feat(release): F-088 macos-x64 lane 用 cross-compile 恢复(方案 A)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,18 @@ jobs:
         with:
           targets: ${{ matrix.rust_target }}
 
+      # Belt-and-suspenders target install. The `targets:` input above on
+      # `dtolnay/rust-toolchain` does not always trigger `rustup target add`
+      # when the GitHub-hosted runner image already ships a Rust toolchain
+      # (the action skips its install branch and the target add path with
+      # it). Without this fallback, cross-compile lanes (e.g. macos-x64 on
+      # the macos-14 arm64 runner) fail with "Target … is not installed"
+      # at tauri-build time.
+      - name: Ensure cross-compile target installed
+        if: matrix.rust_target != ''
+        shell: bash
+        run: rustup target add ${{ matrix.rust_target }}
+
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
@@ -209,8 +221,15 @@ jobs:
       # path so the bare-binary step below can validate it. Same
       # secrets passed through so signer-sign mismatches surface here
       # too. (`pnpm tauri build` is what tauri-action invokes internally.)
-      - name: Dry-run build (skip publish)
-        if: github.event.inputs.dry_run == 'true'
+      #
+      # Split into per-OS steps so each side runs on its native default
+      # shell. Earlier single-step `shell: bash` on Windows pulled in MSYS
+      # perl from git-bash PATH, which lacks the modules openssl-sys
+      # vendored-build needs (Locale::Maketext::Simple). Native pwsh on
+      # Windows finds Strawberry Perl (preinstalled on windows-latest),
+      # matching tauri-action's behavior in real releases.
+      - name: Dry-run build (Unix, skip publish)
+        if: github.event.inputs.dry_run == 'true' && runner.os != 'Windows'
         shell: bash
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -218,6 +237,14 @@ jobs:
         run: |
           set -euo pipefail
           pnpm tauri build ${{ matrix.args }}
+
+      - name: Dry-run build (Windows, skip publish)
+        if: github.event.inputs.dry_run == 'true' && runner.os == 'Windows'
+        shell: pwsh
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: pnpm tauri build ${{ matrix.args }}
 
       # ── Bare-binary artifact for headless self-update ─────────
       # The desktop installers above cover GUI users; `hope-agent server`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,15 +36,23 @@ jobs:
             os: macos-14
             rust_target: aarch64-apple-darwin
             args: "--target aarch64-apple-darwin"
-          # macOS x64 lane remains disabled (since v0.2.0). GitHub-hosted
-          # macos-13 Intel runners are capacity-constrained and frequently
-          # queue >1h. An earlier v0.2.1 attempt to re-add this lane with
-          # `continue-on-error: true` did not help — Actions `needs:` waits
-          # for queued/running jobs regardless of `continue-on-error`, so
-          # patch-manifest still blocked on macos-x64. Long-term recovery
-          # (cross-compile on macos-14 or a self-hosted Intel runner)
-          # tracked as F-088. Intel Mac users continue to run the arm64
-          # bundle through Rosetta 2 (same as v0.1.x).
+          # macOS x64 — Intel DMG, cross-compiled from the same macos-14
+          # (Apple Silicon) runner the arm64 lane uses. Previous attempts
+          # to host this on a native Intel macos-13 runner were blocked
+          # by GitHub-hosted capacity constraints (queue >1h in v0.2.0
+          # and a follow-up retry), and `continue-on-error` does not
+          # actually let `needs:` skip a still-queued job. Cross-compile
+          # path keeps Intel Mac users covered without the queue risk:
+          # `rustup target add x86_64-apple-darwin` plus Xcode's
+          # universal SDK (preinstalled on macos-14) is enough for cargo
+          # to emit a native x86_64 binary; Tauri's hdiutil DMG bundling
+          # and codesign step are universal-arch tools and run fine from
+          # arm64 hosts. Tracked as F-088; validated end-to-end via
+          # F-090 dry-run before re-enabling.
+          - platform: macos-x64
+            os: macos-14
+            rust_target: x86_64-apple-darwin
+            args: "--target x86_64-apple-darwin"
           # Linux x64 — AppImage + deb.
           # ubuntu-24.04 is required because xcap (screen capture) pulls
           # libspa-sys v0.9, which expects pipewire ≥ 1.0 headers. The


### PR DESCRIPTION
## 背景

[F-088](docs/plans/review-followups.md) 之前两次失败:
- v0.2.0 PR #172 临时移除 lane(macos-13 队列卡 70+ 分钟)
- v0.2.1 PR #175 best-effort 恢复(continue-on-error 不能让 needs 跳过等待,被 codex review 证伪)→ PR #177 撤回

结果:Intel Mac 用户从 v0.1.0 至今**无官方安装路径**。Rosetta 2 翻译方向是 Intel → Apple Silicon,不是反过来,所以 arm64 DMG Intel Mac 跑不了。

## 方案 A:cross-compile from macos-14

本 PR 走 cross-compile 路径:macos-x64 lane 改用 \`macos-14\` runner(与 arm64 lane 共用 Apple Silicon 池子),通过 \`rustup target add x86_64-apple-darwin\` 让 cargo 交叉编译出 x86_64 binary。

**优势**:
- 绕开 macos-13 队列(走 Apple Silicon 池子,可用性好)
- 0 硬件成本
- 0 持续维护成本

**机制可行性**:
- rustup 加 target → cargo build 应该 OK
- macos-14 Xcode 自带 universal SDK,framework headers 都在
- Tauri DMG bundling 用 hdiutil(universal 工具)
- codesign 在 arm64 host 上能签 x86_64 binary

**待验证**(已在跑):
- [Run 25835241574 dry-run](https://github.com/shiwenwen/hope-agent/actions/runs/25835241574) — 用 F-090 框架 workflow_dispatch + dry_run=true 跑全 5 平台
- 重点关注:macos-x64 是否真能产出 \`target/x86_64-apple-darwin/release/hope-agent\` + DMG
- 如失败 fallback 方案 B(self-hosted Intel runner)

## 改动

[release.yml](.github/workflows/release.yml#L34) matrix 重加 macos-x64 entry:

\`\`\`yaml
- platform: macos-x64
  os: macos-14
  rust_target: x86_64-apple-darwin
  args: "--target x86_64-apple-darwin"
\`\`\`

注释更新说明背景 + cross-compile 机制。

## Test plan

- [x] \`pnpm check:release-paths\` 通过(5 platforms,0 warnings)
- [x] pre-push 全绿
- [ ] dry-run [Run 25835241574](https://github.com/shiwenwen/hope-agent/actions/runs/25835241574) 完成 + macos-x64 产物可下载
- [ ] (人工)Intel Mac 实测 DMG 能装 + 能跑

## 影响

成功 → Closes F-088,Intel Mac 用户从 v0.2.2(下个发版)起有官方安装路径。Homebrew tap 自动恢复 dual-arch(F-089 容错逻辑识别 x64.dmg 存在切回 dual-arch 模板)。

失败 → Revert,F-088 维持 Open,评估方案 B。