### PR TITLE
[codex] Polish chat workbench UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **聊天工作台视觉与布局改造**：主界面切成全局 rail + 会话 pane 两层导航，右侧 Browser / Plan / Diff / Canvas / Team 面板统一为共享 shell；空会话时输入框居中加宽并显示品牌 Logo，有消息后回到底部；应用默认窗口尺寸放大到更适合双栏工作台的 1360×860。
 - **聊天界面窄栏自适应整理**：输入框工作目录入口改为纯图标 + 「设置工作目录」提示，统一工具条图标尺寸；无痕模式入口移至顶部标题栏；右侧 Browser / Plan / Diff / Canvas / Team 面板打开时自动收起左侧 session 列表，用户仍可手动展开；输入框溢出菜单改为按容器宽度触发，修复右侧面板压缩聊天列时「+」菜单不出现。
 - **聊天消息 Markdown / 纯文本渲染可切换**：用户消息现在与模型消息一样默认支持 Markdown 渲染，气泡 hover 操作区新增 Markdown / 纯文本切换按钮，复制仍保留原始文本。两种模式都会自动识别裸链接（`https://...` / `www.example.com` / 邮箱）并渲染为可点击超链，复用既有外链与本地路径打开策略。
 - **Chromium 运行时自动安装兜底**：系统没装 Chrome / Edge / Brave / Chromium 时，agent 可调 `profile.op=install_runtime` 或 settings → Browser → 「Install Chromium runtime」按钮，自动下载 pinned Chromium snapshot（约 150 MB）解压到 `~/.hope-agent/browser/runtime/chromium-{rev}/`，下载完后 `profile.op=launch` 自动使用。下载进度通过 EventBus `browser:chromium_download_progress` 推送给 UI 进度条；zip-slip / chmod +x / `--version` smoke-test 三道防线。新增 `browser_install_chromium_runtime` Tauri 命令 + `POST /api/browser/install-chromium-runtime` HTTP 路由 + 12 语言文案。
@@ -41,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **聊天任务视图消息操作区补齐**：任务视图下模型消息恢复「详情」按钮，复制 / Markdown 切换 / 详情三枚按钮统一对齐；`showPlainText` / `renderMarkdown` 补齐 12 语言文案；亮色主题用户气泡改为更克制的冷灰色，并修复首次打开时 session pane 宽度被空 `localStorage` 错夹到最小值的问题。
 - **MCP 工具开关热更新一致性**：`mcpGlobal.enabled` / `deniedServers` / server `enabled` 现在会同步更新 live registry、schema cache、`tool_search` 与执行反查表；修改 server `allowedTools` / `deniedTools` 不再把已 Ready 的 MCP 工具清空到必须手动 Reconnect。server `autoApprove` 现在只在 `trustLevel=Trusted` 时真正跳过普通工具审批，且不会绕过 Plan Mode ask。
 - **切回流式输出中的会话不再从头重放打字机动画**：MarkdownRenderer 在 mount 时把当前 content 长度记为基线，已经看过的内容直接整段显示，仅对 mount 之后新到达的 delta 继续走 typewriter + blurIn 动画。修复切到别的会话再切回时整段内容"咵地从头一字一字 / 模糊变清晰重放一遍"的视觉问题。
 - **会话内切换模型不再污染全局默认 & 不再闪回**：聊天界面 ModelPicker、桌面斜杠 `/model` 卡片、IM `/model` 命令现在都只把模型固定到**当前会话**（写入 `sessions.provider_id/model_id`），不再改 `config.active_model`。下次发消息时 chat_engine 解析顺序变为 **session > agent.primary > config.active_model**。同一会话切模型 UI 由 `manualModelOverrideRef` 兜底，不会再因 `config:changed` 广播被回退成旧值。全局默认模型现在仅由「设置 → 模型」面板修改。

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,8 +20,8 @@
           "x": 8,
           "y": 18
         },
-        "width": 1200,
-        "height": 800,
+        "width": 1360,
+        "height": 860,
         "minWidth": 840,
         "minHeight": 480,
         "resizable": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -413,7 +413,7 @@ export default function App() {
     <ErrorBoundary>
       <TooltipProvider>
         <LightboxProvider>
-          <div className="flex flex-col h-screen overflow-hidden bg-background">
+          <div className="flex flex-col h-screen overflow-hidden bg-surface-app">
             <StarrySky />
             <Toaster />
             <DangerousModeBanner />

--- a/src/components/chat/BrowserPanel.tsx
+++ b/src/components/chat/BrowserPanel.tsx
@@ -151,7 +151,7 @@ export default function BrowserPanel({
       >
         <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
       </div>
-      <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-border/70 bg-background text-foreground shadow-sm">
+      <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-panel border border-border-soft bg-surface-panel text-foreground shadow-panel">
       {/* Header */}
       <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
         <Globe className="h-4 w-4 text-muted-foreground" />

--- a/src/components/chat/BrowserPanel.tsx
+++ b/src/components/chat/BrowserPanel.tsx
@@ -7,6 +7,7 @@ import { logger } from "@/lib/logger"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { IconTip } from "@/components/ui/tooltip"
+import { RightPanelShell } from "./right-panel/RightPanelShell"
 
 // ── Types (mirror ha_core::browser::frame::BrowserFramePayload) ─────────
 
@@ -105,53 +106,14 @@ export default function BrowserPanel({
     return () => clearInterval(interval)
   }, [paused, refresh])
 
-  // Same column-drag UX as the sibling CanvasPanel: an invisible 3px gutter
-  // on the panel's left edge becomes a faint divider on hover/active, and
-  // disables iframe pointer-events during the drag so the cursor stays sane.
-  const handlePanelDragStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault()
-      const startX = e.clientX
-      const startWidth = panelWidth
-      const maxWidth = Math.min(960, Math.max(420, window.innerWidth * 0.55))
-      const onMouseMove = (ev: MouseEvent) => {
-        const newWidth = Math.min(maxWidth, Math.max(360, startWidth - (ev.clientX - startX)))
-        onPanelWidthChange?.(newWidth)
-      }
-      const iframes = document.querySelectorAll("iframe")
-      iframes.forEach((f) => ((f as HTMLElement).style.pointerEvents = "none"))
-      const onMouseUp = () => {
-        document.removeEventListener("mousemove", onMouseMove)
-        document.removeEventListener("mouseup", onMouseUp)
-        document.body.style.cursor = ""
-        document.body.style.userSelect = ""
-        iframes.forEach((f) => ((f as HTMLElement).style.pointerEvents = ""))
-      }
-      document.addEventListener("mousemove", onMouseMove)
-      document.addEventListener("mouseup", onMouseUp)
-      document.body.style.cursor = "col-resize"
-      document.body.style.userSelect = "none"
-    },
-    [panelWidth, onPanelWidthChange],
-  )
-
   // ── Render ─────────────────────────────────────────────────────────────
 
   return (
-    <div
-      className="relative flex h-full min-h-0 shrink-0 min-w-[360px] max-w-[55%] p-3 pl-2"
-      style={{ width: panelWidth }}
+    <RightPanelShell
+      width={panelWidth}
+      onWidthChange={onPanelWidthChange}
+      resizeLabel={t("chat.browserPanel.resizePanel", "Resize browser panel")}
     >
-      <div
-        className="group absolute left-0 top-3 bottom-3 z-10 flex w-3 cursor-col-resize items-center justify-center"
-        onMouseDown={handlePanelDragStart}
-        role="separator"
-        aria-orientation="vertical"
-        aria-label={t("chat.browserPanel.resizePanel", "Resize browser panel")}
-      >
-        <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
-      </div>
-      <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-panel border border-border-soft bg-surface-panel text-foreground shadow-panel">
       {/* Header */}
       <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
         <Globe className="h-4 w-4 text-muted-foreground" />
@@ -262,7 +224,6 @@ export default function BrowserPanel({
             : ""}
         </div>
       </div>
-      </div>
-    </div>
+    </RightPanelShell>
   )
 }

--- a/src/components/chat/CanvasPanel.tsx
+++ b/src/components/chat/CanvasPanel.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { X, RefreshCw, Maximize2, Minimize2, ExternalLink, PanelLeftClose } from "lucide-react"
 import { IconTip } from "@/components/ui/tooltip"
+import { RightPanelShell } from "./right-panel/RightPanelShell"
 
 interface CanvasInfo {
   projectId: string
@@ -384,33 +385,6 @@ export default function CanvasPanel({
     setDetached(false)
   }, [])
 
-  const handlePanelDragStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault()
-      const startX = e.clientX
-      const startWidth = panelWidth
-      const maxWidth = Math.min(960, Math.max(420, window.innerWidth * 0.55))
-      const onMouseMove = (ev: MouseEvent) => {
-        const newWidth = Math.min(maxWidth, Math.max(360, startWidth - (ev.clientX - startX)))
-        onPanelWidthChange?.(newWidth)
-      }
-      const iframes = document.querySelectorAll("iframe")
-      iframes.forEach((f) => ((f as HTMLElement).style.pointerEvents = "none"))
-      const onMouseUp = () => {
-        document.removeEventListener("mousemove", onMouseMove)
-        document.removeEventListener("mouseup", onMouseUp)
-        document.body.style.cursor = ""
-        document.body.style.userSelect = ""
-        iframes.forEach((f) => ((f as HTMLElement).style.pointerEvents = ""))
-      }
-      document.addEventListener("mousemove", onMouseMove)
-      document.addEventListener("mouseup", onMouseUp)
-      document.body.style.cursor = "col-resize"
-      document.body.style.userSelect = "none"
-    },
-    [panelWidth, onPanelWidthChange],
-  )
-
   if (!canvas) return null
 
   // Build the iframe URL via the transport — `asset://` scheme in Tauri,
