### PR TITLE
fix(settings): Provider 引导 wizard 模型步骤布局过窄 + i18n key 缺失

### DIFF
--- a/src/components/settings/provider-setup/CustomWizard.tsx
+++ b/src/components/settings/provider-setup/CustomWizard.tsx
@@ -200,7 +200,7 @@ export function CustomWizard({
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto px-6 py-6 max-w-lg mx-auto w-full">
+      <div className="flex-1 overflow-y-auto px-6 py-6 max-w-4xl mx-auto w-full">
         {customStep === 0 && (
           <div className="space-y-3">
             <h3 className="text-base font-semibold text-foreground">{t("wizard.selectApiType")}</h3>
@@ -335,7 +335,7 @@ export function CustomWizard({
           <div className="space-y-3">
             <div className="flex items-center justify-between">
               <div>
-                <h3 className="text-base font-semibold text-foreground">{t("model.addModels")}</h3>
+                <h3 className="text-base font-semibold text-foreground">{t("model.addModel")}</h3>
                 <p className="text-xs text-muted-foreground mt-0.5">
                   {t("model.configModels")}
                   {models.length > 1 && (


### PR DESCRIPTION
## 问题

设置 → 模型配置 → 添加 Provider 走自定义引导，第 3 步「模型」：

1. **标题显示成 i18n key 字面量** \`model.addModels\` —— 12 个语言文件都没有这个 key，t() fallback 到 key 自身。
2. **模型卡片挤在中间一窄列**，左侧大块空白 —— 容器硬编码 \`max-w-lg\`（512px），第 3 步要承载 Model ID + 显示名称 + Context Window + Max Tokens + 输入/输出成本多组两列字段，很局促。

## 修复

- **i18n**：复用已有的 \`model.addModel\`（"添加模型" / "Add Model"），单复数中文不区分、英文也通顺，无需新增翻译。
- **布局**：\`max-w-lg\` → \`max-w-4xl\`，与 AGENTS.md 前端规范"避免硬编码过小的 max-width，用 max-w-4xl 以上或弹性伸缩"一致。前两步的窄表单视觉影响可接受（输入框 / 选项卡片自然变宽，更舒展），不再分 step 维护两套宽度。

## Test plan

- [ ] 设置 → 模型配置 → 添加自定义 Provider，走到第 3 步
- [ ] 标题正确显示「添加模型」/「Add Model」，不再是 \`model.addModels\` 字面量
- [ ] 模型卡片宽度足够展开两列字段，不再挤在窄列里
- [ ] 第 1、2 步（API 类型 / 连接配置）布局没有破坏感
- [ ] 切换 12 种语言，标题在每种语言下都是已翻译的「添加模型」近义词