### PR TITLE
[codex] 支持聊天消息 Markdown 渲染切换

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **聊天消息 Markdown / 纯文本渲染可切换**：用户消息现在与模型消息一样默认支持 Markdown 渲染，气泡 hover 操作区新增 Markdown / 纯文本切换按钮，复制仍保留原始文本。两种模式都会自动识别裸链接（`https://...` / `www.example.com` / 邮箱）并渲染为可点击超链，复用既有外链与本地路径打开策略。
 - **浏览器 `profile.op=launch target=system`**：模型可显式调起用户**日常浏览器**（Chrome / Edge / Brave / Chromium），自动复用用户已有的全部登录态、扩展、书签和浏览历史，不再仅限 hope-agent 隔离 profile。三种 target：`managed`（默认，旧行为）/ `user_attach`（agent 专用日常 Chrome，独立 user-data-dir）/ `system`（用户真实日常浏览器，需要审批）。`system` 在 default / smart 模式弹 ask_user_question 模态明确警示「agent 将获得 Gmail / 银行 / SSO 等全部登录态」+「会先关闭你当前的浏览器，可能丢失未保存草稿」；yolo 模式按既有承担风险跳过。Chrome 在跑时一次审批同时覆盖关闭 + 接管，graceful quit 5s 超时自动 force_kill 兜底，仍超时报错引导手动 Cmd+Q。跨平台覆盖 macOS / Linux / Windows 的真实 user-data-dir 路径。
 - **Chromium 运行时自动安装兜底**：系统没装 Chrome / Edge / Brave / Chromium 时，agent 可调 `profile.op=install_runtime` 或 settings → Browser → 「Install Chromium runtime」按钮，自动下载 pinned Chromium snapshot（约 150 MB）解压到 `~/.hope-agent/browser/runtime/chromium-{rev}/`，下载完后 `profile.op=launch` 自动使用。下载进度通过 EventBus `browser:chromium_download_progress` 推送给 UI 进度条；zip-slip / chmod +x / `--version` smoke-test 三道防线。新增 `browser_install_chromium_runtime` Tauri 命令 + `POST /api/browser/install-chromium-runtime` HTTP 路由 + 12 语言文案。
 - **Docker 镜像内置 Chromium**：`Dockerfile` 加 `chromium` + 字体 / nss / libgbm / libxss 共享库，让 `profile.op=launch headless=true` 在服务器 / CI / 容器内开箱即用。镜像体积增加约 250 MB；不需要浏览器自动化的部署可 fork 移除。

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -4,7 +4,17 @@ import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { cn } from "@/lib/utils"
 import { IconTip } from "@/components/ui/tooltip"
