### PR TITLE
fix(chat): desktop retry context loss + drop reasoning replay

### DIFF
--- a/crates/ha-core/src/agent/context.rs
+++ b/crates/ha-core/src/agent/context.rs
@@ -682,15 +682,15 @@ impl AssistantAgent {
         for item in history {
             let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
             match item_type {
-                // Reasoning items are only safe to replay with `store: false`
-                // when the encrypted payload is present. Old persisted items
-                // that only carry an `rs_*` id make the backend look up state
-                // it deliberately did not store, causing 404s.
-                "reasoning" => {
-                    if let Some(item) = Self::stateless_responses_reasoning_item(item) {
-                        result.push(item);
-                    }
-                }
+                // Reasoning items are never replayed. Hope Agent always calls
+                // the Responses API with `store: false`, which makes `rs_*`
+                // ids dangling references — the server has no record of them
+                // and 404s the request. Even payloads carrying
+                // `encrypted_content` still get matched by id first, so the
+                // safest invariant is "drop every reasoning item, every time."
+                // Streamed thinking is still surfaced to the UI live; it just
+                // never persists into history.
+                "reasoning" => continue,
                 // Native Responses API items — pass through
                 "message" | "function_call" | "function_call_output" => {
                     result.push(item.clone());
@@ -756,29 +756,6 @@ impl AssistantAgent {
             }
         }
         result
-    }
-
-    pub(super) fn stateless_responses_reasoning_item(
-        item: &serde_json::Value,
-    ) -> Option<serde_json::Value> {
-        if item.get("type").and_then(|t| t.as_str()) != Some("reasoning") {
-            return None;
-        }
-
-        let encrypted_content = item
-            .get("encrypted_content")
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .filter(|s| !s.is_empty())?;
-
-        let mut replayable = item.clone();
-        if let Some(obj) = replayable.as_object_mut() {
-            obj.insert(
-                "encrypted_content".to_string(),
-                serde_json::Value::String(encrypted_content.to_string()),
-            );
-        }
-        Some(replayable)
     }
 
     /// Push a user message, merging with the last message if it's also a user message.
@@ -976,8 +953,12 @@ mod responses_history_tests {
     use super::*;
     use serde_json::json;
 
+    // Hope Agent always calls Responses with `store: false`, where
+    // any reasoning item — id-only OR with encrypted_content — is a
+    // landmine for the next request. The invariant: normalize must drop
+    // every `reasoning` item regardless of payload completeness.
     #[test]
-    fn responses_history_drops_reasoning_without_encrypted_content() {
+    fn responses_history_drops_all_reasoning_items() {
         let history = vec![
             json!({"role": "user", "content": "hello"}),
             json!({
@@ -988,18 +969,25 @@ mod responses_history_tests {
             }),
             json!({
                 "type": "reasoning",
-                "id": "rs_ok",
+                "id": "rs_with_payload",
                 "summary": [],
-                "encrypted_content": " sealed ",
+                "encrypted_content": "sealed",
                 "status": "completed"
             }),
+            json!({"role": "assistant", "content": "hi back"}),
         ];
 
         let normalized = AssistantAgent::normalize_history_for_responses(&history);
 
+        assert!(
+            normalized
+                .iter()
+                .all(|v| v.get("type").and_then(|t| t.as_str()) != Some("reasoning")),
+            "reasoning item leaked into normalized history: {:?}",
+            normalized
+        );
+        // user + assistant survive; both reasoning items dropped.
         assert_eq!(normalized.len(), 2);
-        assert_eq!(normalized[1]["id"], "rs_ok");
-        assert_eq!(normalized[1]["encrypted_content"], "sealed");
     }
 }
 

--- a/crates/ha-core/src/agent/llm_adapter.rs
+++ b/crates/ha-core/src/agent/llm_adapter.rs
@@ -397,7 +397,7 @@ impl<'a> LlmApiAdapter for CodexAdapter<'a> {
 
         let cancel = AtomicBool::new(false);
         let noop = |_: &str| {};
-        let (text, _tool_calls, mut usage, _thinking, _ttft, _reasoning) = match parse_openai_sse(
+        let (text, _tool_calls, mut usage, _thinking, _ttft) = match parse_openai_sse(
             resp,
             request_start,
             &cancel,

--- a/crates/ha-core/src/agent/llm_adapter.rs
+++ b/crates/ha-core/src/agent/llm_adapter.rs
@@ -865,8 +865,13 @@ mod tests {
         );
     }
 
+    // With `store: false`, *any* reasoning item replayed in a follow-up
+    // request 404s on the server (id is a dangling reference; even
+    // encrypted_content-bearing items get looked up by id first). The
+    // cached body must therefore drop every reasoning item, not just the
+    // ones missing encrypted_content.
     #[test]
-    fn responses_cached_body_filters_non_replayable_reasoning() {
+    fn responses_cached_body_drops_all_reasoning_items() {
         let mut params = cached_responses();
         params.conversation_history.push(json!({
             "type": "reasoning",
@@ -876,7 +881,7 @@ mod tests {
         }));
         params.conversation_history.push(json!({
             "type": "reasoning",
-            "id": "rs_ok",
+            "id": "rs_with_payload",
             "summary": [],
             "encrypted_content": "enc",
             "status": "completed"
@@ -889,13 +894,16 @@ mod tests {
 
         let body = build_responses_body("gpt-5", &req, ProviderFormat::OpenAIResponses);
         let input = body.get("input").and_then(|v| v.as_array()).unwrap();
-        let reasoning_ids: Vec<&str> = input
+        let reasoning_items: Vec<&serde_json::Value> = input
             .iter()
             .filter(|item| item.get("type").and_then(|t| t.as_str()) == Some("reasoning"))
-            .filter_map(|item| item.get("id").and_then(|id| id.as_str()))
             .collect();
 
-        assert_eq!(reasoning_ids, vec!["rs_ok"]);
+        assert!(
+            reasoning_items.is_empty(),
+            "reasoning item leaked into cached body: {:?}",
+            reasoning_items
+        );
     }
 
     #[test]

--- a/crates/ha-core/src/agent/providers/anthropic_adapter.rs
+++ b/crates/ha-core/src/agent/providers/anthropic_adapter.rs
@@ -294,7 +294,6 @@ impl<'a> StreamingChatAdapter for AnthropicStreamingAdapter<'a> {
             usage,
             ttft_ms,
             stop_reason,
-            reasoning_items: Vec::new(), // Anthropic puts thinking inline, no raw items
         })
     }
 

--- a/crates/ha-core/src/agent/providers/codex_adapter.rs
+++ b/crates/ha-core/src/agent/providers/codex_adapter.rs
@@ -115,11 +115,11 @@ impl<'a> StreamingChatAdapter for CodexStreamingAdapter<'a> {
             instructions: req.system_prompt.to_string(),
             input: api_input.clone(),
             reasoning: self.reasoning.clone(),
-            include: if self.reasoning.is_some() {
-                Some(vec!["reasoning.encrypted_content".to_string()])
-            } else {
-                None
-            },
+            // `reasoning.encrypted_content` is not requested: with
+            // `store: false` we don't replay reasoning items into the next
+            // round, so the encrypted payload would just inflate the SSE
+            // response with no consumer.
+            include: None,
             tools: if req.is_final_round {
                 None
             } else {

--- a/crates/ha-core/src/agent/providers/codex_adapter.rs
+++ b/crates/ha-core/src/agent/providers/codex_adapter.rs
@@ -312,11 +312,10 @@ impl<'a> StreamingChatAdapter for CodexStreamingAdapter<'a> {
                 usage: Default::default(),
                 ttft_ms: None,
                 stop_reason: None,
-                reasoning_items: Vec::new(),
             });
         }
 
-        let (text, tool_calls, usage, thinking_text, ttft_ms, reasoning_items) =
+        let (text, tool_calls, usage, thinking_text, ttft_ms) =
             parse_openai_sse(resp, request_start, cancel.as_ref(), on_delta).await?;
 
         if let Some(logger) = crate::get_logger() {
@@ -353,16 +352,7 @@ impl<'a> StreamingChatAdapter for CodexStreamingAdapter<'a> {
             usage,
             ttft_ms,
             stop_reason: None,
-            reasoning_items,
         })
-    }
-
-    fn append_reasoning_items(&self, history: &mut Vec<Value>, outcome: &RoundOutcome) {
-        for ri in &outcome.reasoning_items {
-            if let Some(item) = AssistantAgent::stateless_responses_reasoning_item(ri) {
-                history.push(item);
-            }
-        }
     }
 
     fn append_round_to_history(

--- a/crates/ha-core/src/agent/providers/openai_chat_adapter.rs
+++ b/crates/ha-core/src/agent/providers/openai_chat_adapter.rs
@@ -454,8 +454,7 @@ impl<'a> StreamingChatAdapter for OpenAIChatStreamingAdapter<'a> {
             tool_calls,
             usage,
             ttft_ms,
-            stop_reason: None,           // OpenAI Chat exits via empty tool_calls
-            reasoning_items: Vec::new(), // reasoning_content goes inline, no raw items
+            stop_reason: None, // OpenAI Chat exits via empty tool_calls
         })
     }
 

--- a/crates/ha-core/src/agent/providers/openai_responses_adapter.rs
+++ b/crates/ha-core/src/agent/providers/openai_responses_adapter.rs
@@ -245,45 +245,6 @@ fn finalize_pending_tool_calls(
     0
 }
 
-fn push_stateless_reasoning_item(reasoning_items: &mut Vec<Value>, item: &Value) {
-    let Some(replayable) = AssistantAgent::stateless_responses_reasoning_item(item) else {
-        return;
-    };
-
-    let id = replayable.get("id").and_then(|v| v.as_str());
-    let encrypted_content = replayable.get("encrypted_content").and_then(|v| v.as_str());
-    let already_seen = reasoning_items.iter().any(|existing| {
-        let existing_id = existing.get("id").and_then(|v| v.as_str());
-        let existing_encrypted = existing.get("encrypted_content").and_then(|v| v.as_str());
-        (id.is_some() && id == existing_id)
-            || (encrypted_content.is_some() && encrypted_content == existing_encrypted)
-    });
-
-    if !already_seen {
-        reasoning_items.push(replayable);
-    }
-}
-
-fn collect_reasoning_item_from_raw_event(reasoning_items: &mut Vec<Value>, raw_event: &Value) {
-    if let Some(item) = raw_event.get("item") {
-        if item.get("type").and_then(|t| t.as_str()) == Some("reasoning") {
-            push_stateless_reasoning_item(reasoning_items, item);
-        }
-    }
-
-    if let Some(outputs) = raw_event
-        .get("response")
-        .and_then(|r| r.get("output"))
-        .and_then(|o| o.as_array())
-    {
-        for item in outputs {
-            if item.get("type").and_then(|t| t.as_str()) == Some("reasoning") {
-                push_stateless_reasoning_item(reasoning_items, item);
-            }
-        }
-    }
-}
-
 fn handle_openai_sse_event_block(
     request_id: &str,
     event_block: &str,
@@ -295,7 +256,6 @@ fn handle_openai_sse_event_block(
     pending_calls: &mut std::collections::HashMap<String, FunctionCallItem>,
     usage: &mut ChatUsage,
     first_token_time: &mut Option<u64>,
-    reasoning_items: &mut Vec<Value>,
 ) -> Result<()> {
     let data_lines: Vec<&str> = event_block
         .lines()
@@ -311,8 +271,6 @@ fn handle_openai_sse_event_block(
     if data.is_empty() || data == "[DONE]" {
         return Ok(());
     }
-
-    let raw_event = serde_json::from_str::<Value>(&data).ok();
 
     match serde_json::from_str::<SseEvent>(&data) {
         Ok(event) => {
@@ -397,11 +355,12 @@ fn handle_openai_sse_event_block(
                                 tool_calls.push(tc);
                             }
                         }
-                        if item.item_type.as_deref() == Some("reasoning") {
-                            if let Some(raw) = raw_event.as_ref() {
-                                collect_reasoning_item_from_raw_event(reasoning_items, raw);
-                            }
-                        }
+                        // Responses/Codex run with `store: false`, so any
+                        // `rs_*` reasoning item the server emits is throwaway
+                        // — we never replay it back. The streaming `thinking`
+                        // text is captured via `collected_thinking` above and
+                        // surfaces in the UI; the structured item itself is
+                        // deliberately dropped here.
                     }
                 }
                 "error" => {
@@ -427,9 +386,6 @@ fn handle_openai_sse_event_block(
                     return Err(anyhow::anyhow!("{}", msg));
                 }
                 "response.completed" | "response.done" => {
-                    if let Some(raw) = raw_event.as_ref() {
-                        collect_reasoning_item_from_raw_event(reasoning_items, raw);
-                    }
                     if let Some(resp_obj) = &event.response {
                         if let Some(u) = &resp_obj.usage {
                             if let Some(it) = u.input_tokens {
@@ -724,7 +680,7 @@ impl<'a> StreamingChatAdapter for OpenAIResponsesStreamingAdapter<'a> {
             ));
         }
 
-        let (text, tool_calls, usage, thinking_text, ttft_ms, reasoning_items) =
+        let (text, tool_calls, usage, thinking_text, ttft_ms) =
             parse_openai_sse(resp, request_start, cancel.as_ref(), on_delta).await?;
 
         if let Some(logger) = crate::get_logger() {
@@ -761,19 +717,7 @@ impl<'a> StreamingChatAdapter for OpenAIResponsesStreamingAdapter<'a> {
             usage,
             ttft_ms,
             stop_reason: None,
-            reasoning_items, // raw items pushed by orchestrator via append_reasoning_items
         })
-    }
-
-    fn append_reasoning_items(&self, history: &mut Vec<Value>, outcome: &RoundOutcome) {
-        // Push only stateless-replayable reasoning items. With `store: false`,
-        // an item that only has an `rs_*` id will make the backend look for
-        // server-side state that does not exist.
-        for ri in &outcome.reasoning_items {
-            if let Some(item) = AssistantAgent::stateless_responses_reasoning_item(ri) {
-                history.push(item);
-            }
-        }
     }
 
     fn append_round_to_history(
@@ -815,8 +759,9 @@ impl<'a> StreamingChatAdapter for OpenAIResponsesStreamingAdapter<'a> {
         _last_thinking: &str,
     ) {
         // Responses API final assistant is a `message` item with `output_text`
-        // content. Thinking already lives in history as standalone reasoning
-        // items pushed by `append_reasoning_items` each round.
+        // content. With `store: false` we never replay reasoning items, so
+        // thinking is intentionally dropped here — it streams to the UI live
+        // but does not persist into history.
         if !final_text.is_empty() {
             history.push(json!({
                 "type": "message",
@@ -833,20 +778,13 @@ impl<'a> StreamingChatAdapter for OpenAIResponsesStreamingAdapter<'a> {
 }
 
 /// Parse OpenAI SSE stream (Responses API + Codex share this).
-/// Returns `(collected_text, tool_calls, usage, thinking, ttft_ms, reasoning_items)`.
+/// Returns `(collected_text, tool_calls, usage, thinking, ttft_ms)`.
 pub(in crate::agent) async fn parse_openai_sse(
     resp: reqwest::Response,
     request_start: std::time::Instant,
     cancel: &AtomicBool,
     on_delta: &(dyn for<'s> Fn(&'s str) + Send + Sync),
-) -> Result<(
-    String,
-    Vec<FunctionCallItem>,
-    ChatUsage,
-    String,
-    Option<u64>,
-    Vec<Value>,
-)> {
+) -> Result<(String, Vec<FunctionCallItem>, ChatUsage, String, Option<u64>)> {
     use futures_util::StreamExt;
 
     let request_id = sse_request_id(&resp);
@@ -857,7 +795,6 @@ pub(in crate::agent) async fn parse_openai_sse(
         std::collections::HashMap::new();
     let mut usage = ChatUsage::default();
     let mut first_token_time: Option<u64> = None;
-    let mut reasoning_items: Vec<Value> = Vec::new();
 
     let mut stream = resp.bytes_stream();
     let mut buffer = String::new();
@@ -910,7 +847,6 @@ pub(in crate::agent) async fn parse_openai_sse(
                                     "thinking_length": collected_thinking.len(),
                                     "tool_call_count": tool_calls.len(),
                                     "pending_tool_call_count": pending_calls.len(),
-                                    "reasoning_item_count": reasoning_items.len(),
                                 })
                                 .to_string(),
                             ),
@@ -937,7 +873,6 @@ pub(in crate::agent) async fn parse_openai_sse(
                 &mut pending_calls,
                 &mut usage,
                 &mut first_token_time,
-                &mut reasoning_items,
             )?;
         }
     }
@@ -954,7 +889,6 @@ pub(in crate::agent) async fn parse_openai_sse(
             &mut pending_calls,
             &mut usage,
             &mut first_token_time,
-            &mut reasoning_items,
         )?;
     }
 
@@ -1022,7 +956,6 @@ pub(in crate::agent) async fn parse_openai_sse(
         usage,
         collected_thinking,
         first_token_time,
-        reasoning_items,
     ))
 }
 
@@ -1149,47 +1082,13 @@ mod tests {
         format!("data: {}", payload)
     }
 
+    // Reasoning-item replay was deleted as part of the `store: false`
+    // hardening: Hope Agent never persists `rs_*` ids back into the
+    // conversation history because the server has no record of them.
+    // The invariant "no reasoning items survive into normalized history"
+    // is owned by `normalize_history_for_responses` and its test.
     #[test]
-    fn reasoning_item_without_encrypted_content_is_not_collected() {
-        let event = sse_event_block(serde_json::json!({
-            "type": "response.output_item.done",
-            "item": {
-                "type": "reasoning",
-                "id": "rs_missing",
-                "summary": [],
-                "status": "completed"
-            }
-        }));
-
-        let mut text = String::new();
-        let mut thinking = String::new();
-        let mut tool_calls = Vec::new();
-        let mut pending = HashMap::new();
-        let mut usage = ChatUsage::default();
-        let mut first_token_time = None;
-        let mut reasoning_items = Vec::new();
-        let on_delta = |_s: &str| {};
-
-        handle_openai_sse_event_block(
-            "-",
-            &event,
-            std::time::Instant::now(),
-            &on_delta,
-            &mut text,
-            &mut thinking,
-            &mut tool_calls,
-            &mut pending,
-            &mut usage,
-            &mut first_token_time,
-            &mut reasoning_items,
-        )
-        .expect("handle event");
-
-        assert!(reasoning_items.is_empty());
-    }
-
-    #[test]
-    fn response_completed_collects_encrypted_reasoning_from_raw_output() {
+    fn response_completed_yields_output_text() {
         let event = sse_event_block(serde_json::json!({
             "type": "response.completed",
             "response": {
@@ -1216,7 +1115,6 @@ mod tests {
         let mut pending = HashMap::new();
         let mut usage = ChatUsage::default();
         let mut first_token_time = None;
-        let mut reasoning_items = Vec::new();
         let on_delta = |_s: &str| {};
 
         handle_openai_sse_event_block(
@@ -1230,13 +1128,9 @@ mod tests {
             &mut pending,
             &mut usage,
             &mut first_token_time,
-            &mut reasoning_items,
         )
         .expect("handle event");
 
         assert_eq!(text, "done");
-        assert_eq!(reasoning_items.len(), 1);
-        assert_eq!(reasoning_items[0]["id"], "rs_ok");
-        assert_eq!(reasoning_items[0]["encrypted_content"], "enc");
     }
 }

--- a/crates/ha-core/src/agent/providers/openai_responses_adapter.rs
+++ b/crates/ha-core/src/agent/providers/openai_responses_adapter.rs
@@ -535,11 +535,11 @@ impl<'a> StreamingChatAdapter for OpenAIResponsesStreamingAdapter<'a> {
             instructions: req.system_prompt.to_string(),
             input: api_input.clone(),
             reasoning: self.reasoning.clone(),
-            include: if self.reasoning.is_some() {
-                Some(vec!["reasoning.encrypted_content".to_string()])
-            } else {
-                None
-            },
+            // `reasoning.encrypted_content` is not requested: with
+            // `store: false` we don't replay reasoning items into the next
+            // round, so the encrypted payload would just inflate the SSE
+            // response with no consumer.
+            include: None,
             tools: if req.is_final_round {
                 None
             } else {

--- a/crates/ha-core/src/agent/providers/openai_responses_adapter.rs
+++ b/crates/ha-core/src/agent/providers/openai_responses_adapter.rs
@@ -4,7 +4,9 @@
 //! `instructions` + `input` fields), HTTP send, SSE event decoding (with
 //! `response.output_text.delta` / `response.function_call_arguments.delta` /
 //! reasoning summary events), and history persistence as Responses native
-//! items (`function_call` + `function_call_output` + raw `reasoning` items).
+//! items (`function_call` + `function_call_output`). Reasoning items are
+//! intentionally dropped from history — Hope Agent runs with `store: false`,
+//! where any `rs_*` id replayed in a follow-up request 404s.
 //!
 //! The SSE parser ([`parse_openai_sse`]) is shared with the Codex adapter
 //! since they speak the same protocol — only auth header and endpoint differ.
@@ -784,7 +786,13 @@ pub(in crate::agent) async fn parse_openai_sse(
     request_start: std::time::Instant,
     cancel: &AtomicBool,
     on_delta: &(dyn for<'s> Fn(&'s str) + Send + Sync),
-) -> Result<(String, Vec<FunctionCallItem>, ChatUsage, String, Option<u64>)> {
+) -> Result<(
+    String,
+    Vec<FunctionCallItem>,
+    ChatUsage,
+    String,
+    Option<u64>,
+)> {
     use futures_util::StreamExt;
 
     let request_id = sse_request_id(&resp);

--- a/crates/ha-core/src/agent/streaming_adapter.rs
+++ b/crates/ha-core/src/agent/streaming_adapter.rs
@@ -74,11 +74,6 @@ pub(crate) struct RoundOutcome {
     /// Anthropic-only: stop_reason ("tool_use" / "end_turn" / "max_tokens" / ...).
     /// Other providers leave this `None` and rely on `tool_calls.is_empty()`.
     pub stop_reason: Option<String>,
-    /// Responses/Codex-only: raw reasoning items (with `encrypted_content` and
-    /// `summary` fields) to write back into next round's input array
-    /// **byte-perfect** for multi-turn reasoning chain continuity. Empty for
-    /// Anthropic / OpenAI Chat (those persist thinking inline in messages).
-    pub reasoning_items: Vec<Value>,
 }
 
 /// One executed tool call, ready to be appended to history by the adapter.
@@ -144,8 +139,9 @@ pub(crate) trait StreamingChatAdapter: Send + Sync {
     ///  - Anthropic: `{role:assistant, content:[thinking,text,tool_use...]}`
     ///    + `{role:user, content:[tool_result...]}`
     ///  - OpenAI Chat: assistant message with `tool_calls` + role=tool messages
-    ///  - Responses/Codex: `function_call` + `function_call_output` items + raw
-    ///    reasoning items (from `outcome.reasoning_items`)
+    ///  - Responses/Codex: `function_call` + `function_call_output` items
+    ///    (reasoning items are intentionally not replayed; both providers run
+    ///    with `store: false`, where stale `rs_*` ids 404 the next request)
     ///
     /// Implementations must use `crate::context_compact::push_and_stamp` to
     /// stamp the `_oc_round` metadata for compaction round-boundary alignment.
@@ -168,13 +164,6 @@ pub(crate) trait StreamingChatAdapter: Send + Sync {
         final_text: &str,
         last_thinking: &str,
     );
-
-    /// Push per-round reasoning items (Responses/Codex only) into history
-    /// before either tool dispatch or the final assistant message. Called by
-    /// the orchestrator on every round so multi-turn reasoning chains stay
-    /// continuous. Default no-op for Anthropic / OpenAI Chat which carry
-    /// thinking inline in messages instead of as standalone history items.
-    fn append_reasoning_items(&self, _history: &mut Vec<Value>, _outcome: &RoundOutcome) {}
 
     /// Decide whether the tool loop should exit after this round's outcome.
     ///  - Anthropic: `stop_reason != Some("tool_use")` (model decided to stop)

--- a/crates/ha-core/src/agent/streaming_loop.rs
+++ b/crates/ha-core/src/agent/streaming_loop.rs
@@ -382,12 +382,6 @@ impl AssistantAgent {
             last_round_thinking = outcome.thinking.clone();
             total_usage.accumulate_round(&outcome.usage);
 
-            // Per-round reasoning items (Responses/Codex only) must be persisted
-            // before either tool dispatch or the natural-exit final message so
-            // the next turn can reference the encrypted_content. No-op for
-            // Anthropic / OpenAI Chat (their thinking lives inline in messages).
-            adapter.append_reasoning_items(&mut messages, &outcome);
-
             if adapter.loop_should_exit(&outcome) {
                 natural_exit = true;
                 break;

--- a/crates/ha-core/src/chat_engine/finalize/mod.rs
+++ b/crates/ha-core/src/chat_engine/finalize/mod.rs
@@ -696,6 +696,50 @@ mod tests {
         );
     }
 
+    // Invariant: a failed turn must leave the user message persisted in
+    // `context_json`. Without this, the next `restore_agent_context` call
+    // hands the model an empty history and the LLM has no clue what the
+    // user just asked — the classic "retry lost my prompt" symptom.
+    #[test]
+    fn provider_failed_keeps_user_message_in_context() {
+        let _lock = test_lock();
+        let db = temp_db();
+        let (sid, turn_id) = fresh_session(&db);
+
+        let partial = PartialMeta {
+            user_message: Some("read kefu source and compare with visitor-next".into()),
+            provider_kind: Some(ProviderApiKind::OpenAIResponses),
+            turn_id: Some(turn_id),
+            ..Default::default()
+        };
+        let outcome = finalize_turn_context_blocking(
+            &db,
+            &sid,
+            TerminationReason::ProviderFailed {
+                last_kind: crate::failover::FailoverReason::Unknown,
+                last_message: "rs_xxx not found".into(),
+                is_codex_auth: false,
+            },
+            partial,
+            ChatSource::Desktop,
+        );
+        assert!(outcome.context_assistant_appended);
+
+        let ctx_json = db.load_context(&sid).unwrap().unwrap();
+        let history: Vec<Value> = serde_json::from_str(&ctx_json).unwrap();
+        let user_text_present = history.iter().any(|m| {
+            m.get("role").and_then(|r| r.as_str()) == Some("user")
+                && m.get("content")
+                    .and_then(|c| c.as_str())
+                    .map(|s| s.contains("read kefu"))
+                    .unwrap_or(false)
+        });
+        assert!(
+            user_text_present,
+            "context_json must keep the user message after a failed turn; got: {ctx_json}"
+        );
+    }
+
     #[test]
     fn reentry_is_noop() {
         let _lock = test_lock();

--- a/docs/architecture/provider-system.md
+++ b/docs/architecture/provider-system.md
@@ -484,23 +484,27 @@ Provider 通过 `on_delta` 回调实时推送 JSON 事件：
 }
 ```
 
-**关键特性：`reasoning.encrypted_content` 回传**
+**Reasoning item 不回传（`store: false` 红线）**
 
-1. 请求中加 `include: ["reasoning.encrypted_content"]`
-2. SSE 响应中，`response.output_item.done` 事件携带完整 reasoning item（含加密内容）
-3. 通过 raw JSON 解析捕获完整 reasoning item（保留所有字段）
-4. reasoning items 存入 `conversation_history`，下一轮原样回传
-5. 与 Anthropic `thinkingSignature` 机制等价，保留思考块完整性
+Hope Agent 始终用 `store: false` 调 Responses API。在这一模式下，服务端**不持久化** reasoning item，`rs_*` id 是一次性引用——下一轮请求只要带上历史 reasoning item，无论是否携带 `encrypted_content`，服务端都会按 id 查持久化记录并 404（`Item with id 'rs_xxx' not found. Items are not persisted when store is set to false.`）。
+
+因此契约是：**reasoning item 从不进入 `conversation_history`，从不参与下一轮 replay**。
+
+1. 请求中**不再加** `include: ["reasoning.encrypted_content"]`（即便加了也不写回 history）
+2. SSE 中收到 reasoning 事件时，`response.reasoning_summary_text.delta` 流给前端做"思考可视化"，但其结构化的 reasoning item（id + encrypted_content）**就地丢弃**
+3. `parse_openai_sse` 返回签名不含 `reasoning_items`；`RoundOutcome` 也不再有该字段
+4. `normalize_history_for_responses` 把任何残留的 `type: reasoning` item 一并 `continue`（兜底，防御旧版本写下的 context_json）
+5. 每轮独立 reasoning 与 `store=false` 的 stateless 语义完全对齐——少几秒 reasoning 时间换稳定性
 
 **SSE 事件处理：**
 
 | 事件 | 处理 |
 |------|------|
-| `response.reasoning_summary_text.delta` | → `emit_thinking_delta` + 累积 |
+| `response.reasoning_summary_text.delta` | → `emit_thinking_delta` + 累积（仅 UI 可视化） |
 | `response.reasoning_summary_part.done` | → 追加 `\n\n` 段落分隔 |
 | `response.output_text.delta` | → `emit_text_delta` + 累积 |
 | `response.output_item.added` (function_call) | → 创建 pending tool call |
-| `response.output_item.done` (reasoning) | → 捕获完整 reasoning item JSON |
+| `response.output_item.done` (reasoning) | → 丢弃结构化 item（thinking 已通过 delta 路径累积） |
 | `response.output_item.done` (function_call) | → 完成 tool call |
 | `response.completed` | → 提取 usage + fallback 文本提取 |
 
@@ -508,7 +512,6 @@ Provider 通过 `on_delta` 回调实时推送 JSON 事件：
 ```json
 [
   { "role": "user", "content": "问题" },
-  { "type": "reasoning", "id": "rs_xxx", "encrypted_content": "...", "summary": [...] },
   { "type": "message", "role": "assistant", "content": [{ "type": "output_text", "text": "回复" }], "status": "completed" },
   { "type": "function_call", "id": "fc_xxx", "call_id": "fc_xxx", "name": "read", "arguments": "{...}" },
   { "type": "function_call_output", "call_id": "fc_xxx", "output": "文件内容" }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -762,13 +762,7 @@ pub async fn chat(
 
             Ok(result.response)
         }
-        Err(e) => {
-            // Persist any in-memory compaction before returning error
-            if let Some(ref agent) = *state.agent.lock().await {
-                crate::chat_engine::save_agent_context(&db, &sid, agent);
-            }
-            Err(CmdError::msg(e))
-        }
+        Err(e) => Err(CmdError::msg(e)),
     }
 }
 


### PR DESCRIPTION
## Summary

- **Bug A — Desktop retry 丢上下文**：`src-tauri/src/commands/chat.rs` 的 `chat()` 命令在 `run_chat_engine` 失败路径里用 `state.agent` 锁里的旧 agent 调 `save_agent_context`，把 `chat_engine::finalize::rebuild_and_save_context` 刚写好的 `context_json`（含 user message + failure marker）覆盖成上次成功 turn 残留的空/旧 history。下次 `restore_agent_context` 读到的就是 0 条 → 用户再点「重试」时模型看不到原始任务，等同于裸输入。`chat_engine` 已经在所有终止路径（`persist_round_context` / `save_agent_context` / `rebuild_and_save_context`）独占持有 `context_json` 写入责任；wrapper 不应该再碰，直接删掉这条错位调用。新增 `provider_failed_keeps_user_message_in_context` invariant 测试卡未来回归。HTTP/server 路径不受影响。

- **Bug B — `store=false` 下 reasoning item replay 链路彻底拔除**：Hope Agent 对 OpenAI Responses + Codex 永远走 `store: false`，server 不持久化 reasoning item，任何 `rs_*` id 都是 dangling 引用，下一轮请求带上就 404（`Item with id 'rs_xxx' not found. Items are not persisted when store is set to false.`）。原来的"`encrypted_content` 非空才 replay"是症状级修复——`clone()` 保留了 `id` 字段，server 仍按 id 查持久化记录而 404。改成根本性方案：**永不 replay reasoning item**。`RoundOutcome.reasoning_items` 字段删除、`StreamingChatAdapter::append_reasoning_items` trait 方法删除、`parse_openai_sse` / `handle_openai_sse_event_block` 签名瘦身、`stateless_responses_reasoning_item` / `push_stateless_reasoning_item` / `collect_reasoning_item_from_raw_event` helper 删除，4 个 adapter 同步清理。`normalize_history_for_responses` 兜底丢掉残留 reasoning item（防御旧 context_json）。Thinking 仍通过 `reasoning_summary_text.delta` 流给前端做可视化，仅结构化 replay 路径消失。代价：模型每轮独立 reasoning，多几秒延迟，但与 `store=false` 的 stateless 语义完全对齐。新增 `responses_history_drops_all_reasoning_items` invariant 测试。

- **Bug B follow-up — 同步停止请求 `encrypted_content`**：Codex review 指出既然不再 replay，请求里就别让 server 推 `reasoning.encrypted_content` 浪费带宽和解析成本。两个 adapter 的 `ResponsesRequest::include` 改成无条件 `None`。

- **文档同步**：`docs/architecture/provider-system.md` 更新 reasoning item 处理契约。

## Test plan

- [x] `cargo check -p ha-core --tests --locked`
- [x] `cargo check -p hope-agent --locked`
- [x] `cargo fmt --all --check`
- [x] 单测 `agent::context::responses_history_tests::responses_history_drops_all_reasoning_items` 通过
- [x] 单测 `chat_engine::finalize::tests::provider_failed_keeps_user_message_in_context` 通过
- [x] 单测 `agent::providers::openai_responses_adapter::tests::*`（8 项全过）
- [x] pre-push hook 6 项（fmt / clippy / cargo test / typecheck / lint / vitest）本地通过
- [ ] CI 跑全套
- [ ] 手动复现：起一个会话，先发原始任务（让 OpenAI Responses turn 失败，例如断网或制造 rs_xxx not found）→ 发"重试" → 模型应该看到原始任务而不是召回无关记忆
- [ ] 手动复现：开启 reasoning 模型连续对话多轮 → 不再因 `rs_xxx not found` 中断