### PR TITLE
fix(settings): 修 Provider 模板配置页过窄 + 引导 wizard 第 3 步模型卡片被截断

### DIFF
--- a/src/components/settings/provider-setup/CustomWizard.tsx
+++ b/src/components/settings/provider-setup/CustomWizard.tsx
@@ -368,7 +368,7 @@ export function CustomWizard({
                 {t("common.add")}
               </Button>
             </div>
-            <div className="space-y-2.5 max-h-[400px] overflow-y-auto pr-1">
+            <div className="space-y-2.5">
               <DndContext
                 sensors={modelSensors}
                 collisionDetection={closestCenter}

--- a/src/components/settings/provider-setup/TemplateConfig.tsx
+++ b/src/components/settings/provider-setup/TemplateConfig.tsx
@@ -160,7 +160,7 @@ export function TemplateConfig({
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto px-6 py-6 max-w-lg mx-auto w-full space-y-4">
+      <div className="flex-1 overflow-y-auto px-6 py-6 max-w-4xl mx-auto w-full space-y-4">
         {/* Provider info */}
         <div className="bg-card border border-border rounded-xl p-4 space-y-3">
           <div className="space-y-1.5">


### PR DESCRIPTION
## Summary

两处 Provider 设置页布局问题（v0.2 现网可见）：

- **TemplateConfig 整页过窄**：内层容器仍为 `max-w-lg`(512px)，表单挤成窄列。与 #186 已改宽的 CustomWizard 视觉不一致。改 `max-w-4xl`，对齐 CustomWizard；引导页 ProviderStep 外层 `max-w-3xl mx-auto` 会自然兜住，不会突破。
- **CustomWizard 第 3 步模型卡片被截断**：模型列表容器硬编码 `max-h-[400px] overflow-y-auto`。单张模型卡片完整展开（模型 ID / 显示名 / 输入类型 / Context Window / Max Tokens / 思考 / 输入输出成本）就超过 400px，导致「输入成本/输出成本」以下被裁。外层 Content 容器本来就能滚，内层去除限高交给外层整体滚动。

两处 className 单行修改，无逻辑变更。

## Test plan

- [ ] 设置 → 模型 → 添加 → 选模板（如 OpenAI）：表单卡片宽度与 CustomWizard 一致，不再挤成窄列
- [ ] 设置 → 模型 → 添加 → 自定义 → 第 3 步「模型」：单卡片完整展开，「输入成本/输出成本」及末尾区域可见，必要时由外层滚动
- [ ] 首次启动引导第 2 步：模板配置 / 自定义 wizard 两条路径与上方标题宽度对齐，不溢出