### PR TITLE
[codex] add Cmd+N new chat shortcut

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -683,6 +683,24 @@ export default function ChatScreen({
     return () => window.removeEventListener("keydown", handler)
   }, [currentSessionId, openSessionSearch, focusGlobalSearch])
 
+  // Cmd/Ctrl+N: start a fresh draft chat with the current agent, matching the
+  // sidebar New Chat button and tray "new-session" behavior.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const modKey = e.metaKey || e.ctrlKey
+      if (!modKey || e.altKey || e.shiftKey || e.repeat) return
+      if (e.key.toLowerCase() !== "n") return
+
+      const target = e.target as HTMLElement | null
+      if (target?.isContentEditable) return
+
+      e.preventDefault()
+      void handleStartNewChat(currentAgentId)
+    }
+    window.addEventListener("keydown", handler)
+    return () => window.removeEventListener("keydown", handler)
+  }, [handleStartNewChat, currentAgentId])
+
   // Listen for tray "new-session" event to trigger new chat
   useEffect(() => {
     return getTransport().listen("new-session", () => {


### PR DESCRIPTION
## Summary
- Add a window-level Cmd/Ctrl+N shortcut on the chat screen.
- Reuse the existing new-chat draft flow so shortcut behavior matches the sidebar button and tray event.

## Validation
- pnpm typecheck
- cargo fmt --all --check
- cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings
- cargo test -p ha-core -p ha-server --locked was started but interrupted per request before completion.

## Notes
- Pushed with HA_SKIP_PREPUSH=1 after the user requested to submit directly.