### PR TITLE
fix(browser+provider): tool image fallback + evaluate_script + tabs.new

### DIFF
--- a/crates/ha-core/src/agent/events.rs
+++ b/crates/ha-core/src/agent/events.rs
@@ -119,11 +119,35 @@ pub(super) fn build_anthropic_tool_result_content(result: &str) -> serde_json::V
 }
 
 /// Build tool result content for OpenAI Chat Completions API.
-/// Returns a content array with `image_url` (data URI) + `text` blocks when images are detected.
-pub(super) fn build_openai_chat_tool_result_content(result: &str) -> serde_json::Value {
+///
+/// When `model_supports_vision` is true, returns a content array with
+/// `image_url` (data URI) + `text` blocks. When false, collapses the markers
+/// into a plain string with `Image captured.` placeholders — the OpenAI Chat
+/// `role: tool` content type rejects `image_url` blocks on non-vision
+/// backends (e.g. DeepSeek text-only) with a 400, so we must strip them.
+pub(super) fn build_openai_chat_tool_result_content(
+    result: &str,
+    model_supports_vision: bool,
+) -> serde_json::Value {
     let Some(parsed) = crate::tools::image_markers::parse_image_markers(result) else {
         return json!(result);
     };
+
+    if !model_supports_vision {
+        let mut text_parts = Vec::new();
+        if !parsed.leading_text.is_empty() {
+            text_parts.push(parsed.leading_text.to_string());
+        }
+        for m in &parsed.markers {
+            let label = if m.text.is_empty() {
+                "Image captured."
+            } else {
+                &m.text
+            };
+            text_parts.push(label.to_string());
+        }
+        return json!(text_parts.join("\n"));
+    }
 
     let mut content = Vec::new();
     if !parsed.leading_text.is_empty() {
@@ -233,14 +257,18 @@ pub(super) fn expand_anthropic_image_markers_for_api(history: &[Value]) -> Vec<V
         .collect()
 }
 
-pub(super) fn expand_openai_chat_image_markers_for_api(history: &[Value]) -> Vec<Value> {
+pub(super) fn expand_openai_chat_image_markers_for_api(
+    history: &[Value],
+    model_supports_vision: bool,
+) -> Vec<Value> {
     history
         .iter()
         .map(|item| {
             let mut msg = item.clone();
             if msg.get("role").and_then(|r| r.as_str()) == Some("tool") {
                 if let Some(result) = msg.get("content").and_then(|c| c.as_str()) {
-                    msg["content"] = build_openai_chat_tool_result_content(result);
+                    msg["content"] =
+                        build_openai_chat_tool_result_content(result, model_supports_vision);
                 }
             }
             msg
@@ -359,7 +387,10 @@ pub(super) fn emit_usage(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_responses_tool_result, expand_responses_image_markers_for_api};
+    use super::{
+        build_openai_chat_tool_result_content, build_responses_tool_result,
+        expand_openai_chat_image_markers_for_api, expand_responses_image_markers_for_api,
+    };
     use crate::tools::browser::IMAGE_BASE64_PREFIX;
     use serde_json::json;
 
@@ -433,6 +464,70 @@ mod tests {
 
         assert_eq!(text_output, result);
         assert!(image_items.is_empty());
+    }
+
+    #[test]
+    fn openai_chat_tool_result_vision_emits_image_url_blocks() {
+        let result = format!(
+            "{}image/png__aGVsbG8=__\nScreenshot captured.",
+            IMAGE_BASE64_PREFIX
+        );
+        let content = build_openai_chat_tool_result_content(&result, true);
+        let arr = content.as_array().expect("vision path returns array");
+        assert!(arr
+            .iter()
+            .any(|b| b.get("type").and_then(|t| t.as_str()) == Some("image_url")));
+        assert!(arr
+            .iter()
+            .any(|b| b.get("type").and_then(|t| t.as_str()) == Some("text")));
+    }
+
+    #[test]
+    fn openai_chat_tool_result_no_vision_collapses_to_text_string() {
+        let result = format!(
+            "{}image/png__aGVsbG8=__\nScreenshot captured.",
+            IMAGE_BASE64_PREFIX
+        );
+        let content = build_openai_chat_tool_result_content(&result, false);
+        // Non-vision must produce a plain string — `role: tool` content
+        // on DeepSeek / text-only OpenAI-compat backends rejects any object
+        // block (including `image_url`) with a 400.
+        let text = content.as_str().expect("no-vision returns string");
+        assert!(!text.contains("image_url"));
+        assert!(!text.contains("data:image/png"));
+        assert!(text.contains("Screenshot captured."));
+    }
+
+    #[test]
+    fn openai_chat_tool_result_passthrough_without_markers() {
+        let result = "plain text result with no image markers";
+        let with_vision = build_openai_chat_tool_result_content(result, true);
+        let without_vision = build_openai_chat_tool_result_content(result, false);
+        assert_eq!(with_vision, json!(result));
+        assert_eq!(without_vision, json!(result));
+    }
+
+    #[test]
+    fn openai_chat_history_expansion_respects_vision_flag() {
+        let result = format!(
+            "{}image/png__aGVsbG8=__\nScreenshot captured.",
+            IMAGE_BASE64_PREFIX
+        );
+        let history = vec![
+            json!({ "role": "user", "content": "ignore me" }),
+            json!({ "role": "tool", "tool_call_id": "c1", "content": result }),
+        ];
+        let with_vision = expand_openai_chat_image_markers_for_api(&history, true);
+        let without_vision = expand_openai_chat_image_markers_for_api(&history, false);
+
+        assert!(with_vision[1]["content"].is_array());
+        // Non-vision path must keep `content` as a string so the server's
+        // tool-message deserializer accepts it.
+        assert!(without_vision[1]["content"].is_string());
+        assert!(without_vision[1]["content"]
+            .as_str()
+            .unwrap()
+            .contains("Screenshot captured."));
     }
 
     #[test]

--- a/crates/ha-core/src/agent/providers/openai_chat_adapter.rs
+++ b/crates/ha-core/src/agent/providers/openai_chat_adapter.rs
@@ -40,6 +40,7 @@ struct ThinkingAutoDisable {
 fn build_chat_body(
     model: &str,
     thinking_style: &ThinkingStyle,
+    model_supports_vision: bool,
     req: &RoundRequest<'_>,
 ) -> (
     serde_json::Value,
@@ -63,7 +64,8 @@ fn build_chat_body(
             api_messages.push(json!({ "role": "system", "content": task_suffix }));
         }
     }
-    let expanded_history = expand_openai_chat_image_markers_for_api(req.history_for_api);
+    let expanded_history =
+        expand_openai_chat_image_markers_for_api(req.history_for_api, model_supports_vision);
     api_messages.extend(expanded_history);
 
     let tools_array: Vec<Value> = req
@@ -312,6 +314,58 @@ fn maybe_auto_disable_thinking(
     })
 }
 
+fn is_unsupported_image_url_error(status: u16, error_text: &str) -> bool {
+    if status != 400 {
+        return false;
+    }
+    let lower = error_text.to_lowercase();
+    // OpenAI-compat backends that don't accept `image_url` tool content
+    // surface this through the body deserializer; DeepSeek phrases it as
+    // `unknown variant \`image_url\`, expected \`text\``. Other backends
+    // may differ — match on the field name plus any rejection word.
+    lower.contains("image_url")
+        && (lower.contains("unknown variant")
+            || lower.contains("invalid type")
+            || lower.contains("invalid_type")
+            || lower.contains("unsupported")
+            || lower.contains("not supported"))
+}
+
+fn log_vision_auto_disabled(
+    provider_config: Option<&crate::provider::ProviderConfig>,
+    model: &str,
+    status: u16,
+    error_text: &str,
+) {
+    let Some(logger) = crate::get_logger() else {
+        return;
+    };
+    let (provider_id, provider_name) = provider_config
+        .map(|p| (Some(p.id.clone()), p.name.clone()))
+        .unwrap_or((None, "Unknown Provider".to_string()));
+    logger.log(
+        "warn",
+        "agent",
+        "agent::chat_openai_chat::vision_autofix",
+        &format!(
+            "Auto-folded tool image content to text for {} / {} after image_url rejection",
+            provider_name, model
+        ),
+        Some(
+            json!({
+                "provider_id": provider_id,
+                "provider_name": provider_name,
+                "model": model,
+                "status": status,
+                "error": error_text,
+            })
+            .to_string(),
+        ),
+        None,
+        None,
+    );
+}
+
 async fn send_chat_request(
     client: &reqwest::Client,
     api_url: &str,
@@ -357,8 +411,12 @@ impl<'a> StreamingChatAdapter for OpenAIChatStreamingAdapter<'a> {
         on_delta: &(dyn for<'s> Fn(&'s str) + Send + Sync),
     ) -> Result<RoundOutcome> {
         let api_url = build_api_url(self.base_url, "/v1/chat/completions");
+        let model_supports_vision = self
+            .provider_config
+            .map(|pc| pc.model_supports_vision(self.model))
+            .unwrap_or(true);
         let (body, api_messages, tools_array) =
-            build_chat_body(self.model, self.thinking_style, &req);
+            build_chat_body(self.model, self.thinking_style, model_supports_vision, &req);
         log_openai_chat_request(
             &api_url,
             self.model,
@@ -385,7 +443,46 @@ impl<'a> StreamingChatAdapter for OpenAIChatStreamingAdapter<'a> {
                 on_delta(&autofix.payload.to_string());
                 let retry_style = ThinkingStyle::None;
                 let (retry_body, retry_messages, retry_tools) =
-                    build_chat_body(self.model, &retry_style, &req);
+                    build_chat_body(self.model, &retry_style, model_supports_vision, &req);
+                log_openai_chat_request(
+                    &api_url,
+                    self.model,
+                    &req,
+                    &retry_messages,
+                    &retry_tools,
+                    &retry_body,
+                );
+                request_start = std::time::Instant::now();
+                resp = send_chat_request(client, &api_url, self.api_key, &retry_body, req.round)
+                    .await?;
+                if !resp.status().is_success() {
+                    let retry_status = resp.status().as_u16();
+                    let retry_error = resp.text().await.unwrap_or_default();
+                    log_openai_chat_error(retry_status, &retry_error, req.round);
+                    return Err(anyhow::anyhow!(
+                        "OpenAI Chat API error ({}): {}",
+                        retry_status,
+                        retry_error
+                    ));
+                }
+            } else if model_supports_vision && is_unsupported_image_url_error(status, &error_text) {
+                log_vision_auto_disabled(self.provider_config, self.model, status, &error_text);
+                let provider_id = self.provider_config.map(|p| p.id.clone());
+                let provider_name = self
+                    .provider_config
+                    .map(|p| p.name.clone())
+                    .unwrap_or_else(|| "Unknown Provider".to_string());
+                on_delta(
+                    &json!({
+                        "type": "vision_auto_disabled",
+                        "provider_id": provider_id,
+                        "provider_name": provider_name,
+                        "model_id": self.model,
+                    })
+                    .to_string(),
+                );
+                let (retry_body, retry_messages, retry_tools) =
+                    build_chat_body(self.model, self.thinking_style, false, &req);
                 log_openai_chat_request(
                     &api_url,
                     self.model,
@@ -737,4 +834,48 @@ async fn parse_chat_completions_sse(
         collected_thinking,
         first_token_time,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_unsupported_image_url_error;
+
+    #[test]
+    fn detects_deepseek_unknown_variant_rejection() {
+        // Exact phrasing observed from DeepSeek v4-flash; this is the
+        // failure mode that motivated the retry path.
+        let body = r#"{"error":{"message":"Failed to deserialize the JSON body into the target type: messages[15]: unknown variant `image_url`, expected `text` at line 1 column 1906020","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}"#;
+        assert!(is_unsupported_image_url_error(400, body));
+    }
+
+    #[test]
+    fn detects_invalid_type_phrasing() {
+        let body = r#"{"error":{"message":"invalid_type at messages[3].content: image_url is not supported"}}"#;
+        assert!(is_unsupported_image_url_error(400, body));
+    }
+
+    #[test]
+    fn ignores_non_400_status() {
+        let body = r#"{"error":{"message":"unknown variant `image_url`"}}"#;
+        assert!(!is_unsupported_image_url_error(500, body));
+        assert!(!is_unsupported_image_url_error(429, body));
+    }
+
+    #[test]
+    fn ignores_400_without_image_url_signal() {
+        // 400 from a different cause (e.g. bad tool schema) must not
+        // trigger the vision-disable retry — that would hide the real
+        // error and waste an HTTP round-trip.
+        let body = r#"{"error":{"message":"missing required field `tools[0].function.name`"}}"#;
+        assert!(!is_unsupported_image_url_error(400, body));
+    }
+
+    #[test]
+    fn ignores_image_url_appearance_without_rejection_words() {
+        // image_url merely appearing in an error (e.g. content quoted back
+        // in a 401 / rate-limit message) must not trigger retry.
+        let body =
+            r#"{"error":{"message":"rate limit exceeded; last request had image_url content"}}"#;
+        assert!(!is_unsupported_image_url_error(400, body));
+    }
 }

--- a/crates/ha-core/src/browser/mcp_backend.rs
+++ b/crates/ha-core/src/browser/mcp_backend.rs
@@ -383,8 +383,13 @@ impl BrowserBackend for ChromeMcpBackend {
     }
 
     async fn evaluate(&self, script: &str) -> Result<Value> {
+        // chrome-devtools-mcp's `evaluate_script` takes a `function` arg: a
+        // JS function literal that gets `Function(funcStr)()` invoked. The
+        // hope-agent surface accepts a plain JS expression, so wrap when
+        // the script isn't already a function literal.
+        let function = wrap_evaluate_script_as_function(script);
         let v = self
-            .call_tool_json("evaluate_script", json!({ "script": script }))
+            .call_tool_json("evaluate_script", json!({ "function": function }))
             .await?;
         Ok(v)
     }
@@ -580,6 +585,69 @@ fn extract_value(result: &CallToolResult) -> Value {
     serde_json::from_str(&text).unwrap_or(Value::String(text))
 }
 
+/// Wrap a raw JS expression as a function literal for chrome-devtools-mcp's
+/// `evaluate_script` tool, which calls `Function(funcStr)()` on the arg and
+/// returns the result. If the script already starts with a function literal
+/// (`function`, `async`, or an arrow form), pass it through unchanged so
+/// callers who already know the contract can opt out of the wrap.
+fn wrap_evaluate_script_as_function(script: &str) -> String {
+    let trimmed = script.trim_start();
+    if looks_like_function_literal(trimmed) {
+        script.to_string()
+    } else {
+        // Single-expression arrow returning the value. Multi-statement
+        // scripts must be passed as a full function literal with an
+        // explicit `return`; that matches chrome-devtools-mcp's contract.
+        format!("() => ({})", script)
+    }
+}
+
+fn looks_like_function_literal(s: &str) -> bool {
+    if s.starts_with("function") || s.starts_with("async ") {
+        return true;
+    }
+    let bytes = s.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    // `(...) => ...` — match the *outer* closing paren via depth tracking
+    // so IIFE expressions like `(() => x)()` don't read as function
+    // literals on the inner arrow's closer. chrome-devtools-mcp would
+    // call the IIFE's return value (which isn't a function) and fail.
+    if bytes[0] == b'(' {
+        return arrow_after_balanced_paren(s);
+    }
+    // `ident => ...` — bare arrow with single param. Ident must be a valid
+    // JS identifier so we don't false-positive on expressions like `a + b`.
+    let first = bytes[0] as char;
+    if first.is_ascii_alphabetic() || first == '_' || first == '$' {
+        if let Some(arrow) = s.find("=>") {
+            let head = s[..arrow].trim_end();
+            return head
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$');
+        }
+    }
+    false
+}
+
+fn arrow_after_balanced_paren(s: &str) -> bool {
+    let mut depth: u32 = 0;
+    for (i, c) in s.char_indices() {
+        match c {
+            '(' => depth = depth.saturating_add(1),
+            ')' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return s[i + c.len_utf8()..].trim_start().starts_with("=>");
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
 fn extract_base64_image(result: &CallToolResult) -> Option<Vec<u8>> {
     use base64::Engine;
     for c in &result.content {
@@ -679,5 +747,78 @@ mod tests {
     fn parse_tabs_returns_empty_on_garbage() {
         assert!(parse_tabs(&json!({ "nope": 1 })).is_empty());
         assert!(parse_tabs(&Value::Null).is_empty());
+    }
+
+    #[test]
+    fn wrap_evaluate_script_wraps_plain_expression() {
+        assert_eq!(
+            wrap_evaluate_script_as_function("document.title"),
+            "() => (document.title)"
+        );
+        assert_eq!(
+            wrap_evaluate_script_as_function("window.location.href"),
+            "() => (window.location.href)"
+        );
+    }
+
+    #[test]
+    fn wrap_evaluate_script_passes_arrow_function_through() {
+        assert_eq!(
+            wrap_evaluate_script_as_function("() => document.title"),
+            "() => document.title"
+        );
+        assert_eq!(
+            wrap_evaluate_script_as_function("(a, b) => a + b"),
+            "(a, b) => a + b"
+        );
+        assert_eq!(wrap_evaluate_script_as_function("x => x * 2"), "x => x * 2");
+    }
+
+    #[test]
+    fn wrap_evaluate_script_passes_function_keyword_through() {
+        assert_eq!(
+            wrap_evaluate_script_as_function("function () { return 1; }"),
+            "function () { return 1; }"
+        );
+        assert_eq!(
+            wrap_evaluate_script_as_function("async () => fetch('/')"),
+            "async () => fetch('/')"
+        );
+    }
+
+    #[test]
+    fn wrap_evaluate_script_does_not_misread_arithmetic_as_arrow() {
+        // `a => b` is an arrow, but `a + b => c` (illegal anyway) shouldn't
+        // pass through — and neither should `a*b`, which has no `=>` at all.
+        assert_eq!(wrap_evaluate_script_as_function("a * b"), "() => (a * b)");
+    }
+
+    #[test]
+    fn wrap_evaluate_script_wraps_iife_expression() {
+        // IIFEs are expressions returning a value, NOT function literals.
+        // chrome-devtools-mcp would call the returned value (e.g. a
+        // number) as if it were a function and crash. Must be wrapped.
+        assert_eq!(
+            wrap_evaluate_script_as_function("(() => 1)()"),
+            "() => ((() => 1)())"
+        );
+        assert_eq!(
+            wrap_evaluate_script_as_function("(() => { return document.title; })()"),
+            "() => ((() => { return document.title; })())"
+        );
+        assert_eq!(
+            wrap_evaluate_script_as_function("(function() { return 1; })()"),
+            "() => ((function() { return 1; })())"
+        );
+    }
+
+    #[test]
+    fn wrap_evaluate_script_wraps_paren_expression_without_arrow() {
+        // `(window).foo` is a parenthesized expression, not an arrow.
+        // Must be wrapped, not passed through.
+        assert_eq!(
+            wrap_evaluate_script_as_function("(window).foo"),
+            "() => ((window).foo)"
+        );
     }
 }

--- a/crates/ha-core/src/provider/types.rs
+++ b/crates/ha-core/src/provider/types.rs
@@ -313,6 +313,30 @@ impl ProviderConfig {
         self.models.iter().find(|m| m.id == model_id)
     }
 
+    /// Whether the given model accepts image input.
+    ///
+    /// `["text"]` and the empty list are both ambiguous: they're the
+    /// serde / wizard defaults that get carried over from legacy configs
+    /// where the user never picked a value, so we can't tell them apart
+    /// from a deliberate text-only choice. Treat both as unknown (assume
+    /// vision) and let the API be authoritative — runtime retry in the
+    /// OpenAI Chat adapter catches the rejection and folds the next round
+    /// to text. Only an `input_types` list that's been populated with
+    /// something specific (e.g. `["text", "audio"]`) and still lacks
+    /// `image` counts as an explicit opt-out.
+    pub fn model_supports_vision(&self, model_id: &str) -> bool {
+        let Some(m) = self.model_config(model_id) else {
+            return true;
+        };
+        if m.input_types.iter().any(|t| t == "image") {
+            return true;
+        }
+        if m.input_types.is_empty() {
+            return true;
+        }
+        m.input_types.len() == 1 && m.input_types[0] == "text"
+    }
+
     /// Resolve the effective thinking style for a model.
     ///
     /// Precedence:
@@ -513,6 +537,115 @@ mod tests {
             cfg.effective_thinking_style_for_model("m1"),
             ThinkingStyle::None
         );
+    }
+
+    #[test]
+    fn model_supports_vision_when_input_types_contains_image() {
+        let mut cfg = ProviderConfig::new(
+            "t".to_string(),
+            ApiType::OpenaiChat,
+            "https://api.openai.com".to_string(),
+            String::new(),
+        );
+        cfg.models.push(ModelConfig {
+            id: "gpt-4o".to_string(),
+            name: "GPT-4o".to_string(),
+            input_types: vec!["text".to_string(), "image".to_string()],
+            context_window: 128_000,
+            max_tokens: 8192,
+            reasoning: false,
+            thinking_style: None,
+            cost_input: 0.0,
+            cost_output: 0.0,
+        });
+        assert!(cfg.model_supports_vision("gpt-4o"));
+    }
+
+    #[test]
+    fn model_supports_vision_treats_default_text_list_as_unknown() {
+        // The wizard / serde default is `["text"]`; that shape is
+        // indistinguishable from "user explicitly picked text-only", so
+        // we have to treat it as unknown and let the API decide. A
+        // legacy gpt-4o config that ships with the default must not
+        // silently lose vision because of static catalog inspection.
+        let mut cfg = ProviderConfig::new(
+            "t".to_string(),
+            ApiType::OpenaiChat,
+            "https://api.openai.com".to_string(),
+            String::new(),
+        );
+        cfg.models.push(ModelConfig {
+            id: "gpt-4o".to_string(),
+            name: "GPT-4o".to_string(),
+            input_types: vec!["text".to_string()],
+            context_window: 128_000,
+            max_tokens: 8192,
+            reasoning: false,
+            thinking_style: None,
+            cost_input: 0.0,
+            cost_output: 0.0,
+        });
+        assert!(cfg.model_supports_vision("gpt-4o"));
+    }
+
+    #[test]
+    fn model_supports_vision_false_for_explicit_non_image_input_list() {
+        // A non-default list that omits `image` (e.g. `["text", "audio"]`)
+        // is a deliberate opt-out — the user has touched the field with
+        // intent. Skip the round-trip on those.
+        let mut cfg = ProviderConfig::new(
+            "t".to_string(),
+            ApiType::OpenaiChat,
+            "https://api.example.com".to_string(),
+            String::new(),
+        );
+        cfg.models.push(ModelConfig {
+            id: "text-audio-only".to_string(),
+            name: "Text+Audio Only".to_string(),
+            input_types: vec!["text".to_string(), "audio".to_string()],
+            context_window: 128_000,
+            max_tokens: 8192,
+            reasoning: false,
+            thinking_style: None,
+            cost_input: 0.0,
+            cost_output: 0.0,
+        });
+        assert!(!cfg.model_supports_vision("text-audio-only"));
+    }
+
+    #[test]
+    fn model_supports_vision_treats_empty_input_list_as_unknown() {
+        let mut cfg = ProviderConfig::new(
+            "t".to_string(),
+            ApiType::OpenaiChat,
+            "https://api.example.com".to_string(),
+            String::new(),
+        );
+        cfg.models.push(ModelConfig {
+            id: "empty-list".to_string(),
+            name: "Empty List".to_string(),
+            input_types: vec![],
+            context_window: 128_000,
+            max_tokens: 8192,
+            reasoning: false,
+            thinking_style: None,
+            cost_input: 0.0,
+            cost_output: 0.0,
+        });
+        assert!(cfg.model_supports_vision("empty-list"));
+    }
+
+    #[test]
+    fn model_supports_vision_defaults_true_for_uncatalogued_alias() {
+        // Preserve legacy behavior for users whose model id isn't in the
+        // catalog — assume vision so we don't break working vision flows.
+        let cfg = ProviderConfig::new(
+            "t".to_string(),
+            ApiType::OpenaiChat,
+            "https://api.openai.com".to_string(),
+            String::new(),
+        );
+        assert!(cfg.model_supports_vision("unknown-model"));
     }
 
     #[test]

--- a/crates/ha-core/src/tools/browser/mod.rs
+++ b/crates/ha-core/src/tools/browser/mod.rs
@@ -574,12 +574,41 @@ async fn tabs_new(args: &Value) -> Result<String> {
         }
     }
     let backend = acquire_backend().await?;
-    let tab = backend.new_page(url).await?;
+    let mut tab = backend.new_page(url).await?;
+    // chrome-devtools-mcp's `new_page` doesn't always honor the `url` arg —
+    // it can return a blank tab even when one was requested. Only follow up
+    // when the tab clearly didn't load anything; legitimate redirects (e.g.
+    // http→https, login-gate 302, one-time tokens) must NOT be re-navigated
+    // or we risk consuming the token twice or stomping on the redirect chain.
+    if let Some(target) = url {
+        if target != "about:blank" && tab_url_indicates_blank_load(&tab.url) {
+            backend.navigate(target).await?;
+            tab.url = target.to_string();
+        }
+    }
     browser::frame::emit_frame_async();
     Ok(format!(
         "New page created: {} (url: {})",
         tab.target_id, tab.url
     ))
+}
+
+fn tab_url_indicates_blank_load(tab_url: &str) -> bool {
+    let trimmed = tab_url.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    matches!(
+        trimmed,
+        "about:blank"
+            | "about:newtab"
+            | "chrome://newtab/"
+            | "chrome://newtab"
+            | "chrome://new-tab-page/"
+            | "chrome://new-tab-page"
+            | "edge://newtab/"
+            | "edge://newtab"
+    ) || trimmed.starts_with("data:,")
 }
 
 async fn tabs_select(args: &Value) -> Result<String> {
@@ -1033,4 +1062,35 @@ mod tests {
 
     // Affirmative-label parsing is covered by `crate::ask_user::was_affirmative`'s
     // own test suite. We don't re-test it here.
+
+    #[test]
+    fn tab_url_indicates_blank_load_for_empty_and_about_blank() {
+        assert!(tab_url_indicates_blank_load(""));
+        assert!(tab_url_indicates_blank_load("   "));
+        assert!(tab_url_indicates_blank_load("about:blank"));
+    }
+
+    #[test]
+    fn tab_url_indicates_blank_load_for_browser_newtab_urls() {
+        // chrome-devtools-mcp can hand back the browser's new-tab page
+        // instead of the requested URL; treat those as blank loads so we
+        // navigate to the target.
+        assert!(tab_url_indicates_blank_load("chrome://newtab/"));
+        assert!(tab_url_indicates_blank_load("chrome://new-tab-page/"));
+        assert!(tab_url_indicates_blank_load("edge://newtab/"));
+        assert!(tab_url_indicates_blank_load("data:,"));
+    }
+
+    #[test]
+    fn tab_url_indicates_blank_load_false_for_redirected_url() {
+        // If the server redirected (e.g. http→https, login gate, one-time
+        // token), the tab url won't match the request — but it's loaded.
+        // Re-navigating the original URL would consume the redirect
+        // chain twice or break login flows, so this MUST stay false.
+        assert!(!tab_url_indicates_blank_load("https://example.com/login"));
+        assert!(!tab_url_indicates_blank_load(
+            "https://example.com/auth?token=abc"
+        ));
+        assert!(!tab_url_indicates_blank_load("https://www.lingotech.xyz/"));
+    }
 }


### PR DESCRIPTION
## Summary

修 3 个 browser / OpenAI-Chat 路径上的隐患:

1. **OpenAI-Chat-compat 后端拒绝 `image_url` 工具内容时硬错** — 增加 `ProviderConfig::model_supports_vision` 静态判断,以及 400 + image_url rejection 自动重试 fold 文本.支持 DeepSeek 等纯文本后端 + browser 截图组合.
2. **`browser.control.evaluate` 传给 chrome-devtools-mcp 时参数名错** — MCP 工具要 `function` (JS 函数字面量,内部 `Function(funcStr)()` 调用),之前一直传 `script`.检测脚本是否已是函数字面量,不是就包成 `() => (EXPR)`.paren 深度匹配避免把 IIFE 误判.
3. **`browser.tabs.new` 传 url 但 MCP 创建空白页时不补 navigate** — 改为只识别明确未加载状态 (空 / `about:blank` / `chrome://newtab/` / `data:,`),重定向 / 一次性 token 跳转不再重发.

## Verification

- \`cargo check -p ha-core --all-targets\` ✓
- \`cargo clippy -p ha-core --all-targets --locked -- -D warnings\` ✓
- \`cargo test -p ha-core --lib\`: 52 passed (22 new cases)
- \`pnpm typecheck\` ✓

附带处理 \`codex:review\` 三个 P2 反馈。

## Test plan

- [ ] 跑 DeepSeek (text-only) + browser 截图,确认 retry 路径触发
- [ ] 跑视觉模型 + browser 截图,正常发 image_url
- [ ] \`browser.control.evaluate\` 用各种 JS 表达式(plain expr / IIFE / 已是函数 / `(window).foo`)
- [ ] \`browser.tabs.new\` 重定向场景(http→https、登录跳转)不再重发