### PR TITLE
backport: patch-latest-json.mjs 改 merge 模式(from main #182)

### DIFF
--- a/scripts/patch-latest-json.mjs
+++ b/scripts/patch-latest-json.mjs
@@ -73,8 +73,14 @@ for (const [platformDir, meta] of Object.entries(PLATFORM_MAP)) {
   console.log(`[patch-latest-json] added bare_binary entry for ${meta.key}`);
 }
 
-manifest.bare_binary = { platforms: bareBinaryPlatforms };
+// Merge mode: keep entries that already exist on the manifest (e.g.
+// from a previous release.yml patch run), and add/override only the
+// platforms we found artifacts for in this run. This lets independent
+// best-effort workflows (e.g. build-macos-x64.yml) backfill a single
+// platform's entry without wiping the other four.
+const existing = manifest.bare_binary?.platforms || {};
+manifest.bare_binary = { platforms: { ...existing, ...bareBinaryPlatforms } };
 fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");
 console.log(
-  `[patch-latest-json] wrote ${Object.keys(bareBinaryPlatforms).length} bare_binary entries to ${manifestPath}`,
+  `[patch-latest-json] merged ${Object.keys(bareBinaryPlatforms).length} new bare_binary entries into ${manifestPath} (manifest now has ${Object.keys(manifest.bare_binary.platforms).length} platforms total)`,
 );


### PR DESCRIPTION
Cherry-pick from main [PR #182](https://github.com/shiwenwen/hope-agent/pull/182) (commit 08f9f922) 的脚本部分。

## 改动

[scripts/patch-latest-json.mjs](scripts/patch-latest-json.mjs) 改 merge 模式:preserve 已有 \`bare_binary.platforms\` entries,只 add/override 当前 artifacts dir 里发现的平台。

## 为什么 backport

main 上的脚本是 merge 模式,release/v0.2 上还是老 reset 模式。当 v0.2.x patch 发版时:
- release.yml 内 patch-manifest job checkout 的是 tag 上的源码(release/v0.2 切出的 tag)
- 调用的是 tag 上的脚本(还是 reset 模式)

行为向后兼容(release.yml 第一次 patch 时 existing 为空,两种模式等价),但作为 defensive 措施,统一两个分支上脚本逻辑,未来给 release/v0.2 patch 流程加额外 platform 时不会意外清空 entries。

## 为什么不 backport build-macos-x64.yml

\`release.published\` 事件 + \`workflow_dispatch\` 都只看 default branch (main) 上的 workflow file。release/v0.2 上加副本没用,反而是噪音。本 backport 范围只含脚本。

## Test plan

- [x] diff 验证只动 scripts/patch-latest-json.mjs(merge mode 改动)
- [ ] PR CI 8 项 status check 全绿
- [ ] 不需要触发 release.yml 验证(行为向后兼容)