### PR TITLE
fix(release): build-macos-x64.yml inline patch latest.json,不依赖 tag 上的脚本

### DIFF
--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -168,20 +168,44 @@ jobs:
           gh release upload "${RELEASE_TAG}" "${{ steps.bare_binary.outputs.archive }}" "${{ steps.bare_binary.outputs.sig }}" --clobber
 
       # Backfill the darwin-x86_64 entry into latest.json so headless
-      # Intel Mac installs can self-update. Reuses
-      # scripts/patch-latest-json.mjs which is in merge mode — it
-      # preserves existing platform entries from the original
-      # release.yml run and only adds/overrides darwin-x86_64.
+      # Intel Mac installs can self-update.
+      #
+      # The patch logic is *inlined* below rather than reusing
+      # scripts/patch-latest-json.mjs from the workspace checkout above.
+      # Reason: that checkout pins to the release tag's commit, where
+      # patch-latest-json.mjs may still be in its original "reset and
+      # rebuild" form (any tag cut before the merge-mode change shipped).
+      # Calling it would wipe the 4 existing bare_binary platform entries
+      # and leave only darwin-x86_64, breaking self-update on every other
+      # OS for that release. Tags are immutable, so we can't fix that
+      # script retroactively — inline merge logic here keeps the
+      # backfill safe regardless of what the tag's script looks like.
       - name: Patch latest.json with darwin-x86_64 bare_binary entry
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIG_PATH: ${{ steps.bare_binary.outputs.sig }}
         run: |
           set -euo pipefail
           version="${RELEASE_TAG#v}"
-          mkdir -p artifacts/bare-binary-macos-x64
-          cp "${{ steps.bare_binary.outputs.archive }}" "${{ steps.bare_binary.outputs.sig }}" artifacts/bare-binary-macos-x64/
           gh release download "${RELEASE_TAG}" --pattern latest.json --dir .
-          node scripts/patch-latest-json.mjs latest.json artifacts "$version"
+
+          export ARCHIVE_URL="https://github.com/shiwenwen/hope-agent/releases/download/${RELEASE_TAG}/hope-agent-${version}-darwin-x86_64.tar.gz"
+
+          node -e '
+            const fs = require("fs");
+            const m = JSON.parse(fs.readFileSync("latest.json", "utf8"));
+            m.bare_binary = m.bare_binary || { platforms: {} };
+            m.bare_binary.platforms = m.bare_binary.platforms || {};
+            m.bare_binary.platforms["darwin-x86_64"] = {
+              url: process.env.ARCHIVE_URL,
+              signature: fs.readFileSync(process.env.SIG_PATH, "utf8").trim(),
+              archive: "tar_gz",
+              binary_path: "hope-agent",
+            };
+            fs.writeFileSync("latest.json", JSON.stringify(m, null, 2) + "\n");
+            console.log("latest.json: bare_binary.platforms now has " + Object.keys(m.bare_binary.platforms).length + " entries");
+          '
+
           gh release upload "${RELEASE_TAG}" latest.json --clobber
 
       # Re-trigger the Homebrew tap update so the cask flips from the


### PR DESCRIPTION
## 问题

PR #182 引入的 [build-macos-x64.yml](.github/workflows/build-macos-x64.yml) 有个隐藏 bug:

第一个 \`actions/checkout@v6\` step 用 \`ref: <release tag>\` checkout 整个 workspace —— 包括 \`scripts/patch-latest-json.mjs\`。

但 tag 不可变。**v0.2.0 tag 上的 patch-latest-json.mjs 是老版本 reset 模式**:

\`\`\`js
manifest.bare_binary = { platforms: bareBinaryPlatforms };  // 清空已有,只写当前 run 找到的
\`\`\`

我在 PR #182 把脚本改成 merge 模式只对 main 上的脚本生效,**对 v0.2.0 / v0.2.1 等已发布 tag 上的脚本无法回溯**。如果对老 tag 触发 backfill,会清掉 latest.json 已有的 4 个 bare_binary entries,只留 darwin-x86_64,其它 OS self-update 失效。

刚才对 v0.2.0 触发 [Run 25839740233](https://github.com/shiwenwen/hope-agent/actions/runs/25839740233) 在 macos-13 排队阶段被及时 cancel,**v0.2.0 没造成损坏**(release assets 仍 22 个,latest.json 未触动)。

## 修复

把 patch latest.json 步骤的逻辑**直接 inline 进 workflow yaml**,不依赖 \`scripts/patch-latest-json.mjs\`。Merge 逻辑用 inline \`node -e\` 写,通过 env vars 传 \`ARCHIVE_URL\` / \`SIG_PATH\`,read 现有 latest.json + add/override darwin-x86_64 entry + write。

这样不论 tag 上的脚本是 reset 还是 merge 模式都没影响 —— 完全 bypass 它。Tag 不可变是硬约束,inline 是唯一 safe 解。

## Test plan

- [x] 本地手动 review inline node 脚本 syntax
- [ ] PR CI 8 项 status check 全绿
- [ ] merge 后重新 dispatch 对 v0.2.0:验证 latest.json 现有 4 个 bare_binary 不被清空,且 darwin-x86_64 entry 正确添加

## 注意

\`scripts/patch-latest-json.mjs\` 的 merge mode 改动仍在 main 上(PR #182 引入),对未来 v0.2.2+ tag 上的脚本会生效(release.yml 内的 patch-manifest job 也会受益)。本 fix 是 backfill workflow 的独立加固,不动 main 上的脚本。