### PR TITLE
refactor(dashboard): /simplify cleanup for local-models panel

### DIFF
--- a/crates/ha-core/src/dashboard/local_models.rs
+++ b/crates/ha-core/src/dashboard/local_models.rs
@@ -68,12 +68,11 @@ pub fn query_local_model_usage(
 
     let in_placeholders = vec!["?"; local_provider_names.len()].join(", ");
     let in_clause = format!("s.provider_name IN ({in_placeholders})");
+    let (where_sql, params) = local_where_clause(filter, &in_clause, local_provider_names);
+    let params_slice = params_ref(&params);
 
     // ── Daily trend ──
-    let (trend_sql, trend_params) = build_query(
-        filter,
-        &in_clause,
-        local_provider_names,
+    let trend_sql = format!(
         "SELECT DATE(m.timestamp) as d,
                 COALESCE(SUM(m.tokens_in), 0),
                 COALESCE(SUM(m.tokens_out), 0),
@@ -82,10 +81,10 @@ pub fn query_local_model_usage(
          JOIN sessions s ON s.id = m.session_id
          {where_sql}
          GROUP BY d
-         ORDER BY d ASC",
+         ORDER BY d ASC"
     );
     let mut stmt = conn.prepare(&trend_sql)?;
-    let rows = stmt.query_map(params_ref(&trend_params).as_slice(), |r| {
+    let rows = stmt.query_map(params_slice.as_slice(), |r| {
         Ok(TokenUsageTrend {
             date: r.get(0)?,
             input_tokens: crate::sql_u64(r, 1)?,
@@ -97,10 +96,7 @@ pub fn query_local_model_usage(
     drop(stmt);
 
     // ── By model ──
-    let (by_model_sql, by_model_params) = build_query(
-        filter,
-        &in_clause,
-        local_provider_names,
+    let by_model_sql = format!(
         "SELECT COALESCE(s.model_id, 'unknown'),
                 COALESCE(s.provider_name, 'unknown'),
                 COUNT(DISTINCT CASE WHEN m.role = 'assistant' THEN m.id END),
@@ -112,10 +108,10 @@ pub fn query_local_model_usage(
          JOIN sessions s ON s.id = m.session_id
          {where_sql}
          GROUP BY s.model_id, s.provider_name
-         ORDER BY SUM(m.tokens_in) + SUM(m.tokens_out) DESC",
+         ORDER BY SUM(m.tokens_in) + SUM(m.tokens_out) DESC"
     );
     let mut stmt = conn.prepare(&by_model_sql)?;
-    let rows = stmt.query_map(params_ref(&by_model_params).as_slice(), |r| {
+    let rows = stmt.query_map(params_slice.as_slice(), |r| {
         Ok(LocalModelUsageRow {
             model_id: r.get(0)?,
             provider_name: r.get(1)?,
@@ -130,20 +126,17 @@ pub fn query_local_model_usage(
     drop(stmt);
 
     // ── Totals (single row) ──
-    let (totals_sql, totals_params) = build_query(
-        filter,
-        &in_clause,
-        local_provider_names,
+    let totals_sql = format!(
         "SELECT COUNT(DISTINCT CASE WHEN m.role = 'assistant' THEN m.id END),
                 COALESCE(SUM(m.tokens_in), 0),
                 COALESCE(SUM(m.tokens_out), 0),
                 AVG(CASE WHEN m.ttft_ms IS NOT NULL AND m.role = 'assistant' THEN m.ttft_ms END)
          FROM messages m
          JOIN sessions s ON s.id = m.session_id
-         {where_sql}",
+         {where_sql}"
     );
     let (total_calls, total_input_tokens, total_output_tokens, avg_ttft_ms) =
-        conn.query_row(&totals_sql, params_ref(&totals_params).as_slice(), |r| {
+        conn.query_row(&totals_sql, params_slice.as_slice(), |r| {
             Ok((
                 crate::sql_u64(r, 0)?,
                 crate::sql_u64(r, 1)?,
@@ -163,14 +156,13 @@ pub fn query_local_model_usage(
     })
 }
 
-/// Build the (sql, params) pair for a local-model query by appending the
-/// IN-clause to whatever `build_session_filter` produces. The template is
-/// expected to contain the literal `{where_sql}` placeholder.
-fn build_query(
+/// Compose `build_session_filter`'s WHERE clause with the provider IN-clause,
+/// returning the combined SQL fragment plus its bound params (base filter
+/// params followed by one bind per provider name).
+fn local_where_clause(
     filter: &DashboardFilter,
     in_clause: &str,
     local_provider_names: &[String],
-    template: &str,
 ) -> (String, Vec<Box<dyn ToSql>>) {
     let FilterClause {
         where_sql: base_where,
@@ -184,7 +176,7 @@ fn build_query(
     for name in local_provider_names {
         params.push(Box::new(name.clone()) as Box<dyn ToSql>);
     }
-    (template.replace("{where_sql}", &where_sql), params)
+    (where_sql, params)
 }
 
 #[cfg(test)]

--- a/docs/plans/review-followups.md
+++ b/docs/plans/review-followups.md
@@ -1170,3 +1170,60 @@
 - **来源**：2026-04-30 F-029 收尾 `/simplify` review（quality agent）
 - **关闭**：2026-04-30 / commit 紧跟 F-028..F-031 收尾
 - **修复方式**：发现 [`plan::PlanModeState`](../../crates/ha-core/src/plan/types.rs) enum 已存在并完整支持 `from_str`/`as_str`/serde rename_all snake_case + `is_valid_transition`，直接复用即可（不需要新建 PlanMode）。给 PlanModeState 加 `Copy` 派生（6 个 unit variant，1 字节）让消费方按值传递。`SessionMeta.plan_mode: String` → `PlanModeState`，DB row→struct 边界用 `from_str` 一次性转 enum；`update_session_plan_mode` 参数改成 `PlanModeState`，6 处 caller（slash_commands/handlers/plan.rs 5 处 + tools/plan_step.rs + tools/submit_plan.rs + ha-server/routes/plan.rs 2 处 + src-tauri/commands/plan.rs 3 处 + commands/chat.rs 2 处）改用 enum variant；`should_create_execution_checkpoint(persisted_plan_mode: Option<&str>)` 改成 `Option<PlanModeState>`；`restore_from_db(plan_mode_str: &str)` 改成 `state: PlanModeState`，删除内部 from_str 重复转换。`meta.plan_mode == "off"` 等 stringly compare 全部改成 enum 匹配。ha-core 771 / ha-server 18 单测全绿。
+
+
+---
+
+### F-033 `SectionSkeleton` 在 dashboard 6 个 section 重复实现
+
+- **来源**：2026-05-14 `feat/dashboard-local-models` `/simplify` review（reuse agent）
+- **现象**：[`LocalModelsSection.tsx`](../../src/components/dashboard/LocalModelsSection.tsx)、[`SystemMetricsSection.tsx`](../../src/components/dashboard/SystemMetricsSection.tsx)、[`TaskSection.tsx`](../../src/components/dashboard/TaskSection.tsx)、[`ErrorSection.tsx`](../../src/components/dashboard/ErrorSection.tsx)、[`InsightsSection.tsx`](../../src/components/dashboard/InsightsSection.tsx)、[`SessionSection.tsx`](../../src/components/dashboard/SessionSection.tsx) 各自定义同一个 8 行的 `SectionSkeleton` 组件（`<div className="w-full bg-muted animate-pulse rounded-lg" style={{ height }} />`）。
+- **为什么留**：pre-existing debt，本期 PR 只是第 6 个复制点；抽出会动 5 个无关 section 文件，扩散 PR scope。
+- **改的话要做什么**：抽到 `src/components/dashboard/SectionSkeleton.tsx` 单文件，6 个 section import；同 PR 删掉本地定义。
+- **影响面**：纯重复，无 bug。
+- **触发时机建议**：下次有 dashboard section 重构 PR 顺手清。
+
+---
+
+### F-034 dashboard 局部 `Badge` 应迁到 shadcn `src/components/ui/badge.tsx`
+
+- **来源**：2026-05-14 `feat/dashboard-local-models` `/simplify` review（reuse agent）
+- **现象**：[`LocalModelsSection.tsx:76-95`](../../src/components/dashboard/LocalModelsSection.tsx) 内联定义了一个 17 行的 `Badge` span 组件（rounded-md border + 文本徽章），项目 `src/components/ui/` 下没有 shadcn `badge.tsx`。
+- **为什么留**：当期仅 LocalModelsSection 一处用，没有现成的可复用。等下次有第 2 个调用方时再升级到 shadcn 标准 Badge。
+- **改的话要做什么**：用 `pnpm dlx shadcn@latest add badge` 装标准 Badge（或手抄 shadcn Badge 模板）到 `src/components/ui/badge.tsx`；删除 LocalModelsSection 内联定义；把 7 处使用迁过去。
+- **影响面**：纯重复，无 bug。
+- **触发时机建议**：下一个 dashboard / settings PR 想用 badge 时顺手做。
+
+---
+
+### F-035 `local_model_job_list` 无 server-side status filter，前端 fetch 全量 jobs
+
+- **来源**：2026-05-14 `feat/dashboard-local-models` `/simplify` review（efficiency agent）
+- **现象**：[`local_model_jobs.rs`](../../crates/ha-core/src/local_model_jobs.rs) 的 list 命令始终返回 `local_model_jobs.db` 全部记录，前端 `LocalModelsSection` 再用 `isLocalModelJobVisible` 客户端筛选。jobs 表每次 ollama-pull / preload / chat_model / embedding 都落一条，长期会膨胀。
+- **为什么留**：当期表预估 ≤ 几十条，client-side filter 没用户感知延迟。
+- **改的话要做什么**：给 `local_model_job_list` 加可选参数 `status_filter: Vec<LocalModelJobStatus>`，SQL `WHERE status IN (...)`。Tauri 命令 + HTTP route 同步加 query param；dashboard 调用时传 `["running","cancelling","paused","interrupted","failed"]`。
+- **影响面**：性能，当 jobs 表 > 1000 行后可能感知到 list 慢。
+- **触发时机建议**：下次发现 jobs 表膨胀 / dashboard 加载变慢时。
+
+---
+
+### F-036 `query_local_model_usage` 第 3 个 totals SQL 可折叠到 by_model
+
+- **来源**：2026-05-14 `feat/dashboard-local-models` `/simplify` review（efficiency agent）
+- **现象**：[`crates/ha-core/src/dashboard/local_models.rs:131-159`](../../crates/ha-core/src/dashboard/local_models.rs) 串行跑 3 个 SQL（trend / by_model / totals），totals 完全可从 by_model 求和；avg_ttft_ms 需在 `LocalModelUsageRow` 加 `ttft_sample_count` 字段才能精确加权折叠（`AVG(CASE...)` 分母是非 NULL 行数，不是 call_count）。
+- **为什么留**：暴露 `ttft_sample_count` 内部字段到前端 wire type 不优雅；本地 SQLite 多一个 query <1ms，无感知。
+- **改的话要做什么**：扩 LocalModelUsageRow 加 `ttft_sample_count: u64`；删 totals SQL；Rust 端 fold `Σ(sum_ttft)/Σ(sample_count)`。或保持现状用 CTE 合并 trend + totals。
+- **影响面**：messages 表 > 10 万行后能省 ~33% 查询时间，普通用户无感。
+- **触发时机建议**：用户反馈 dashboard 慢 / messages 表膨胀到百万级时。
+
+---
+
+### F-037 LocalModelsSection 运行中模型倒计时仅在 refresh 时更新
+
+- **来源**：2026-05-14 `feat/dashboard-local-models` `/simplify` review（efficiency agent）
+- **现象**：[`LocalModelsSection.tsx`](../../src/components/dashboard/LocalModelsSection.tsx) `formatExpiresIn(m.expiresAt)` 在 render 时算 "X 分钟后卸载"，render 之间不变。autoRefresh=60s 时倒计时只在每次 refresh 跳变；autoRefresh=off 时数值不动直到用户手动刷新。
+- **为什么留**：autoRefresh 已经覆盖大部分场景，倒计时漂移 ≤ 60s 用户感知低；加 setInterval 强制 re-render 会和 React.memo 优化打架。
+- **改的话要做什么**：抽 `<RelativeTimeCountdown expiresAt=... />` 小组件，内部 `useState + useEffect` 30s setInterval 强制 re-render，limited blast radius。
+- **影响面**：UX 微瑕，无 bug。
+- **触发时机建议**：用户反馈倒计时不准时再做。
+

--- a/src/components/dashboard/LocalModelsSection.tsx
+++ b/src/components/dashboard/LocalModelsSection.tsx
@@ -30,7 +30,6 @@ import { Button } from "@/components/ui/button"
 import { Progress } from "@/components/ui/progress"
 import { cn } from "@/lib/utils"
 import MetricCard from "@/components/common/MetricCard"
-import { formatBytes as formatRawBytes } from "@/lib/format"
 import type { SettingsSection } from "@/components/settings/types"
 import type {
   HardwareInfo,
@@ -44,7 +43,7 @@ import {
   localModelJobPercent,
 } from "@/types/local-model-jobs"
 import type { DashboardLocalModelUsage } from "./types"
-import { chartName, chartNumber, formatNumber } from "./types"
+import { chartName, chartNumber, formatDashboardBytes, formatNumber } from "./types"
 
 interface LocalModelsSectionProps {
   loading: boolean
@@ -55,10 +54,6 @@ interface LocalModelsSectionProps {
   usage: DashboardLocalModelUsage | null
   jobs: LocalModelJobSnapshot[] | null
   onOpenSettings?: (section?: SettingsSection) => void
-}
-
-function formatBytes(bytes: number): string {
-  return formatRawBytes(bytes, { fractionDigits: { GB: 2, TB: 2 } })
 }
 
 function mbToBytes(mb: number): number {
@@ -144,7 +139,7 @@ const LocalModelsSection = React.memo(function LocalModelsSection({
     () => (models ?? []).filter((m) => m.running),
     [models],
   )
-  const installedModels = useMemo(() => models ?? [], [models])
+  const installedModels = models ?? []
   const visibleJobs = useMemo(
     () => (jobs ?? []).filter(isLocalModelJobVisible),
     [jobs],
@@ -246,8 +241,8 @@ const LocalModelsSection = React.memo(function LocalModelsSection({
           <MetricCard
             icon={MemoryStick}
             label={t("dashboard.localModels.hardware.totalMemory")}
-            value={formatBytes(mbToBytes(hardware.totalMemoryMb))}
-            subValue={`${t("dashboard.localModels.hardware.available")}: ${formatBytes(
+            value={formatDashboardBytes(mbToBytes(hardware.totalMemoryMb))}
+            subValue={`${t("dashboard.localModels.hardware.available")}: ${formatDashboardBytes(
               mbToBytes(hardware.availableMemoryMb),
             )}`}
             colorClass="text-purple-500"
@@ -259,7 +254,7 @@ const LocalModelsSection = React.memo(function LocalModelsSection({
             value={hardware.gpu?.name ?? t("dashboard.localModels.hardware.integratedGpu")}
             subValue={
               hardware.gpu?.vramMb != null
-                ? `${t("dashboard.localModels.hardware.vram")}: ${formatBytes(mbToBytes(hardware.gpu.vramMb))}`
+                ? `${t("dashboard.localModels.hardware.vram")}: ${formatDashboardBytes(mbToBytes(hardware.gpu.vramMb))}`
                 : undefined
             }
             colorClass="text-blue-500"
@@ -268,7 +263,7 @@ const LocalModelsSection = React.memo(function LocalModelsSection({
           <MetricCard
             icon={Gauge}
             label={t("dashboard.localModels.hardware.budget")}
-            value={formatBytes(mbToBytes(hardware.budgetMb))}
+            value={formatDashboardBytes(mbToBytes(hardware.budgetMb))}
             subValue={t(
               `dashboard.localModels.hardware.budgetSource.${hardware.budgetSource}`,
             )}
@@ -301,8 +296,8 @@ const LocalModelsSection = React.memo(function LocalModelsSection({
           </h3>
           {runningModels.length > 0 && budgetBytes > 0 && (
             <span className="text-xs text-muted-foreground tabular-nums">
-              {formatBytes(totalVramBytes)} /{" "}
-              {formatBytes(budgetBytes)}
+              {formatDashboardBytes(totalVramBytes)} /{" "}
+              {formatDashboardBytes(budgetBytes)}
             </span>
           )}
         </div>
@@ -331,7 +326,7 @@ const LocalModelsSection = React.memo(function LocalModelsSection({
                         {m.sizeVramBytes != null && (
                           <span className="tabular-nums">
                             {t("dashboard.localModels.running.vramUsed")}:{" "}
-                            {formatBytes(m.sizeVramBytes)}
+                            {formatDashboardBytes(m.sizeVramBytes)}
                           </span>
                         )}
                         {m.contextWindow != null && (
@@ -376,7 +371,7 @@ const LocalModelsSection = React.memo(function LocalModelsSection({
                       {m.details?.family ??
                         t("dashboard.localModels.installed.unknownFamily")}
                       {m.sizeBytes != null
-                        ? ` · ${formatBytes(m.sizeBytes)}`
+                        ? ` · ${formatDashboardBytes(m.sizeBytes)}`
                         : ""}
                       {m.contextWindow != null
                         ? ` · ctx ${formatNumber(m.contextWindow)}`
@@ -435,25 +430,33 @@ const LocalModelsSection = React.memo(function LocalModelsSection({
           </h3>
         </div>
 
-        {usage == null ? null : usage.localProviderNames.length === 0 ? (
-          <div className="py-8 flex flex-col items-center gap-2 text-muted-foreground text-sm">
-            <AlertCircle className="h-7 w-7 opacity-30" />
-            <span>{t("dashboard.localModels.empty.noProvider")}</span>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={() => onOpenSettings?.("modelConfig")}
-            >
-              {t("dashboard.localModels.empty.goToSettings")}
-            </Button>
-          </div>
-        ) : usage.totalCalls === 0 ? (
-          <div className="py-8 flex flex-col items-center gap-2 text-muted-foreground text-sm">
-            <Zap className="h-7 w-7 opacity-30" />
-            <span>{t("dashboard.localModels.usage.empty")}</span>
-          </div>
-        ) : (
-          <>
+        {(() => {
+          if (usage == null) return null
+          if (usage.localProviderNames.length === 0) {
+            return (
+              <div className="py-8 flex flex-col items-center gap-2 text-muted-foreground text-sm">
+                <AlertCircle className="h-7 w-7 opacity-30" />
+                <span>{t("dashboard.localModels.empty.noProvider")}</span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onOpenSettings?.("modelConfig")}
+                >
+                  {t("dashboard.localModels.empty.goToSettings")}
+                </Button>
+              </div>
+            )
+          }
+          if (usage.totalCalls === 0) {
+            return (
+              <div className="py-8 flex flex-col items-center gap-2 text-muted-foreground text-sm">
+                <Zap className="h-7 w-7 opacity-30" />
+                <span>{t("dashboard.localModels.usage.empty")}</span>
+              </div>
+            )
+          }
+          return (
+            <>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
               <MetricCard
                 icon={Zap}
@@ -616,8 +619,9 @@ const LocalModelsSection = React.memo(function LocalModelsSection({
                 </div>
               </div>
             )}
-          </>
-        )}
+            </>
+          )
+        })()}
       </div>
 
       {/* Block F — Background jobs */}

--- a/src/components/dashboard/SystemMetricsSection.tsx
+++ b/src/components/dashboard/SystemMetricsSection.tsx
@@ -26,18 +26,13 @@ import {
   ArrowUpFromLine,
 } from "lucide-react"
 import MetricCard from "@/components/common/MetricCard"
-import { formatBytes as formatRawBytes } from "@/lib/format"
 import type { SystemMetrics } from "./types"
-import { chartName, chartNumber, formatUptime } from "./types"
+import { chartName, chartNumber, formatDashboardBytes as formatBytes, formatUptime } from "./types"
 
 export interface SystemHistoryPoint {
   t: number
   cpu: number
   mem: number
-}
-
-function formatBytes(bytes: number): string {
-  return formatRawBytes(bytes, { fractionDigits: { GB: 2, TB: 2 } })
 }
 
 interface SystemMetricsSectionProps {

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -1,3 +1,5 @@
+import { formatBytes as formatBytesRaw } from "@/lib/format"
+
 export interface DashboardFilter {
   startDate: string | null
   endDate: string | null
@@ -378,6 +380,15 @@ export function chartName(value: unknown): string {
 /** Format USD currency */
 export function formatCost(n: number): string {
   return `$${n.toFixed(2)}`
+}
+
+/**
+ * Dashboard convention for byte sizes: 2 fraction digits at GB / TB scale,
+ * default elsewhere. Wraps `@/lib/format::formatBytes` so every section
+ * shows memory / disk numbers identically.
+ */
+export function formatDashboardBytes(bytes: number): string {
+  return formatBytesRaw(bytes, { fractionDigits: { GB: 2, TB: 2 } })
 }
 
 /** Format seconds to human readable uptime */


### PR DESCRIPTION
## Summary

PR #178 合并后做的 \`/simplify\` review 没赶上同一 PR,这里单独提。3 个 review agent(reuse / quality / efficiency)发现的 4 处可修问题:

- **HIGH** — 提取 \`formatDashboardBytes\` 共享 helper 到 [\`dashboard/types.ts\`](src/components/dashboard/types.ts),[\`LocalModelsSection.tsx\`](src/components/dashboard/LocalModelsSection.tsx) + [\`SystemMetricsSection.tsx\`](src/components/dashboard/SystemMetricsSection.tsx) 都用它,消除 byte-for-byte 重复
- **MEDIUM** — [\`local_models.rs\`](crates/ha-core/src/dashboard/local_models.rs) \`build_query\` placeholder 风格(\`String::replace("{where_sql}", ...)\`)改为返回 \`(where_sql, params)\` 让调用点 \`format!\` 拼,跟 [\`queries.rs\`](crates/ha-core/src/dashboard/queries.rs) 既有模式对齐
- **MEDIUM** — 删 \`installedModels\` 的 identity \`useMemo(() => models ?? [], [models])\`
- **MEDIUM** — Block E 三层 nested ternary 改成 IIFE early return

## 不修但登记 review-followups

[\`docs/plans/review-followups.md\`](docs/plans/review-followups.md):

- F-033 \`SectionSkeleton\` 6 个 dashboard section 重复(pre-existing debt)
- F-034 inline \`Badge\` 应迁到 shadcn \`ui/badge.tsx\`
- F-035 \`local_model_job_list\` 加 server-side status filter
- F-036 \`query_local_model_usage\` totals 折叠到 by_model 省 1 个 SQL roundtrip
- F-037 LocalModelsSection 运行中模型倒计时仅 refresh 时更新(autoRefresh 已兜底)

## Test plan

- [x] \`cargo test -p ha-core --lib dashboard::local_models\` 5/5 通过
- [x] \`cargo check -p ha-core -p ha-server\` / fmt / clippy 全绿(pre-push 套件)
- [x] \`pnpm typecheck\` / lint / vitest 全绿
- [ ] CI 8 项 status check 全绿