### PR TITLE
feat(release): build-macos-x64.yml 异步 backfill Intel DMG(方案 D)

### DIFF
--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -1,0 +1,200 @@
+name: Build macOS x64 (best-effort backfill)
+
+# Independent best-effort lane for the macOS Intel (x86_64) DMG + bare
+# binary. This workflow is intentionally not part of release.yml: the
+# GitHub-hosted macos-13 Intel runner pool has a small capacity that
+# regularly causes >1h queue stalls, which would block the entire
+# release pipeline (release.yml waits for every matrix entry before
+# patch-manifest can run; `continue-on-error` does not let `needs:`
+# skip queued/running jobs — see PR #175 / #177 history).
+#
+# Splitting it out means the four-platform main release (macos-arm64
+# / linux-x64 / linux-arm64 / windows-x64) publishes immediately. This
+# workflow then runs in parallel, takes however long macos-13 needs,
+# and backfills the Intel DMG + bare binary into the already-published
+# Release, patches latest.json to include the darwin-x86_64
+# bare_binary entry, and re-triggers update-homebrew-tap.yml so the
+# Homebrew cask flips from arm-only to dual-arch.
+#
+# If this workflow fails or never gets a runner (GitHub auto-cancels
+# queues after the default 24h timeout), the release simply ships
+# without an Intel DMG for that version — `update-homebrew-tap.yml`
+# already handles the missing-x64.dmg case by rendering the arm-only
+# cask template (see F-089). Intel Mac users can install when the
+# next release succeeds.
+#
+# Triggers:
+#   - release.published — fires automatically right after the manual
+#     publish in §1.4 of docs/release-process.md.
+#   - workflow_dispatch — manual re-run with a tag input, for when
+#     the macos-13 runner pool was unavailable and you want to retry
+#     a backfill for an already-published release without cutting a
+#     new version.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to backfill (for example v0.2.1)
+        required: true
+        type: string
+
+concurrency:
+  # Per-tag concurrency so two dispatches against the same tag don't
+  # double-build, but different tags can run in parallel.
+  group: build-macos-x64-${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write  # gh release upload
+  actions: write   # gh workflow run (re-trigger update-homebrew-tap.yml)
+
+jobs:
+  build:
+    runs-on: macos-13
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+    steps:
+      # Check out the source at the release tag, not the default
+      # branch. The release was built off this commit; doing the
+      # backfill off any other commit would ship code that does not
+      # match the rest of the release.
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-apple-darwin
+
+      # Belt-and-suspenders target install. The `targets:` input above
+      # does not always trigger `rustup target add` when the runner
+      # image already ships a Rust toolchain (it skips its install
+      # branch and the target add path with it). On native macos-13
+      # the default toolchain already targets x86_64-apple-darwin so
+      # this is usually a no-op, but the explicit add keeps the
+      # workflow robust to runner image changes.
+      - name: Ensure x86_64-apple-darwin target installed
+        run: rustup target add x86_64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Same Minisign pubkey guard as release.yml — refuse to build if
+      # the desktop bundle (`tauri-plugin-updater`) and headless
+      # self-update (`ha_core::updater`) disagree.
+      - name: Verify updater pubkey sync (tauri.conf.json ↔ ha-core)
+        run: node scripts/verify-updater-pubkey.mjs
+
+      # Sanity-check that the tag we're backfilling actually matches
+      # the source-tree version checked out above. If they drift, the
+      # produced binary self-identifies as a different version than
+      # the Release it's being uploaded to — confusing for both users
+      # and self-update.
+      - name: Verify tag matches app version
+        run: pnpm release:verify -- --tag "${{ env.RELEASE_TAG }}"
+
+      # Build the macOS Intel DMG. We invoke `pnpm tauri build`
+      # directly rather than tauri-action because the Release already
+      # exists — we just need the binary, not draft-release creation.
+      - name: Build macOS Intel DMG
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: pnpm tauri build --target x86_64-apple-darwin
+
+      - name: Upload Intel DMG to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          dmg="target/x86_64-apple-darwin/release/bundle/dmg/Hope.Agent_${version}_x64.dmg"
+          if [ ! -f "$dmg" ]; then
+            echo "::error::Intel DMG not found at $dmg"
+            ls "target/x86_64-apple-darwin/release/bundle/dmg/" || true
+            exit 1
+          fi
+          gh release upload "${RELEASE_TAG}" "$dmg" --clobber
+          echo "Uploaded $dmg to ${RELEASE_TAG}"
+
+      # Bundle + sign bare binary for headless self-update (Intel Mac
+      # users running `hope-agent server` or `hope-agent acp` on Intel
+      # hardware need this to receive updates). Same Minisign keypair
+      # as release.yml — `ha_core::updater` verifies against the
+      # pubkey in `ha-core/updater/keys.rs`.
+      - name: Bundle + sign bare binary
+        id: bare_binary
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          target_dir=target/x86_64-apple-darwin/release
+          bin_path="$target_dir/hope-agent"
+          if [ ! -f "$bin_path" ]; then
+            echo "::error::Bare binary not found at $bin_path"
+            ls "$target_dir" || true
+            exit 1
+          fi
+          out_dir="bare-binary-bundle"
+          mkdir -p "$out_dir"
+          archive="$out_dir/hope-agent-${version}-darwin-x86_64.tar.gz"
+          tar -C "$target_dir" -czf "$archive" "hope-agent"
+          pnpm tauri signer sign --private-key "$TAURI_SIGNING_PRIVATE_KEY" --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" "$archive"
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+          echo "sig=$archive.sig" >> "$GITHUB_OUTPUT"
+
+      - name: Upload bare binary to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload "${RELEASE_TAG}" "${{ steps.bare_binary.outputs.archive }}" "${{ steps.bare_binary.outputs.sig }}" --clobber
+
+      # Backfill the darwin-x86_64 entry into latest.json so headless
+      # Intel Mac installs can self-update. Reuses
+      # scripts/patch-latest-json.mjs which is in merge mode — it
+      # preserves existing platform entries from the original
+      # release.yml run and only adds/overrides darwin-x86_64.
+      - name: Patch latest.json with darwin-x86_64 bare_binary entry
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#v}"
+          mkdir -p artifacts/bare-binary-macos-x64
+          cp "${{ steps.bare_binary.outputs.archive }}" "${{ steps.bare_binary.outputs.sig }}" artifacts/bare-binary-macos-x64/
+          gh release download "${RELEASE_TAG}" --pattern latest.json --dir .
+          node scripts/patch-latest-json.mjs latest.json artifacts "$version"
+          gh release upload "${RELEASE_TAG}" latest.json --clobber
+
+      # Re-trigger the Homebrew tap update so the cask flips from the
+      # arm-only template (rendered by the release.published-triggered
+      # run that fired before this workflow finished) to the dual-arch
+      # template (now that Hope.Agent_<v>_x64.dmg exists in the
+      # release). update-homebrew-tap.yml already detects which DMGs
+      # are present and picks the right template — F-089.
+      #
+      # --ref main pins this dispatch to whatever update-homebrew-tap
+      # logic is on the default branch at the time of backfill, not
+      # the release tag's version of that workflow file.
+      - name: Re-trigger Homebrew tap update (now dual-arch)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run update-homebrew-tap.yml --ref main -f tag="${RELEASE_TAG}"

--- a/scripts/patch-latest-json.mjs
+++ b/scripts/patch-latest-json.mjs
@@ -73,8 +73,14 @@ for (const [platformDir, meta] of Object.entries(PLATFORM_MAP)) {
   console.log(`[patch-latest-json] added bare_binary entry for ${meta.key}`);
 }
 
-manifest.bare_binary = { platforms: bareBinaryPlatforms };
+// Merge mode: keep entries that already exist on the manifest (e.g.
+// from a previous release.yml patch run), and add/override only the
+// platforms we found artifacts for in this run. This lets independent
+// best-effort workflows (e.g. build-macos-x64.yml) backfill a single
+// platform's entry without wiping the other four.
+const existing = manifest.bare_binary?.platforms || {};
+manifest.bare_binary = { platforms: { ...existing, ...bareBinaryPlatforms } };
 fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
 console.log(
-  `[patch-latest-json] wrote ${Object.keys(bareBinaryPlatforms).length} bare_binary entries to ${manifestPath}`,
+  `[patch-latest-json] merged ${Object.keys(bareBinaryPlatforms).length} new bare_binary entries into ${manifestPath} (manifest now has ${Object.keys(manifest.bare_binary.platforms).length} platforms total)`,
 );


### PR DESCRIPTION
## 背景

GitHub-hosted macos-13 Intel runner 池容量有限,排队 >1h 是常态。之前两次尝试让 macos-x64 走主 release 流程都失败:

- [PR #172](https://github.com/shiwenwen/hope-agent/pull/172) 临时移除整个 lane(v0.2.0 紧急救火)
- [PR #175](https://github.com/shiwenwen/hope-agent/pull/175) 加 \`continue-on-error\` best-effort 恢复 — codex review 证伪(\`needs:\` 等待 queued/running 子任务,跟 \`continue-on-error\` 无关),[PR #177](https://github.com/shiwenwen/hope-agent/pull/177) 撤回
- F-088 试 cross-compile [PR #179](https://github.com/shiwenwen/hope-agent/pull/179) — fastembed → ort-sys 没 x86_64-apple-darwin prebuilt,死路,关闭

## 方案 D:完全拆出主流程

不进 release.yml,做成独立 best-effort workflow。**每次发版**:

\`\`\`
tag push
  ↓
release.yml 跑 4 平台 → publish v0.X.Y(无 Intel DMG)
  ↓ (release.published 事件并发触发)
  ├── update-homebrew-tap.yml(F-089 容错): 看到无 x64.dmg → arm-only cask 推 tap
  └── build-macos-x64.yml: 排队等 macos-13 runner(无时间限制)
        ↓ macos-13 跑通 (几分钟 ~ 几小时)
        ↓ gh release upload Intel DMG + bare-binary tar.gz + sig
        ↓ patch latest.json 加 darwin-x86_64 entry(merge mode,不动其他平台)
        ↓ gh workflow run update-homebrew-tap.yml(自动 re-trigger)
              ↓ concurrency group 让它排在第一次后
              ↓ 看到 x64.dmg → 切 dual-arch cask 覆盖 arm-only
        ↓ done
\`\`\`

**user 体验**:tag push 一次,剩下全自动。

## 改动

- **新增** [\`.github/workflows/build-macos-x64.yml\`](.github/workflows/build-macos-x64.yml)
  - trigger:\`release.published\` 自动 + \`workflow_dispatch\` 手动 retry
  - runner:\`macos-13\` native(不 cross-compile —— [F-088 cross-compile 死路](#背景))
  - checkout 指向 tag 而不是 main,保证 backfill 用的源码版本和 release 一致
  - permissions:\`contents: write\`(upload assets) + \`actions: write\`(re-trigger update-homebrew-tap)
  - concurrency:per-tag(不同 tag 可并行,同 tag 不重复跑)
- **改** [\`scripts/patch-latest-json.mjs\`](scripts/patch-latest-json.mjs):merge 模式,preserve 已有 bare_binary.platforms entries,只 add/override 当前 artifacts dir 里的平台。release.yml patch-manifest 行为向后兼容(原从空开始重建,merge 模式 existing 为空时等价)

## 边缘情况

| 情况 | 结果 |
|---|---|
| macos-13 几分钟内拿到 runner,build 顺利 | DMG + bare-binary backfill,latest.json 完整 5 平台,cask 切 dual-arch |
| macos-13 排队几小时 | 同上,只是延后 |
| build 编译失败(未来某天上游 break Intel) | workflow fail,无 backfill,cask 维持 arm-only,等修复后手动 dispatch |
| 24h 队列超时(GitHub 自动 cancel) | 同上 |

## v0.2.1 影响

本 PR base 是 main 不是 release/v0.2 —— GitHub release.published trigger 取 default branch 上的 workflow file。要 v0.2.1 发版起就生效,merge 后需要 cherry-pick \`build-macos-x64.yml\` + \`patch-latest-json.mjs\` 改动到 release/v0.2(独立 PR)。

## Test plan

- [x] pre-push 全绿
- [ ] PR CI 8 项 status check 全绿
- [ ] merge 后,手动 workflow_dispatch trigger 一次(tag=v0.2.0,已发布的版本)验证 macos-13 native build 能跑通 + Intel DMG 能 backfill 进 v0.2.0 release
- [ ] 验证 latest.json patch + update-homebrew-tap 自动 re-trigger 链路对

## Closes

- F-088(实施完毕,需要 dry-run / 实战 validate)