### PR TITLE
fix(chat): 切回流式输出中的会话不再从头重放打字机动画

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **切回流式输出中的会话不再从头重放打字机动画**：MarkdownRenderer 在 mount 时把当前 content 长度记为基线，已经看过的内容直接整段显示，仅对 mount 之后新到达的 delta 继续走 typewriter + blurIn 动画。修复切到别的会话再切回时整段内容"咵地从头一字一字 / 模糊变清晰重放一遍"的视觉问题。
 - **会话内切换模型不再污染全局默认 & 不再闪回**：聊天界面 ModelPicker、桌面斜杠 `/model` 卡片、IM `/model` 命令现在都只把模型固定到**当前会话**（写入 `sessions.provider_id/model_id`），不再改 `config.active_model`。下次发消息时 chat_engine 解析顺序变为 **session > agent.primary > config.active_model**。同一会话切模型 UI 由 `manualModelOverrideRef` 兜底，不会再因 `config:changed` 广播被回退成旧值。全局默认模型现在仅由「设置 → 模型」面板修改。
 
 ## [0.2.0] - 2026-05-13

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -6,7 +6,15 @@ import {
   useMemo,
   type AnchorHTMLAttributes,
 } from "react"
-import { Streamdown, type AnimateOptions, type PluginConfig } from "streamdown"
+import {
+  Streamdown,
+  createAnimatePlugin,
+  defaultRehypePlugins,
+  type AnimateOptions,
+  type PluginConfig,
+} from "streamdown"
+
+type AnimatePlugin = ReturnType<typeof createAnimatePlugin>
 import { code } from "@streamdown/code"
 import { cjk } from "@streamdown/cjk"
 import {
@@ -341,9 +349,32 @@ interface MarkdownRendererProps {
 
 export default function MarkdownRenderer({ content, isStreaming = false }: MarkdownRendererProps) {
   const plugins = useHeavyPlugins(content)
-  const [displayLen, setDisplayLen] = useState(() => (isStreaming ? 0 : content.length))
 
-  const cursorRef = useRef(isStreaming ? 0 : content.length)
+  // 外部接管 Streamdown 的 animate plugin 生命周期。Streamdown 自带的
+  // `animated={AnimateOptions}` 简便用法把 plugin 实例藏在内部 useMemo，且
+  // Block 组件每帧 render 会调 `setPrevContentLength(getLastRenderCharCount())`
+  // —— 首次 render 时 lastRenderCharCount 还是 0，prevContentLength 被回写 0，
+  // 整段已渲染内容会被当成新内容跑 blurIn。组件 unmount + remount（切会话回到
+  // 流式输出中的会话 / 虚拟滚动剔出再返回视口）会重新走这条 0-baseline 路径，
+  // 视觉上整段重放动画一次。
+  //
+  // 外部托管时：(a) 在首次 render 之前调一次 `setPrevContentLength(content.length)`，
+  // 让 mount 那刻已经存在的内容全部标记 duration=0；(b) 通过 `rehypePlugins`
+  // prop 把 plugin 注入 Streamdown（用 `animated={false}` 关掉内部建实例的路径，
+  // 也就同时关掉 Block 内部那条覆盖 prevContentLength 的逻辑）；(c) 每帧 commit
+  // 后用 effect 把上一帧 rehype 跑出的 `lastRenderCharCount` 续写为下一帧的
+  // baseline（plugin rehype 跑完会自动清 prevContentLength=0，必须每帧重新设）。
+  // useState lazy initializer 一次性创建 plugin 并 set mount baseline；reference
+  // 跨 render 稳定，且不通过 .current 访问，避开 react-hooks/refs 规则。
+  const [animatePlugin] = useState<AnimatePlugin>(() => {
+    const plugin = createAnimatePlugin(streamingAnimation)
+    plugin.setPrevContentLength(content.length)
+    return plugin
+  })
+
+  const [displayLen, setDisplayLen] = useState(() => content.length)
+
+  const cursorRef = useRef(content.length)
   const targetRef = useRef(content.length)
   const streamingRef = useRef(isStreaming)
   const rafRef = useRef<number | null>(null)
@@ -356,6 +387,14 @@ export default function MarkdownRenderer({ content, isStreaming = false }: Markd
   targetRef.current = content.length
   // eslint-disable-next-line react-hooks/refs
   streamingRef.current = isStreaming
+
+  // 每帧 commit 后把上一帧 rehype 跑出的字符数续写为下一帧的 baseline。
+  // animate plugin 的 rehype 跑完会自动把 prevContentLength 清 0，因此必须
+  // 每帧重新设。没有 deps：commit phase 都跑。
+  useEffect(() => {
+    const count = animatePlugin.getLastRenderCharCount()
+    if (count > 0) animatePlugin.setPrevContentLength(count)
+  })
 
   // Non-streaming (history): show full content immediately
   useEffect(() => {
@@ -434,14 +473,22 @@ export default function MarkdownRenderer({ content, isStreaming = false }: Markd
   const displayContent = revealing ? content.slice(0, displayLen) : content
   const isActive = isStreaming || revealing
 
+  // 流式期间把外部 animate plugin 注入 rehype 链尾；静态历史消息直接复用
+  // streamdown 默认 rehype（raw/sanitize/harden 安全基线）。`animated={false}`
+  // 关掉 streamdown 内部建实例的路径，避免与外部 plugin 重复跑。
+  const rehypePlugins = isActive
+    ? [...Object.values(defaultRehypePlugins), animatePlugin.rehypePlugin]
+    : Object.values(defaultRehypePlugins)
+
   return (
     <div ref={containerRef} className={isActive ? "streaming-height markdown-content" : "markdown-content"}>
       <div ref={contentRef}>
         <Streamdown
-          animated={isActive ? streamingAnimation : true}
+          animated={false}
           plugins={plugins}
           isAnimating={isActive}
           parseIncompleteMarkdown={isActive}
+          rehypePlugins={rehypePlugins}
           linkSafety={linkSafetyDisabled}
           components={markdownComponents}
         >


### PR DESCRIPTION
## Summary

切到别的会话再切回仍在流式输出的会话时，整段已渲染内容会"咵地从头一字一字 / 模糊变清晰"重放一遍——这是渲染器层 bug，跟数据流无关（后端 `chat:stream_delta` 的 seq 不会重发历史，前端 `sessionCacheRef` 切走时也持续累积 delta，content 字符串是完整的）。

根因在 [MarkdownRenderer.tsx](src/components/common/MarkdownRenderer.tsx)：

1. **第一层（自家 rAF）**：`displayLen` 字符级 reveal 用 `useState(() => isStreaming ? 0 : content.length)` 初始化——`isStreaming=true` 时切回 mount 也从 0 开始追，整段重新打字机
2. **第二层（Streamdown blurIn）**：用 `animated={AnimateOptions}` 简便用法时，plugin 实例由 streamdown 内部 `useMemo` 持有，外部拿不到引用。Streamdown 的 Block 组件每帧 render 会调 `setPrevContentLength(getLastRenderCharCount())`——首次 render 时 `lastRenderCharCount=0`，baseline 被回写 0，整段已渲染内容被当新内容跑一次 `blurIn`

## 修复

### 第一层：rAF cursor 对齐 content 末尾

`useState` / `cursorRef` 初始化不再读 `isStreaming`，统一从 `content.length` 开始。mount 后已存在的字符直接显示，rAF tick 只对**之后** delta 推动 target 时做 catchup 追赶。

### 第二层：外部托管 Streamdown 的 animate plugin

用 streamdown export 的 `createAnimatePlugin` + `defaultRehypePlugins` 替代简便 prop：

- `useState` lazy initializer 一次性创建 plugin，**首次 render 之前**调 `setPrevContentLength(content.length)`，让 mount 那刻已存在的内容全部标记 `duration=0`
- 通过 `rehypePlugins` prop 把 plugin 注入 Streamdown，`animated={false}` 关掉内部建实例的路径（也就同时关掉 Block 内部那条覆盖 `prevContentLength` 的逻辑）
- 每帧 commit 后 effect 把 `getLastRenderCharCount()` 续写为下一帧 baseline（plugin 跑完 rehype 会自动清 `prevContentLength=0`，必须每帧重新设）

### 行为矩阵

| 场景 | mount baseline | 第一次 rehype 后 | 表现 |
|---|---|---|---|
| 首次创建 assistant（content="" → 流入） | 0 | 跟随 lastRenderCharCount | 新增 word 走 blurIn |
| 流式中切走再切回 | N（已累积长度） | N，新 delta 后续写 | 已收齐 N 字符全部 duration=0 不动画，新 delta 才走 blurIn |
| 切回后新 delta 又到 | N → N+k | N+k | 仅新增 k 个字符所属 word 动画 |
| 流式结束后回看历史 | — | isActive=false 不挂 plugin | streamdown 默认 rehype，instant |

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（pre-push 钩子全套 6 项 check 通过）
- [ ] 桌面端手动验证：开一个长输出（要求模型写 500 字），切到别的会话，等几秒，切回——应**接续看到**而非重放，且新 delta 仍走 blurIn 动画
- [ ] 边界：流式刚开始（content="" 那一瞬）切走 → 切回，确认继续从空开始打字机
- [ ] 边界：流式结束后切走 → 切回，`isStreaming=false`，整段 instant 显示无动画
- [ ] 长 content（>1000 字符）确认 plugin baseline 续写不漏字
- [ ] 切走 → 切回 → 切走 → 切回 反复操作，确认 plugin 状态稳定

## Codex review 痕迹

第一稿只改了第一层（rAF cursor 对齐），codex review 命中第二层 Streamdown 内部的 baseline 清 0 路径，已在当前 commit 一并修掉。