### PR TITLE
fix(chat): 切模型只影响当前会话，不再污染全局默认

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **官方 Docker 镜像 + docker-compose 部署**：新增多架构容器镜像 `ghcr.io/shiwenwen/hope-agent`（覆盖 `linux/amd64` / `linux/arm64`），随每次 Release Tag 自动构建发布；浏览器访问容器暴露端口即得完整 Web GUI 与桌面端等价。默认 loopback + 浏览器 token 输入对话框 + `?token=` URL 一次性 bootstrap；`app_update` 工具在容器内检测后引导 `docker pull` 升级而非 binary swap。 (#171)
 
+### Fixed
+
+- **会话内切换模型不再污染全局默认 & 不再闪回**：聊天界面 ModelPicker、桌面斜杠 `/model` 卡片、IM `/model` 命令现在都只把模型固定到**当前会话**（写入 `sessions.provider_id/model_id`），不再改 `config.active_model`。下次发消息时 chat_engine 解析顺序变为 **session > agent.primary > config.active_model**。同一会话切模型 UI 由 `manualModelOverrideRef` 兜底，不会再因 `config:changed` 广播被回退成旧值。全局默认模型现在仅由「设置 → 模型」面板修改。
+
 ## [0.2.0] - 2026-05-13
 
 ### Changed

--- a/crates/ha-core/src/channel/worker/dispatcher.rs
+++ b/crates/ha-core/src/channel/worker/dispatcher.rs
@@ -563,7 +563,26 @@ async fn handle_inbound_message(
         .map(|d| d.config.model.clone())
         .unwrap_or_default();
 
-    let (primary, fallbacks) = crate::provider::resolve_model_chain(&agent_model_config, &store);
+    // Session-scoped model pin — IM `/model` writes sessions.provider_id/model_id;
+    // we have to read it back here so the next inbound message actually uses the
+    // pinned model. Mirrors the same `session_pinned_model` injection in
+    // src-tauri/src/commands/chat.rs and crates/ha-server/src/routes/chat.rs.
+    let session_pinned_model: Option<String> = session_db
+        .get_session(&session_id)
+        .ok()
+        .flatten()
+        .and_then(|meta| match (meta.provider_id, meta.model_id) {
+            (Some(p), Some(m)) if !p.is_empty() && !m.is_empty() => Some(format!("{}::{}", p, m)),
+            _ => None,
+        });
+
+    let (primary, fallbacks) = if let Some(ref pinned) = session_pinned_model {
+        let mut cfg = agent_model_config.clone();
+        cfg.primary = Some(pinned.clone());
+        crate::provider::resolve_model_chain(&cfg, &store)
+    } else {
+        crate::provider::resolve_model_chain(&agent_model_config, &store)
+    };
     let mut model_chain = Vec::new();
     if let Some(p) = primary {
         model_chain.push(p);

--- a/crates/ha-core/src/channel/worker/slash.rs
+++ b/crates/ha-core/src/channel/worker/slash.rs
@@ -180,17 +180,18 @@ pub(super) async fn dispatch_slash_for_channel(
             })
         }
 
-        // ── Model switch — persist + notify frontend ──
+        // ── Model switch — pin to current session, notify GUI ──
         Some(CommandAction::SwitchModel {
             provider_id,
             model_id,
         }) => {
-            if let Err(e) = set_active_model_core(&provider_id, &model_id).await {
+            if let Err(e) = set_session_model_core(session_id, &provider_id, &model_id).await {
                 app_warn!("channel", "worker", "Failed to switch model: {}", e);
             } else if let Some(bus) = crate::get_event_bus() {
                 bus.emit(
-                    "slash:model_switched",
+                    "session:model_updated",
                     serde_json::json!({
+                        "sessionId": session_id,
                         "providerId": provider_id,
                         "modelId": model_id,
                     }),
@@ -573,53 +574,40 @@ pub(super) async fn dispatch_slash_for_channel(
 
 // ── Core helpers (migrated from src-tauri/src/commands/) ──────────
 
-/// Switch the active model. Equivalent to the old `commands::provider::set_active_model_core`.
-async fn set_active_model_core(provider_id: &str, model_id: &str) -> Result<(), String> {
-    use crate::agent::AssistantAgent;
-    use crate::provider::ApiType;
-
-    // Clone the provider before awaiting on agent/codex_token locks —
-    // the Arc from `cached_config()` must be dropped first to avoid deadlock.
+/// Pin a provider/model to the IM-bound session. Validates that the provider /
+/// model still exist + are enabled, then writes `sessions.provider_id /
+/// provider_name / model_id`. The next chat turn picks it up via the
+/// `session_pinned_model` branch in commands::chat / routes::chat. **Does not**
+/// touch `config.active_model` — per-session selection no longer leaks into
+/// the application-wide default.
+async fn set_session_model_core(
+    session_id: &str,
+    provider_id: &str,
+    model_id: &str,
+) -> Result<(), String> {
     let provider = {
         let store = crate::config::cached_config();
         let found = store
             .providers
             .iter()
-            .find(|p| p.id == provider_id)
+            .find(|p| p.id == provider_id && p.enabled)
             .cloned()
-            .ok_or_else(|| format!("Provider not found: {}", provider_id))?;
+            .ok_or_else(|| format!("Provider not found or disabled: {}", provider_id))?;
         if !found.models.iter().any(|m| m.id == model_id) {
             return Err(format!("Model not found: {}", model_id));
         }
         found
     };
 
-    let cached_agent = crate::require_cached_agent().map_err(|e| e.to_string())?;
-
-    if provider.api_type == ApiType::Codex {
-        let token_info = match crate::get_codex_token_cache() {
-            Some(cell) => cell.lock().await.clone(),
-            None => None,
-        };
-        if let Some((access_token, account_id)) = token_info {
-            let agent = AssistantAgent::new_openai(&access_token, &account_id, model_id);
-            *cached_agent.lock().await = Some(agent);
-        }
-    } else {
-        let agent = AssistantAgent::try_new_from_provider(&provider, model_id)
-            .await
-            .map_err(|e| e.to_string())?
-            .with_failover_context(&provider);
-        *cached_agent.lock().await = Some(agent);
-    }
-
-    crate::provider::set_active_model(
-        provider_id.to_string(),
-        model_id.to_string(),
-        "slash-channel",
-    )
-    .map(|_| ())
-    .map_err(|e| e.to_string())
+    let session_db = crate::require_session_db().map_err(|e| e.to_string())?;
+    session_db
+        .update_session_model(
+            session_id,
+            Some(provider_id),
+            Some(provider.name.as_str()),
+            Some(model_id),
+        )
+        .map_err(|e| e.to_string())
 }
 
 /// Set reasoning effort. Equivalent to the old `commands::auth::set_reasoning_effort_core`.

--- a/crates/ha-server/src/lib.rs
+++ b/crates/ha-server/src/lib.rs
@@ -125,6 +125,10 @@ fn build_router_with_cors(
             patch(routes::sessions::update_session_agent),
         )
         .route(
+            "/sessions/{id}/model",
+            patch(routes::sessions::set_session_model),
+        )
+        .route(
             "/sessions/{id}/purge-if-incognito",
             post(routes::sessions::purge_session_if_incognito),
         )

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -255,11 +255,31 @@ pub async fn chat(
         .map(|def| def.config.model.clone())
         .unwrap_or_default();
 
+    // Session-scoped model pin trumps agent.primary and config.active_model
+    // when no explicit per-turn override was provided. Mirrors the desktop
+    // commands::chat path so the two transports stay in sync.
+    let session_pinned_model: Option<String> = if body.model_override.is_none() {
+        db.get_session(&sid).ok().flatten().and_then(|meta| {
+            match (meta.provider_id, meta.model_id) {
+                (Some(p), Some(m)) if !p.is_empty() && !m.is_empty() => {
+                    Some(format!("{}::{}", p, m))
+                }
+                _ => None,
+            }
+        })
+    } else {
+        None
+    };
+
     let (primary, fallbacks) = if let Some(ref override_str) = body.model_override {
         let mut cfg = agent_model_config.clone();
         if provider::parse_model_ref(override_str).is_some() {
             cfg.primary = Some(override_str.clone());
         }
+        provider::resolve_model_chain(&cfg, &store)
+    } else if let Some(ref pinned) = session_pinned_model {
+        let mut cfg = agent_model_config.clone();
+        cfg.primary = Some(pinned.clone());
         provider::resolve_model_chain(&cfg, &store)
     } else {
         provider::resolve_model_chain(&agent_model_config, &store)

--- a/crates/ha-server/src/routes/sessions.rs
+++ b/crates/ha-server/src/routes/sessions.rs
@@ -108,6 +108,13 @@ pub struct SessionAgentBody {
     pub agent_id: String,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionModelBody {
+    pub provider_id: String,
+    pub model_id: String,
+}
+
 // ── Response wrapper for paginated lists ────────────────────────
 
 #[derive(Debug, Serialize)]
@@ -238,6 +245,41 @@ pub async fn update_session_agent(
     ctx.session_db
         .update_session_agent(&id, &body.agent_id)
         .map_err(|e| AppError::bad_request(e.to_string()))?;
+    Ok(Json(json!({ "updated": true })))
+}
+
+/// `PATCH /api/sessions/:id/model` — pin the model used by this session.
+/// Replaces the legacy "切模型 = 写全局 active_model" path. Future chat turns
+/// on this session resolve provider/model from this row before falling back to
+/// `agent.model.primary` / `config.active_model`.
+pub async fn set_session_model(
+    State(ctx): State<Arc<AppContext>>,
+    Path(id): Path<String>,
+    Json(body): Json<SessionModelBody>,
+) -> Result<Json<Value>, AppError> {
+    let provider_name = ha_core::config::cached_config()
+        .providers
+        .iter()
+        .find(|p| p.id == body.provider_id && p.enabled)
+        .map(|p| p.name.clone());
+    ctx.session_db
+        .update_session_model(
+            &id,
+            Some(&body.provider_id),
+            provider_name.as_deref(),
+            Some(&body.model_id),
+        )
+        .map_err(|e| AppError::bad_request(e.to_string()))?;
+    if let Some(bus) = ha_core::get_event_bus() {
+        bus.emit(
+            "session:model_updated",
+            json!({
+                "sessionId": id,
+                "providerId": body.provider_id,
+                "modelId": body.model_id,
+            }),
+        );
+    }
     Ok(Json(json!({ "updated": true })))
 }
 

--- a/docs/architecture/api-reference.md
+++ b/docs/architecture/api-reference.md
@@ -148,7 +148,8 @@ Tauri ↔ COMMAND_MAP 差集为 7 条合法非 REST 命令（4 条 Desktop-only 
 
 | 事件名 | 触发点 | Payload |
 |---|---|---|
-| `slash:model_switched` / `slash:effort_changed` / `slash:plan_changed` / `slash:session_cleared` | `crates/ha-core/src/channel/worker/slash.rs` 经 `bus.emit(...)` | model 名 / effort 字段 / sessionId 等（具体见各调用点） |
+| `slash:effort_changed` / `slash:plan_changed` / `slash:session_cleared` | `crates/ha-core/src/channel/worker/slash.rs` 经 `bus.emit(...)` | effort 字段 / sessionId 等（具体见各调用点） |
+| `session:model_updated` | `crates/ha-core/src/channel/worker/slash.rs` (IM `/model`)、`src-tauri/src/commands/session.rs::set_session_model`、`crates/ha-server/src/routes/sessions.rs::set_session_model` | `{ sessionId, providerId, modelId }` — 桌面 GUI 仅在 `sessionId == currentSessionId` 时同步 ModelPicker UI |
 
 > 这些事件经 EventBus 广播，HTTP / Tauri 两条桥都会转发。
 
@@ -221,6 +222,7 @@ Tauri ↔ COMMAND_MAP 差集为 7 条合法非 REST 命令（4 条 Desktop-only 
 | `set_session_incognito` | `PATCH /api/sessions/{sessionId}/incognito` | ✅ |
 | `set_session_working_dir` | `PATCH /api/sessions/{sessionId}/working-dir` | ✅ |
 | `update_session_agent_cmd` | `PATCH /api/sessions/{sessionId}/agent` | ✅ |
+| `set_session_model` | `PATCH /api/sessions/{sessionId}/model` | ✅ |
 | `purge_session_if_incognito` | `POST /api/sessions/{sessionId}/purge-if-incognito` | ✅ |
 | `search_sessions_cmd` | `GET /api/sessions/search` | ✅ |
 | `search_session_messages_cmd` | `GET /api/sessions/{sessionId}/messages/search` | ✅ |
@@ -243,6 +245,8 @@ Tauri ↔ COMMAND_MAP 差集为 7 条合法非 REST 命令（4 条 Desktop-only 
 `create_session_cmd` 与 `chat` 在自动创建新会话时都支持可选 `incognito: boolean`，返回的 `SessionMeta` 也会包含 `incognito` 字段；主聊天 UI 将 incognito 视为“新会话预设”，只在尚未 materialize session 的草稿态提供入口，已有会话不再暴露切换按钮。`set_session_incognito` 保留给兼容调用和非主 UI 适配，但不应作为常规会话内开关使用。当请求同时带了 `project_id` 时 `incognito` 被强制为 `false`（互斥）。`list_sessions_cmd` / `search_sessions_cmd` / `list_project_sessions_cmd` 接受可选 `active_session_id` 参数：默认会过滤掉所有 incognito 会话，`active_session_id` 让正在打开的那个无痕会话仍出现在 sidebar / 搜索结果里。`purge_session_if_incognito` 在前端 `handleSwitchSession / handleNewChat / handleNewChatInProject` 切走当前 session 之前调用，仅当目标 session 当前为 incognito 时硬删，否则 no-op。
 
 `update_session_agent_cmd` 接受 `{ agentId: string }`，后端在 SQL 层校验 `messages` 表中该 session 没有 `role IN ('user','assistant')` 的记录，否则返回 400。前端 `ChatTitleBar` 的 `AgentSwitcher` dropdown 在 `messages.length > 0` 时会把触发器降级为只读 `<span>`，作为 UX 防御层。
+
+`set_session_model` 接受 `{ providerId, modelId }`，把模型固定到当前会话（写 `sessions.provider_id` / `provider_name` / `model_id`），不写 `AppConfig.active_model`——v0.2.1 起这是「会话内切模型」的唯一合法入口。`get_active_model` / `POST /api/models/active` 仍然存在，但**只该被 Settings 「模型」面板 / onboarding wizard / 本地 LLM 安装路径**调用，用来修改应用全局默认；任何 chat 内或 IM 内的"切模型"语义都必须落到 session 级。chat_engine 解析优先级 `plan_model > 本轮 model_override > sessions.provider_id > agent.model.primary > AppConfig.active_model`（详见 [`provider-system.md` § 7.2](provider-system.md#72-模型链解析)）。写入后 emit `session:model_updated`，桌面 GUI 仅在 `sessionId == currentSessionId` 时同步 ModelPicker。
 
 `export_session_cmd` / `GET /api/sessions/{sessionId}/export` 是两端**形态不对称**的特例：Tauri 端走 IPC，由前端先弹原生 save dialog 拿到 `output_path` 再传进来，后端写盘后返回最终路径字符串；HTTP 端走 GET 直接返回二进制流（`Content-Type` + `Content-Disposition: attachment; filename*=UTF-8''<percent>`），浏览器用 `URL.createObjectURL` + `<a download>` 触发下载。两端共用 [`ha_core::session::export::export_session`](../../crates/ha-core/src/session/export.rs) 序列化器，Query 参数 `format ∈ {md,json,html}` / `includeThinking` / `includeTools` 与 Tauri 命令的字段一一对应。前端 Transport 抽象 [`exportSession`](../../src/lib/transport.ts) 是这一对端点的统一入口，调用方不需要分支。
 

--- a/docs/architecture/provider-system.md
+++ b/docs/architecture/provider-system.md
@@ -685,10 +685,22 @@ flowchart TD
   PLAN{"Plan Mode?"} -->|"是"| PLANCHAIN["[plan_model, primary, fallback1, ...]"]
   PLAN -->|"否"| CHAIN
   OVERRIDE{"model_override?"} -->|"是"| OVERCHAIN["[override, fallback1, fallback2, ...]"]
-  OVERRIDE -->|"否"| CHAIN
+  OVERRIDE -->|"否"| SESSPIN{"session.provider_id<br/>+ model_id?"}
+  SESSPIN -->|"是"| PINCHAIN["[session_pin, fallback1, fallback2, ...]"]
+  SESSPIN -->|"否"| CHAIN
 
   CHAIN --> ITERATE["for model in chain:<br/>build → restore → chat → save/fallback"]
 ```
+
+**chat 入口决策优先级（高到低）**（[`src-tauri/src/commands/chat.rs`](../../src-tauri/src/commands/chat.rs) / [`crates/ha-server/src/routes/chat.rs`](../../crates/ha-server/src/routes/chat.rs) 完全对称）：
+
+1. **Plan Mode `plan_model`**（仅 Planning 阶段，临时降级到便宜模型）
+2. **本轮显式 `model_override`**（前端 `useChatStream` 把当前 `activeModel` 作为 modelOverride 透传，IM 也可经由 `body.model_override`）
+3. **`sessions.provider_id` + `sessions.model_id`**（用户对该会话 pin 的模型；由 `set_session_model` Tauri 命令 / `PATCH /api/sessions/{id}/model` HTTP / IM `/model` 命令写入。chat_engine 每轮事后亦会回写当前实际使用的模型）
+4. **`agent.model.primary`**（Agent 配置的首选）
+5. **`AppConfig.active_model`**（应用全局默认，由「设置 → 模型」面板修改）
+
+第 3 项 session pin 是 v0.2.1 引入的——之前会话内切模型走 `set_active_model` 写 `AppConfig.active_model`，等于改全应用默认；现在只写当前会话行，跨会话不再相互影响。`set_session_model` 写入后 emit `session:model_updated` 事件（payload `{ sessionId, providerId, modelId }`），桌面 GUI 仅在 `sessionId == currentSessionId` 时同步 UI，避免 IM 远程切换误更新本地正在看的另一个会话。
 
 ### 7.3 重试策略
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -490,6 +490,23 @@ pub async fn chat(
         // else: use_subagent=false, fall through to inline PlanAgent mode below
     }
 
+    // Session-scoped model pin trumps both agent.primary and config.active_model
+    // when no explicit per-turn override was provided. This is how /api PATCH
+    // /sessions/{id}/model and the new set_session_model Tauri command surface
+    // their effect on subsequent turns. Plan Mode plan_model still wins.
+    let session_pinned_model: Option<String> = if model_override.is_none() {
+        db.get_session(&sid).ok().flatten().and_then(|meta| {
+            match (meta.provider_id, meta.model_id) {
+                (Some(p), Some(m)) if !p.is_empty() && !m.is_empty() => {
+                    Some(format!("{}::{}", p, m))
+                }
+                _ => None,
+            }
+        })
+    } else {
+        None
+    };
+
     let (primary, fallbacks) = {
         // Plan Mode model override: use cheaper/faster model during Planning phase
         let plan_model_override = if early_plan_state == crate::plan::PlanModeState::Planning {
@@ -510,6 +527,11 @@ pub async fn chat(
             if override_model.is_some() {
                 model_cfg.primary = Some(override_str.clone());
             }
+            provider::resolve_model_chain(&model_cfg, &cfg)
+        } else if let Some(ref pinned) = session_pinned_model {
+            // Session has its own pinned model (set via set_session_model)
+            let mut model_cfg = agent_model_config.clone();
+            model_cfg.primary = Some(pinned.clone());
             provider::resolve_model_chain(&model_cfg, &cfg)
         } else {
             provider::resolve_model_chain(&agent_model_config, &cfg)

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -155,6 +155,42 @@ pub async fn update_session_agent_cmd(
         .map_err(Into::into)
 }
 
+/// Pin the provider/model used by a chat session. The next chat turn will
+/// resolve provider/model from this row before falling back to the agent's
+/// `model.primary` and finally `config.active_model`. Replaces the legacy
+/// "切模型 = 写全局" path so per-session selection no longer leaks into the
+/// application-wide default.
+#[tauri::command]
+pub async fn set_session_model(
+    session_id: String,
+    provider_id: String,
+    model_id: String,
+    state: State<'_, AppState>,
+) -> Result<(), CmdError> {
+    let provider_name = ha_core::config::cached_config()
+        .providers
+        .iter()
+        .find(|p| p.id == provider_id && p.enabled)
+        .map(|p| p.name.clone());
+    state.session_db.update_session_model(
+        &session_id,
+        Some(&provider_id),
+        provider_name.as_deref(),
+        Some(&model_id),
+    )?;
+    if let Some(bus) = ha_core::get_event_bus() {
+        bus.emit(
+            "session:model_updated",
+            serde_json::json!({
+                "sessionId": session_id,
+                "providerId": provider_id,
+                "modelId": model_id,
+            }),
+        );
+    }
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn delete_session_cmd(
     session_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -455,6 +455,7 @@ pub fn run() {
             commands::session::set_session_incognito,
             commands::session::set_session_working_dir,
             commands::session::update_session_agent_cmd,
+            commands::session::set_session_model,
             commands::session::purge_session_if_incognito,
             commands::session::delete_session_cmd,
             commands::session::rename_session_cmd,

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -374,9 +374,9 @@ export default function ChatScreen({
       const [providerId, modelId] = key.split("::")
       if (!providerId || !modelId) return
       manualModelOverrideRef.current = { providerId, modelId }
-      await handleModelChange(key)
+      await handleModelChange(key, currentSessionId)
     },
-    [handleModelChange],
+    [handleModelChange, currentSessionId],
   )
 
   // Auto-show team panel when a team is created
@@ -621,13 +621,18 @@ export default function ChatScreen({
   useEffect(() => {
     const unlisteners: Array<() => void> = []
 
-    // Model switched from channel (/model)
+    // Session model pinned (from IM /model, set_session_model command, or
+    // PATCH /api/sessions/{id}/model). The IM channel may target a different
+    // session than the one the desktop UI currently has open — gate by
+    // sessionId so we don't apply a remote change to the wrong picker.
     unlisteners.push(
-      getTransport().listen("slash:model_switched", (payload) => {
-        const { providerId, modelId } = payload as {
+      getTransport().listen("session:model_updated", (payload) => {
+        const { sessionId, providerId, modelId } = payload as {
+          sessionId: string
           providerId: string
           modelId: string
         }
+        if (!sessionId || sessionId !== session.currentSessionId) return
         manualModelOverrideRef.current = { providerId, modelId }
         applyModelForDisplay(`${providerId}::${modelId}`)
       }),
@@ -1486,7 +1491,7 @@ export default function ChatScreen({
                   availableModels={availableModels}
                   activeModel={activeModel}
                   reasoningEffort={reasoningEffort}
-                  onModelChange={handleModelChange}
+                  onModelChange={handleManualModelChange}
                   onEffortChange={handleSessionEffortChange}
                   attachedFiles={stream.attachedFiles}
                   onAttachFiles={(files) => stream.setAttachedFiles((prev) => [...prev, ...files])}

--- a/src/components/chat/hooks/useModelState.ts
+++ b/src/components/chat/hooks/useModelState.ts
@@ -16,7 +16,7 @@ export interface UseModelStateReturn {
   setSessionTemperature: React.Dispatch<React.SetStateAction<number | null>>
   globalActiveModelRef: React.MutableRefObject<ActiveModel | null>
   applyModelForDisplay: (key: string) => void
-  handleModelChange: (key: string) => Promise<void>
+  handleModelChange: (key: string, sessionId?: string | null) => Promise<void>
   handleEffortChange: (effort: string, sessionId?: string | null) => Promise<void>
 }
 
@@ -57,15 +57,27 @@ export function useModelState(): UseModelStateReturn {
     }
   }, [])
 
+  // 切换会话内使用的模型：
+  // - 已有 sessionId：写到 sessions.provider_id/model_id（只影响这个会话）
+  // - 没有 sessionId：仅更新 UI state，等首次发消息时 useChatStream 把
+  //   activeModel 作为 modelOverride 透传，chat_engine 的事后 update_session_model
+  //   会自动把它落到 sessions 行
+  // 全局默认模型现在只能由 Settings 里的 GlobalModelPanel 修改。
   const handleModelChange = useCallback(
-    async (key: string) => {
+    async (key: string, sessionId?: string | null) => {
       const [providerId, modelId] = key.split("::")
       if (!providerId || !modelId) return
       setActiveModel({ providerId, modelId })
-      try {
-        await getTransport().call("set_active_model", { providerId, modelId })
-      } catch (e) {
-        logger.error("ui", "ChatScreen::modelChange", "Failed to set model", e)
+      if (sessionId) {
+        try {
+          await getTransport().call("set_session_model", {
+            sessionId,
+            providerId,
+            modelId,
+          })
+        } catch (e) {
+          logger.error("ui", "ChatScreen::modelChange", "Failed to pin session model", e)
+        }
       }
       const newModel = availableModels.find(
         (m) => m.providerId === providerId && m.modelId === modelId,
@@ -73,7 +85,7 @@ export function useModelState(): UseModelStateReturn {
       if (newModel) {
         const normalized = normalizeEffortForModel(newModel, reasoningEffort, t)
         if (normalized !== reasoningEffort) {
-          handleEffortChange(normalized)
+          handleEffortChange(normalized, sessionId)
         }
       }
     },

--- a/src/components/chat/hooks/useModelState.ts
+++ b/src/components/chat/hooks/useModelState.ts
@@ -85,7 +85,16 @@ export function useModelState(): UseModelStateReturn {
       if (newModel) {
         const normalized = normalizeEffortForModel(newModel, reasoningEffort, t)
         if (normalized !== reasoningEffort) {
-          handleEffortChange(normalized, sessionId)
+          if (sessionId) {
+            handleEffortChange(normalized, sessionId)
+          } else {
+            // 草稿模式（会话还没创建）：只更新本地 reasoningEffort，
+            // 不调 handleEffortChange——后者会把 effort 写到后端的全局 in-memory
+            // state，导致一次草稿切模型把 Think 默认泄漏到其它会话。
+            // 首次发消息时 chat_engine 会把 modelOverride + reasoningEffort 一起带
+            // 上去，落到新创建的 sessions 行。
+            setReasoningEffort(normalized)
+          }
         }
       }
     },

--- a/src/components/chat/useQuickChatSession.ts
+++ b/src/components/chat/useQuickChatSession.ts
@@ -333,7 +333,11 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
     [currentAgentId, agents, loadSessionMessages, resetPagination],
   )
 
-  // Model change
+  // Pin model to the current Quick Chat session — same semantics as the main
+  // ChatScreen path: write sessions.provider_id/model_id, do not touch the
+  // app-global default. If the session hasn't been materialized yet, only the
+  // UI state changes; first chat send carries it via modelOverride and the
+  // engine's post-turn update_session_model commits it.
   const handleModelChange = useCallback(
     async (key: string) => {
       const [providerId, modelId] = key.split("::")
@@ -346,10 +350,17 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
       if (newModel) {
         setReasoningEffort((prev) => normalizeEffortForModel(newModel, prev, (k) => k))
       }
-      try {
-        await getTransport().call("set_active_model", { providerId, modelId })
-      } catch (e) {
-        logger.error("ui", "QuickChat::modelChange", "Failed to set model", e)
+      const sessionId = currentSessionIdRef.current
+      if (sessionId) {
+        try {
+          await getTransport().call("set_session_model", {
+            sessionId,
+            providerId,
+            modelId,
+          })
+        } catch (e) {
+          logger.error("ui", "QuickChat::modelChange", "Failed to pin session model", e)
+        }
       }
     },
     [availableModels],

--- a/src/lib/transport-http.ts
+++ b/src/lib/transport-http.ts
@@ -65,6 +65,7 @@ const COMMAND_MAP: Record<string, EndpointDef> = {
   set_session_incognito:           { method: "PATCH",  path: "/api/sessions/{sessionId}/incognito" },
   set_session_working_dir:         { method: "PATCH",  path: "/api/sessions/{sessionId}/working-dir" },
   update_session_agent_cmd:        { method: "PATCH",  path: "/api/sessions/{sessionId}/agent" },
+  set_session_model:               { method: "PATCH",  path: "/api/sessions/{sessionId}/model" },
   purge_session_if_incognito:      { method: "POST",   path: "/api/sessions/{sessionId}/purge-if-incognito" },
   search_sessions_cmd:             { method: "GET",    path: "/api/sessions/search" },
   search_session_messages_cmd:     { method: "GET",    path: "/api/sessions/{sessionId}/messages/search" },


### PR DESCRIPTION
## 背景

发现两个相关问题：

1. **切换模型 UI 闪烁回退**：已有消息的会话点 ModelPicker 切到新模型，UI 闪一下又跳回旧模型。
2. **会话内切模型会改全应用全局默认**：用户在某个会话切到便宜模型，整个 app 的 `config.active_model` 都跟着变，其他 agent / 其他新会话都被污染。

根因是「会话内切模型」与「全局默认配置」走同一个 `set_active_model` invoke：

- 前端 `handleModelChange` 直接调 `set_active_model` 写全局 `AppConfig.active_model`
- 后端 emit `config:changed` → 前端 `refreshRuntimeModelState` 触发 → 优先级读 `sessionMeta.provider_id`（之前一轮 chat 事后写的"用过什么"记录）→ UI 回退
- IM `/model` 同样写全局；桌面斜杠 `/model` 也走同一路径
- chat_engine 解析顺序 `agent.primary > config.active_model`，根本不参考 `sessions.provider_id` 列——这意味着会话级别的语义事实上不存在

## 修复方案

**chat_engine 解析顺序新增 session pin 层**：

```
plan_model > 本轮 model_override > sessions.provider_id > agent.model.primary > AppConfig.active_model
```

**入口收敛**：

| 入口 | 写哪 |
|---|---|
| Chat ModelPicker (主屏 + Quick Chat) | session 列 |
| 桌面斜杠 `/model` 卡片选择 | session 列（自动跟着 ModelPicker 改） |
| IM `/model` 斜杠 | session 列（之前是全局，本 PR 改） |
| HTTP `PATCH /api/sessions/{id}/model` 新增 | session 列 |
| Tauri `set_session_model` 新增 | session 列 |
| Settings「模型」面板 | 全局（保留，唯一合法全局入口） |
| Provider 引导 wizard / 本地 LLM 安装 | 全局（onboarding 场景，保留） |

**事件改名**：`slash:model_switched` → `session:model_updated`，payload 加 `sessionId`。桌面 GUI 仅在 `sessionId == currentSessionId` 时同步 UI——避免 IM 远程切换某个会话误更新桌面正在看的另一个会话。

**UI 闪烁顺手修**：[`ChatScreen.tsx:1535`](src/components/chat/ChatScreen.tsx#L1535) `onModelChange` 由裸 `handleModelChange` 改绑 `handleManualModelChange`（后者会设置 `manualModelOverrideRef`，挡住 `config:changed` 触发的 refresh 回退）。配合「不再写全局 config」一起，这个路径根本不会再触发 `config:changed`，竞态根源消失。

## 改动

**后端**：
- `crates/ha-core/src/channel/worker/slash.rs` IM `/model` 改为 `set_session_model_core(session_id, ...)` 写 sessions 行
- `src-tauri/src/commands/session.rs` 新增 `set_session_model` Tauri 命令
- `crates/ha-server/src/routes/sessions.rs` 新增 `PATCH /api/sessions/{id}/model`
- `src-tauri/src/commands/chat.rs` + `crates/ha-server/src/routes/chat.rs` 在 model_chain 解析前注入 `session_pinned_model` 作 model_override fallback（两端对称）

**前端**：
- `src/components/chat/hooks/useModelState.ts` `handleModelChange(key, sessionId?)` 调 `set_session_model`；无 sessionId 时仅本地 state，由首次发消息 + chat_engine 事后 `update_session_model` 自动落库
- `src/components/chat/useQuickChatSession.ts` 同语义对齐
- `src/components/chat/ChatScreen.tsx` ModelPicker 绑 `handleManualModelChange`；监听器从 `slash:model_switched` 换 `session:model_updated` 并按 sessionId 过滤

**文档**：
- `docs/architecture/provider-system.md § 7.2` 模型链解析图加 SESSION_PIN 节点 + 优先级文字说明
- `docs/architecture/api-reference.md` 加 `set_session_model` / `PATCH /api/sessions/{id}/model` 表项 + 事件列表更新
- `CHANGELOG.md` `[Unreleased].Fixed`

## 验证

- ✅ `cargo fmt --all --check`
- ✅ `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- ✅ `cargo test -p ha-core -p ha-server --locked`（1291 + 其余 0 failed）
- ✅ `pnpm typecheck`
- ✅ `pnpm lint`
- ✅ `pnpm test`（28 files / 123 tests）
- ✅ pre-push hook 通过

## Test plan

- [ ] 在已有消息的会话切换模型，UI 不闪、不回退
- [ ] 切完模型后新建另一个会话，新会话使用的还是 Agent 默认（不被前一个会话污染）
- [ ] 在 IM 群里发 `/model X`，桌面 app 上其他会话的 ModelPicker 不变；该会话桌面端在切回去时显示 X
- [ ] Failover 切到 fallback 模型：会话 sessionMeta 被更新；下次发消息从 fallback 起步（已有行为，保持）
- [ ] Settings「模型」面板改全局默认，新会话生效；已 pin 过模型的旧会话不受影响

## 备注

base 选 `release/v0.2`。合并发版后按 release-process 单独 cherry-pick 到 main 再发一个 PR。