### PR TITLE
feat(ui): 🦭 右侧面板纯白底 + 技能草稿归位自我进化 Tab

### DIFF
--- a/src/components/chat/BrowserPanel.tsx
+++ b/src/components/chat/BrowserPanel.tsx
@@ -151,7 +151,7 @@ export default function BrowserPanel({
       >
         <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
       </div>
-      <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-border/70 bg-card text-card-foreground shadow-sm">
+      <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-border/70 bg-background text-foreground shadow-sm">
       {/* Header */}
       <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
         <Globe className="h-4 w-4 text-muted-foreground" />

--- a/src/components/chat/CanvasPanel.tsx
+++ b/src/components/chat/CanvasPanel.tsx
@@ -480,13 +480,13 @@ export default function CanvasPanel({
         className={
           maximized
             ? "fixed inset-0 z-50 flex flex-col bg-background"
-            : "flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-border/70 bg-card shadow-sm"
+            : "flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
         }
       >
         {/* Title Bar */}
         <div
           className={cn(
-            "flex h-11 items-center gap-2 border-b border-border/60 bg-card/95 px-4 shrink-0",
+            "flex h-11 items-center gap-2 border-b border-border/60 bg-background px-4 shrink-0",
             maximized && "h-[72px] items-end pb-2 pt-7",
           )}
           data-tauri-drag-region

--- a/src/components/chat/diff-panel/DiffPanel.tsx
+++ b/src/components/chat/diff-panel/DiffPanel.tsx
@@ -57,7 +57,7 @@ export function DiffPanel({
   const change = changes[safeIndex]
 
   const wrapperClasses = cn(
-    "flex h-full min-h-0 w-full flex-col rounded-lg border border-border bg-card shadow-sm",
+    "flex h-full min-h-0 w-full flex-col rounded-lg border border-border bg-background shadow-sm",
     embedded ? "" : "max-w-4xl",
   )
 

--- a/src/components/chat/plan-mode/PlanPanel.tsx
+++ b/src/components/chat/plan-mode/PlanPanel.tsx
@@ -301,7 +301,7 @@ export function PlanPanel({
     : cn(
         "flex h-full min-h-0 flex-col shrink-0 overflow-hidden animate-in slide-in-from-right-2 duration-200",
         embedded
-          ? "w-full rounded-xl border border-border/70 bg-card shadow-sm"
+          ? "w-full rounded-xl border border-border/70 bg-background shadow-sm"
           : desktopMode
             ? "max-w-[40vw] bg-background"
             : "max-w-[42vw] border-l border-border/70 bg-background/95",
@@ -309,7 +309,7 @@ export function PlanPanel({
   const headerClass = cn(
     "flex items-center gap-2 px-3 border-b shrink-0",
     embedded
-      ? "h-11 border-border/60 bg-card/95 px-4"
+      ? "h-11 border-border/60 bg-background px-4"
       : desktopMode
         ? "py-2 border-border bg-secondary/30"
         : "h-10 border-border/70 bg-background/95",
@@ -317,7 +317,7 @@ export function PlanPanel({
   )
   const actionBarClass = cn(
     "px-3 py-3 border-t border-border shrink-0 space-y-2",
-    embedded ? "bg-card/95" : desktopMode ? "bg-secondary/20" : "bg-background/95",
+    embedded ? "bg-background" : desktopMode ? "bg-secondary/20" : "bg-background/95",
   )
 
   // Detached: show compact placeholder

--- a/src/components/settings/skills-panel/DraftReviewSection.tsx
+++ b/src/components/settings/skills-panel/DraftReviewSection.tsx
@@ -27,7 +27,7 @@ export default function DraftReviewSection({
   if (drafts.length === 0) return null
 
   return (
-    <div className="mb-5 rounded-lg border border-amber-500/40 bg-amber-500/5 p-3">
+    <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3">
       <div className="flex items-center gap-2 mb-2">
         <Sparkles className="h-4 w-4 text-amber-500" />
         <h3 className="text-sm font-semibold text-foreground">
@@ -40,7 +40,7 @@ export default function DraftReviewSection({
       <p className="text-xs text-muted-foreground mb-3">
         {t("settings.skillsDraftsDesc")}
       </p>
-      <div className="space-y-1.5">
+      <div className="space-y-1.5 max-h-48 overflow-y-auto pr-1">
         {drafts.map((d) => {
           const pending = pendingAction[d.name]
           return (

--- a/src/components/settings/skills-panel/SkillEvolutionView.tsx
+++ b/src/components/settings/skills-panel/SkillEvolutionView.tsx
@@ -18,6 +18,8 @@ import { IconTip } from "@/components/ui/tooltip"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import { cn } from "@/lib/utils"
+import type { SkillSummary } from "../types"
+import DraftReviewSection from "./DraftReviewSection"
 
 // ──────────────────────────────────────────────────────────────────────
 // Types — kept locally; the Rust side serializes camelCase via serde.
@@ -87,6 +89,11 @@ interface SkillEvolutionViewProps {
   autoReviewPromotion: boolean
   onSetAutoReviewEnabled: (v: boolean) => void
   onSetAutoReviewPromotion: (v: boolean) => void
+  drafts: SkillSummary[]
+  draftPending: Record<string, "activate" | "discard" | undefined>
+  onActivateDraft: (name: string) => void
+  onDiscardDraft: (name: string) => void
+  onSelectSkill: (name: string) => void
 }
 
 type SaveStatus = "idle" | "saving" | "saved" | "failed"
@@ -96,6 +103,11 @@ export default function SkillEvolutionView({
   autoReviewPromotion,
   onSetAutoReviewEnabled,
   onSetAutoReviewPromotion,
+  drafts,
+  draftPending,
+  onActivateDraft,
+  onDiscardDraft,
+  onSelectSkill,
 }: SkillEvolutionViewProps) {
   const { t } = useTranslation()
   const [cfg, setCfg] = useState<AutoReviewConfig | null>(null)
@@ -322,6 +334,15 @@ export default function SkillEvolutionView({
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto p-6 space-y-5">
+      {/* ── Drafts awaiting review ──────────────────────────────────── */}
+      <DraftReviewSection
+        drafts={drafts}
+        pendingAction={draftPending}
+        onActivate={onActivateDraft}
+        onDiscard={onDiscardDraft}
+        onSelectSkill={onSelectSkill}
+      />
+
       {/* ── Hero: master switch ─────────────────────────────────────── */}
       <div className="overflow-hidden rounded-2xl border border-violet-500/25 bg-gradient-to-br from-violet-500/10 via-fuchsia-500/8 to-pink-500/5 dark:border-violet-400/30 dark:from-violet-500/15 dark:via-fuchsia-500/12 dark:to-pink-500/8">
         <div className="flex items-start gap-4 p-6">

--- a/src/components/settings/skills-panel/index.tsx
+++ b/src/components/settings/skills-panel/index.tsx
@@ -22,6 +22,7 @@ import QuickImportDialog from "./QuickImportDialog"
 export default function SkillsPanel() {
   const { t } = useTranslation()
   const { drafts } = useDraftSkillsStore()
+  const [activeTab, setActiveTab] = useState<"manage" | "evolution">("manage")
   const [skills, setSkills] = useState<SkillSummary[]>([])
   const [draftPending, setDraftPending] = useState<
     Record<string, "activate" | "discard" | undefined>
@@ -69,12 +70,15 @@ export default function SkillsPanel() {
     return unlisten
   }, [reload])
 
-  // Whenever the panel is open and the draft list changes (mount, store
-  // refresh, or live event), the user is implicitly "seeing" the current set —
-  // clear the unseen-count badge that drives the IconSidebar / SettingsView dots.
+  // Drafts now live inside the Evolution tab — only mark them seen when the
+  // user actually lands on (or is already on) that tab. Doing it on panel
+  // mount would clear the IconSidebar / SettingsView dots before the user
+  // ever sees the list.
   useEffect(() => {
-    markDraftsSeen()
-  }, [drafts])
+    if (activeTab === "evolution") {
+      markDraftsSeen()
+    }
+  }, [activeTab, drafts])
 
   useEffect(() => {
     let cancelled = false
@@ -306,7 +310,11 @@ export default function SkillsPanel() {
   // ── Skills List View ───────────────────────────────────────────
   return (
     <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
-      <Tabs defaultValue="manage" className="flex-1 flex flex-col min-h-0">
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as "manage" | "evolution")}
+        className="flex-1 flex flex-col min-h-0"
+      >
         <div className="px-6 pt-4 shrink-0">
           <TabsList>
             <TabsTrigger value="manage">{t("settings.skillsTab.manage")}</TabsTrigger>

--- a/src/components/settings/skills-panel/index.tsx
+++ b/src/components/settings/skills-panel/index.tsx
@@ -17,7 +17,6 @@ import type { SkillDetail } from "./types"
 import SkillListView from "./SkillListView"
 import SkillEvolutionView from "./SkillEvolutionView"
 import SkillDetailView from "./SkillDetailView"
-import DraftReviewSection from "./DraftReviewSection"
 import QuickImportDialog from "./QuickImportDialog"
 
 export default function SkillsPanel() {
@@ -307,23 +306,17 @@ export default function SkillsPanel() {
   // ── Skills List View ───────────────────────────────────────────
   return (
     <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
-      {drafts.length > 0 && (
-        <div className="px-6 pt-4">
-          <DraftReviewSection
-            drafts={drafts}
-            pendingAction={draftPending}
-            onActivate={handleActivateDraft}
-            onDiscard={handleDiscardDraft}
-            onSelectSkill={handleSelectSkill}
-          />
-        </div>
-      )}
       <Tabs defaultValue="manage" className="flex-1 flex flex-col min-h-0">
         <div className="px-6 pt-4 shrink-0">
           <TabsList>
             <TabsTrigger value="manage">{t("settings.skillsTab.manage")}</TabsTrigger>
-            <TabsTrigger value="evolution">
+            <TabsTrigger value="evolution" className="gap-1.5">
               {t("settings.skillsTab.evolution")}
+              {drafts.length > 0 && (
+                <span className="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-amber-500/15 px-1.5 text-[10px] font-semibold text-amber-600 dark:text-amber-400">
+                  {drafts.length}
+                </span>
+              )}
             </TabsTrigger>
           </TabsList>
         </div>
@@ -349,6 +342,11 @@ export default function SkillsPanel() {
             autoReviewPromotion={autoReviewPromotion}
             onSetAutoReviewEnabled={handleSetAutoReviewEnabled}
             onSetAutoReviewPromotion={handleSetAutoReviewPromotion}
+            drafts={drafts}
+            draftPending={draftPending}
+            onActivateDraft={handleActivateDraft}
+            onDiscardDraft={handleDiscardDraft}
+            onSelectSkill={handleSelectSkill}
           />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
## Summary

- Plan / Canvas / Browser / Diff 四个对话右侧面板根容器由 `bg-card` 改为 `bg-background`，光照模式下从 `hsl(0 0% 98%)` 微灰转为纯白
- 技能面板「待审核草稿」(`DraftReviewSection`) 从顶部块移入「自我进化」Tab 滚动容器，原位置改在 Tab Trigger 上加琥珀色数量 badge 提示
- 草稿列表内置 `max-h-48` 滚动，避免大量草稿撑长外层 evolution 滚动条
- Codex review [P2] 修复：`<Tabs>` 改成受控，`markDraftsSeen()` 守卫到 `activeTab === "evolution"` 才执行，避免用户停在默认 manage 页就丢掉 IconSidebar / SettingsView 未读红点

## Test plan

- [ ] 桌面 Tauri：技能面板默认进 manage 页，evolution Tab 上若有草稿可见琥珀 badge + 数量；不点 Tab，关掉面板再开，IconSidebar 红点仍在
- [ ] 切到 evolution Tab，草稿区可见 + 红点消除；激活/丢弃草稿后 badge 数量同步刷新
- [ ] 唤起 Plan / Canvas / Browser / Diff 面板，根背景纯白（不是 0 0% 98% 那种微灰），header / action bar 与正文一体
- [ ] Dark mode 下 4 个面板背景依旧是 `--color-background` 的暗色调，无明显回归