### PR TITLE
Polish chat panel toolbar and responsive overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **聊天界面窄栏自适应整理**：输入框工作目录入口改为纯图标 + 「设置工作目录」提示，统一工具条图标尺寸；无痕模式入口移至顶部标题栏；右侧 Browser / Plan / Diff / Canvas / Team 面板打开时自动收起左侧 session 列表，用户仍可手动展开；输入框溢出菜单改为按容器宽度触发，修复右侧面板压缩聊天列时「+」菜单不出现。
 - **聊天消息 Markdown / 纯文本渲染可切换**：用户消息现在与模型消息一样默认支持 Markdown 渲染，气泡 hover 操作区新增 Markdown / 纯文本切换按钮，复制仍保留原始文本。两种模式都会自动识别裸链接（`https://...` / `www.example.com` / 邮箱）并渲染为可点击超链，复用既有外链与本地路径打开策略。
 - **Chromium 运行时自动安装兜底**：系统没装 Chrome / Edge / Brave / Chromium 时，agent 可调 `profile.op=install_runtime` 或 settings → Browser → 「Install Chromium runtime」按钮，自动下载 pinned Chromium snapshot（约 150 MB）解压到 `~/.hope-agent/browser/runtime/chromium-{rev}/`，下载完后 `profile.op=launch` 自动使用。下载进度通过 EventBus `browser:chromium_download_progress` 推送给 UI 进度条；zip-slip / chmod +x / `--version` smoke-test 三道防线。新增 `browser_install_chromium_runtime` Tauri 命令 + `POST /api/browser/install-chromium-runtime` HTTP 路由 + 12 语言文案。
 - **Docker 镜像内置 Chromium**：`Dockerfile` 加 `chromium` + 字体 / nss / libgbm / libxss 共享库，让 `profile.op=launch headless=true` 在服务器 / CI / 容器内开箱即用。镜像体积增加约 250 MB；不需要浏览器自动化的部署可 fork 移除。

--- a/src/components/chat/CanvasPanel.tsx
+++ b/src/components/chat/CanvasPanel.tsx
@@ -46,12 +46,14 @@ interface CanvasPanelProps {
   panelWidth?: number
   onPanelWidthChange?: (width: number) => void
   currentSessionId?: string | null
+  onOpenChange?: (open: boolean) => void
 }
 
 export default function CanvasPanel({
   panelWidth = 480,
   onPanelWidthChange,
   currentSessionId = null,
+  onOpenChange,
 }: CanvasPanelProps) {
   const { t } = useTranslation()
   const [canvas, setCanvas] = useState<CanvasInfo | null>(null)
@@ -118,6 +120,10 @@ export default function CanvasPanel({
       win.setMinSize(new LogicalSize(840, 480))
     }
   }, [canvas, detached])