@@ -421,122 +395,26 @@ export default function CanvasPanel({
   // When detached, show a compact placeholder panel
   if (detached) {
     return (
-      <div
-        className="relative flex h-full min-h-0 shrink-0 min-w-[360px] max-w-[55%] p-3 pl-2"
-        style={{ width: panelWidth }}
-      >
-        <div
-          className="group absolute left-0 top-3 bottom-3 z-10 flex w-3 cursor-col-resize items-center justify-center"
-          onMouseDown={handlePanelDragStart}
-          role="separator"
-          aria-orientation="vertical"
-          aria-label={t("canvas.resizePanel", "Resize canvas panel")}
-        >
-          <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
-        </div>
-        <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-panel border border-border-soft bg-surface-panel shadow-panel">
-          {/* Title Bar */}
-          <div
-            className="flex h-11 items-center gap-2 border-b border-border-soft bg-surface-panel/95 px-4 shrink-0"
-            data-tauri-drag-region
-          >
-            <span className="text-sm font-medium truncate flex-1">{canvas.title}</span>
-            <div className="flex items-center gap-0.5">
-              <IconTip label={t("canvas.reattach")}>
-                <button
-                  onClick={handleReattach}
-                  className="p-1 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
-                >
-                  <PanelLeftClose className="h-3.5 w-3.5" />
-                </button>
-              </IconTip>
-              <IconTip label={t("canvas.close")}>
-                <button
-                  onClick={handleClose}
-                  className="p-1 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              </IconTip>
-            </div>
-          </div>
-          <div className="flex-1 flex items-center justify-center p-4">
-            <p className="text-xs text-muted-foreground text-center">{t("canvas.popOutActive")}</p>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div
-      className="relative flex h-full min-h-0 shrink-0 min-w-[360px] max-w-[55%] p-3 pl-2"
-      style={{ width: panelWidth }}
-    >
-      <div
-        className="group absolute left-0 top-3 bottom-3 z-10 flex w-3 cursor-col-resize items-center justify-center"
-        onMouseDown={handlePanelDragStart}
-        role="separator"
-        aria-orientation="vertical"
-        aria-label={t("canvas.resizePanel", "Resize canvas panel")}
-      >
-        <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
-      </div>
-      <div
-        className={
-          maximized
-            ? "fixed inset-0 z-50 flex flex-col bg-surface-app"
-            : "flex h-full min-h-0 w-full flex-col overflow-hidden rounded-panel border border-border-soft bg-surface-panel shadow-panel"
-        }
+      <RightPanelShell
+        width={panelWidth}
+        onWidthChange={onPanelWidthChange}
+        resizeLabel={t("canvas.resizePanel", "Resize canvas panel")}
       >
         {/* Title Bar */}
         <div
-          className={cn(
-            "flex h-11 items-center gap-2 border-b border-border-soft bg-surface-panel px-4 shrink-0",
-            maximized && "h-[72px] items-end pb-2 pt-7",
-          )}
+          className="flex h-11 items-center gap-2 border-b border-border-soft bg-surface-panel/95 px-4 shrink-0"
           data-tauri-drag-region
         >
-          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-            {canvas.contentType}
-          </span>
           <span className="text-sm font-medium truncate flex-1">{canvas.title}</span>
-
           <div className="flex items-center gap-0.5">
-            <IconTip label={t("canvas.refresh")}>
+            <IconTip label={t("canvas.reattach")}>
               <button
-                onClick={handleRefresh}
+                onClick={handleReattach}
                 className="p-1 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
               >
-                <RefreshCw className="h-3.5 w-3.5" />
+                <PanelLeftClose className="h-3.5 w-3.5" />
               </button>
             </IconTip>
-
-            {/* Detach is desktop-only — spawning a WebviewWindow requires Tauri. */}
-            {isTauriMode() && (
-              <IconTip label={t("canvas.popOut")}>
-                <button
-                  onClick={handleDetach}
-                  className="p-1 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
-                >
-                  <ExternalLink className="h-3.5 w-3.5" />
-                </button>
-              </IconTip>
-            )}
-
-            <IconTip label={maximized ? t("canvas.minimize") : t("canvas.maximize")}>
-              <button
-                onClick={() => setMaximized((v) => !v)}
-                className="p-1 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
-              >
-                {maximized ? (
-                  <Minimize2 className="h-3.5 w-3.5" />
-                ) : (
-                  <Maximize2 className="h-3.5 w-3.5" />
-                )}
-              </button>
-            </IconTip>
-
             <IconTip label={t("canvas.close")}>
               <button
                 onClick={handleClose}
@@ -547,19 +425,90 @@ export default function CanvasPanel({
             </IconTip>
           </div>
         </div>
+        <div className="flex-1 flex items-center justify-center p-4">
+          <p className="text-xs text-muted-foreground text-center">{t("canvas.popOutActive")}</p>
+        </div>
+      </RightPanelShell>
+    )
+  }
 
-        {/* iframe preview */}
-        <div className="flex-1 overflow-hidden bg-white dark:bg-surface-app">
-          <iframe
-            ref={iframeRef}
-            key={`${canvas.projectId}-${refreshKey}`}
-            src={iframeSrc}
-            sandbox="allow-scripts"
-            className="w-full h-full border-0"
-            title={canvas.title}
-          />
+  return (
+    <RightPanelShell
+      width={panelWidth}
+      onWidthChange={onPanelWidthChange}
+      resizeLabel={t("canvas.resizePanel", "Resize canvas panel")}
+      maximized={maximized}
+    >
+      {/* Title Bar */}
+      <div
+        className={cn(
+          "flex h-11 items-center gap-2 border-b border-border-soft bg-surface-panel px-4 shrink-0",
+          maximized && "h-[72px] items-end pb-2 pt-7",
+        )}
+        data-tauri-drag-region
+      >
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          {canvas.contentType}
+        </span>
+        <span className="text-sm font-medium truncate flex-1">{canvas.title}</span>
+
+        <div className="flex items-center gap-0.5">
+          <IconTip label={t("canvas.refresh")}>
+            <button
+              onClick={handleRefresh}
+              className="p-1 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+            </button>
+          </IconTip>
+
+          {/* Detach is desktop-only — spawning a WebviewWindow requires Tauri. */}
+          {isTauriMode() && (
+            <IconTip label={t("canvas.popOut")}>
+              <button
+                onClick={handleDetach}
+                className="p-1 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </button>
+            </IconTip>
+          )}
+
+          <IconTip label={maximized ? t("canvas.minimize") : t("canvas.maximize")}>
+            <button
+              onClick={() => setMaximized((v) => !v)}
+              className="p-1 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
+            >
+              {maximized ? (
+                <Minimize2 className="h-3.5 w-3.5" />
+              ) : (
+                <Maximize2 className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </IconTip>
+
+          <IconTip label={t("canvas.close")}>
+            <button
+              onClick={handleClose}
+              className="p-1 rounded hover:bg-secondary transition-colors text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </IconTip>
         </div>
       </div>
-    </div>
+
+      {/* iframe preview */}
+      <div className="flex-1 overflow-hidden bg-white dark:bg-surface-app">
+        <iframe
+          ref={iframeRef}
+          key={`${canvas.projectId}-${refreshKey}`}
+          src={iframeSrc}
+          sandbox="allow-scripts"
+          className="w-full h-full border-0"
+          title={canvas.title}
+        />
+      </div>
+    </RightPanelShell>
   )
 }

--- a/src/components/chat/CanvasPanel.tsx
+++ b/src/components/chat/CanvasPanel.tsx
@@ -434,10 +434,10 @@ export default function CanvasPanel({
         >
           <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
         </div>
-        <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-border/70 bg-card shadow-sm">
+        <div className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-panel border border-border-soft bg-surface-panel shadow-panel">
           {/* Title Bar */}
           <div
-            className="flex h-11 items-center gap-2 border-b border-border/60 bg-card/95 px-4 shrink-0"
+            className="flex h-11 items-center gap-2 border-b border-border-soft bg-surface-panel/95 px-4 shrink-0"
             data-tauri-drag-region
           >
             <span className="text-sm font-medium truncate flex-1">{canvas.title}</span>
@@ -485,14 +485,14 @@ export default function CanvasPanel({
       <div
         className={
           maximized
-            ? "fixed inset-0 z-50 flex flex-col bg-background"
-            : "flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-border/70 bg-background shadow-sm"
+            ? "fixed inset-0 z-50 flex flex-col bg-surface-app"
+            : "flex h-full min-h-0 w-full flex-col overflow-hidden rounded-panel border border-border-soft bg-surface-panel shadow-panel"
         }
       >
         {/* Title Bar */}
         <div
           className={cn(
-            "flex h-11 items-center gap-2 border-b border-border/60 bg-background px-4 shrink-0",
+            "flex h-11 items-center gap-2 border-b border-border-soft bg-surface-panel px-4 shrink-0",
             maximized && "h-[72px] items-end pb-2 pt-7",
           )}
           data-tauri-drag-region
@@ -549,7 +549,7 @@ export default function CanvasPanel({
         </div>
 
         {/* iframe preview */}
-        <div className="flex-1 overflow-hidden bg-white dark:bg-zinc-900">
+        <div className="flex-1 overflow-hidden bg-white dark:bg-surface-app">
           <iframe
             ref={iframeRef}
             key={`${canvas.projectId}-${refreshKey}`}

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -1533,7 +1533,7 @@ export default function ChatScreen({
       />
 
       {/* Conversation workspace */}
-      <div className="flex-1 flex flex-col min-w-0 bg-background">
+      <div className="flex-1 flex flex-col min-w-0 bg-surface-app">
         <ChatTitleBar
           agentName={session.agentName}
           currentAgentId={session.currentAgentId}

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -49,6 +49,7 @@ import { useModelState } from "./hooks/useModelState"
 import SystemPromptDialog from "./SystemPromptDialog"
 import { PlanPanel } from "./plan-mode/PlanPanel"
 import type { BuiltPlanComment } from "./plan-mode/planCommentMessage"
+import { RightPanelShell } from "./right-panel/RightPanelShell"
 import { useProjects } from "./project/hooks/useProjects"
 import ProjectDialog from "./project/ProjectDialog"
 import ProjectOverviewDialog from "./project/ProjectOverviewDialog"
@@ -1300,60 +1301,6 @@ export default function ChatScreen({
     lastRightPanelKeyRef.current = rightPanelKey
   }, [rightPanelKey])
 
-  const handlePlanPanelDragStart = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.preventDefault()
-      const startX = e.clientX
-      const startWidth = planPanelWidth
-      const maxWidth = Math.min(860, Math.max(420, window.innerWidth * 0.55))
-      const onMouseMove = (ev: MouseEvent) => {
-        const newWidth = Math.min(maxWidth, Math.max(360, startWidth - (ev.clientX - startX)))
-        setPlanPanelWidth(newWidth)
-      }
-      const iframes = document.querySelectorAll("iframe")
-      iframes.forEach((f) => ((f as HTMLElement).style.pointerEvents = "none"))
-      const onMouseUp = () => {
-        document.removeEventListener("mousemove", onMouseMove)
-        document.removeEventListener("mouseup", onMouseUp)
-        document.body.style.cursor = ""
-        document.body.style.userSelect = ""
-        iframes.forEach((f) => ((f as HTMLElement).style.pointerEvents = ""))
-      }
-      document.addEventListener("mousemove", onMouseMove)
-      document.addEventListener("mouseup", onMouseUp)
-      document.body.style.cursor = "col-resize"
-      document.body.style.userSelect = "none"
-    },
-    [planPanelWidth],
-  )
-
-  const handleDiffPanelDragStart = useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.preventDefault()
-      const startX = e.clientX
-      const startWidth = diffPanel.panelWidth
-      const maxWidth = Math.min(860, Math.max(420, window.innerWidth * 0.55))
-      const onMouseMove = (ev: MouseEvent) => {
-        const newWidth = Math.min(maxWidth, Math.max(360, startWidth - (ev.clientX - startX)))
-        diffPanel.setPanelWidth(newWidth)
-      }
-      const iframes = document.querySelectorAll("iframe")
-      iframes.forEach((f) => ((f as HTMLElement).style.pointerEvents = "none"))
-      const onMouseUp = () => {
-        document.removeEventListener("mousemove", onMouseMove)
-        document.removeEventListener("mouseup", onMouseUp)
-        document.body.style.cursor = ""
-        document.body.style.userSelect = ""
-        iframes.forEach((f) => ((f as HTMLElement).style.pointerEvents = ""))
-      }
-      document.addEventListener("mousemove", onMouseMove)
-      document.addEventListener("mouseup", onMouseUp)
-      document.body.style.cursor = "col-resize"
-      document.body.style.userSelect = "none"
-    },
-    [diffPanel],
-  )
-
   // Right-side panels (PlanPanel / CanvasPanel / DiffPanel / BrowserPanel)
   // are mutually exclusive at the visual level — opening one closes the
   // others but keeps their internal state so re-toggling restores the prior
@@ -1707,19 +1654,12 @@ export default function ChatScreen({
 
           {/* Diff panel (right side; mutually exclusive with PlanPanel) */}
           {diffPanel.showPanel && diffPanel.activeChanges.length > 0 && (
-            <div
-              className="relative flex h-full min-h-0 shrink-0 min-w-[360px] max-w-[55%] p-3 pl-2"
-              style={{ width: diffPanel.panelWidth }}
+            <RightPanelShell
+              width={diffPanel.panelWidth}
+              onWidthChange={diffPanel.setPanelWidth}
+              resizeLabel={t("diffPanel.resizePanel", "Resize diff panel")}
+              maxWidth={860}
             >
-              <div
-                className="group absolute left-0 top-3 bottom-3 z-10 flex w-3 cursor-col-resize items-center justify-center"
-                onMouseDown={handleDiffPanelDragStart}
-                role="separator"
-                aria-orientation="vertical"
-                aria-label={t("diffPanel.resizePanel", "Resize diff panel")}
-              >
-                <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
-              </div>
               <DiffPanel
                 changes={diffPanel.activeChanges}
                 activeIndex={diffPanel.activeIndex}
@@ -1727,24 +1667,17 @@ export default function ChatScreen({
                 onClose={diffPanel.closeDiff}
                 embedded
               />
-            </div>
+            </RightPanelShell>
           )}
 
           {/* Plan workspace (right side, integrated under the shared title bar) */}
           {shouldShowPlanPanel && (
-            <div
-              className="relative flex h-full min-h-0 shrink-0 min-w-[360px] max-w-[55%] p-3 pl-2"
-              style={{ width: planPanelWidth }}
+            <RightPanelShell
+              width={planPanelWidth}
+              onWidthChange={setPlanPanelWidth}
+              resizeLabel={t("planMode.resizePanel", "Resize plan panel")}
+              maxWidth={860}
             >
-              <div
-                className="group absolute left-0 top-3 bottom-3 z-10 flex w-3 cursor-col-resize items-center justify-center"
-                onMouseDown={handlePlanPanelDragStart}
-                role="separator"
-                aria-orientation="vertical"
-                aria-label={t("planMode.resizePanel", "Resize plan panel")}
-              >
-                <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
-              </div>
               <PlanPanel
                 planState={planMode.planState}
                 planContent={planMode.planContent}
@@ -1757,7 +1690,7 @@ export default function ChatScreen({
                 onRequestChanges={handleRequestChanges}
                 embedded
               />
-            </div>
+            </RightPanelShell>
           )}
 
           {/* Canvas Preview Panel */}

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -60,6 +60,12 @@ import {
   readChatDisplayModePreference,
   writeChatDisplayModePreference,
 } from "./chatDisplayModePreference"
+import {
+  CHAT_SIDEBAR_DEFAULT_WIDTH,
+  CHAT_SIDEBAR_MAX_WIDTH,
+  CHAT_SIDEBAR_MIN_WIDTH,
+  CHAT_SIDEBAR_WIDTH_STORAGE_KEY,
+} from "./sidebar/types"
 import type { Project, ProjectMeta } from "@/types/project"
 
 interface ChatScreenProps {
@@ -73,6 +79,10 @@ interface ChatScreenProps {
   pendingChatInsert?: string
   /** Called once the insert has been consumed so App can clear the pending slot. */
   onChatInsertConsumed?: () => void
+}
+
+function clampChatSidebarWidth(width: number): number {
+  return Math.min(CHAT_SIDEBAR_MAX_WIDTH, Math.max(CHAT_SIDEBAR_MIN_WIDTH, width))
 }
 
 export default function ChatScreen({
@@ -104,11 +114,22 @@ export default function ChatScreen({
   } = useModelState()
 
   // Sidebar panel width
-  const [panelWidth, setPanelWidth] = useState(288)
+  const [panelWidth, setPanelWidth] = useState(() => {
+    if (typeof window === "undefined") return CHAT_SIDEBAR_DEFAULT_WIDTH
+    const stored = Number(window.localStorage.getItem(CHAT_SIDEBAR_WIDTH_STORAGE_KEY))
+    return Number.isFinite(stored)
+      ? clampChatSidebarWidth(stored)
+      : CHAT_SIDEBAR_DEFAULT_WIDTH
+  })
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     if (typeof window === "undefined") return false
     return window.localStorage.getItem("hope.chatSidebarCollapsed") === "true"
   })
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    window.localStorage.setItem(CHAT_SIDEBAR_WIDTH_STORAGE_KEY, String(panelWidth))
+  }, [panelWidth])
 
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -1502,7 +1523,6 @@ export default function ChatScreen({
           loading={session.loading}
           compacting={compacting}
           setCompacting={setCompacting}
-          onOpenAgentSettings={onOpenAgentSettings}
           onRenameSession={handleRenameSession}
           onViewSystemPrompt={loadSystemPrompt}
           systemPromptLoading={systemPromptLoading}

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -116,9 +116,12 @@ export default function ChatScreen({
   // Sidebar panel width
   const [panelWidth, setPanelWidth] = useState(() => {
     if (typeof window === "undefined") return CHAT_SIDEBAR_DEFAULT_WIDTH
-    const stored = Number(window.localStorage.getItem(CHAT_SIDEBAR_WIDTH_STORAGE_KEY))
-    return Number.isFinite(stored)
-      ? clampChatSidebarWidth(stored)
+    const stored = window.localStorage.getItem(CHAT_SIDEBAR_WIDTH_STORAGE_KEY)
+    if (!stored) return CHAT_SIDEBAR_DEFAULT_WIDTH
+
+    const storedWidth = Number(stored)
+    return Number.isFinite(storedWidth)
+      ? clampChatSidebarWidth(storedWidth)
       : CHAT_SIDEBAR_DEFAULT_WIDTH
   })
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -4,6 +4,7 @@ import { getTransport } from "@/lib/transport-provider"
 import { save } from "@tauri-apps/plugin-dialog"
 import { useTranslation } from "react-i18next"
 import { logger } from "@/lib/logger"
+import { cn } from "@/lib/utils"
 import { Brain } from "lucide-react"
 import type {
   ActiveModel,
@@ -1347,6 +1348,14 @@ export default function ChatScreen({
     }
   }, [])
 
+  const emptySessionInputHero =
+    session.messages.length === 0 &&
+    !session.loading &&
+    !planMode.pendingQuestionGroup &&
+    !planMode.planCardInfo &&
+    !planMode.planSubagentRunning &&
+    !searchBarOpen
+
   return (
     <>
       {/* Sidebar */}
@@ -1521,7 +1530,7 @@ export default function ChatScreen({
         />
 
         <div className="flex-1 flex min-h-0 overflow-hidden">
-          <div className="flex-1 flex flex-col min-w-0">
+          <div className="relative flex-1 flex flex-col min-w-0">
             {activeTeamId && !showTeamPanel && (
               <div className="px-3 py-1 border-b border-border">
                 <TeamMiniIndicator teamId={activeTeamId} onClick={() => setShowTeamPanel(true)} />
@@ -1585,9 +1594,22 @@ export default function ChatScreen({
                * so it doesn't shrink the MessageList scroll container when it
                * appears/disappears. */}
             {!isCronSession && !isSubagentSession && (
-              <div className="relative">
+              <div
+                className={cn(
+                  "relative",
+                  emptySessionInputHero &&
+                    "absolute inset-x-0 top-[48%] z-20 flex -translate-y-1/2 justify-center px-5 sm:px-8",
+                )}
+              >
                 {memoryToast && (
-                  <div className="absolute left-0 right-0 bottom-full mx-4 mb-2 flex items-center gap-2 px-3 py-1.5 rounded-lg bg-secondary/50 text-xs text-muted-foreground animate-in fade-in slide-in-from-bottom-2 duration-300 z-10">
+                  <div
+                    className={cn(
+                      "absolute bottom-full mb-2 flex items-center gap-2 px-3 py-1.5 rounded-lg bg-secondary/50 text-xs text-muted-foreground animate-in fade-in slide-in-from-bottom-2 duration-300 z-10",
+                      emptySessionInputHero
+                        ? "inset-x-5 mx-auto max-w-[920px] sm:inset-x-8"
+                        : "left-0 right-0 mx-4",
+                    )}
+                  >
                     <Brain className="h-3.5 w-3.5 shrink-0" />
                     <span>{t("settings.memoryExtractedToast", { count: memoryToast.count })}</span>
                     <button
@@ -1599,55 +1621,60 @@ export default function ChatScreen({
                   </div>
                 )}
 
-                <ChatInput
-                  input={stream.input}
-                  onInputChange={stream.setInput}
-                  onSend={() => stream.handleSend()}
-                  loading={session.loading}
-                  availableModels={availableModels}
-                  activeModel={activeModel}
-                  reasoningEffort={reasoningEffort}
-                  onModelChange={handleManualModelChange}
-                  onEffortChange={handleSessionEffortChange}
-                  attachedFiles={stream.attachedFiles}
-                  onAttachFiles={(files) => stream.setAttachedFiles((prev) => [...prev, ...files])}
-                  onRemoveFile={(index) =>
-                    stream.setAttachedFiles((prev) => prev.filter((_, i) => i !== index))
-                  }
-                  pendingMessage={stream.pendingMessage}
-                  onCancelPending={() => {
-                    stream.setInput(stream.pendingMessage || "")
-                    stream.setPendingMessage(null)
-                  }}
-                  onDiscardPending={() => {
-                    stream.setPendingMessage(null)
-                  }}
-                  onStop={stream.handleStop}
-                  currentSessionId={session.currentSessionId}
-                  currentAgentId={session.currentAgentId}
-                  onCommandAction={handleCommandAction}
-                  permissionMode={stream.permissionMode}
-                  onPermissionModeChange={stream.setPermissionMode}
-                  sessionTemperature={sessionTemperature}
-                  onSessionTemperatureChange={setSessionTemperature}
-                  incognitoEnabled={incognitoEnabled}
-                  workingDir={session.currentSessionId ? effectiveWorkingDir : draftWorkingDir}
-                  workingDirInherited={
-                    session.currentSessionId ? workingDirSource === "project" : false
-                  }
-                  workingDirSaving={workingDirSaving}
-                  onWorkingDirChange={handleWorkingDirChange}
-                  planState={planMode.planState}
-                  onEnterPlanMode={planMode.enterPlanMode}
-                  onExitPlanMode={planMode.exitPlanMode}
-                  onTogglePlanPanel={() => planMode.setShowPanel((p) => !p)}
-                  taskProgressSnapshot={taskProgressSnapshot}
-                  executionState={
-                    session.currentSessionId
-                      ? stream.executionStateBySession.get(session.currentSessionId) ?? null
-                      : null
-                  }
-                />
+                <div className={cn(emptySessionInputHero && "w-full max-w-[920px]")}>
+                  <ChatInput
+                    input={stream.input}
+                    onInputChange={stream.setInput}
+                    onSend={() => stream.handleSend()}
+                    loading={session.loading}
+                    availableModels={availableModels}
+                    activeModel={activeModel}
+                    reasoningEffort={reasoningEffort}
+                    onModelChange={handleManualModelChange}
+                    onEffortChange={handleSessionEffortChange}
+                    attachedFiles={stream.attachedFiles}
+                    onAttachFiles={(files) =>
+                      stream.setAttachedFiles((prev) => [...prev, ...files])
+                    }
+                    onRemoveFile={(index) =>
+                      stream.setAttachedFiles((prev) => prev.filter((_, i) => i !== index))
+                    }
+                    pendingMessage={stream.pendingMessage}
+                    onCancelPending={() => {
+                      stream.setInput(stream.pendingMessage || "")
+                      stream.setPendingMessage(null)
+                    }}
+                    onDiscardPending={() => {
+                      stream.setPendingMessage(null)
+                    }}
+                    onStop={stream.handleStop}
+                    currentSessionId={session.currentSessionId}
+                    currentAgentId={session.currentAgentId}
+                    onCommandAction={handleCommandAction}
+                    permissionMode={stream.permissionMode}
+                    onPermissionModeChange={stream.setPermissionMode}
+                    sessionTemperature={sessionTemperature}
+                    onSessionTemperatureChange={setSessionTemperature}
+                    incognitoEnabled={incognitoEnabled}
+                    workingDir={session.currentSessionId ? effectiveWorkingDir : draftWorkingDir}
+                    workingDirInherited={
+                      session.currentSessionId ? workingDirSource === "project" : false
+                    }
+                    workingDirSaving={workingDirSaving}
+                    onWorkingDirChange={handleWorkingDirChange}
+                    planState={planMode.planState}
+                    onEnterPlanMode={planMode.enterPlanMode}
+                    onExitPlanMode={planMode.exitPlanMode}
+                    onTogglePlanPanel={() => planMode.setShowPanel((p) => !p)}
+                    taskProgressSnapshot={taskProgressSnapshot}
+                    executionState={
+                      session.currentSessionId
+                        ? stream.executionStateBySession.get(session.currentSessionId) ?? null
+                        : null
+                    }
+                    hero={emptySessionInputHero}
+                  />
+                </div>
               </div>
             )}
           </div>

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -17,7 +17,7 @@ import {
   FolderCheck,
   ListChecks,
   Loader2,
-  MessagesSquare,
+  MessageCircle,
   Search,
   Send,
   Ghost,
@@ -371,7 +371,7 @@ export default function ChatTitleBar({
               }
             >
               {displayMode === "timeline" ? (
-                <MessagesSquare className="h-4 w-4" />
+                <MessageCircle className="h-4 w-4" />
               ) : (
                 <ListChecks className="h-4 w-4" />
               )}

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -245,7 +245,7 @@ export default function ChatTitleBar({
 
   return (
     <div
-      className="h-10 flex items-end justify-between px-4 bg-background shrink-0"
+      className="h-10 flex items-end justify-between px-4 bg-surface-app shrink-0"
       data-tauri-drag-region
     >
       <div className="flex items-end gap-2 min-w-0 pb-1.5">

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -6,7 +6,6 @@ import { useAppVersion } from "@/lib/appMeta"
 import { basename } from "@/lib/path"
 import { IconTip } from "@/components/ui/tooltip"
 import {
-  Settings,
   Copy,
   BarChart3,
   Pencil,
@@ -22,7 +21,7 @@ import {
   Send,
   Ghost,
   Share2,
-  PanelLeftOpen,
+  PanelLeft,
 } from "lucide-react"
 import { ExportSessionDialog } from "@/components/chat/export/ExportSessionDialog"
 import ChannelIcon from "@/components/common/ChannelIcon"
@@ -55,7 +54,6 @@ interface ChatTitleBarProps {
   loading: boolean
   compacting: boolean
   setCompacting: (v: boolean) => void
-  onOpenAgentSettings?: (agentId: string) => void
   onRenameSession?: (sessionId: string, title: string) => void
   onViewSystemPrompt?: () => void
   systemPromptLoading?: boolean
@@ -119,7 +117,6 @@ export default function ChatTitleBar({
   compacting,
   setCompacting,
   onRenameSession,
-  onOpenAgentSettings,
   onViewSystemPrompt,
   systemPromptLoading,
   onCommandAction,
@@ -256,7 +253,7 @@ export default function ChatTitleBar({
               aria-label={t("chat.expandSidebar")}
               onClick={onExpandSidebar}
             >
-              <PanelLeftOpen className="h-4 w-4" />
+              <PanelLeft className="h-4 w-4" />
             </button>
           </IconTip>
         )}
@@ -778,17 +775,6 @@ export default function ChatTitleBar({
               onClick={() => onOpenHandover(currentSessionId)}
             >
               <Send className="h-4 w-4" />
-            </button>
-          </IconTip>
-        )}
-        {/* Settings Button */}
-        {onOpenAgentSettings && (
-          <IconTip label={t("settings.agentSettings")}>
-            <button
-              className="pb-1.5 text-muted-foreground hover:text-foreground transition-colors"
-              onClick={() => onOpenAgentSettings(currentAgentId)}
-            >
-              <Settings className="h-4 w-4" />
             </button>
           </IconTip>
         )}

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -21,7 +21,7 @@ import {
   Search,
   Send,
   Ghost,
-  Download,
+  Share2,
   PanelLeftOpen,
 } from "lucide-react"
 import { ExportSessionDialog } from "@/components/chat/export/ExportSessionDialog"
@@ -766,7 +766,7 @@ export default function ChatTitleBar({
               className="pb-1.5 text-muted-foreground hover:text-foreground transition-colors"
               onClick={() => setExportOpen(true)}
             >
-              <Download className="h-4 w-4" />
+              <Share2 className="h-4 w-4" />
             </button>
           </IconTip>
         )}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ArrowDown, Ghost } from "lucide-react"
+import alphaLogoUrl from "@/assets/alpha-logo.png"
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
 import { applyInlineHighlight, clearInlineHighlight } from "@/lib/inlineHighlight"
@@ -883,7 +884,15 @@ export default function MessageList({
                     <p className="mt-2 text-sm leading-relaxed">{t("chat.incognitoEmptyBody")}</p>
                   </div>
                 ) : (
-                  <p className="text-muted-foreground text-sm">{t("chat.howCanIHelp")}</p>
+                  <div className="px-4 text-center">
+                    <img
+                      src={alphaLogoUrl}
+                      alt=""
+                      className="mx-auto mb-5 h-[72px] w-[72px] object-contain opacity-95"
+                      draggable={false}
+                    />
+                    <p className="text-sm text-muted-foreground">{t("chat.howCanIHelp")}</p>
+                  </div>
                 )}
               </div>
             )}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -877,11 +877,11 @@ export default function MessageList({
       </div>
 
       {compactUserAnchor && compactUserAnchorVisible && (
-        <div className="pointer-events-none absolute inset-x-0 top-0 z-30">
+        <div className="pointer-events-none absolute inset-x-0 top-2 z-30 flex justify-end px-5 sm:px-6">
           <button
             type="button"
             onClick={handleCompactUserAnchorClick}
-            className="pointer-events-auto flex h-10 w-full cursor-pointer items-center border-b border-border/70 bg-background/95 px-5 text-right text-sm font-medium text-foreground backdrop-blur transition-colors hover:bg-muted supports-[backdrop-filter]:bg-background/85 sm:px-6"
+            className="pointer-events-auto flex h-9 max-w-[min(720px,85%)] cursor-pointer items-center rounded-full border border-border-soft bg-surface-floating/95 px-3.5 text-right text-sm font-medium text-foreground shadow-panel backdrop-blur transition-colors hover:bg-surface-subtle supports-[backdrop-filter]:bg-surface-floating/85"
           >
             <span className="min-w-0 flex-1 truncate">
               {compactUserAnchor.text}

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -77,6 +77,8 @@ const LOAD_MORE_THRESHOLD_PX = 200
 // — only the render slice. See `displayedStart`.
 const MAX_DOM_MESSAGES = 200
 const UNLOAD_BATCH = 30
+const COMPACT_USER_ANCHOR_LEAD_PX = 32
+const COMPACT_USER_ANCHOR_EXIT_MS = 200
 
 function shouldPassExecutionStateToBubble(
   isLast: boolean,
@@ -128,6 +130,7 @@ export default function MessageList({
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
   const [highlightMessageId, setHighlightMessageId] = useState<number | null>(null)
   const [compactUserAnchorVisible, setCompactUserAnchorVisible] = useState(false)
+  const [compactUserAnchorMounted, setCompactUserAnchorMounted] = useState(false)
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [contextMenu, setContextMenu] = useState<{
@@ -285,14 +288,27 @@ export default function MessageList({
       return
     }
     const containerTop = el.getBoundingClientRect().top
-    const targetTop = target.getBoundingClientRect().top
-    const visible = targetTop < containerTop - 1
+    const targetBottom = target.getBoundingClientRect().bottom
+    const visible = targetBottom < containerTop - COMPACT_USER_ANCHOR_LEAD_PX
     setCompactUserAnchorVisible((prev) => (prev === visible ? prev : visible))
   }, [compactUserAnchor?.rowKey])
 
   useLayoutEffect(() => {
     updateCompactUserAnchor()
   }, [items, updateCompactUserAnchor])
+
+  useEffect(() => {
+    if (compactUserAnchorVisible) {
+      setCompactUserAnchorMounted(true)
+      return
+    }
+
+    const timer = setTimeout(
+      () => setCompactUserAnchorMounted(false),
+      COMPACT_USER_ANCHOR_EXIT_MS,
+    )
+    return () => clearTimeout(timer)
+  }, [compactUserAnchorVisible])
 
   // Baseline for entrance animation: only messages appended *after* this
   // session was opened animate in. The initial set renders statically — no
@@ -876,12 +892,22 @@ export default function MessageList({
         </div>
       </div>
 
-      {compactUserAnchor && compactUserAnchorVisible && (
-        <div className="pointer-events-none absolute inset-x-0 top-2 z-30 flex justify-end px-5 sm:px-6">
+      {compactUserAnchor && (compactUserAnchorVisible || compactUserAnchorMounted) && (
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-x-0 top-2 z-30 flex justify-end px-5 transition-all duration-200 ease-out sm:px-6",
+            compactUserAnchorVisible
+              ? "translate-y-0 opacity-100 animate-in fade-in-0 slide-in-from-top-1"
+              : "-translate-y-1 opacity-0",
+          )}
+        >
           <button
             type="button"
             onClick={handleCompactUserAnchorClick}
-            className="pointer-events-auto flex h-9 max-w-[min(720px,85%)] cursor-pointer items-center rounded-full border border-border-soft bg-surface-floating/95 px-3.5 text-right text-sm font-medium text-foreground shadow-panel backdrop-blur transition-colors hover:bg-surface-subtle supports-[backdrop-filter]:bg-surface-floating/85"
+            className={cn(
+              "pointer-events-auto flex h-9 max-w-[min(720px,85%)] cursor-pointer items-center rounded-full border border-border-soft bg-surface-floating/95 px-3.5 text-right text-sm font-medium text-foreground shadow-panel backdrop-blur transition-colors hover:bg-surface-subtle supports-[backdrop-filter]:bg-surface-floating/85",
+              !compactUserAnchorVisible && "pointer-events-none",
+            )}
           >
             <span className="min-w-0 flex-1 truncate">
               {compactUserAnchor.text}

--- a/src/components/chat/diff-panel/DiffPanel.tsx
+++ b/src/components/chat/diff-panel/DiffPanel.tsx
@@ -57,7 +57,7 @@ export function DiffPanel({
   const change = changes[safeIndex]
 
   const wrapperClasses = cn(
-    "flex h-full min-h-0 w-full flex-col rounded-lg border border-border bg-background shadow-sm",
+    "flex h-full min-h-0 w-full flex-col rounded-panel border border-border-soft bg-surface-panel shadow-panel",
     embedded ? "" : "max-w-4xl",
   )
 

--- a/src/components/chat/diff-panel/DiffPanel.tsx
+++ b/src/components/chat/diff-panel/DiffPanel.tsx
@@ -57,8 +57,10 @@ export function DiffPanel({
   const change = changes[safeIndex]
 
   const wrapperClasses = cn(
-    "flex h-full min-h-0 w-full flex-col rounded-panel border border-border-soft bg-surface-panel shadow-panel",
-    embedded ? "" : "max-w-4xl",
+    "flex h-full min-h-0 w-full flex-col overflow-hidden",
+    embedded
+      ? ""
+      : "max-w-4xl rounded-panel border border-border-soft bg-surface-panel shadow-panel",
   )
 
   return (

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -345,7 +345,7 @@ export default function ChatInput({
     <div className="px-3 pb-3 pt-2">
       <div
         ref={inputShellRef}
-        className="relative rounded-2xl border border-border bg-white dark:bg-card"
+        className="relative rounded-input-dock border border-border-soft bg-surface-floating shadow-input-dock"
       >
         {/* Slash Command Menu */}
         {slash.isOpen && (
@@ -408,7 +408,7 @@ export default function ChatInput({
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Portal>
                   <DropdownMenu.Content
-                    className="min-w-[140px] bg-popover/95 backdrop-blur-xl border border-border/60 rounded-xl shadow-[0_8px_30px_rgb(0,0,0,0.12)] p-1.5 z-50 animate-in fade-in-0 zoom-in-95 duration-150"
+                    className="min-w-[140px] bg-surface-floating/95 backdrop-blur-xl border border-border-soft rounded-floating shadow-floating p-1.5 z-50 animate-in fade-in-0 zoom-in-95 duration-150"
                     sideOffset={6}
                     align="end"
                   >
@@ -522,7 +522,7 @@ export default function ChatInput({
                 </Tooltip>
                 <DropdownMenu.Portal>
                   <DropdownMenu.Content
-                    className="z-50 min-w-[180px] overflow-hidden rounded-xl border border-border/60 bg-white p-1.5 text-popover-foreground shadow-[0_8px_30px_rgb(0,0,0,0.12)] backdrop-blur-xl animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150 dark:bg-popover/95"
+                    className="z-50 min-w-[180px] overflow-hidden rounded-floating border border-border-soft bg-surface-floating/95 p-1.5 text-popover-foreground shadow-floating backdrop-blur-xl animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1 duration-150"
                     side="top"
                     align="start"
                     sideOffset={8}

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -98,6 +98,8 @@ interface ChatInputProps {
   // Session-scoped Todo progress
   taskProgressSnapshot?: TaskProgressSnapshot | null
   executionState?: ChatTurnStatus | null
+  /** Larger centered presentation for a brand-new empty conversation. */
+  hero?: boolean
 }
 
 export default function ChatInput({
@@ -135,6 +137,7 @@ export default function ChatInput({
   onTogglePlanPanel,
   taskProgressSnapshot,
   executionState,
+  hero = false,
 }: ChatInputProps) {
   const { t } = useTranslation()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -342,10 +345,13 @@ export default function ChatInput({
   )
 
   return (
-    <div className="px-3 pb-3 pt-2">
+    <div className={cn("px-3 pb-3 pt-2", hero && "px-0 pb-0 pt-0")}>
       <div
         ref={inputShellRef}
-        className="relative rounded-input-dock border border-border-soft bg-surface-floating shadow-input-dock"
+        className={cn(
+          "relative rounded-input-dock border border-border-soft bg-surface-floating shadow-input-dock",
+          hero && "shadow-floating",
+        )}
       >
         {/* Slash Command Menu */}
         {slash.isOpen && (
@@ -475,8 +481,11 @@ export default function ChatInput({
             onSelect={() => mention.recheckTrigger()}
             onClick={() => mention.recheckTrigger()}
             onScroll={(e) => setMirrorScrollTop(e.currentTarget.scrollTop)}
-            rows={1}
-            className="relative border-0 shadow-none bg-transparent px-4 pt-3 pb-1 text-sm leading-[1.5] text-foreground placeholder:text-muted-foreground focus-visible:ring-0 resize-none min-h-[42px] max-h-[40vh] overflow-y-auto break-words"
+            rows={hero ? 2 : 1}
+            className={cn(
+              "relative border-0 shadow-none bg-transparent px-4 pt-3 pb-1 text-sm leading-[1.5] text-foreground placeholder:text-muted-foreground focus-visible:ring-0 resize-none min-h-[42px] max-h-[40vh] overflow-y-auto break-words",
+              hero && "min-h-[72px] pt-4 pb-2",
+            )}
           />
         </div>
 

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -312,6 +312,8 @@ function MessageBubbleInner({
   const hasTextContent = hasRenderableTextContent(msg)
   const hasDetails = msg.role === "assistant" && !!(msg.usage || msg.model)
   const hasToolbarActions = hasTextContent || hasDetails
+  const toolbarButtonClass =
+    "flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors"
   const renderToggleLabel =
     contentRenderMode === "markdown"
       ? String(t("chat.showPlainText", { defaultValue: "Show plain text" }))
@@ -325,7 +327,7 @@ function MessageBubbleInner({
         onClick={() =>
           setContentRenderMode((mode) => (mode === "markdown" ? "text" : "markdown"))
         }
-        className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors"
+        className={toolbarButtonClass}
       >
         {contentRenderMode === "markdown" ? (
           <Type className="h-3.5 w-3.5" />
@@ -334,6 +336,109 @@ function MessageBubbleInner({
         )}
       </button>
     </IconTip>
+  ) : null
+  const detailsButton = hasDetails ? (
+    <div className="relative flex h-6 w-6 items-center justify-center">
+      <IconTip label={t("chat.details")}>
+        <button
+          type="button"
+          onClick={() => setDetailsIndex(detailsIndex === index ? null : index)}
+          className={cn(
+            toolbarButtonClass,
+            detailsIndex === index && "text-foreground bg-muted/80",
+          )}
+        >
+          <Info className="h-3.5 w-3.5" />
+        </button>
+      </IconTip>
+      {detailsIndex === index && (
+        <div className="absolute bottom-full left-0 z-50 mb-1 w-64 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover p-2.5 shadow-lg">
+          <div className="space-y-1.5 text-xs">
+            {msg.model && (
+              <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                  {t("chat.statusModel")}
+                </span>
+                <IconTip label={msg.model}>
+                  <span className="block truncate text-right font-medium text-foreground">
+                    {msg.model}
+                  </span>
+                </IconTip>
+              </div>
+            )}
+            {msg.model && msg.usage?.inputTokens != null && (
+              <div className="border-t border-border" />
+            )}
+            {(() => {
+              const inputTokens = msg.usage?.inputTokens
+              const lastInputTokens = msg.usage?.lastInputTokens
+              const showLastInput =
+                inputTokens != null &&
+                lastInputTokens != null &&
+                lastInputTokens !== inputTokens
+              if (inputTokens == null) return null
+              return (
+                <>
+                  <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                    <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                      {showLastInput
+                        ? t("chat.inputTokensCumulative")
+                        : t("chat.inputTokens")}
+                    </span>
+                    <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                      {formatTokens(inputTokens)}
+                    </span>
+                  </div>
+                  {showLastInput && lastInputTokens != null && (
+                    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                      <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                        {t("chat.lastRoundInputTokens")}
+                      </span>
+                      <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                        {formatTokens(lastInputTokens)}
+                      </span>
+                    </div>
+                  )}
+                </>
+              )
+            })()}
+            {msg.usage?.outputTokens != null && (
+              <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                  {t("chat.outputTokens")}
+                </span>
+                <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                  {formatTokens(msg.usage.outputTokens)}
+                </span>
+              </div>
+            )}
+            {msg.usage?.inputTokens != null && msg.usage?.outputTokens != null && (
+              <>
+                <div className="border-t border-border" />
+                <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                  <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                    {t("chat.totalTokens")}
+                  </span>
+                  <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                    {formatTokens(msg.usage.inputTokens + msg.usage.outputTokens)}
+                  </span>
+                </div>
+              </>
+            )}
+            {msg.usage?.durationMs != null && (
+              <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                  {t("chat.duration")}
+                </span>
+                <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                  {formatDuration(msg.usage.durationMs)}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
   ) : null
 
   if (msg.role === "event" && !isUserAligned) {
@@ -539,14 +644,16 @@ function MessageBubbleInner({
           <div
             className={cn(
               "ml-7 mt-0.5 flex h-6 items-center gap-0.5",
-              (!hasTextContent || !(isHovered || isCopied)) && "invisible",
+              (!hasToolbarActions || !(isHovered || isCopied || detailsIndex === index)) &&
+                "invisible",
             )}
           >
             {msg.content && (
               <IconTip label={t("chat.copy")}>
                 <button
+                  type="button"
                   onClick={() => onCopy(msg.content, index)}
-                  className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors"
+                  className={toolbarButtonClass}
                 >
                   {isCopied ? (
                     <Check className="h-3.5 w-3.5 text-green-500" />
@@ -557,6 +664,7 @@ function MessageBubbleInner({
               </IconTip>
             )}
             {renderToggleButton}
+            {detailsButton}
           </div>
         </div>
       </div>
@@ -680,8 +788,9 @@ function MessageBubbleInner({
           {msg.content && (
             <IconTip label={t("chat.copy")}>
               <button
+                type="button"
                 onClick={() => onCopy(msg.content, index)}
-                className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors"
+                className={toolbarButtonClass}
               >
                 {isCopied ? (
                   <Check className="h-3.5 w-3.5 text-green-500" />
@@ -692,108 +801,7 @@ function MessageBubbleInner({
             </IconTip>
           )}
           {renderToggleButton}
-          {hasDetails && (
-            <div className="relative">
-              <IconTip label={t("chat.details")}>
-                <button
-                  onClick={() => setDetailsIndex(detailsIndex === index ? null : index)}
-                  className={cn(
-                    "p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors",
-                    detailsIndex === index && "text-foreground bg-muted/80",
-                  )}
-                >
-                  <Info className="h-3.5 w-3.5" />
-                </button>
-              </IconTip>
-              {detailsIndex === index && (
-                <div className="absolute bottom-full left-0 z-50 mb-1 w-64 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover p-2.5 shadow-lg">
-                  <div className="space-y-1.5 text-xs">
-                    {msg.model && (
-                      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                        <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                          {t("chat.statusModel")}
-                        </span>
-                        <IconTip label={msg.model}>
-                          <span className="block truncate text-right font-medium text-foreground">
-                            {msg.model}
-                          </span>
-                        </IconTip>
-                      </div>
-                    )}
-                    {msg.model && msg.usage?.inputTokens != null && (
-                      <div className="border-t border-border" />
-                    )}
-                    {(() => {
-                      const inputTokens = msg.usage?.inputTokens
-                      const lastInputTokens = msg.usage?.lastInputTokens
-                      const showLastInput =
-                        inputTokens != null &&
-                        lastInputTokens != null &&
-                        lastInputTokens !== inputTokens
-                      if (inputTokens == null) return null
-                      return (
-                        <>
-                          <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                            <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                              {showLastInput
-                                ? t("chat.inputTokensCumulative")
-                                : t("chat.inputTokens")}
-                            </span>
-                            <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                              {formatTokens(inputTokens)}
-                            </span>
-                          </div>
-                          {showLastInput && lastInputTokens != null && (
-                            <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                              <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                                {t("chat.lastRoundInputTokens")}
-                              </span>
-                              <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                                {formatTokens(lastInputTokens)}
-                              </span>
-                            </div>
-                          )}
-                        </>
-                      )
-                    })()}
-                    {msg.usage?.outputTokens != null && (
-                      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                        <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                          {t("chat.outputTokens")}
-                        </span>
-                        <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                          {formatTokens(msg.usage.outputTokens)}
-                        </span>
-                      </div>
-                    )}
-                    {msg.usage?.inputTokens != null && msg.usage?.outputTokens != null && (
-                      <>
-                        <div className="border-t border-border" />
-                        <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                          <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                            {t("chat.totalTokens")}
-                          </span>
-                          <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                            {formatTokens(msg.usage.inputTokens + msg.usage.outputTokens)}
-                          </span>
-                        </div>
-                      </>
-                    )}
-                    {msg.usage?.durationMs != null && (
-                      <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                        <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                          {t("chat.duration")}
-                        </span>
-                        <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                          {formatDuration(msg.usage.durationMs)}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
+          {detailsButton}
         </div>
       </div>
     </div>

--- a/src/components/chat/plan-mode/PlanPanel.tsx
+++ b/src/components/chat/plan-mode/PlanPanel.tsx
@@ -297,27 +297,27 @@ export function PlanPanel({
   // Whether inline commenting is enabled
   const canComment = (planState === "review" || planState === "planning") && !!onRequestChanges
   const panelShellClass = maximized
-    ? "fixed inset-0 z-50 flex flex-col bg-background"
+    ? "fixed inset-0 z-50 flex flex-col bg-surface-app"
     : cn(
         "flex h-full min-h-0 flex-col shrink-0 overflow-hidden animate-in slide-in-from-right-2 duration-200",
         embedded
-          ? "w-full rounded-xl border border-border/70 bg-background shadow-sm"
+          ? "w-full rounded-panel border border-border-soft bg-surface-panel shadow-panel"
           : desktopMode
-            ? "max-w-[40vw] bg-background"
-            : "max-w-[42vw] border-l border-border/70 bg-background/95",
+            ? "max-w-[40vw] bg-surface-panel"
+            : "max-w-[42vw] border-l border-border-soft bg-surface-panel/95",
       )
   const headerClass = cn(
     "flex items-center gap-2 px-3 border-b shrink-0",
     embedded
-      ? "h-11 border-border/60 bg-background px-4"
+      ? "h-11 border-border-soft bg-surface-panel px-4"
       : desktopMode
-        ? "py-2 border-border bg-secondary/30"
-        : "h-10 border-border/70 bg-background/95",
+        ? "py-2 border-border-soft bg-surface-subtle"
+        : "h-10 border-border-soft bg-surface-panel/95",
     maximized && desktopMode && "h-[72px] items-end pb-2 pt-7",
   )
   const actionBarClass = cn(
     "px-3 py-3 border-t border-border shrink-0 space-y-2",
-    embedded ? "bg-background" : desktopMode ? "bg-secondary/20" : "bg-background/95",
+    embedded ? "bg-surface-panel" : desktopMode ? "bg-surface-subtle" : "bg-surface-panel/95",
   )
 
   // Detached: show compact placeholder
@@ -327,14 +327,14 @@ export function PlanPanel({
         className={cn(
           "flex flex-col shrink-0 animate-in slide-in-from-right-2 duration-200",
           embedded
-            ? "h-full w-full overflow-hidden rounded-xl border border-border/70 bg-card shadow-sm"
-            : "w-[200px] bg-background",
+            ? "h-full w-full overflow-hidden rounded-panel border border-border-soft bg-surface-panel shadow-panel"
+            : "w-[200px] bg-surface-panel",
         )}
       >
         <div
           className={cn(
             "flex items-center gap-2 px-3 py-2 border-b border-border shrink-0",
-            embedded ? "bg-card/95" : "bg-secondary/30",
+            embedded ? "bg-surface-panel/95" : "bg-surface-subtle",
           )}
           data-tauri-drag-region={desktopMode ? true : undefined}
         >

--- a/src/components/chat/plan-mode/PlanPanel.tsx
+++ b/src/components/chat/plan-mode/PlanPanel.tsx
@@ -301,7 +301,7 @@ export function PlanPanel({
     : cn(
         "flex h-full min-h-0 flex-col shrink-0 overflow-hidden animate-in slide-in-from-right-2 duration-200",
         embedded
-          ? "w-full rounded-panel border border-border-soft bg-surface-panel shadow-panel"
+          ? "w-full"
           : desktopMode
             ? "max-w-[40vw] bg-surface-panel"
             : "max-w-[42vw] border-l border-border-soft bg-surface-panel/95",
@@ -327,7 +327,7 @@ export function PlanPanel({
         className={cn(
           "flex flex-col shrink-0 animate-in slide-in-from-right-2 duration-200",
           embedded
-            ? "h-full w-full overflow-hidden rounded-panel border border-border-soft bg-surface-panel shadow-panel"
+            ? "h-full w-full overflow-hidden"
             : "w-[200px] bg-surface-panel",
         )}
       >

--- a/src/components/chat/right-panel/RightPanelShell.tsx
+++ b/src/components/chat/right-panel/RightPanelShell.tsx
@@ -1,0 +1,103 @@
+import { useCallback, type ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+interface RightPanelShellProps {
+  width: number
+  onWidthChange?: (width: number) => void
+  resizeLabel: string
+  children: ReactNode
+  minWidth?: number
+  maxWidth?: number
+  maxViewportRatio?: number
+  maximized?: boolean
+  surfaceClassName?: string
+  bodyClassName?: string
+}
+
+export function RightPanelShell({
+  width,
+  onWidthChange,
+  resizeLabel,
+  children,
+  minWidth = 360,
+  maxWidth = 960,
+  maxViewportRatio = 0.55,
+  maximized = false,
+  surfaceClassName,
+  bodyClassName,
+}: RightPanelShellProps) {
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!onWidthChange) return
+      e.preventDefault()
+      const startX = e.clientX
+      const startWidth = width
+      const effectiveMaxWidth = Math.min(
+        maxWidth,
+        Math.max(420, window.innerWidth * maxViewportRatio),
+      )
+      const onMouseMove = (ev: MouseEvent) => {
+        const nextWidth = Math.min(
+          effectiveMaxWidth,
+          Math.max(minWidth, startWidth - (ev.clientX - startX)),
+        )
+        onWidthChange(nextWidth)
+      }
+      const iframes = document.querySelectorAll("iframe")
+      iframes.forEach((frame) => ((frame as HTMLElement).style.pointerEvents = "none"))
+      const onMouseUp = () => {
+        document.removeEventListener("mousemove", onMouseMove)
+        document.removeEventListener("mouseup", onMouseUp)
+        document.body.style.cursor = ""
+        document.body.style.userSelect = ""
+        iframes.forEach((frame) => ((frame as HTMLElement).style.pointerEvents = ""))
+      }
+      document.addEventListener("mousemove", onMouseMove)
+      document.addEventListener("mouseup", onMouseUp)
+      document.body.style.cursor = "col-resize"
+      document.body.style.userSelect = "none"
+    },
+    [maxViewportRatio, maxWidth, minWidth, onWidthChange, width],
+  )
+
+  if (maximized) {
+    return (
+      <div
+        className={cn(
+          "fixed inset-0 z-50 flex min-h-0 flex-col overflow-hidden bg-surface-app",
+          surfaceClassName,
+        )}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="relative flex h-full min-h-0 shrink-0 min-w-[360px] max-w-[55%] p-3 pl-2"
+      style={{ width }}
+    >
+      <div
+        className={cn(
+          "group absolute left-0 top-3 bottom-3 z-10 flex w-3 items-center justify-center",
+          onWidthChange && "cursor-col-resize",
+        )}
+        onMouseDown={handleDragStart}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label={resizeLabel}
+      >
+        <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
+      </div>
+      <div
+        className={cn(
+          "flex h-full min-h-0 w-full flex-col overflow-hidden rounded-panel border border-border-soft bg-surface-panel shadow-panel",
+          bodyClassName,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/sidebar/AgentSection.tsx
+++ b/src/components/chat/sidebar/AgentSection.tsx
@@ -136,6 +136,19 @@ export default function AgentSection({
                         {agent.name}
                       </span>
                     </button>
+                    {onEditAgent && (
+                      <IconTip label={t("common.settings")}>
+                        <button
+                          className="shrink-0 p-0.5 rounded text-muted-foreground/0 group-hover/agent:text-muted-foreground/60 hover:!text-primary transition-colors"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            onEditAgent(agent.id)
+                          }}
+                        >
+                          <Settings className="h-3 w-3" />
+                        </button>
+                      </IconTip>
+                    )}
                     {/* New chat button */}
                     <IconTip label={t("chat.newChat")}>
                       <button

--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -12,11 +12,16 @@ import {
 } from "@/components/ui/alert-dialog"
 import { IconTip } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
-import { Bot, MessageSquarePlus, PanelLeftClose } from "lucide-react"
+import { Bot, MessageSquarePlus, PanelLeftDashed } from "lucide-react"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import type { SessionSearchResult } from "@/types/chat"
-import type { ChatSidebarProps, SessionFilterType } from "./types"
+import {
+  CHAT_SIDEBAR_MAX_WIDTH,
+  CHAT_SIDEBAR_MIN_WIDTH,
+  type ChatSidebarProps,
+  type SessionFilterType,
+} from "./types"
 import { sortSessionSearchResults } from "../chatUtils"
 import { SEARCH_LIMIT } from "../hooks/constants"
 import AgentSection from "./AgentSection"
@@ -167,21 +172,27 @@ export default function ChatSidebar({
 
   // Drag handler for resizable panel
   const isDragging = useRef(false)
+  const [isResizing, setIsResizing] = useState(false)
   const handleDragStart = (e: React.MouseEvent) => {
     e.preventDefault()
     isDragging.current = true
+    setIsResizing(true)
     const startX = e.clientX
     const startWidth = panelWidth
 
     const onMouseMove = (ev: MouseEvent) => {
       if (!isDragging.current) return
       const delta = ev.clientX - startX
-      const newWidth = Math.min(400, Math.max(180, startWidth + delta))
+      const newWidth = Math.min(
+        CHAT_SIDEBAR_MAX_WIDTH,
+        Math.max(CHAT_SIDEBAR_MIN_WIDTH, startWidth + delta),
+      )
       onPanelWidthChange(newWidth)
     }
 
     const onMouseUp = () => {
       isDragging.current = false
+      setIsResizing(false)
       document.removeEventListener("mousemove", onMouseMove)
       document.removeEventListener("mouseup", onMouseUp)
       document.body.style.cursor = ""
@@ -249,7 +260,10 @@ export default function ChatSidebar({
     <>
       <div
         style={{ width: sidebarCollapsed ? 0 : panelWidth }}
-        className="relative h-full shrink-0 transition-[width] duration-200 ease-out"
+        className={cn(
+          "relative h-full shrink-0",
+          !isResizing && "transition-[width] duration-200 ease-out",
+        )}
       >
         <div className="h-full overflow-hidden">
           <div
@@ -257,35 +271,35 @@ export default function ChatSidebar({
             aria-hidden={sidebarCollapsed}
             inert={sidebarCollapsed ? true : undefined}
             className={cn(
-              "h-full border-r border-border-soft bg-surface-sidebar flex flex-col transition-[opacity,transform] duration-200 ease-out",
+              "h-full border-r border-border-soft bg-surface-panel shadow-panel flex flex-col transition-[opacity,transform] duration-200 ease-out",
               sidebarCollapsed
                 ? "pointer-events-none -translate-x-3 opacity-0"
                 : "translate-x-0 opacity-100",
             )}
           >
             {/* Title bar */}
-            <div className="h-10 flex items-end px-4 shrink-0" data-tauri-drag-region>
-              <h2 className="text-sm font-semibold text-foreground pb-1.5">
+            <div className="h-12 flex items-end px-3.5 shrink-0" data-tauri-drag-region>
+              <h2 className="text-sm font-semibold text-foreground pb-2">
                 {t("chat.conversations")}
               </h2>
-              <div className="ml-auto flex items-center gap-1 pb-1.5">
+              <div className="ml-auto flex items-center gap-1 pb-2">
                 <IconTip label={t("chat.collapseSidebar")}>
                   <button
-                    className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface-subtle hover:text-foreground"
                     aria-label={t("chat.collapseSidebar")}
                     onClick={(e) => {
                       e.currentTarget.blur()
                       onSidebarCollapsedChange(true)
                     }}
                   >
-                    <PanelLeftClose className="h-4 w-4" />
+                    <PanelLeftDashed className="h-4 w-4" />
                   </button>
                 </IconTip>
                 {/* New Chat button */}
                 <div className="relative" ref={newChatMenuRef}>
                   <IconTip label={t("chat.newChat")}>
                     <button
-                      className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
+                      className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface-subtle hover:text-foreground"
                       onClick={() => {
                         if (agents.length === 1) {
                           onNewChat(agents[0].id)
@@ -299,11 +313,11 @@ export default function ChatSidebar({
                   </IconTip>
                   {/* Agent selector popup */}
                   {showNewChatMenu && (
-                    <div className="absolute right-0 top-full mt-1 bg-popover/95 backdrop-blur-xl border border-border/60 rounded-xl shadow-lg z-50 min-w-[180px] p-1.5 animate-in fade-in-0 zoom-in-95 duration-150">
+                    <div className="absolute right-0 top-full mt-1 bg-surface-floating/95 backdrop-blur-xl border border-border-soft rounded-floating shadow-floating z-50 min-w-[180px] p-1.5 animate-in fade-in-0 zoom-in-95 duration-150">
                       {agents.map((agent) => (
                         <button
                           key={agent.id}
-                          className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[13px] rounded-md text-foreground/80 hover:bg-secondary/60 hover:text-foreground transition-colors"
+                          className="flex items-center gap-2 w-full px-2.5 py-1.5 text-[13px] rounded-md text-foreground/80 hover:bg-surface-subtle hover:text-foreground transition-colors"
                           onClick={() => {
                             onNewChat(agent.id)
                             setShowNewChatMenu(false)

--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -257,7 +257,7 @@ export default function ChatSidebar({
             aria-hidden={sidebarCollapsed}
             inert={sidebarCollapsed ? true : undefined}
             className={cn(
-              "h-full border-r border-border bg-background flex flex-col transition-[opacity,transform] duration-200 ease-out",
+              "h-full border-r border-border-soft bg-surface-sidebar flex flex-col transition-[opacity,transform] duration-200 ease-out",
               sidebarCollapsed
                 ? "pointer-events-none -translate-x-3 opacity-0"
                 : "translate-x-0 opacity-100",

--- a/src/components/chat/sidebar/types.ts
+++ b/src/components/chat/sidebar/types.ts
@@ -1,6 +1,11 @@
 import type { SessionMeta, AgentSummaryForSidebar } from "@/types/chat"
 import type { ProjectMeta } from "@/types/project"
 
+export const CHAT_SIDEBAR_WIDTH_STORAGE_KEY = "hope.chatSidebarPanelWidth"
+export const CHAT_SIDEBAR_DEFAULT_WIDTH = 260
+export const CHAT_SIDEBAR_MIN_WIDTH = 220
+export const CHAT_SIDEBAR_MAX_WIDTH = 360
+
 export interface ChatSidebarProps {
   sessions: SessionMeta[]
   agents: AgentSummaryForSidebar[]

--- a/src/components/common/IconSidebar.tsx
+++ b/src/components/common/IconSidebar.tsx
@@ -91,9 +91,9 @@ export default function IconSidebar({
   const { unseenCount: skillDraftUnseen } = useDraftSkillsStore()
 
   return (
-    <div className="w-[72px] shrink-0 border-r border-border-soft bg-surface-sidebar flex flex-col items-center">
+    <div className="w-[76px] shrink-0 border-r border-border-soft bg-surface-sidebar flex flex-col items-center">
         {/* Drag region for window movement — covers traffic light area */}
-        <div className="w-full pt-10 flex flex-col items-center gap-2" data-tauri-drag-region>
+        <div className="w-full pt-10 flex flex-col items-center gap-1.5" data-tauri-drag-region>
           {/* User avatar (if set) */}
           {userAvatar && (
             <IconTip label={t("settings.profile")} side="right">
@@ -150,6 +150,8 @@ export default function IconSidebar({
             </ContextMenuContent>
           </ContextMenu>
         </div>
+
+        <div className="my-1 h-px w-6 bg-border-soft/80" />
 
         {/* Agents entry */}
         <div className="w-full flex justify-center mt-1">
@@ -251,6 +253,8 @@ export default function IconSidebar({
           </IconTip>
         </div>
 
+        <div className="my-1 h-px w-6 bg-border-soft/60" />
+
         {/* Calendar / Scheduled Tasks entry */}
         <div className="w-full flex justify-center mt-1">
           <IconTip label={t("cron.title")} side="right">
@@ -308,6 +312,8 @@ export default function IconSidebar({
           </IconTip>
         </div>
 
+        <div className="my-1 h-px w-6 bg-border-soft/60" />
+
         <div className="flex-1" />
 
         <div className="py-3 flex flex-col items-center gap-2">
@@ -364,7 +370,7 @@ export default function IconSidebar({
             {showLangMenu && (
               <>
                 <div className="fixed inset-0 z-40" onClick={() => setShowLangMenu(false)} />
-                <div className="absolute left-12 bottom-0 z-50 bg-surface-floating border border-border-soft rounded-floating shadow-floating py-1 min-w-[160px] max-h-[400px] overflow-y-auto animate-in fade-in-0 zoom-in-95 slide-in-from-left-1 duration-150">
+                <div className="absolute left-14 bottom-0 z-50 bg-surface-floating border border-border-soft rounded-floating shadow-floating py-1 min-w-[160px] max-h-[400px] overflow-y-auto animate-in fade-in-0 zoom-in-95 slide-in-from-left-1 duration-150">
                   {/* Follow System option */}
                   <button
                     className={`flex items-center gap-2.5 w-full px-3 py-1.5 text-xs transition-colors hover:bg-secondary ${

--- a/src/components/common/IconSidebar.tsx
+++ b/src/components/common/IconSidebar.tsx
@@ -91,7 +91,7 @@ export default function IconSidebar({
   const { unseenCount: skillDraftUnseen } = useDraftSkillsStore()
 
   return (
-    <div className="w-[72px] shrink-0 border-r border-border bg-secondary/30 flex flex-col items-center">
+    <div className="w-[72px] shrink-0 border-r border-border-soft bg-surface-sidebar flex flex-col items-center">
         {/* Drag region for window movement — covers traffic light area */}
         <div className="w-full pt-10 flex flex-col items-center gap-2" data-tauri-drag-region>
           {/* User avatar (if set) */}
@@ -364,7 +364,7 @@ export default function IconSidebar({
             {showLangMenu && (
               <>
                 <div className="fixed inset-0 z-40" onClick={() => setShowLangMenu(false)} />
-                <div className="absolute left-12 bottom-0 z-50 bg-card border border-border rounded-lg shadow-lg py-1 min-w-[160px] max-h-[400px] overflow-y-auto animate-in fade-in-0 zoom-in-95 slide-in-from-left-1 duration-150">
+                <div className="absolute left-12 bottom-0 z-50 bg-surface-floating border border-border-soft rounded-floating shadow-floating py-1 min-w-[160px] max-h-[400px] overflow-y-auto animate-in fade-in-0 zoom-in-95 slide-in-from-left-1 duration-150">
                   {/* Follow System option */}
                   <button
                     className={`flex items-center gap-2.5 w-full px-3 py-1.5 text-xs transition-colors hover:bg-secondary ${
@@ -436,7 +436,7 @@ export default function IconSidebar({
                 variant="ghost"
                 size="icon"
                 aria-label={t("about.title")}
-                className="h-11 w-11 rounded-full border border-border/70 bg-background/80 p-0 shadow-sm hover:bg-secondary hover:shadow-md"
+                className="h-11 w-11 rounded-full border border-border-soft bg-surface-floating/80 p-0 shadow-panel hover:bg-secondary hover:shadow-floating"
                 onClick={() => onOpenSettings("about")}
               >
                 <span className="flex h-9 w-9 items-center justify-center overflow-hidden rounded-full bg-secondary">

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -255,9 +255,9 @@ export default function SettingsView({
   }, [])
 
   return (
-    <div className="flex flex-1 h-full overflow-hidden bg-background">
+    <div className="flex flex-1 h-full overflow-hidden bg-surface-app">
       {/* Left Sidebar — Settings Navigation */}
-      <div className="w-[220px] shrink-0 border-r border-border bg-secondary/20 flex flex-col">
+      <div className="w-[220px] shrink-0 border-r border-border-soft bg-surface-sidebar flex flex-col">
         {/* Header with back button + drag region */}
         <div className="h-10 flex items-end px-4 gap-2 shrink-0" data-tauri-drag-region>
           <Button

--- a/src/components/team/TeamPanel.tsx
+++ b/src/components/team/TeamPanel.tsx
@@ -1,10 +1,10 @@
-import { useState, useCallback, useRef } from "react"
+import { useState, useCallback } from "react"
 import { X } from "lucide-react"
 import { useTranslation } from "react-i18next"
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { getTransport } from "@/lib/transport-provider"
+import { RightPanelShell } from "@/components/chat/right-panel/RightPanelShell"
 import { useTeam } from "./useTeam"
 import { TeamToolbar } from "./TeamToolbar"
 import { TeamDashboard } from "./TeamDashboard"
@@ -35,38 +35,7 @@ export function TeamPanel({
     useTeam(teamId)
   const [tab, setTab] = useState("dashboard")
 
-  // ── Drag resize handle ──────────────────────────────────
-  const dragging = useRef(false)
-  const startX = useRef(0)
-  const startW = useRef(0)
-
   const width = panelWidth ?? DEFAULT_WIDTH
-
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      e.preventDefault()
-      dragging.current = true
-      startX.current = e.clientX
-      startW.current = width
-
-      const handleMove = (ev: PointerEvent) => {
-        if (!dragging.current) return
-        const delta = startX.current - ev.clientX // drag left = wider
-        const next = Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startW.current + delta))
-        onPanelWidthChange?.(next)
-      }
-
-      const handleUp = () => {
-        dragging.current = false
-        document.removeEventListener("pointermove", handleMove)
-        document.removeEventListener("pointerup", handleUp)
-      }
-
-      document.addEventListener("pointermove", handleMove)
-      document.addEventListener("pointerup", handleUp)
-    },
-    [width, onPanelWidthChange],
-  )
 
   // ── Actions ─────────────────────────────────────────────
   const handlePause = useCallback(async () => {
@@ -83,36 +52,29 @@ export function TeamPanel({
 
   if (!team) {
     return (
-      <div
-        className="relative flex h-full min-h-0 shrink-0 min-w-[360px] max-w-[55%] p-3 pl-2"
-        style={{ width }}
+      <RightPanelShell
+        width={width}
+        onWidthChange={onPanelWidthChange}
+        resizeLabel={t("team.resizePanel", "Resize team panel")}
+        minWidth={MIN_WIDTH}
+        maxWidth={MAX_WIDTH}
       >
-        <div className="flex h-full min-h-0 w-full items-center justify-center rounded-xl border border-border/70 bg-card text-sm text-muted-foreground shadow-sm">
+        <div className="flex h-full min-h-0 w-full items-center justify-center text-sm text-muted-foreground">
           {t("team.loading", "Loading...")}
         </div>
-      </div>
+      </RightPanelShell>
     )
   }
 
   return (
-    <div
-      className="relative flex h-full min-h-0 shrink-0 min-w-[360px] max-w-[55%] p-3 pl-2"
-      style={{ width }}
+    <RightPanelShell
+      width={width}
+      onWidthChange={onPanelWidthChange}
+      resizeLabel={t("team.resizePanel", "Resize team panel")}
+      minWidth={MIN_WIDTH}
+      maxWidth={MAX_WIDTH}
     >
-      {/* Drag handle */}
-      <div
-        className={cn(
-          "group absolute left-0 top-3 bottom-3 z-10 flex w-3 cursor-col-resize items-center justify-center",
-        )}
-        onPointerDown={handlePointerDown}
-        role="separator"
-        aria-orientation="vertical"
-        aria-label={t("team.resizePanel", "Resize team panel")}
-      >
-        <div className="h-full w-px rounded-full bg-transparent transition-colors group-hover:bg-primary/35 group-active:bg-primary/50" />
-      </div>
-
-      <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden rounded-xl border border-border/70 bg-card shadow-sm">
+      <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden">
         {/* Close button */}
         <Button
           variant="ghost"
@@ -171,6 +133,6 @@ export function TeamPanel({
           </TabsContent>
         </Tabs>
       </div>
-    </div>
+    </RightPanelShell>
   )
 }

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "سيؤدي هذا الإجراء إلى حذف هذه المحادثة وجميع رسائلها نهائيًا. لا يمكن التراجع عن هذا الإجراء. هل أنت متأكد؟",
     "detachOnDesktopNoop": "لا توجد محادثة IM مرتبطة بهذه الجلسة على سطح المكتب — detach لا يفعل شيئًا هنا.",
     "details": "التفاصيل",
+    "showPlainText": "عرض النص العادي",
+    "renderMarkdown": "عرض Markdown",
     "duration": "المدة",
     "fallbackError": "تفاصيل الخطأ",
     "fallbackFrom": "النموذج الأصلي",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "This will permanently delete this conversation and all its messages. This action cannot be undone. Are you sure?",
     "detachOnDesktopNoop": "Detach has no effect on desktop — no IM chat is bound to this session here.",
     "details": "Details",
+    "showPlainText": "Show plain text",
+    "renderMarkdown": "Render Markdown",
     "duration": "Duration",
     "fallbackError": "Error Details",
     "fallbackFrom": "Original",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "Esta acción eliminará permanentemente esta conversación y todos sus mensajes. No se puede deshacer. ¿Estás seguro?",
     "detachOnDesktopNoop": "Detach no tiene efecto en el escritorio — no hay un chat de IM vinculado a esta sesión aquí.",
     "details": "Detalles",
+    "showPlainText": "Mostrar texto sin formato",
+    "renderMarkdown": "Renderizar Markdown",
     "duration": "Duración",
     "fallbackError": "Detalles del Error",
     "fallbackFrom": "Modelo original",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "この操作により、この会話とすべてのメッセージが完全に削除されます。この操作は元に戻せません。続行しますか？",
     "detachOnDesktopNoop": "デスクトップでは IM チャットへの接続がないため、detach は何もしません。",
     "details": "詳細",
+    "showPlainText": "プレーンテキストを表示",
+    "renderMarkdown": "Markdown をレンダリング",
     "duration": "所要時間",
     "fallbackError": "エラー詳細",
     "fallbackFrom": "元のモデル",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "이 작업은 이 대화와 모든 메시지를 영구적으로 삭제합니다. 이 작업은 되돌릴 수 없습니다. 계속하시겠습니까?",
     "detachOnDesktopNoop": "데스크톱은 IM 채팅에 바인딩되지 않으므로 detach는 효과가 없습니다.",
     "details": "상세",
+    "showPlainText": "일반 텍스트 표시",
+    "renderMarkdown": "Markdown 렌더링",
     "duration": "소요 시간",
     "fallbackError": "오류 상세",
     "fallbackFrom": "원래 모델",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "Tindakan ini akan memadamkan perbualan ini dan semua mesejnya secara kekal. Tindakan ini tidak boleh dibatalkan. Adakah anda pasti?",
     "detachOnDesktopNoop": "Pada desktop tiada ikatan IM chat — detach tidak berkesan di sini.",
     "details": "Butiran",
+    "showPlainText": "Tunjuk teks biasa",
+    "renderMarkdown": "Papar Markdown",
     "duration": "Tempoh",
     "fallbackError": "Butiran Ralat",
     "fallbackFrom": "Model asal",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "Esta ação excluirá permanentemente esta conversa e todas as suas mensagens. Não é possível desfazer. Tem certeza?",
     "detachOnDesktopNoop": "Detach não tem efeito no desktop — nenhum chat de IM vinculado a esta sessão aqui.",
     "details": "Detalhes",
+    "showPlainText": "Mostrar texto simples",
+    "renderMarkdown": "Renderizar Markdown",
     "duration": "Duração",
     "fallbackError": "Detalhes do Erro",
     "fallbackFrom": "Modelo original",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "Это действие навсегда удалит этот разговор и все его сообщения. Отменить невозможно. Вы уверены?",
     "detachOnDesktopNoop": "На рабочем столе нет привязки к IM-чату — detach не имеет эффекта.",
     "details": "Подробности",
+    "showPlainText": "Показать простой текст",
+    "renderMarkdown": "Отобразить Markdown",
     "duration": "Длительность",
     "fallbackError": "Детали ошибки",
     "fallbackFrom": "Исходная модель",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "Bu işlem bu sohbeti ve tüm mesajlarını kalıcı olarak silecektir. Bu işlem geri alınamaz. Emin misiniz?",
     "detachOnDesktopNoop": "Masaüstünde IM sohbetine bağlama yok — detach burada etkisiz.",
     "details": "Ayrıntılar",
+    "showPlainText": "Düz metni göster",
+    "renderMarkdown": "Markdown olarak işle",
     "duration": "Süre",
     "fallbackError": "Hata Ayrıntıları",
     "fallbackFrom": "Orijinal model",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "Thao tác này sẽ xóa vĩnh viễn cuộc trò chuyện này và tất cả tin nhắn. Không thể hoàn tác. Bạn có chắc chắn không?",
     "detachOnDesktopNoop": "Trên máy tính không có liên kết IM chat — detach không có tác dụng ở đây.",
     "details": "Chi tiết",
+    "showPlainText": "Hiển thị văn bản thuần",
+    "renderMarkdown": "Kết xuất Markdown",
     "duration": "Thời gian",
     "fallbackError": "Chi tiết lỗi",
     "fallbackFrom": "Mô hình gốc",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "此操作將永久刪除該對話及其所有消息記錄，且無法恢複。請確認是否繼續？",
     "detachOnDesktopNoop": "桌面端不繫結 IM chat,detach 在此處無效。",
     "details": "詳情",
+    "showPlainText": "顯示純文字",
+    "renderMarkdown": "渲染 Markdown",
     "duration": "耗時",
     "fallbackError": "錯誤詳情",
     "fallbackFrom": "原模型",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -291,6 +291,8 @@
     "deleteSessionWarning": "此操作将永久删除该对话及其所有消息记录，且无法恢复。请确认是否继续？",
     "detachOnDesktopNoop": "桌面端不绑定 IM chat,detach 在此处无效。",
     "details": "详情",
+    "showPlainText": "显示纯文本",
+    "renderMarkdown": "渲染 Markdown",
     "duration": "耗时",
     "fallbackError": "错误详情",
     "fallbackFrom": "原模型",

--- a/src/index.css
+++ b/src/index.css
@@ -25,11 +25,23 @@
   --color-accent: hsl(0 0% 93%);
   --color-accent-foreground: hsl(0 0% 9%);
   --color-border: hsl(0 0% 89%);
+  --color-border-soft: hsl(220 16% 90%);
   --color-input: hsl(0 0% 89%);
   --color-destructive: hsl(0 84% 60%);
   --color-destructive-foreground: hsl(0 0% 100%);
   --color-ring: hsl(0 0% 45%);
+  --color-surface-app: hsl(220 20% 98%);
+  --color-surface-sidebar: hsl(215 20% 96%);
+  --color-surface-panel: hsl(0 0% 99%);
+  --color-surface-floating: hsl(0 0% 100%);
+  --color-surface-subtle: hsl(220 18% 95%);
   --radius: 0.5rem;
+  --radius-panel: 0.5rem;
+  --radius-floating: 0.75rem;
+  --radius-input-dock: 1rem;
+  --shadow-panel: 0 1px 2px hsl(220 18% 20% / 0.04), 0 10px 30px hsl(220 18% 20% / 0.04);
+  --shadow-floating: 0 8px 30px hsl(220 18% 20% / 0.12);
+  --shadow-input-dock: 0 1px 2px hsl(220 18% 20% / 0.05), 0 16px 48px hsl(220 18% 20% / 0.08);
   --color-user-bubble: hsl(210 40% 93%);
 }
 
@@ -50,10 +62,16 @@
   --color-accent: hsl(220 13% 20%);
   --color-accent-foreground: hsl(210 20% 90%);
   --color-border: hsl(220 13% 22%);
+  --color-border-soft: hsl(220 13% 25%);
   --color-input: hsl(220 13% 22%);
   --color-destructive: hsl(0 72% 51%);
   --color-destructive-foreground: hsl(0 0% 100%);
   --color-ring: hsl(215 15% 50%);
+  --color-surface-app: hsl(220 13% 11%);
+  --color-surface-sidebar: hsl(220 13% 14%);
+  --color-surface-panel: hsl(220 13% 13%);
+  --color-surface-floating: hsl(220 13% 15%);
+  --color-surface-subtle: hsl(220 13% 18%);
   --color-user-bubble: hsl(215 20% 28%);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -42,7 +42,7 @@
   --shadow-panel: 0 1px 2px hsl(220 18% 20% / 0.04), 0 10px 30px hsl(220 18% 20% / 0.04);
   --shadow-floating: 0 8px 30px hsl(220 18% 20% / 0.12);
   --shadow-input-dock: 0 1px 2px hsl(220 18% 20% / 0.05), 0 16px 48px hsl(220 18% 20% / 0.08);
-  --color-user-bubble: hsl(210 40% 93%);
+  --color-user-bubble: hsl(220 14% 94%);
 }
 
 /* Dark theme overrides */


### PR DESCRIPTION
## Summary

- Add shared workbench surface tokens and unify the right-side Browser / Plan / Diff / Canvas / Team panel shell.
- Refine the chat workspace layout with global rail + session pane navigation, centered empty-session input, brand logo, larger default window size, and adjusted sidebar controls.
- Polish message actions: restore the task/timeline details button, align toolbar icons, localize Markdown/plain-text toggles, and soften the light-theme user bubble.
- Fix first-run sidebar width persistence so missing localStorage falls back to the default width instead of the minimum.

## Impact

This is a desktop UI polish pass focused on chat workspace density, panel consistency, and task-view message ergonomics. It does not change backend behavior.

## Validation

Pre-push passed:

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `cargo test -p ha-core -p ha-server --locked`

Also ran `node scripts/sync-i18n.mjs --check` after adding the new locale keys.
