### PR TITLE
fix(chat): 多会话并发 streaming 时切回会话不再丢失气泡

### DIFF
--- a/src/components/chat/hooks/useChatSession.ts
+++ b/src/components/chat/hooks/useChatSession.ts
@@ -547,13 +547,13 @@ export function useChatSession({
         setLoading(loadingSessionsRef.current.has(sessionId))
         setCurrentSessionId(sessionId)
         touchSessionCacheLru(sessionId)
-        // Background reload — pushes the merged result into the view only
-        // if we're still on this session AND it isn't streaming (streaming
-        // owns the array during a turn; a stale DB batch would clobber
-        // dbId-upgraded placeholders). Cache write inside the helper is
-        // unconditional and safe. The in-flight guard collapses redundant
-        // DB reads when the user rapidly cycles back to the same session.
-        if (!inFlightReloadsRef.current.has(sessionId)) {
+        // Skip background reload while streaming — the helper's unconditional
+        // cache write would drop the in-flight assistant placeholder (no DB
+        // row yet), making the bubble vanish mid-stream.
+        if (
+          !inFlightReloadsRef.current.has(sessionId) &&
+          !loadingSessionsRef.current.has(sessionId)
+        ) {
           inFlightReloadsRef.current.add(sessionId)
           void reloadAndMergeSessionMessages({
             sessionId,


### PR DESCRIPTION
## 问题

多个会话同时执行生成任务时，在它们之间来回切换，正在生成内容的气泡会突然消失（不可见），底部输入栏状态正常；要等本轮生成完全结束，气泡才瞬间恢复显示。

## 根因

切回正在 streaming 的 cached session 时，[useChatSession.ts](https://github.com/shiwenwen/hope-agent/blob/release/v0.2/src/components/chat/hooks/useChatSession.ts) 在 cache 命中分支会 spawn 一个 background reload-and-merge：

1. [reloadAndMergeSessionMessages](https://github.com/shiwenwen/hope-agent/blob/release/v0.2/src/components/chat/chatUtils.ts#L494) 从 DB 拉最新消息 fresh，调 [mergeMessagesByDbId](https://github.com/shiwenwen/hope-agent/blob/release/v0.2/src/components/chat/chatUtils.ts#L606) 与 cache 合并。
2. in-flight assistant placeholder 只有 ` _clientId`、无 `dbId`，且 fresh 里没对应 role 的新行可承接它的 `_clientId` —— **被直接丢弃**。
3. helper 又**无条件**把 merged 写回 `sessionCacheRef`（cache 被污染，placeholder 没了）。
4. 视图本来有 `loadingSessionsRef` guard 保护，不会被 setMessages 覆盖；**但下一帧 stream delta 来时**，[updateSessionMessages](https://github.com/shiwenwen/hope-agent/blob/release/v0.2/src/components/chat/hooks/useChatSession.ts#L226) 读到污染后的 prev（last 不再是 assistant），updater 直接 return prev，再**无条件** setMessages 把无 placeholder 的视图 push 出去 —— **气泡瞬间消失**。
5. 直到 turn 落 DB → 再次 reload-and-merge → fresh 已经包含 final assistant 行 → 气泡恢复。

## 修复

在 cache 命中分支加 `loadingSessionsRef` guard：该 session 仍在 streaming 时彻底跳过 background reload，等 turn 自然结束后再 reload-and-merge。最干净的局部修法 —— 不动 `mergeMessagesByDbId` / `reloadAndMergeSessionMessages` 的语义（它们在 turn 结束后还需要正常 reconcile）。

## Test plan

- [ ] 起两个会话 A、B，分别开始生成（agent 跑长 turn 或叫它思考一段时间）
- [ ] 在 A、B 之间快速来回切换若干次
- [ ] 切换后正在 streaming 的气泡**应该持续可见** + 持续打字机效果，**不再消失**
- [ ] 等 turn 结束，最终消息正常落地
- [ ] 切到一个空闲（非 streaming）会话再切回，背景 reload 仍然正常工作（外部 IM/CLI 推到该 session 的更新仍能通过 ~1 RTT 收敛进来）