+
+  useEffect(() => {
+    onOpenChange?.(!!canvas)
+  }, [canvas, onOpenChange])
 
   // Restore canvas when switching sessions: query the session's canvas
   // projects and adopt the most recent one. Backend `canvas_show` events

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -153,6 +153,7 @@ export default function ChatScreen({
   // Right panel widths (resizable)
   const [planPanelWidth, setPlanPanelWidth] = useState(520)
   const [canvasPanelWidth, setCanvasPanelWidth] = useState(480)
+  const [canvasPanelOpen, setCanvasPanelOpen] = useState(false)
   const [browserPanelWidth, setBrowserPanelWidth] = useState(480)
 
   // Right side diff panel (write/edit/apply_patch metadata viewer)
@@ -1278,6 +1279,26 @@ export default function ChatScreen({
     planMode.showPanel &&
     planMode.planState !== "off" &&
     (planMode.planState === "planning" || planMode.planContent.trim().length > 0)
+  const rightPanelKey =
+    diffPanel.showPanel && diffPanel.activeChanges.length > 0
+      ? "diff"
+      : shouldShowPlanPanel
+        ? "plan"
+        : showBrowserPanel
+          ? "browser"
+          : canvasPanelOpen
+            ? "canvas"
+            : activeTeamId && showTeamPanel
+              ? "team"
+              : null
+  const lastRightPanelKeyRef = useRef<string | null>(rightPanelKey)
+
+  useEffect(() => {
+    if (rightPanelKey && rightPanelKey !== lastRightPanelKeyRef.current) {
+      setSidebarCollapsed(true)
+    }
+    lastRightPanelKeyRef.current = rightPanelKey
+  }, [rightPanelKey])
 
   const handlePlanPanelDragStart = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -1547,6 +1568,9 @@ export default function ChatScreen({
           onExpandSidebar={() => setSidebarCollapsed(false)}
           displayMode={displayMode}
           onDisplayModeChange={handleDisplayModeChange}
+          incognitoEnabled={incognitoEnabled}
+          incognitoDisabledReason={incognitoDisabledReason}
+          onIncognitoChange={handleIncognitoChange}
         />
 
         <div className="flex-1 flex min-h-0 overflow-hidden">
@@ -1660,8 +1684,6 @@ export default function ChatScreen({
                   sessionTemperature={sessionTemperature}
                   onSessionTemperatureChange={setSessionTemperature}
                   incognitoEnabled={incognitoEnabled}
-                  incognitoDisabledReason={incognitoDisabledReason}
-                  onIncognitoChange={handleIncognitoChange}
                   workingDir={session.currentSessionId ? effectiveWorkingDir : draftWorkingDir}
                   workingDirInherited={
                     session.currentSessionId ? workingDirSource === "project" : false
@@ -1743,6 +1765,7 @@ export default function ChatScreen({
             panelWidth={canvasPanelWidth}
             onPanelWidthChange={setCanvasPanelWidth}
             currentSessionId={currentSessionId}
+            onOpenChange={setCanvasPanelOpen}
           />
 
           {/* Browser live-mirror panel — open on first `browser:frame` push,

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -29,6 +29,7 @@ import ChannelIcon from "@/components/common/ChannelIcon"
 import { formatCacheUsageDisplay, formatCompactTokenCount } from "./cacheUsageDisplay"
 import { formatMessageTime, getContextUsageTokens } from "./chatUtils"
 import { INCOGNITO_BADGE_LABEL_CLASSES } from "./input/incognitoStyles"
+import IncognitoToggle, { type IncognitoDisabledReason } from "./input/IncognitoToggle"
 import { logger } from "@/lib/logger"
 import AgentSwitcher from "./AgentSwitcher"
 import ProjectIcon from "./project/ProjectIcon"
@@ -98,6 +99,11 @@ interface ChatTitleBarProps {
   displayMode?: ChatDisplayMode
   /** Switches between bubble and task timeline presentation. */
   onDisplayModeChange?: (mode: ChatDisplayMode) => void
+  /** Draft/new-session incognito toggle, surfaced in the title bar. */
+  incognitoEnabled?: boolean
+  incognitoSaving?: boolean
+  incognitoDisabledReason?: IncognitoDisabledReason
+  onIncognitoChange?: (enabled: boolean) => void
 }
 
 export default function ChatTitleBar({
@@ -130,6 +136,10 @@ export default function ChatTitleBar({
   onExpandSidebar,
   displayMode = "bubble",
   onDisplayModeChange,
+  incognitoEnabled = false,
+  incognitoSaving = false,
+  incognitoDisabledReason,
+  onIncognitoChange,
 }: ChatTitleBarProps) {
   const { t } = useTranslation()
   const appVersion = useAppVersion()
@@ -327,6 +337,17 @@ export default function ChatTitleBar({
         )}
       </div>
       <div className="flex items-end gap-1">
+        {!currentSessionId && onIncognitoChange && (
+          <IncognitoToggle
+            sessionId={null}
+            enabled={incognitoEnabled}
+            saving={incognitoSaving}
+            disabledReason={incognitoDisabledReason}
+            variant="titlebar"
+            showLabel={false}
+            onChange={onIncognitoChange}
+          />
+        )}
         {onDisplayModeChange && (
           <IconTip
             label={
@@ -338,7 +359,6 @@ export default function ChatTitleBar({
             <button
               className={cn(
                 "pb-1.5 text-muted-foreground hover:text-foreground transition-colors",
-                displayMode === "timeline" && "text-foreground",
               )}
               aria-pressed={displayMode === "timeline"}
               aria-label={

--- a/src/components/chat/input/AttachmentBar.tsx
+++ b/src/components/chat/input/AttachmentBar.tsx
@@ -94,7 +94,7 @@ export function AttachFilesMenuItem({ onAttachFiles, onPicked }: AttachFilesMenu
         className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[13px] text-foreground/80 outline-none transition-all duration-150 hover:bg-secondary/60 hover:text-foreground focus-visible:bg-secondary/60 focus-visible:text-foreground"
         onClick={() => fileInputRef.current?.click()}
       >
-        <Paperclip className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <Paperclip className="h-4 w-4 shrink-0 text-muted-foreground" />
         <span className="truncate">{t("chat.attachPhotosAndFiles")}</span>
       </button>
       <input

--- a/src/components/chat/input/AwarenessToggle.tsx
+++ b/src/components/chat/input/AwarenessToggle.tsx
@@ -134,9 +134,9 @@ export default function AwarenessToggle({ sessionId, disabled = false }: Props) 
           )}
         >
           {isDisabledLocally ? (
-            <EyeOff className="h-3.5 w-3.5" />
+            <EyeOff className="h-4 w-4" />
           ) : (
-            <Eye className="h-3.5 w-3.5" />
+            <Eye className="h-4 w-4" />
           )}
         </button>
       </IconTip>

--- a/src/components/chat/input/ChatInput.test.tsx
+++ b/src/components/chat/input/ChatInput.test.tsx
@@ -148,19 +148,6 @@ describe("ChatInput", () => {
     expect(onSend).toHaveBeenCalledTimes(1)
   })
 
-  test("renders incognito controls when enabled by the caller", () => {
-    const onIncognitoChange = vi.fn()
-    renderChatInput({
-      currentSessionId: null,
-      incognitoEnabled: true,
-      onIncognitoChange,
-    })
-
-    fireEvent.click(screen.getByRole("button", { name: "chat.incognito" }))
-
-    expect(onIncognitoChange).toHaveBeenCalledWith(false)
-  })
-
   test("explicit interrupted execution state wins over loading for task progress", () => {
     renderChatInput({
       loading: true,

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -15,8 +15,6 @@ import {
   BetweenHorizontalStart,
   X,
   Plus,
-  Ghost,
-  Loader2,
   FolderPlus,
 } from "lucide-react"
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
@@ -40,20 +38,17 @@ import ModelPicker from "./ModelPicker"
 import PermissionModeSwitcher from "./PermissionModeSwitcher"
 import TemperatureSlider from "./TemperatureSlider"
 import AwarenessToggle from "./AwarenessToggle"
-import IncognitoToggle, { type IncognitoDisabledReason } from "./IncognitoToggle"
 import WorkingDirectoryButton from "./WorkingDirectoryButton"
 import TaskProgressPanel from "@/components/chat/tasks/TaskProgressPanel"
 import {
   shouldShowTaskProgressPanel,
   type TaskProgressSnapshot,
 } from "@/components/chat/tasks/taskProgress"
-import { Switch } from "@/components/ui/switch"
 import {
   CHAT_INPUT_INLINE_ADD_ACTIONS_CLASS,
   CHAT_INPUT_OVERFLOW_BREAKPOINT_PX,
   CHAT_INPUT_OVERFLOW_MENU_CLASS,
   getChatInputOverflowActionIds,
-  shouldShowIncognitoPresetAction,
   type ChatInputOverflowActionId,
 } from "./toolbarOverflow"
 
@@ -86,9 +81,6 @@ interface ChatInputProps {
   onSessionTemperatureChange?: (temp: number | null) => void
   // Incognito
   incognitoEnabled?: boolean
-  incognitoSaving?: boolean
-  incognitoDisabledReason?: IncognitoDisabledReason
-  onIncognitoChange?: (enabled: boolean) => void
   // Working directory
   workingDir?: string | null
   /** True when `workingDir` is inherited from the parent project rather than
@@ -133,9 +125,6 @@ export default function ChatInput({
   sessionTemperature,
   onSessionTemperatureChange,
   incognitoEnabled = false,
-  incognitoSaving = false,
-  incognitoDisabledReason,
-  onIncognitoChange,
   workingDir,
   workingDirInherited = false,
   workingDirSaving = false,
@@ -149,7 +138,9 @@ export default function ChatInput({
 }: ChatInputProps) {
   const { t } = useTranslation()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const inputShellRef = useRef<HTMLDivElement>(null)
   const [showOverflowMenu, setShowOverflowMenu] = useState(false)
+  const [toolbarCompact, setToolbarCompact] = useState(false)
 
   // Slash commands
   const slashActions: SlashCommandActions = {
@@ -178,20 +169,35 @@ export default function ChatInput({
     adjustTextareaHeight()
   }, [input, adjustTextareaHeight])
 
-  // The overflow `+` trigger is hidden via CSS once the viewport widens past
-  // the breakpoint, but Radix keeps the open popper mounted in a Portal — with
-  // no measurable trigger it falls back to (0,0). Listen for the breakpoint
-  // crossing and force-close the menu when it goes wide.
+  // The chat column can shrink when a right-side panel opens while the viewport
+  // stays wide, so the overflow affordance has to follow the input container
+  // width instead of a viewport media query.
   useEffect(() => {
-    if (!showOverflowMenu) return
-    if (typeof window === "undefined" || !window.matchMedia) return
-    const mql = window.matchMedia(`(min-width: ${CHAT_INPUT_OVERFLOW_BREAKPOINT_PX + 1}px)`)
-    const onChange = (e: MediaQueryListEvent) => {
-      if (e.matches) setShowOverflowMenu(false)
+    const el = inputShellRef.current
+    if (!el || typeof window === "undefined") return
+
+    const update = (width = el.getBoundingClientRect().width) => {
+      setToolbarCompact(width <= CHAT_INPUT_OVERFLOW_BREAKPOINT_PX)
     }
-    mql.addEventListener("change", onChange)
-    return () => mql.removeEventListener("change", onChange)
-  }, [showOverflowMenu])
+
+    update()
+
+    if (typeof ResizeObserver === "undefined") {
+      const handleResize = () => update()
+      window.addEventListener("resize", handleResize)
+      return () => window.removeEventListener("resize", handleResize)
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      update(entries[0]?.contentRect.width)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (showOverflowMenu && !toolbarCompact) setShowOverflowMenu(false)
+  }, [showOverflowMenu, toolbarCompact])
 
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
@@ -244,25 +250,9 @@ export default function ChatInput({
 
   const overflowMenuItemClass =
     "flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-left text-[13px] text-foreground/80 outline-none transition-all duration-150 hover:bg-secondary/60 hover:text-foreground focus-visible:bg-secondary/60 focus-visible:text-foreground disabled:pointer-events-none disabled:opacity-50"
-  const showIncognitoPreset = shouldShowIncognitoPresetAction(
-    currentSessionId ?? null,
-    !!onIncognitoChange,
-  )
 
   const toggleSlashCommandMenu = () => {
     slash.setOpen(!slash.isOpen)
-  }
-
-  const toggleIncognito = (next = !incognitoEnabled) => {
-    if (
-      !onIncognitoChange ||
-      !showIncognitoPreset ||
-      incognitoSaving ||
-      incognitoDisabledReason !== undefined
-    ) {
-      return
-    }
-    onIncognitoChange(next)
   }
 
   const visibleTaskProgress = shouldShowTaskProgressPanel(taskProgressSnapshot)
@@ -280,7 +270,6 @@ export default function ChatInput({
     <>
       {onWorkingDirChange && (
         <WorkingDirectoryButton
-          sessionId={currentSessionId ?? null}
           workingDir={workingDir ?? null}
           inherited={workingDirInherited}
           saving={workingDirSaving}
@@ -296,18 +285,9 @@ export default function ChatInput({
           className="h-8 w-8 rounded-lg text-muted-foreground hover:text-foreground"
           onClick={toggleSlashCommandMenu}
         >
-          <Slash className="h-3.5 w-3.5" />
+          <Slash className="h-4 w-4" />
         </Button>
       </IconTip>
-      {showIncognitoPreset && onIncognitoChange && (
-        <IncognitoToggle
-          sessionId={currentSessionId ?? null}
-          enabled={incognitoEnabled}
-          saving={incognitoSaving}
-          disabledReason={incognitoDisabledReason}
-          onChange={onIncognitoChange}
-        />
-      )}
     </>
   )
 
@@ -323,7 +303,6 @@ export default function ChatInput({
       case "working-dir":
         return onWorkingDirChange ? (
           <WorkingDirectoryButton
-            sessionId={currentSessionId ?? null}
             workingDir={workingDir ?? null}
             inherited={workingDirInherited}
             saving={workingDirSaving}
@@ -333,7 +312,7 @@ export default function ChatInput({
           />
         ) : (
           <button type="button" disabled className={overflowMenuItemClass}>
-            <FolderPlus className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <FolderPlus className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="truncate">{t("chat.addWorkingDirectory")}</span>
           </button>
         )
@@ -347,65 +326,27 @@ export default function ChatInput({
               toggleSlashCommandMenu()
             }}
           >
-            <Slash className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <Slash className="h-4 w-4 shrink-0 text-muted-foreground" />
             <span className="truncate">{t("slashCommands.buttonTip")}</span>
           </button>
         )
-      case "incognito": {
-        if (!onIncognitoChange || !showIncognitoPreset) return null
-        const disabled = incognitoSaving || incognitoDisabledReason !== undefined
-        return (
-          <div
-            role="button"
-            tabIndex={disabled ? -1 : 0}
-            aria-disabled={disabled}
-            className={cn(
-              overflowMenuItemClass,
-              "justify-between",
-              disabled && "pointer-events-none opacity-50",
-            )}
-            onClick={() => toggleIncognito()}
-            onKeyDown={(e) => {
-              if (disabled) return
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault()
-                toggleIncognito()
-              }
-            }}
-          >
-            <span className="flex min-w-0 items-center gap-3">
-              {incognitoSaving ? (
-                <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
-              ) : (
-                <Ghost className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              )}
-              <span className="truncate">{t("chat.incognito")}</span>
-            </span>
-            <Switch
-              checked={incognitoEnabled}
-              disabled={disabled}
-              onClick={(e) => e.stopPropagation()}
-              onCheckedChange={(checked) => toggleIncognito(checked)}
-            />
-          </div>
-        )
-      }
     }
   }
 
   const renderOverflowMenuItems = () => (
     <>
-      {getChatInputOverflowActionIds(currentSessionId ?? null, !!onIncognitoChange).map(
-        (actionId) => (
-          <Fragment key={actionId}>{renderOverflowMenuItem(actionId)}</Fragment>
-        ),
-      )}
+      {getChatInputOverflowActionIds().map((actionId) => (
+        <Fragment key={actionId}>{renderOverflowMenuItem(actionId)}</Fragment>
+      ))}
     </>
   )
 
   return (
     <div className="px-3 pb-3 pt-2">
-      <div className="relative rounded-2xl border border-border bg-white dark:bg-card">
+      <div
+        ref={inputShellRef}
+        className="relative rounded-2xl border border-border bg-white dark:bg-card"
+      >
         {/* Slash Command Menu */}
         {slash.isOpen && (
           <SlashCommandMenu
@@ -558,9 +499,11 @@ export default function ChatInput({
         {/* Toolbar */}
         <div className="flex items-end justify-between gap-2 px-2 pb-2">
           <div className="flex items-center gap-1 flex-wrap min-w-0">
-            <div className={CHAT_INPUT_INLINE_ADD_ACTIONS_CLASS}>{renderInlineAddControls()}</div>
+            <div className={toolbarCompact ? "hidden" : CHAT_INPUT_INLINE_ADD_ACTIONS_CLASS}>
+              {renderInlineAddControls()}
+            </div>
 
-            <div className={CHAT_INPUT_OVERFLOW_MENU_CLASS}>
+            <div className={toolbarCompact ? "block" : CHAT_INPUT_OVERFLOW_MENU_CLASS}>
               <DropdownMenu.Root open={showOverflowMenu} onOpenChange={setShowOverflowMenu}>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -632,7 +575,7 @@ export default function ChatInput({
                         : "text-muted-foreground hover:text-foreground",
                 )}
               >
-                <ClipboardList className="h-3.5 w-3.5 shrink-0" />
+                <ClipboardList className="h-4 w-4 shrink-0" />
                 <span>{planToggleLabel}</span>
               </button>
             </IconTip>

--- a/src/components/chat/input/IncognitoToggle.tsx
+++ b/src/components/chat/input/IncognitoToggle.tsx
@@ -16,6 +16,8 @@ interface IncognitoToggleProps {
   enabled: boolean
   saving?: boolean
   disabledReason?: IncognitoDisabledReason
+  variant?: "toolbar" | "titlebar"
+  showLabel?: boolean
   onChange: (enabled: boolean) => void
 }
 
@@ -24,6 +26,8 @@ export default function IncognitoToggle({
   enabled,
   saving = false,
   disabledReason,
+  variant = "toolbar",
+  showLabel = true,
   onChange,
 }: IncognitoToggleProps) {
   const { t } = useTranslation()
@@ -32,27 +36,33 @@ export default function IncognitoToggle({
   const tooltip = disabled
     ? t(DISABLED_REASON_KEY[disabledReason] ?? "chat.incognitoMutuallyExclusive")
     : t(sessionId ? "chat.incognito" : "chat.incognitoPreset")
+  const titlebar = variant === "titlebar"
 
   return (
     <IconTip label={tooltip}>
       <button
         type="button"
+        aria-label={showLabel ? t("chat.incognito") : tooltip}
         disabled={saving || disabled}
         onClick={() => onChange(!enabled)}
         className={cn(
-          "flex items-center gap-1 bg-transparent text-xs font-medium px-2 py-1 rounded-lg cursor-pointer transition-colors hover:bg-secondary shrink-0 whitespace-nowrap disabled:cursor-not-allowed disabled:opacity-50",
+          titlebar
+            ? "pb-1.5 text-muted-foreground hover:text-foreground transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            : "flex items-center gap-1 bg-transparent text-xs font-medium px-2 py-1 rounded-lg cursor-pointer transition-colors hover:bg-secondary shrink-0 whitespace-nowrap disabled:cursor-not-allowed disabled:opacity-50",
           saving && "disabled:cursor-wait disabled:opacity-70",
           enabled && !disabled
-            ? INCOGNITO_TOGGLE_ON_CLASSES
+            ? titlebar
+              ? "text-slate-700 dark:text-slate-200"
+              : INCOGNITO_TOGGLE_ON_CLASSES
             : "text-muted-foreground hover:text-foreground",
         )}
       >
         {saving ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          <Loader2 className="h-4 w-4 animate-spin" />
         ) : (
-          <Ghost className="h-3.5 w-3.5" />
+          <Ghost className="h-4 w-4" />
         )}
-        <span>{t("chat.incognito")}</span>
+        {showLabel && <span>{t("chat.incognito")}</span>}
       </button>
     </IconTip>
   )

--- a/src/components/chat/input/ModelPicker.tsx
+++ b/src/components/chat/input/ModelPicker.tsx
@@ -140,7 +140,7 @@ export default function ModelPicker({
             onClick={() => setShowThinkMenu(!showThinkMenu)}
             className="flex items-center gap-1 bg-transparent text-muted-foreground hover:text-foreground text-xs font-medium px-2 py-1 rounded-lg cursor-pointer transition-colors hover:bg-secondary shrink-0 whitespace-nowrap"
           >
-            <Brain className="h-3.5 w-3.5 shrink-0" />
+            <Brain className="h-4 w-4 shrink-0" />
             <span>
               {getEffortOptionsForModel(currentModelInfo, t).find(
                 (o) => o.value === reasoningEffort,

--- a/src/components/chat/input/PermissionModeSwitcher.tsx
+++ b/src/components/chat/input/PermissionModeSwitcher.tsx
@@ -58,7 +58,7 @@ export default function PermissionModeSwitcher({
           activeTheme.buttonTone,
         )}
       >
-        <ActiveIcon className="h-3.5 w-3.5 shrink-0" />
+        <ActiveIcon className="h-4 w-4 shrink-0" />
         <span>{t(`chat.permissionMode.${permissionMode}.label`)}</span>
       </button>
 
@@ -82,7 +82,7 @@ export default function PermissionModeSwitcher({
                     setOpen(false)
                   }}
                 >
-                  <Icon className={cn("h-3.5 w-3.5 mt-0.5 shrink-0", theme.iconTone)} />
+                  <Icon className={cn("h-4 w-4 mt-0.5 shrink-0", theme.iconTone)} />
                   <div className="flex flex-col">
                     <span className="text-[13px]">
                       {t(`chat.permissionMode.${mode}.label`)}

--- a/src/components/chat/input/TemperatureSlider.tsx
+++ b/src/components/chat/input/TemperatureSlider.tsx
@@ -33,7 +33,7 @@ export default function TemperatureSlider({
               : "text-muted-foreground hover:text-foreground",
           )}
         >
-          <Thermometer className="h-3.5 w-3.5 shrink-0" />
+          <Thermometer className="h-4 w-4 shrink-0" />
           {sessionTemperature != null && (
             <span>{sessionTemperature.toFixed(1)}</span>
           )}

--- a/src/components/chat/input/WorkingDirectoryButton.tsx
+++ b/src/components/chat/input/WorkingDirectoryButton.tsx
@@ -8,7 +8,6 @@ import ServerDirectoryBrowser from "./ServerDirectoryBrowser"
 import { useDirectoryPicker } from "./useDirectoryPicker"
 
 interface WorkingDirectoryButtonProps {
-  sessionId: string | null
   workingDir: string | null | undefined
   /**
    * `workingDir` came from the parent project (session itself has no
@@ -29,7 +28,6 @@ interface WorkingDirectoryButtonProps {
 }
 
 export default function WorkingDirectoryButton({
-  sessionId,
   workingDir,
   inherited = false,
   saving = false,
@@ -62,14 +60,7 @@ export default function WorkingDirectoryButton({
     onChange(null)
   }
 
-  const tooltipLabel = hasSelection
-    ? inherited
-      ? `${t("chat.workingDir.titleBarInherited")}: ${workingDir}`
-      : `${t("chat.workingDir.current")}: ${workingDir}`
-    : sessionId
-      ? t("chat.workingDir.select")
-      : t("chat.workingDir.selectPreset")
-
+  const tooltipLabel = t("chat.workingDir.select")
   const label = hasSelection ? basename(workingDir!) : t("chat.workingDir.select")
 
   if (variant === "menu") {
@@ -86,11 +77,11 @@ export default function WorkingDirectoryButton({
           )}
         >
           {saving ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0 text-muted-foreground" />
+            <Loader2 className="h-4 w-4 animate-spin shrink-0 text-muted-foreground" />
           ) : hasSelection ? (
-            <FolderCheck className="h-3.5 w-3.5 shrink-0 text-primary" />
+            <FolderCheck className="h-4 w-4 shrink-0 text-primary" />
           ) : (
-            <FolderPlus className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <FolderPlus className="h-4 w-4 shrink-0 text-muted-foreground" />
           )}
           <span className="truncate">{hasSelection ? label : t("chat.addWorkingDirectory")}</span>
         </button>
@@ -111,10 +102,11 @@ export default function WorkingDirectoryButton({
       <IconTip label={tooltipLabel}>
         <button
           type="button"
+          aria-label={tooltipLabel}
           disabled={saving || disabled}
           onClick={handlePick}
           className={cn(
-            "flex items-center gap-1 bg-transparent text-xs font-medium px-2 py-1 rounded-lg cursor-pointer transition-colors hover:bg-secondary shrink-0 whitespace-nowrap max-w-[200px] disabled:cursor-not-allowed disabled:opacity-50",
+            "inline-flex h-8 w-8 items-center justify-center bg-transparent rounded-lg cursor-pointer transition-colors hover:bg-secondary shrink-0 disabled:cursor-not-allowed disabled:opacity-50",
             saving && "disabled:cursor-wait disabled:opacity-70",
             hasSelection
               ? "text-primary hover:text-primary"
@@ -123,13 +115,12 @@ export default function WorkingDirectoryButton({
           )}
         >
           {saving ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0" />
+            <Loader2 className="h-4 w-4 animate-spin shrink-0" />
           ) : hasSelection ? (
-            <FolderCheck className="h-3.5 w-3.5 shrink-0" />
+            <FolderCheck className="h-4 w-4 shrink-0" />
           ) : (
-            <FolderPlus className="h-3.5 w-3.5 shrink-0" />
+            <FolderPlus className="h-4 w-4 shrink-0" />
           )}
-          <span className="truncate">{label}</span>
         </button>
       </IconTip>
       {showClear && !saving && (

--- a/src/components/chat/input/toolbarOverflow.test.ts
+++ b/src/components/chat/input/toolbarOverflow.test.ts
@@ -13,38 +13,22 @@ test("groups add-style chat input actions behind the overflow menu", () => {
     "working-dir",
     "attach-files",
     "slash-command",
-    "incognito",
   ])
 })
 
 test("keeps overflow visibility classes static for Tailwind scanning", () => {
-  expect(CHAT_INPUT_INLINE_ADD_ACTIONS_CLASS).toBe("contents max-[900px]:hidden")
-  expect(CHAT_INPUT_OVERFLOW_MENU_CLASS).toBe("hidden max-[900px]:block")
-  // JS-side breakpoint must mirror the Tailwind class so the matchMedia
-  // auto-close stays in lockstep with the CSS toggle.
+  expect(CHAT_INPUT_INLINE_ADD_ACTIONS_CLASS).toBe("contents")
+  expect(CHAT_INPUT_OVERFLOW_MENU_CLASS).toBe("hidden")
+  // JS-side breakpoint is measured against the input container width, so
+  // right-side panels can trigger the compact toolbar without resizing window.
   expect(CHAT_INPUT_OVERFLOW_BREAKPOINT_PX).toBe(900)
 })
 
-test("shows the incognito preset action only before a session exists", () => {
-  expect(typeof toolbarOverflow.shouldShowIncognitoPresetAction).toBe("function")
-  const { shouldShowIncognitoPresetAction } = toolbarOverflow
-
-  expect(shouldShowIncognitoPresetAction(null, true)).toBe(true)
-  expect(shouldShowIncognitoPresetAction("session-1", true)).toBe(false)
-  expect(shouldShowIncognitoPresetAction(null, false)).toBe(false)
-})
-
-test("filters overflow incognito action for existing sessions", () => {
+test("returns overflow actions for the compact input toolbar", () => {
   expect(typeof toolbarOverflow.getChatInputOverflowActionIds).toBe("function")
   const { getChatInputOverflowActionIds } = toolbarOverflow
 
-  expect(getChatInputOverflowActionIds(null, true)).toEqual([
-    "working-dir",
-    "attach-files",
-    "slash-command",
-    "incognito",
-  ])
-  expect(getChatInputOverflowActionIds("session-1", true)).toEqual([
+  expect(getChatInputOverflowActionIds()).toEqual([
     "working-dir",
     "attach-files",
     "slash-command",

--- a/src/components/chat/input/toolbarOverflow.ts
+++ b/src/components/chat/input/toolbarOverflow.ts
@@ -2,32 +2,16 @@ export const CHAT_INPUT_OVERFLOW_ACTION_IDS = [
   "working-dir",
   "attach-files",
   "slash-command",
-  "incognito",
 ] as const
 
 export type ChatInputOverflowActionId = (typeof CHAT_INPUT_OVERFLOW_ACTION_IDS)[number]
 
-export function shouldShowIncognitoPresetAction(
-  currentSessionId: string | null | undefined,
-  hasIncognitoHandler: boolean,
-): boolean {
-  return !currentSessionId && hasIncognitoHandler
+export function getChatInputOverflowActionIds(): ChatInputOverflowActionId[] {
+  return [...CHAT_INPUT_OVERFLOW_ACTION_IDS]
 }
 
-export function getChatInputOverflowActionIds(
-  currentSessionId: string | null | undefined,
-  hasIncognitoHandler: boolean,
-): ChatInputOverflowActionId[] {
-  const showIncognito = shouldShowIncognitoPresetAction(currentSessionId, hasIncognitoHandler)
-  return CHAT_INPUT_OVERFLOW_ACTION_IDS.filter((actionId) => {
-    if (actionId === "incognito") return showIncognito
-    return true
-  })
-}
-
-export const CHAT_INPUT_INLINE_ADD_ACTIONS_CLASS = "contents max-[900px]:hidden"
-export const CHAT_INPUT_OVERFLOW_MENU_CLASS = "hidden max-[900px]:block"
-// Mirrors the Tailwind `max-[900px]` arbitrary breakpoint above. JS reads this
-// to auto-close the dropdown when the trigger goes `display:none` on resize —
-// Radix would otherwise leave the orphaned popper at (0,0).
+export const CHAT_INPUT_INLINE_ADD_ACTIONS_CLASS = "contents"
+export const CHAT_INPUT_OVERFLOW_MENU_CLASS = "hidden"
+// Measured against the chat input container, not the viewport. Right-side
+// panels can squeeze the chat column while the app window remains wide.
 export const CHAT_INPUT_OVERFLOW_BREAKPOINT_PX = 900

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -482,7 +482,7 @@
       "loading": "Loading…",
       "parent": "Up one level",
       "pathPlaceholder": "Absolute path, e.g. /srv/projects/app",
-      "select": "Select working directory",
+      "select": "Set working directory",
       "selectCurrent": "Select this directory",
       "selectPreset": "Working directory is set when you start the chat",
       "titleBarInherited": "Inherited from project",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -482,7 +482,7 @@
       "loading": "載入中……",
       "parent": "返回上一層",
       "pathPlaceholder": "絕對路徑，例如 /srv/projects/app",
-      "select": "選擇工作目錄",
+      "select": "設定工作目錄",
       "selectCurrent": "選擇此目錄",
       "selectPreset": "開始對話後即可設定工作目錄",
       "titleBarInherited": "繼承自專案",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -482,7 +482,7 @@
       "loading": "加载中……",
       "parent": "返回上一级",
       "pathPlaceholder": "绝对路径，例如 /srv/projects/app",
-      "select": "选择工作目录",
+      "select": "设置工作目录",
       "selectCurrent": "选择此目录",
       "selectPreset": "开始对话后即可设置工作目录",
       "titleBarInherited": "继承自项目",


### PR DESCRIPTION
## Summary
- Move incognito mode control to the chat title bar and normalize toolbar icon sizing.
- Make the working directory button icon-only with the updated tooltip copy.
- Trigger input overflow from container width and auto-collapse the session sidebar when right panels open.
- Update the changelog for the chat UI polish.

## Tests
- cargo fmt --all --check
- cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings
- cargo test  -p ha-core -p ha-server --locked
- pnpm typecheck
- pnpm lint
- pnpm test