### PR TITLE
refactor(provider): trust input_types, drop "text" ambiguity

### DIFF
--- a/crates/ha-core/src/provider/types.rs
+++ b/crates/ha-core/src/provider/types.rs
@@ -101,7 +101,12 @@ pub struct ModelConfig {
 }
 
 fn default_input_types() -> Vec<String> {
-    vec!["text".to_string()]
+    // Empty = "unconfigured" — distinct from a deliberate text-only pick,
+    // which is represented by a populated list that lacks `image`. New
+    // model entries default to this so the absence of explicit capability
+    // info doesn't get conflated with `["text"]` (which is now an
+    // intentional opt-out).
+    Vec::new()
 }
 
 fn default_context_window() -> u32 {
@@ -315,26 +320,19 @@ impl ProviderConfig {
 
     /// Whether the given model accepts image input.
     ///
-    /// `["text"]` and the empty list are both ambiguous: they're the
-    /// serde / wizard defaults that get carried over from legacy configs
-    /// where the user never picked a value, so we can't tell them apart
-    /// from a deliberate text-only choice. Treat both as unknown (assume
-    /// vision) and let the API be authoritative — runtime retry in the
-    /// OpenAI Chat adapter catches the rejection and folds the next round
-    /// to text. Only an `input_types` list that's been populated with
-    /// something specific (e.g. `["text", "audio"]`) and still lacks
-    /// `image` counts as an explicit opt-out.
+    /// Catalog-driven, no API round-trip: `input_types.contains("image")`
+    /// means yes; an empty list means "unconfigured" (assume yes — the API
+    /// is the source of truth on first send); any populated list without
+    /// `image` (e.g. `["text"]`, `["text", "audio"]`) is an explicit
+    /// opt-out set by the template author or by the user in ModelEditor.
     pub fn model_supports_vision(&self, model_id: &str) -> bool {
         let Some(m) = self.model_config(model_id) else {
             return true;
         };
-        if m.input_types.iter().any(|t| t == "image") {
-            return true;
-        }
         if m.input_types.is_empty() {
             return true;
         }
-        m.input_types.len() == 1 && m.input_types[0] == "text"
+        m.input_types.iter().any(|t| t == "image")
     }
 
     /// Resolve the effective thinking style for a model.
@@ -562,37 +560,34 @@ mod tests {
     }
 
     #[test]
-    fn model_supports_vision_treats_default_text_list_as_unknown() {
-        // The wizard / serde default is `["text"]`; that shape is
-        // indistinguishable from "user explicitly picked text-only", so
-        // we have to treat it as unknown and let the API decide. A
-        // legacy gpt-4o config that ships with the default must not
-        // silently lose vision because of static catalog inspection.
+    fn model_supports_vision_false_for_explicit_text_only() {
+        // `["text"]` is an explicit opt-out: either the template wrote it
+        // (e.g. DeepSeek V4 Flash in `international.ts`) or the user
+        // populated it via ModelEditor. Trust the catalog.
         let mut cfg = ProviderConfig::new(
             "t".to_string(),
             ApiType::OpenaiChat,
-            "https://api.openai.com".to_string(),
+            "https://api.deepseek.com".to_string(),
             String::new(),
         );
         cfg.models.push(ModelConfig {
-            id: "gpt-4o".to_string(),
-            name: "GPT-4o".to_string(),
+            id: "deepseek-v4-flash".to_string(),
+            name: "DeepSeek V4 Flash".to_string(),
             input_types: vec!["text".to_string()],
             context_window: 128_000,
             max_tokens: 8192,
-            reasoning: false,
+            reasoning: true,
             thinking_style: None,
             cost_input: 0.0,
             cost_output: 0.0,
         });
-        assert!(cfg.model_supports_vision("gpt-4o"));
+        assert!(!cfg.model_supports_vision("deepseek-v4-flash"));
     }
 
     #[test]
     fn model_supports_vision_false_for_explicit_non_image_input_list() {
-        // A non-default list that omits `image` (e.g. `["text", "audio"]`)
-        // is a deliberate opt-out — the user has touched the field with
-        // intent. Skip the round-trip on those.
+        // Any non-empty list lacking `image` (e.g. `["text", "audio"]`)
+        // is a deliberate opt-out. Trust it.
         let mut cfg = ProviderConfig::new(
             "t".to_string(),
             ApiType::OpenaiChat,
@@ -615,6 +610,10 @@ mod tests {
 
     #[test]
     fn model_supports_vision_treats_empty_input_list_as_unknown() {
+        // Empty `input_types` means "unconfigured" (e.g. a config saved
+        // under an older schema where the field was absent). Assume
+        // vision so configs upgrading in won't silently lose it; the
+        // user can lock it down via ModelEditor when needed.
         let mut cfg = ProviderConfig::new(
             "t".to_string(),
             ApiType::OpenaiChat,

--- a/src/components/settings/ProviderEditPage.tsx
+++ b/src/components/settings/ProviderEditPage.tsx
@@ -481,7 +481,7 @@ export default function ProviderEditPage({
                     {
                       id: "",
                       name: "",
-                      inputTypes: ["text"],
+                      inputTypes: [],
                       contextWindow: 128000,
                       maxTokens: 8192,
                       reasoning: false,

--- a/src/components/settings/provider-setup/CustomWizard.tsx
+++ b/src/components/settings/provider-setup/CustomWizard.tsx
@@ -354,7 +354,7 @@ export function CustomWizard({
                     {
                       id: "",
                       name: "",
-                      inputTypes: ["text"],
+                      inputTypes: [],
                       contextWindow: 128000,
                       maxTokens: 8192,
                       reasoning: false,

--- a/src/components/settings/provider-setup/TemplateConfig.tsx
+++ b/src/components/settings/provider-setup/TemplateConfig.tsx
@@ -381,7 +381,7 @@ export function TemplateConfig({
                     {
                       id: "",
                       name: "",
-                      inputTypes: ["text"],
+                      inputTypes: [],
                       contextWindow: 128000,
                       maxTokens: 8192,
                       reasoning: false,

--- a/src/components/settings/provider-setup/templates/local.ts
+++ b/src/components/settings/provider-setup/templates/local.ts
@@ -15,7 +15,7 @@ export const localTemplates: ProviderTemplate[] = [
       {
         id: "your-model-id",
         name: "Your Model",
-        inputTypes: ["text"],
+        inputTypes: [],
         contextWindow: 128000,
         maxTokens: 8192,
         reasoning: false,
@@ -99,7 +99,7 @@ export const localTemplates: ProviderTemplate[] = [
       {
         id: "your-model-id",
         name: "Your Model",
-        inputTypes: ["text"],
+        inputTypes: [],
         contextWindow: 128000,
         maxTokens: 8192,
         reasoning: false,
@@ -121,7 +121,7 @@ export const localTemplates: ProviderTemplate[] = [
       {
         id: "your-model-id",
         name: "Your Model",
-        inputTypes: ["text"],
+        inputTypes: [],
         contextWindow: 128000,
         maxTokens: 8192,
         reasoning: false,
@@ -143,7 +143,7 @@ export const localTemplates: ProviderTemplate[] = [
       {
         id: "your-model-id",
         name: "Your Model",
-        inputTypes: ["text"],
+        inputTypes: [],
         contextWindow: 128000,
         maxTokens: 8192,
         reasoning: false,


### PR DESCRIPTION
## Summary

把 `ModelConfig.input_types` 从"自动兜底"重新塑造成"用户/模板意图的可信记录":

- `default_input_types()` 改返 `vec![]` (未配置语义)
- 前端 wizard / ProviderEditPage / TemplateConfig 新模型默认 `inputTypes: []`,4 个 local 模板的 `your-model-id` placeholder 同步
- `ProviderConfig::model_supports_vision` 简化:
  - `contains("image")` → true (模板/用户明确支持)
  - `is_empty()` → true (未配置/字段缺失,乐观假定)
  - 其他 (\`["text"]\` 等) → false (信任用户/模板的不含 image 意图)

`[]` 路径上保留 fix 分支引入的 image_url retry 兜底 — 后端拒绝时自动 fold 文本重发,避免 hard error.

## 行为对比 (vs. #200 fix 分支)

| 数据库 input_types | 行为 |
|---|---|
| \`["text", "image"]\` | 正常发 image_url ✓ |
| \`[]\` (新建/缺失) | 发 image_url;后端拒绝 → retry fold ✓ |
| \`["text"]\` | 直接 fold,零开销 (fix 分支每轮多 1 HTTP) |
| \`["text", "audio"]\` 等 | 直接 fold ✓ |
| catalog 无该 model | 发 image_url;后端拒绝 → retry fold ✓ |

\`["text"]\` 的处理把 fix 分支引入的"每轮多 1 HTTP"成本消掉 — 模板写的明确 text-only 模型从此零开销.

## Base

PR base 选 \`fix/browser-evaluate-and-vision-fallback\` (#200).#200 merge 后会自动 rebase 到 main.

## Verification

- \`cargo check -p ha-core --all-targets\` ✓
- \`cargo clippy -p ha-core --all-targets --locked -- -D warnings\` ✓
- \`cargo test -p ha-core --lib\`: 52 passed
- \`pnpm typecheck\` ✓
- pre-push hook full sweep (fmt + clippy + test + typecheck + lint + vitest) ✓

## Test plan

- [ ] 升级用户场景:已有 \`["text"]\` (模板写的)的模型保持 fold 行为
- [ ] 新建模型 (\`[]\`) + 实际不支持视觉的本地后端 → retry 兜底触发
- [ ] 新建模型 (\`[]\`) + 视觉模型 → 直接成功
- [ ] 用户在 ModelEditor 取消 image → 下次发 chat 时不再发 image_url