### PR TITLE
release: v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,27 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.1] - 2026-05-14
 
 ### Added
 
-- **官方 Docker 镜像 + docker-compose 部署**：新增多架构容器镜像 `ghcr.io/shiwenwen/hope-agent`（覆盖 `linux/amd64` / `linux/arm64`），随每次 Release Tag 自动构建发布；浏览器访问容器暴露端口即得完整 Web GUI 与桌面端等价。默认 loopback + 浏览器 token 输入对话框 + `?token=` URL 一次性 bootstrap；`app_update` 工具在容器内检测后引导 `docker pull` 升级而非 binary swap。 (#171)
+- 官方 Docker 多架构镜像 `ghcr.io/shiwenwen/hope-agent`（`linux/amd64` + `linux/arm64`） + `docker-compose.yml` 一键自托管；浏览器侧 401 自动弹窗输入 Bearer token，容器内 `app_update` 工具引导 `docker pull` 而非 binary swap。 (#171)
+- 消息列表新增可选「时间线」显示模式，按时间排列并合并相邻 narration / 工具调用片段，偏好持久化到本地存储。 (#193)
 
 ### Fixed
 
-- **切回流式输出中的会话不再从头重放打字机动画**：MarkdownRenderer 在 mount 时把当前 content 长度记为基线，已经看过的内容直接整段显示，仅对 mount 之后新到达的 delta 继续走 typewriter + blurIn 动画。修复切到别的会话再切回时整段内容"咵地从头一字一字 / 模糊变清晰重放一遍"的视觉问题。
-- **会话内切换模型不再污染全局默认 & 不再闪回**：聊天界面 ModelPicker、桌面斜杠 `/model` 卡片、IM `/model` 命令现在都只把模型固定到**当前会话**（写入 `sessions.provider_id/model_id`），不再改 `config.active_model`。下次发消息时 chat_engine 解析顺序变为 **session > agent.primary > config.active_model**。同一会话切模型 UI 由 `manualModelOverrideRef` 兜底，不会再因 `config:changed` 广播被回退成旧值。全局默认模型现在仅由「设置 → 模型」面板修改。
+- 「发现新版」弹窗与「关于」面板的更新说明从纯文本两行截断升级为完整 Markdown 渲染，与对话气泡同一 renderer。 (#176)
+- 切回正在流式输出的会话不再从头重放打字机动画，已渲染内容立即显示，仅 mount 后到达的新增片段动画。 (#192)
+- 多会话并发流式时，背景静默刷新不再丢失正在 streaming 的 assistant 气泡。 (#185)
+- 桌面端失败回合「重试」不再丢失刚保存的用户输入，加回归测试守住不变量；Responses 模式下 `store: false` 不再回放 reasoning 项，消除 "Item with id 'rs_...' not found" 404。 (#191)
+- 会话内切换模型（ChatInput ModelPicker / 桌面 `/model` 卡片 / IM `/model`）只影响当前会话，写入 `sessions.provider_id / model_id`，不再污染 `config.active_model`；全局默认仅由「设置 → 模型」面板修改。 (#190)
+- 新建会话时清空旧 session 未答完的 ask_user 问题框，不再泄漏到空白页面。 (#181)
+- Provider 模板配置页与引导 wizard 第 3 步容器从 512 px 放宽到 1024 px，模型卡片底部「输入 / 输出成本」字段不再被裁切；修补 wizard 模型步骤标题缺失的 i18n key。 (#186, #189)
+
+### Changed
+
+- macOS Intel 原生 DMG 与 bare binary 改由独立的 best-effort backfill workflow 在 release publish 后异步构建，遇到 macos-13 runner 排队不再阻塞主发版；Homebrew tap 模板加双架构容错，Intel 包暂时缺失时自动降级为 arm-only cask。 (#175, #177, #188)
+- 新增 release.yml 改动的 PR 阶段静态校验（路径一致性 / 工件契约 / dry-run 模式），降低发版工作流回归概率。 (#174)
 
 ## [0.2.0] - 2026-05-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3221,7 +3221,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.2.1.en.md
+++ b/docs/release-notes/v0.2.1.en.md
@@ -1,0 +1,59 @@
+# Hope Agent 0.2.1 — Conversation stability · Intel Mac restored · Docker self-hosting
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/docs/release-notes/v0.2.1.md) · **English**
+
+> Release date: 2026-05-14
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/CHANGELOG.md#021---2026-05-14) for the full diff.
+
+This is the first patch on the v0.2 line. The main themes are a batch of conversation stability fixes and an optional timeline display mode; it also delivers on v0.2.0's promise of macOS Intel native DMG and Homebrew dual-arch, and adds official multi-arch Docker images plus `docker-compose` for one-command self-hosting.
+
+## Conversation experience
+
+- **New timeline display mode (optional)**: the message list can switch between "bubble" and "timeline" views; timeline mode lays messages out chronologically and folds adjacent narration / tool-call fragments together, which works well for long conversations or cross-session scanning. The preference is persisted to local storage, per device.
+- **Switching back into a streaming session no longer replays the typewriter animation from scratch**: previously, leaving and returning to a streaming session re-rendered character by character from the very beginning — visually jarring on long reasoning / long outputs. Now the already-rendered content shows immediately, and only deltas arriving after this mount animate at word level.
+- **Concurrent streaming sessions no longer drop the bubble when switching back**: a background silent reload colliding with a still-streaming session used to discard the in-flight assistant placeholder, and the next delta couldn't recover. This release skips background reloads for sessions that are still streaming, then reloads cleanly after the turn finishes.
+- **Desktop retry no longer loses context**: a failure-path leak in the desktop wrapper used to overwrite the just-persisted user message, so retrying a failed turn left the model with no prompt to work from. The leak is closed, and a regression test now guards the invariant.
+- **Switching models in a conversation only affects that conversation**: changing the model inside a session previously also rewrote the global default. Now "in-session switch" and "Settings → Models → set default" are two independent paths — in-session switches persist to `sessions.provider_id / model_id` and never touch `config.active_model`.
+- **Creating a new session clears the previous session's ask_user prompt**: an unanswered structured question used to leak into the empty "new conversation" screen. It's now cleared on session change.
+
+## Update prompts now render Markdown
+
+The "new version available" toast and the About panel's update notes used to render the body as plain text with a two-line clamp. Both now go through the same Markdown renderer as conversation bubbles — lists, links, emphasis, and code blocks all display correctly, matching how this release notes file is rendered.
+
+## Settings UI
+
+- The Provider template config page and step 3 of the onboarding wizard widened from 512 px to 1024 px, so model-card fields like input / output cost are no longer clipped at the bottom.
+- A missing i18n key on the wizard's model step title is restored, eliminating the English literal fallback in non-English locales.
+
+## macOS Intel native DMG restored
+
+v0.2.0 temporarily dropped the Intel platform because the GitHub-hosted `macos-13` Intel runner pool was congested. This release moves Intel macOS to an independent "best-effort async backfill" workflow that builds the Intel DMG and bare binary *after* the main release is already published, so a long Intel queue can no longer block the main release or other platforms. Intel Mac users can again download a native `Hope.Agent_0.2.1_x64.dmg` from this release. The Homebrew tap templates gain dual-arch tolerance: when the Intel artifact is briefly missing, the tap auto-degrades to an arm-only cask instead of failing the whole tap update.
+
+## Docker self-hosting in one command
+
+Official multi-arch container images plus a ready-to-use `docker-compose.yml` cover the "run Hope Agent in server mode on a NAS / home server / internal box" use case:
+
+- Images are built automatically on every release and pushed to `ghcr.io/shiwenwen/hope-agent`, supporting `linux/amd64` and `linux/arm64` (Raspberry Pi 4/5, Apple Silicon Asahi Linux, AWS Graviton, Ampere Altra all work natively).
+- `docker compose up -d` brings up just the hope-agent service with the port bound to loopback; `docker compose --profile with-ollama up -d` adds a local Ollama LLM sidecar in one line.
+- Three exposure shapes are documented explicitly: enter the token in the browser, inject `Authorization` via a reverse proxy, or use a VPN / tailnet. The browser flow is powered by a new 401 auto-dialog plus localStorage token entry; the deployment doc gives a minimal working config for each shape.
+- Inside the container, the `app_update` tool detects `HA_DEPLOYMENT=docker` and instructs the user to run `docker pull` instead of attempting an in-container binary swap, so upgrades don't fight the container layer.
+- Bearer tokens are masked in the startup banner, `docker logs`, and the unknown-flag echo path — no plaintext token ever lands in container logs.
+
+Full deployment guide: [`docs/deployment/docker.en.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/docs/deployment/docker.en.md).
+
+## Upgrade
+
+- **Desktop (v0.2.0 users)**: install over the top, or click "Check for Updates" in the app for a one-click upgrade. Config and data are fully compatible.
+- **Package-manager users**: `brew upgrade --cask hope-agent` / `scoop update hope-agent` / `yay -Syu hope-agent-bin` / `apt update && apt install --only-upgrade hope-agent` / `dnf upgrade hope-agent`.
+- **Server / Web mode**: replace the binary and restart the service.
+- **Docker users**: `docker compose pull && docker compose up -d`.
+
+## Known limitations
+
+- The macOS Intel native DMG is delivered via async backfill — it typically lands within ~30 minutes after the main release is published; an extended `macos-13` queue can delay it further but never blocks other platforms.
+- Other known limitations are the same as v0.2.0 — see the [v0.2.0 release notes](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/docs/release-notes/v0.2.0.en.md#known-limitations).
+
+## Full changelog
+
+See [CHANGELOG.md](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/CHANGELOG.md#021---2026-05-14).

--- a/docs/release-notes/v0.2.1.md
+++ b/docs/release-notes/v0.2.1.md
@@ -1,0 +1,59 @@
+# Hope Agent 0.2.1 — 对话体验稳定性 · Intel Mac 回归 · Docker 自托管
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/docs/release-notes/v0.2.1.en.md)
+
+> 发布日期：2026-05-14
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/CHANGELOG.md#021---2026-05-14)。
+
+本版本是 v0.2 系列首个 patch，主轴是对话体验的一组稳定性修复与一项可选的时间线展示模式；同时兑现 v0.2.0 release notes 中关于 macOS Intel 原生 DMG 与 Homebrew 双架构的承诺，并新增 Docker 多架构镜像与 docker-compose 一键自托管。
+
+## 对话体验
+
+- **新增时间线展示模式（可选）**：消息列表可在「气泡」与「时间线」两种视图间切换，时间线模式按时间排列并合并相邻 narration / 工具调用片段，适合长对话回看与跨会话纵览；偏好持久化到本地存储，按设备保留
+- **切回流式输出中的会话不再从头重放打字机动画**：以前切走再切回会从首字符开始逐字符重渲，长 reasoning / 长输出场景视觉抖动严重；现在切回直接显示已渲染部分，仅本次 mount 之后到达的新增片段走 word-level 动画
+- **多会话并发流式切回不再丢失气泡**：背景静默刷新与正在 streaming 的会话碰撞时会丢弃 in-flight assistant 气泡，下一帧 delta 也无法补救；本版给正在 streaming 的会话加例外，等本轮自然结束后再静默刷新
+- **桌面端重试不再丢失上下文**：失败回合的「重试」之前会被异常路径覆盖掉刚刚保存好的用户输入，重试时模型看不到原 prompt；本版彻底关掉这条覆盖路径，并加了回归测试守住边界
+- **切模型只影响当前会话，不再污染全局默认**：之前在会话内换模型会顺手改写全局默认模型；现在「会话内切换」与「Settings 模型面板设默认」是两条独立路径，会话切换通过 `sessions.provider_id / model_id` 落库，不动 `config.active_model`
+- **新建会话清空旧 session 的 ask_user 问题框**：旧会话未答完的结构化问题会泄漏到新建空白会话页面，本版在会话切换时一并清掉
+
+## 桌面应用更新提示支持 Markdown 渲染
+
+「发现新版」弹窗与「关于」面板里的更新说明从纯文本 + 两行截断升级为完整 Markdown 渲染（与对话气泡同一 renderer），列表、链接、强调、代码块都能正常显示，与本份 release notes 的呈现一致。
+
+## 设置 UI
+
+- Provider 模板配置页与引导 wizard 第 3 步的容器宽度从 512 px 放宽到 1024 px，模型卡片底部「输入 / 输出成本」字段不再被裁切
+- 修补引导 wizard 模型步骤标题缺失的 i18n key，避免回落到英文字面量
+
+## macOS Intel 原生 DMG 回归
+
+v0.2.0 因 GitHub macos-13 Intel runner 池排队拥堵临时移除了 Intel 平台。本版改用独立的「best-effort 异步 backfill」工作流，在主发版完成、release 已 publish 之后再异步去构建 Intel DMG 与裸 binary，构建超时不阻塞主发版、不影响其它平台。Intel Mac 用户从本版开始重新可以下载到原生 `Hope.Agent_0.2.1_x64.dmg`；Homebrew tap 模板同步增加双架构容错，当 Intel 包暂时缺失时会自动降级为 arm-only cask、不再让整次 tap 更新失败。
+
+## Docker 一键自托管
+
+新增官方多架构容器镜像与 `docker-compose.yml`，覆盖「在 NAS / 家庭服务器 / 内网机器上跑 Hope Agent server 模式」场景：
+
+- 镜像随每次 release 自动构建并推送到 `ghcr.io/shiwenwen/hope-agent`，同时支持 `linux/amd64` 与 `linux/arm64`（Raspberry Pi 4/5 / Apple Silicon Asahi Linux / AWS Graviton / Ampere Altra 通用）
+- `docker compose up -d` 默认仅 hope-agent 服务并 loopback 暴露端口；`docker compose --profile with-ollama up -d` 一行起本地 LLM sidecar
+- 网络暴露形态明确分三种：浏览器输 token / 反向代理注入 `Authorization` header / VPN 或 tailnet 内网；浏览器形态由新增的 401 自动弹窗 + localStorage token 输入完成，部署文档对每种形态给出最小可工作配置
+- 容器内 `app_update` 工具识别 `HA_DEPLOYMENT=docker` 后会引导用户走 `docker pull` 升级而不是 binary swap，避免覆盖容器层
+- Bearer token 与短 token 在启动 banner、`docker logs`、未知 CLI flag 的 echo 路径全部 mask，不写明文
+
+完整部署指引见 [`docs/deployment/docker.md`](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/docs/deployment/docker.md)。
+
+## 升级
+
+- **桌面（v0.2.0 用户）**：直接覆盖安装或在应用内点「检查更新」一键升级；配置与数据完全兼容
+- **包管理器用户**：`brew upgrade --cask hope-agent` / `scoop update hope-agent` / `yay -Syu hope-agent-bin` / `apt update && apt install --only-upgrade hope-agent` / `dnf upgrade hope-agent`
+- **Server / Web 模式**：替换二进制后重启服务
+- **Docker 用户**：`docker compose pull && docker compose up -d`
+
+## 已知限制
+
+- macOS Intel 原生 DMG 走异步 backfill，主 release publish 后通常 30 分钟左右补齐，遇到 macos-13 runner 长时间排队会延后但不影响其它平台下载
+- 其余已知限制与 v0.2.0 一致，详见 [v0.2.0 release notes](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/docs/release-notes/v0.2.0.md#已知限制)
+
+## 完整变更日志
+
+详见 [CHANGELOG.md](https://github.com/shiwenwen/hope-agent/blob/v0.2.1/CHANGELOG.md#021---2026-05-14)。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.2.0"
+version = "0.2.1"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- bump version: `0.2.0` → `0.2.1`
- `CHANGELOG.md` 新增 `[0.2.1] - 2026-05-14` 段
- `docs/release-notes/v0.2.1.{md,en.md}` 双语 release notes

## 主轴

- **对话体验**：新增可选时间线显示模式（#193）+ 5 项流式 / 会话切换稳定性修复（#181 #185 #190 #191 #192）
- **更新提示 Markdown 渲染**（#176 / F-087）
- **设置 UI**：Provider 模板配置页 / 引导 wizard 模型步骤布局过窄 + i18n 修复（#186 #189）
- **macOS Intel 原生 DMG 回归**：异步 backfill workflow 兑现 v0.2.0 release notes 承诺（#175 #177 #188）
- **Docker 多架构镜像 + docker-compose 一键自托管**（#171）

## Test plan

- [x] `pnpm release:verify -- --tag v0.2.1`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- [x] `cargo test -p ha-core -p ha-server --locked`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] CI lint.yml + rust.yml 全过
- [ ] 合并后在 `release/v0.2` 打 `v0.2.1` tag，触发 `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)