-import { Copy, Check, Info, Network, Timer, PlayCircle, ChevronDown } from "lucide-react"
+import {
+  Copy,
+  Check,
+  Info,
+  Network,
+  Timer,
+  PlayCircle,
+  ChevronDown,
+  Code2,
+  Type,
+} from "lucide-react"
 import ChannelIcon from "@/components/common/ChannelIcon"
 import {
   formatTokens,
@@ -14,6 +24,7 @@ import {
   isUserAlignedMessage,
 } from "../chatUtils"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+import PlainTextRenderer from "@/components/common/PlainTextRenderer"
 import FileAttachments from "./FileAttachments"
 import FallbackBanner from "@/components/chat/FallbackBanner"
 import ProfileRotationBanner from "@/components/chat/ProfileRotationBanner"
@@ -24,6 +35,7 @@ import { AssistantContentBlocks } from "./MessageContent"
 import { PlanCommentBubble } from "./PlanCommentBubble"
 import type {
   ChatDisplayMode,
+  ContentRenderMode,
   Message,
   AgentSummaryForSidebar,
   ProfileRotationEvent,
@@ -59,7 +71,9 @@ export interface MessageBubbleProps {
   onViewSystemPrompt?: () => void
   // Open the right-side diff panel for a file change payload.
   onOpenDiff?: (
-    metadata: import("@/types/chat").FileChangeMetadata | import("@/types/chat").FileChangesMetadata,
+    metadata:
+      | import("@/types/chat").FileChangeMetadata
+      | import("@/types/chat").FileChangesMetadata,
   ) => void
   onResume?: (message: string) => void
   displayMode?: ChatDisplayMode
@@ -74,6 +88,12 @@ const TOOL_JOB_STATUSES = new Set([
   "interrupted",
   "running",
 ])
+
+function hasRenderableTextContent(msg: Message): boolean {
+  return (
+    !!msg.content || !!msg.contentBlocks?.some((block) => block.type === "text" && !!block.content)
+  )
+}
 
 function getXmlishAttribute(attrs: string, name: string): string | undefined {
   const match = attrs.match(new RegExp(`\\b${name}="([^"]*)"`))
@@ -271,6 +291,7 @@ function MessageBubbleInner({
   const { t } = useTranslation()
   const [detailsIndex, setDetailsIndex] = useState<number | null>(null)
   const [resultExpanded, setResultExpanded] = useState(false)
+  const [contentRenderMode, setContentRenderMode] = useState<ContentRenderMode>("markdown")
 
   const modifiedFiles = useMemo(
     () =>
@@ -288,6 +309,32 @@ function MessageBubbleInner({
     }
   }, [msg.content, msg.role])
   const isUserAligned = isUserAlignedMessage(msg)
+  const hasTextContent = hasRenderableTextContent(msg)
+  const hasDetails = msg.role === "assistant" && !!(msg.usage || msg.model)
+  const hasToolbarActions = hasTextContent || hasDetails
+  const renderToggleLabel =
+    contentRenderMode === "markdown"
+      ? String(t("chat.showPlainText", { defaultValue: "Show plain text" }))
+      : String(t("chat.renderMarkdown", { defaultValue: "Render Markdown" }))
+  const renderToggleButton = hasTextContent ? (
+    <IconTip label={renderToggleLabel}>
+      <button
+        type="button"
+        aria-label={renderToggleLabel}
+        aria-pressed={contentRenderMode === "markdown"}
+        onClick={() =>
+          setContentRenderMode((mode) => (mode === "markdown" ? "text" : "markdown"))
+        }
+        className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors"
+      >
+        {contentRenderMode === "markdown" ? (
+          <Type className="h-3.5 w-3.5" />
+        ) : (
+          <Code2 className="h-3.5 w-3.5" />
+        )}
+      </button>
+    </IconTip>
+  ) : null
 
   if (msg.role === "event" && !isUserAligned) {
     // Interactive model picker card
@@ -413,7 +460,12 @@ function MessageBubbleInner({
   // The markdown displayText still lives in `msg.content` as a fallback for
   // IM channels and historical sessions where the metadata wasn't captured.
   if (msg.planComment) {
-    return <PlanCommentBubble selectedText={msg.planComment.selectedText} comment={msg.planComment.comment} />
+    return (
+      <PlanCommentBubble
+        selectedText={msg.planComment.selectedText}
+        comment={msg.planComment.comment}
+      />
+    )
   }
 
   if (displayMode === "timeline" && msg.role === "assistant") {
@@ -472,6 +524,7 @@ function MessageBubbleInner({
             onSwitchSession={onSwitchSession}
             onOpenDiff={onOpenDiff}
             displayMode="timeline"
+            contentRenderMode={contentRenderMode}
           />
           {modifiedFiles.length > 0 && (
             <div className="ml-7">
@@ -486,7 +539,7 @@ function MessageBubbleInner({
           <div
             className={cn(
               "ml-7 mt-0.5 flex h-6 items-center gap-0.5",
-              (!msg.content || !(isHovered || isCopied)) && "invisible",
+              (!hasTextContent || !(isHovered || isCopied)) && "invisible",
             )}
           >
             {msg.content && (
@@ -503,6 +556,7 @@ function MessageBubbleInner({
                 </button>
               </IconTip>
             )}
+            {renderToggleButton}
           </div>
         </div>
       </div>
@@ -557,10 +611,13 @@ function MessageBubbleInner({
           className={cn(
             "px-4 py-2.5 rounded-xl text-sm leading-relaxed overflow-hidden break-words select-text",
             isUserAligned && !msg.fromAgentId
-              ? "bg-[var(--color-user-bubble)] text-foreground whitespace-pre-wrap"
+              ? "bg-[var(--color-user-bubble)] text-foreground"
               : msg.fromAgentId
-                ? "bg-purple-500/10 border border-purple-500/20 text-foreground whitespace-pre-wrap"
+                ? "bg-purple-500/10 border border-purple-500/20 text-foreground"
                 : "bg-card text-foreground/80",
+            contentRenderMode === "markdown"
+              ? "message-markdown-content"
+              : "message-plain-content",
             msg.role === "assistant" &&
               !msg.content &&
               !msg.toolCalls?.length &&
@@ -584,10 +641,12 @@ function MessageBubbleInner({
               onOpenPlanPanel={onOpenPlanPanel}
               onSwitchSession={onSwitchSession}
               onOpenDiff={onOpenDiff}
+              contentRenderMode={contentRenderMode}
             />
+          ) : contentRenderMode === "markdown" ? (
+            <MarkdownRenderer content={msg.content} />
           ) : (
-            // User message content
-            msg.content
+            <PlainTextRenderer content={msg.content} />
           )}
           {/* URL Previews (only for non-streaming messages) */}
           {msg.content && !(loading && isLast) && (
@@ -614,12 +673,11 @@ function MessageBubbleInner({
           className={cn(
             "flex items-center gap-0.5 mt-0.5 h-6",
             isUserAligned ? "justify-end" : "justify-start",
-            (!msg.content || !(isHovered || isCopied || detailsIndex === index)) &&
+            (!hasToolbarActions || !(isHovered || isCopied || detailsIndex === index)) &&
               "invisible",
           )}
         >
           {msg.content && (
-            <>
             <IconTip label={t("chat.copy")}>
               <button
                 onClick={() => onCopy(msg.content, index)}
@@ -632,109 +690,109 @@ function MessageBubbleInner({
                 )}
               </button>
             </IconTip>
-            {msg.role === "assistant" && (msg.usage || msg.model) && (
-              <div className="relative">
-                <IconTip label={t("chat.details")}>
-                  <button
-                    onClick={() => setDetailsIndex(detailsIndex === index ? null : index)}
-                    className={cn(
-                      "p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors",
-                      detailsIndex === index && "text-foreground bg-muted/80",
+          )}
+          {renderToggleButton}
+          {hasDetails && (
+            <div className="relative">
+              <IconTip label={t("chat.details")}>
+                <button
+                  onClick={() => setDetailsIndex(detailsIndex === index ? null : index)}
+                  className={cn(
+                    "p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors",
+                    detailsIndex === index && "text-foreground bg-muted/80",
+                  )}
+                >
+                  <Info className="h-3.5 w-3.5" />
+                </button>
+              </IconTip>
+              {detailsIndex === index && (
+                <div className="absolute bottom-full left-0 z-50 mb-1 w-64 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover p-2.5 shadow-lg">
+                  <div className="space-y-1.5 text-xs">
+                    {msg.model && (
+                      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                        <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                          {t("chat.statusModel")}
+                        </span>
+                        <IconTip label={msg.model}>
+                          <span className="block truncate text-right font-medium text-foreground">
+                            {msg.model}
+                          </span>
+                        </IconTip>
+                      </div>
                     )}
-                  >
-                    <Info className="h-3.5 w-3.5" />
-                  </button>
-                </IconTip>
-                {detailsIndex === index && (
-                  <div className="absolute bottom-full left-0 z-50 mb-1 w-64 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover p-2.5 shadow-lg">
-                    <div className="space-y-1.5 text-xs">
-                      {msg.model && (
-                        <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                          <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                            {t("chat.statusModel")}
-                          </span>
-                          <IconTip label={msg.model}>
-                            <span className="block truncate text-right font-medium text-foreground">
-                              {msg.model}
-                            </span>
-                          </IconTip>
-                        </div>
-                      )}
-                      {msg.model && msg.usage?.inputTokens != null && (
-                        <div className="border-t border-border" />
-                      )}
-                      {(() => {
-                        const inputTokens = msg.usage?.inputTokens
-                        const lastInputTokens = msg.usage?.lastInputTokens
-                        const showLastInput =
-                          inputTokens != null &&
-                          lastInputTokens != null &&
-                          lastInputTokens !== inputTokens
-                        if (inputTokens == null) return null
-                        return (
-                          <>
-                            <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                              <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                                {showLastInput
-                                  ? t("chat.inputTokensCumulative")
-                                  : t("chat.inputTokens")}
-                              </span>
-                              <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                                {formatTokens(inputTokens)}
-                              </span>
-                            </div>
-                            {showLastInput && lastInputTokens != null && (
-                              <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                                <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                                  {t("chat.lastRoundInputTokens")}
-                                </span>
-                                <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                                  {formatTokens(lastInputTokens)}
-                                </span>
-                              </div>
-                            )}
-                          </>
-                        )
-                      })()}
-                      {msg.usage?.outputTokens != null && (
-                        <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                          <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                            {t("chat.outputTokens")}
-                          </span>
-                          <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                            {formatTokens(msg.usage.outputTokens)}
-                          </span>
-                        </div>
-                      )}
-                      {msg.usage?.inputTokens != null && msg.usage?.outputTokens != null && (
+                    {msg.model && msg.usage?.inputTokens != null && (
+                      <div className="border-t border-border" />
+                    )}
+                    {(() => {
+                      const inputTokens = msg.usage?.inputTokens
+                      const lastInputTokens = msg.usage?.lastInputTokens
+                      const showLastInput =
+                        inputTokens != null &&
+                        lastInputTokens != null &&
+                        lastInputTokens !== inputTokens
+                      if (inputTokens == null) return null
+                      return (
                         <>
-                          <div className="border-t border-border" />
                           <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                             <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                              {t("chat.totalTokens")}
+                              {showLastInput
+                                ? t("chat.inputTokensCumulative")
+                                : t("chat.inputTokens")}
                             </span>
                             <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                              {formatTokens(msg.usage.inputTokens + msg.usage.outputTokens)}
+                              {formatTokens(inputTokens)}
                             </span>
                           </div>
+                          {showLastInput && lastInputTokens != null && (
+                            <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                              <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                                {t("chat.lastRoundInputTokens")}
+                              </span>
+                              <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                                {formatTokens(lastInputTokens)}
+                              </span>
+                            </div>
+                          )}
                         </>
-                      )}
-                      {msg.usage?.durationMs != null && (
+                      )
+                    })()}
+                    {msg.usage?.outputTokens != null && (
+                      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                        <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                          {t("chat.outputTokens")}
+                        </span>
+                        <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                          {formatTokens(msg.usage.outputTokens)}
+                        </span>
+                      </div>
+                    )}
+                    {msg.usage?.inputTokens != null && msg.usage?.outputTokens != null && (
+                      <>
+                        <div className="border-t border-border" />
                         <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                           <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                            {t("chat.duration")}
+                            {t("chat.totalTokens")}
                           </span>
                           <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                            {formatDuration(msg.usage.durationMs)}
+                            {formatTokens(msg.usage.inputTokens + msg.usage.outputTokens)}
                           </span>
                         </div>
-                      )}
-                    </div>
+                      </>
+                    )}
+                    {msg.usage?.durationMs != null && (
+                      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                        <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                          {t("chat.duration")}
+                        </span>
+                        <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                          {formatDuration(msg.usage.durationMs)}
+                        </span>
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            )}
-            </>
+                </div>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/src/components/chat/message/MessageContent.test.tsx
+++ b/src/components/chat/message/MessageContent.test.tsx
@@ -2,6 +2,7 @@
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, describe, expect, test, vi } from "vitest"
+import type { ReactNode } from "react"
 import type { ContentBlock, Message, ToolCall } from "@/types/chat"
 import { AssistantContentBlocks } from "./MessageContent"
 
@@ -17,6 +18,9 @@ vi.mock("react-i18next", () => ({
 
 vi.mock("@/components/common/MarkdownRenderer", () => ({
   default: ({ content }: { content: string }) => <div data-testid="markdown">{content}</div>,
+  MarkdownLink: ({ href, children }: { href?: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
 }))
 
 vi.mock("./ThinkingBlock", () => ({

--- a/src/components/chat/message/MessageContent.tsx
+++ b/src/components/chat/message/MessageContent.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+import PlainTextRenderer from "@/components/common/PlainTextRenderer"
 import ToolCallBlock from "./ToolCallBlock"
 import ToolCallGroup from "./ToolCallGroup"
 import ThinkingBlock from "./ThinkingBlock"
@@ -21,6 +22,7 @@ import type {
   ChatDisplayMode,
   ChatTurnStatus,
   ContentBlock,
+  ContentRenderMode,
   FileChangeMetadata,
   FileChangesMetadata,
   ToolCall,
@@ -118,6 +120,7 @@ interface MessageContentProps {
   /** Open the right-side diff panel for a file change payload. */
   onOpenDiff?: (metadata: FileChangeMetadata | FileChangesMetadata) => void
   displayMode?: ChatDisplayMode
+  contentRenderMode?: ContentRenderMode
 }
 
 // Synthesize ContentBlock[] from legacy `msg.thinking` / `msg.toolCalls` /
@@ -209,6 +212,7 @@ export function AssistantContentBlocks({
   onSwitchSession,
   onOpenDiff,
   displayMode = "bubble",
+  contentRenderMode = "markdown",
 }: MessageContentProps) {
   const blocks =
     msg.contentBlocks && msg.contentBlocks.length > 0
@@ -292,10 +296,14 @@ export function AssistantContentBlocks({
         key: `text-${i}`,
         node: (
           <div key={i}>
-            <MarkdownRenderer
-              content={block.content}
-              isStreaming={loading && isLast && i === blocks.length - 1}
-            />
+            {contentRenderMode === "markdown" ? (
+              <MarkdownRenderer
+                content={block.content}
+                isStreaming={loading && isLast && i === blocks.length - 1}
+              />
+            ) : (
+              <PlainTextRenderer content={block.content} />
+            )}
             {block.interrupted ? <InterruptedMark /> : null}
           </div>
         ),

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -38,6 +38,7 @@ import i18next from "i18next"
 import { getTransport } from "@/lib/transport-provider"
 import { openExternalUrl } from "@/lib/openExternalUrl"
 import { cn } from "@/lib/utils"
+import { findAutoLinkMatches } from "@/lib/autoLink"
 
 // Math and mermaid plugins are lazy-loaded on first use to reduce initial bundle size.
 // KaTeX (~300KB) and Mermaid (~200KB) are only loaded when content requires them.
@@ -282,7 +283,7 @@ function linkIconForHref(href: string | undefined, local: boolean): LinkIconInfo
   return { Icon: Link2, kind: "link" }
 }
 
-function MarkdownLink({
+export function MarkdownLink({
   href,
   children,
   className,
@@ -331,6 +332,71 @@ function MarkdownLink({
 }
 
 const markdownComponents = { a: MarkdownLink }
+
+interface HastNode {
+  type?: string
+  tagName?: string
+  value?: string
+  properties?: Record<string, unknown>
+  children?: HastNode[]
+}
+
+const AUTOLINK_SKIP_TAGS = new Set(["a", "code", "pre", "script", "style", "kbd", "samp"])
+
+function createAutoLinkElement(text: string, href: string): HastNode {
+  return {
+    type: "element",
+    tagName: "a",
+    properties: { href },
+    children: [{ type: "text", value: text }],
+  }
+}
+
+function splitTextWithAutoLinks(value: string): HastNode[] {
+  const matches = findAutoLinkMatches(value)
+  if (matches.length === 0) return [{ type: "text", value }]
+
+  const nodes: HastNode[] = []
+  let cursor = 0
+  for (const match of matches) {
+    if (match.start > cursor) {
+      nodes.push({ type: "text", value: value.slice(cursor, match.start) })
+    }
+    nodes.push(createAutoLinkElement(match.text, match.href))
+    cursor = match.end
+  }
+  if (cursor < value.length) {
+    nodes.push({ type: "text", value: value.slice(cursor) })
+  }
+  return nodes
+}
+
+function linkifyHastTextNodes(node: HastNode): void {
+  if (node.type !== "element" && node.type !== "root") return
+  if (node.tagName && AUTOLINK_SKIP_TAGS.has(node.tagName)) return
+  if (!node.children?.length) return
+
+  const children: HastNode[] = []
+  let changed = false
+  for (const child of node.children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      const split = splitTextWithAutoLinks(child.value)
+      children.push(...split)
+      changed ||= split.length !== 1 || split[0]?.value !== child.value
+    } else {
+      linkifyHastTextNodes(child)
+      children.push(child)
+    }
+  }
+
+  if (changed) node.children = children
+}
+
+function autolinkRehypePlugin() {
+  return (tree: HastNode) => {
+    linkifyHastTextNodes(tree)
+  }
+}
 
 /** Start catching up when backlog exceeds this */
 const CATCHUP_THRESHOLD = 60
@@ -476,12 +542,16 @@ export default function MarkdownRenderer({ content, isStreaming = false }: Markd
   // 流式期间把外部 animate plugin 注入 rehype 链尾；静态历史消息直接复用
   // streamdown 默认 rehype（raw/sanitize/harden 安全基线）。`animated={false}`
   // 关掉 streamdown 内部建实例的路径，避免与外部 plugin 重复跑。
+  const defaultRehypePluginList = Object.values(defaultRehypePlugins)
   const rehypePlugins = isActive
-    ? [...Object.values(defaultRehypePlugins), animatePlugin.rehypePlugin]
-    : Object.values(defaultRehypePlugins)
+    ? [...defaultRehypePluginList, autolinkRehypePlugin, animatePlugin.rehypePlugin]
+    : [...defaultRehypePluginList, autolinkRehypePlugin]
 
   return (
-    <div ref={containerRef} className={isActive ? "streaming-height markdown-content" : "markdown-content"}>
+    <div
+      ref={containerRef}
+      className={isActive ? "streaming-height markdown-content" : "markdown-content"}
+    >
       <div ref={contentRef}>
         <Streamdown
           animated={false}

--- a/src/components/common/PlainTextRenderer.tsx
+++ b/src/components/common/PlainTextRenderer.tsx
@@ -1,0 +1,36 @@
+import { Fragment, useMemo, type ReactNode } from "react"
+import { findAutoLinkMatches } from "@/lib/autoLink"
+import { MarkdownLink } from "./MarkdownRenderer"
+
+interface PlainTextRendererProps {
+  content: string
+}
+
+function renderTextWithLinks(content: string) {
+  const matches = findAutoLinkMatches(content)
+  if (matches.length === 0) return content
+
+  const nodes: ReactNode[] = []
+  let cursor = 0
+  for (const match of matches) {
+    if (match.start > cursor) {
+      nodes.push(<Fragment key={`text-${cursor}`}>{content.slice(cursor, match.start)}</Fragment>)
+    }
+    nodes.push(
+      <MarkdownLink key={`link-${match.start}`} href={match.href}>
+        {match.text}
+      </MarkdownLink>,
+    )
+    cursor = match.end
+  }
+  if (cursor < content.length) {
+    nodes.push(<Fragment key={`text-${cursor}`}>{content.slice(cursor)}</Fragment>)
+  }
+  return nodes
+}
+
+export default function PlainTextRenderer({ content }: PlainTextRendererProps) {
+  const rendered = useMemo(() => renderTextWithLinks(content), [content])
+  if (!content) return null
+  return <div className="markdown-content plain-text-content">{rendered}</div>
+}

--- a/src/index.css
+++ b/src/index.css
@@ -560,6 +560,21 @@
   margin-block: 0.375rem;
 }
 
+.plain-text-content {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.message-markdown-content .markdown-content > div > div > :first-child,
+.message-markdown-content .markdown-content p:first-child {
+  margin-top: 0;
+}
+
+.message-markdown-content .markdown-content > div > div > :last-child,
+.message-markdown-content .markdown-content p:last-child {
+  margin-bottom: 0;
+}
+
 .markdown-content [data-streamdown^="heading-"] {
   margin-block: 0.875rem 0.375rem;
   line-height: 1.25;

--- a/src/lib/autoLink.test.ts
+++ b/src/lib/autoLink.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest"
+import { findAutoLinkMatches } from "./autoLink"
+
+describe("findAutoLinkMatches", () => {
+  test("recognizes raw web links and trims trailing punctuation", () => {
+    expect(findAutoLinkMatches("See https://example.com/docs?q=1, please.")).toEqual([
+      {
+        start: 4,
+        end: 32,
+        text: "https://example.com/docs?q=1",
+        href: "https://example.com/docs?q=1",
+      },
+    ])
+  })
+
+  test("recognizes www links and normalizes href", () => {
+    expect(findAutoLinkMatches("Open www.example.com/path")).toEqual([
+      {
+        start: 5,
+        end: 25,
+        text: "www.example.com/path",
+        href: "https://www.example.com/path",
+      },
+    ])
+  })
+
+  test("recognizes email addresses as mailto links", () => {
+    expect(findAutoLinkMatches("Mail dev@example.com")).toEqual([
+      {
+        start: 5,
+        end: 20,
+        text: "dev@example.com",
+        href: "mailto:dev@example.com",
+      },
+    ])
+  })
+
+  test("does not include an unmatched closing bracket", () => {
+    expect(findAutoLinkMatches("(https://example.com/a)")[0]).toMatchObject({
+      text: "https://example.com/a",
+      href: "https://example.com/a",
+    })
+  })
+})

--- a/src/lib/autoLink.ts
+++ b/src/lib/autoLink.ts
@@ -1,0 +1,87 @@
+export interface AutoLinkMatch {
+  start: number
+  end: number
+  text: string
+  href: string
+}
+
+const AUTO_LINK_RE =
+  /(?:https?:\/\/|mailto:)[^\s<]+|www\.[^\s<]+|[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
+
+const TRAILING_PUNCTUATION = new Set([",", ".", "!", "?", ";", ":"])
+const BRACKET_PAIRS: Array<[string, string]> = [
+  ["(", ")"],
+  ["[", "]"],
+  ["{", "}"],
+  ["<", ">"],
+]
+
+function hasBoundaryBefore(text: string, start: number): boolean {
+  if (start === 0) return true
+  return /[\s([{"'`<]/.test(text[start - 1] || "")
+}
+
+function countChar(text: string, char: string): number {
+  let count = 0
+  for (const ch of text) {
+    if (ch === char) count++
+  }
+  return count
+}
+
+function trimmedLinkLength(raw: string): number {
+  let end = raw.length
+
+  while (end > 0 && TRAILING_PUNCTUATION.has(raw[end - 1] || "")) {
+    end--
+  }
+
+  let changed = true
+  while (changed && end > 0) {
+    changed = false
+    const value = raw.slice(0, end)
+    for (const [open, close] of BRACKET_PAIRS) {
+      if (!value.endsWith(close)) continue
+      if (countChar(value, close) > countChar(value, open)) {
+        end--
+        changed = true
+        break
+      }
+    }
+  }
+
+  return end
+}
+
+function hrefForAutoLink(text: string): string {
+  if (/^www\./i.test(text)) return `https://${text}`
+  if (/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(text)) return `mailto:${text}`
+  return text
+}
+
+export function findAutoLinkMatches(text: string): AutoLinkMatch[] {
+  const matches: AutoLinkMatch[] = []
+  AUTO_LINK_RE.lastIndex = 0
+
+  for (;;) {
+    const match = AUTO_LINK_RE.exec(text)
+    if (!match) break
+
+    const start = match.index
+    if (!hasBoundaryBefore(text, start)) continue
+
+    const raw = match[0]
+    const length = trimmedLinkLength(raw)
+    if (length <= 0) continue
+
+    const linkText = raw.slice(0, length)
+    matches.push({
+      start,
+      end: start + length,
+      text: linkText,
+      href: hrefForAutoLink(linkText),
+    })
+  }
+
+  return matches
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -9,6 +9,8 @@ export type ChatTurnStatus = "running" | "cancelling" | "completed" | "interrupt
 
 export type ChatDisplayMode = "bubble" | "timeline"
 
+export type ContentRenderMode = "markdown" | "text"
+
 export type ChatTurnInterruptReason =
   | "user_stop"
   | "shutdown"


### PR DESCRIPTION
## 变更

- 用户消息默认走 Markdown 渲染，与模型消息的展示能力对齐。
- 气泡 hover 操作区新增 Markdown / 纯文本渲染切换，复制仍保留原始文本。
- 新增裸链接识别能力，Markdown 与纯文本模式都会把 `https://...`、`www.example.com` 和邮箱渲染成可点击链接，并复用现有链接打开策略。
- 更新 `CHANGELOG.md` 记录该能力。

## 验证

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `cargo test  -p ha-core -p ha-server --locked`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- push 时 `.husky/pre-push` 再次通过全套检查（含 updater pubkey 校验）