### PR TITLE
[codex] Implement macOS permissions v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **聊天工作台视觉与布局改造**：主界面切成全局 rail + 会话 pane 两层导航，右侧 Browser / Plan / Diff / Canvas / Team 面板统一为共享 shell；空会话时输入框居中加宽并显示品牌 Logo，有消息后回到底部；应用默认窗口尺寸放大到更适合双栏工作台的 1360×860。
+- **macOS 系统权限页 v2**：权限设置切到 macOS 全量权限目录与 v2 数据模型，覆盖辅助功能、屏幕录制、输入监控、媒体/个人数据/文件访问/自动化/通知等类别；可原生检测或请求的权限走 macOS API，无法可靠检测的权限标记为「手动确认」并跳转系统设置。Windows / Linux / HTTP 模式本期显示禁用说明；旧权限命令保留兼容包装，`Info.plist` 补齐本期隐私 usage description。
 - **聊天界面窄栏自适应整理**：输入框工作目录入口改为纯图标 + 「设置工作目录」提示，统一工具条图标尺寸；无痕模式入口移至顶部标题栏；右侧 Browser / Plan / Diff / Canvas / Team 面板打开时自动收起左侧 session 列表，用户仍可手动展开；输入框溢出菜单改为按容器宽度触发，修复右侧面板压缩聊天列时「+」菜单不出现。
 - **聊天消息 Markdown / 纯文本渲染可切换**：用户消息现在与模型消息一样默认支持 Markdown 渲染，气泡 hover 操作区新增 Markdown / 纯文本切换按钮，复制仍保留原始文本。两种模式都会自动识别裸链接（`https://...` / `www.example.com` / 邮箱）并渲染为可点击超链，复用既有外链与本地路径打开策略。
 - **Chromium 运行时自动安装兜底**：系统没装 Chrome / Edge / Brave / Chromium 时，agent 可调 `profile.op=install_runtime` 或 settings → Browser → 「Install Chromium runtime」按钮，自动下载 pinned Chromium snapshot（约 150 MB）解压到 `~/.hope-agent/browser/runtime/chromium-{rev}/`，下载完后 `profile.op=launch` 自动使用。下载进度通过 EventBus `browser:chromium_download_progress` 推送给 UI 进度条；zip-slip / chmod +x / `--version` smoke-test 三道防线。新增 `browser_install_chromium_runtime` Tauri 命令 + `POST /api/browser/install-chromium-runtime` HTTP 路由 + 12 语言文案。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3016,6 +3016,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64 0.22.1",
+ "block2",
  "bollard",
  "calamine",
  "chromiumoxide",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -94,6 +94,7 @@ default = []
 desktop-tools = ["dep:arboard", "dep:xcap"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
+block2 = "0.6.2"
 objc2 = { version = "0.6.4", features = ["std"] }
 objc2-app-kit = { version = "0.3.2", features = ["NSWindow", "NSColor"] }
 objc2-foundation = { version = "0.3.2", features = ["NSArray", "NSDate", "NSError", "NSObject", "NSRunLoop", "NSString"] }

--- a/crates/ha-core/src/permissions.rs
+++ b/crates/ha-core/src/permissions.rs
@@ -1,27 +1,27 @@
-//! macOS system permission checking & requesting.
+//! System permission catalog, checks, and request entrypoints.
 //!
-//! Covers 15 permissions for "computer control".
-//! All checks run in parallel via `tokio::spawn_blocking` with per-check timeouts
-//! to avoid blocking the main thread.
+//! v2 is intentionally macOS-first. Platforms without a real implementation
+//! report `supported=false` instead of returning fake granted states.
 
 use serde::Serialize;
 use std::time::Duration;
 
-/// Per-check timeout for subprocess-based checks (osascript, etc.)
 const CHECK_TIMEOUT: Duration = Duration::from_secs(3);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(65);
 
 // ── Public data types ────────────────────────────────────────────
 
-/// Permission check result: "granted" | "not_granted" | "unknown"
-/// "unknown" = cannot be programmatically detected, user must verify in System Settings.
+/// Legacy v1 state: "granted" | "not_granted" | "unknown".
 pub type PermState = String;
 
 pub fn granted() -> PermState {
     "granted".into()
 }
+
 pub fn not_granted() -> PermState {
     "not_granted".into()
 }
+
 pub fn unknown() -> PermState {
     "unknown".into()
 }
@@ -32,7 +32,7 @@ pub struct PermissionStatus {
     pub status: PermState,
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AllPermissions {
     pub accessibility: PermState,
     pub screen_recording: PermState,
@@ -51,496 +51,1227 @@ pub struct AllPermissions {
     pub files_and_folders: PermState,
 }
 
+impl Default for AllPermissions {
+    fn default() -> Self {
+        Self {
+            accessibility: unknown(),
+            screen_recording: unknown(),
+            automation: unknown(),
+            app_management: unknown(),
+            full_disk_access: unknown(),
+            location: unknown(),
+            contacts: unknown(),
+            calendar: unknown(),
+            reminders: unknown(),
+            photos: unknown(),
+            camera: unknown(),
+            microphone: unknown(),
+            local_network: unknown(),
+            bluetooth: unknown(),
+            files_and_folders: unknown(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SystemPermissionGroup {
+    ControlCapture,
+    FileAccess,
+    PersonalData,
+    DeviceNetwork,
+    SystemServices,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SystemPermissionStatus {
+    Granted,
+    NotGranted,
+    NotDetermined,
+    Restricted,
+    ManualCheck,
+    NotApplicable,
+    NotUsed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SystemPermissionRequestMode {
+    NativePrompt,
+    OpenSettings,
+    TriggerProbe,
+    None,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemPermissionItem {
+    pub id: String,
+    pub group: SystemPermissionGroup,
+    pub status: SystemPermissionStatus,
+    pub request_mode: SystemPermissionRequestMode,
+    pub settings_pane: Option<String>,
+    pub usage: String,
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemPermissionsResponse {
+    pub platform: String,
+    pub supported: bool,
+    pub items: Vec<SystemPermissionItem>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PermissionDef {
+    id: &'static str,
+    group: SystemPermissionGroup,
+    request_mode: SystemPermissionRequestMode,
+    settings_pane: Option<&'static str>,
+    usage: &'static str,
+    note: Option<&'static str>,
+}
+
+impl PermissionDef {
+    fn item(self, status: SystemPermissionStatus) -> SystemPermissionItem {
+        SystemPermissionItem {
+            id: self.id.to_string(),
+            group: self.group,
+            status,
+            request_mode: self.request_mode,
+            settings_pane: self.settings_pane.map(str::to_string),
+            usage: self.usage.to_string(),
+            note: self.note.map(str::to_string),
+        }
+    }
+}
+
+const PERMISSION_DEFS: &[PermissionDef] = &[
+    PermissionDef {
+        id: "accessibility",
+        group: SystemPermissionGroup::ControlCapture,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_Accessibility"),
+        usage: "Control the mouse, keyboard, and other application windows.",
+        note: None,
+    },
+    PermissionDef {
+        id: "screen_recording",
+        group: SystemPermissionGroup::ControlCapture,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_ScreenCapture"),
+        usage: "Capture screen contents for visual understanding and UI automation.",
+        note: None,
+    },
+    PermissionDef {
+        id: "system_audio_capture",
+        group: SystemPermissionGroup::ControlCapture,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_AudioCapture"),
+        usage: "Capture system audio when a future workflow explicitly needs it.",
+        note: Some("macOS does not expose a reliable public preflight API for this permission."),
+    },
+    PermissionDef {
+        id: "input_monitoring",
+        group: SystemPermissionGroup::ControlCapture,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_ListenEvent"),
+        usage: "Listen for keyboard and pointer events needed by desktop automation.",
+        note: None,
+    },
+    PermissionDef {
+        id: "automation_system_events",
+        group: SystemPermissionGroup::ControlCapture,
+        request_mode: SystemPermissionRequestMode::TriggerProbe,
+        settings_pane: Some("Privacy_Automation"),
+        usage: "Allow Apple Events automation of System Events.",
+        note: Some("Per-target Automation consent is best confirmed in System Settings."),
+    },
+    PermissionDef {
+        id: "automation_messages",
+        group: SystemPermissionGroup::ControlCapture,
+        request_mode: SystemPermissionRequestMode::TriggerProbe,
+        settings_pane: Some("Privacy_Automation"),
+        usage: "Allow Apple Events automation of Messages when messaging workflows need it.",
+        note: Some("Per-target Automation consent is best confirmed in System Settings."),
+    },
+    PermissionDef {
+        id: "app_management",
+        group: SystemPermissionGroup::ControlCapture,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_AppBundles"),
+        usage: "Manage or update other applications when a tool explicitly needs it.",
+        note: Some("No reliable public per-app status API is available."),
+    },
+    PermissionDef {
+        id: "developer_tools",
+        group: SystemPermissionGroup::ControlCapture,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_DevTools"),
+        usage: "Use developer tooling that macOS protects behind Developer Tools consent.",
+        note: Some("No reliable public per-app status API is available."),
+    },
+    PermissionDef {
+        id: "full_disk_access",
+        group: SystemPermissionGroup::FileAccess,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_AllFiles"),
+        usage: "Read protected files that normal Files & Folders consent does not cover.",
+        note: Some("Detected with a conservative filesystem probe; absence is shown as manual confirmation."),
+    },
+    PermissionDef {
+        id: "desktop_folder",
+        group: SystemPermissionGroup::FileAccess,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_FilesAndFolders"),
+        usage: "Read and write files on the Desktop when requested by the user.",
+        note: Some("macOS exposes this through Files & Folders; status is probed."),
+    },
+    PermissionDef {
+        id: "documents_folder",
+        group: SystemPermissionGroup::FileAccess,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_FilesAndFolders"),
+        usage: "Read and write files in Documents when requested by the user.",
+        note: Some("macOS exposes this through Files & Folders; status is probed."),
+    },
+    PermissionDef {
+        id: "downloads_folder",
+        group: SystemPermissionGroup::FileAccess,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_FilesAndFolders"),
+        usage: "Read and write files in Downloads when requested by the user.",
+        note: Some("macOS exposes this through Files & Folders; status is probed."),
+    },
+    PermissionDef {
+        id: "removable_volumes",
+        group: SystemPermissionGroup::FileAccess,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_RemovableVolumes"),
+        usage: "Access removable drives when the user asks the app to work there.",
+        note: Some("No reliable public per-volume status API is available."),
+    },
+    PermissionDef {
+        id: "network_volumes",
+        group: SystemPermissionGroup::FileAccess,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_NetworkVolumes"),
+        usage: "Access mounted network volumes when the user asks the app to work there.",
+        note: Some("No reliable public per-volume status API is available."),
+    },
+    PermissionDef {
+        id: "location",
+        group: SystemPermissionGroup::PersonalData,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_LocationServices"),
+        usage: "Use device location for local weather and location-aware workflows.",
+        note: None,
+    },
+    PermissionDef {
+        id: "contacts",
+        group: SystemPermissionGroup::PersonalData,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_Contacts"),
+        usage: "Read contacts only when a user workflow explicitly asks for it.",
+        note: None,
+    },
+    PermissionDef {
+        id: "calendar",
+        group: SystemPermissionGroup::PersonalData,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_Calendars"),
+        usage: "Read or write calendar events when scheduling workflows need it.",
+        note: None,
+    },
+    PermissionDef {
+        id: "reminders",
+        group: SystemPermissionGroup::PersonalData,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_Reminders"),
+        usage: "Read or write reminders when planning workflows need it.",
+        note: None,
+    },
+    PermissionDef {
+        id: "photos",
+        group: SystemPermissionGroup::PersonalData,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_Photos"),
+        usage: "Access the Photos library only when the user asks for photo workflows.",
+        note: None,
+    },
+    PermissionDef {
+        id: "media_library",
+        group: SystemPermissionGroup::PersonalData,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_Media"),
+        usage: "Access the media library only when a media workflow explicitly needs it.",
+        note: Some("No reliable public status API is available for this app surface."),
+    },
+    PermissionDef {
+        id: "speech_recognition",
+        group: SystemPermissionGroup::PersonalData,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_SpeechRecognition"),
+        usage: "Use speech recognition when a voice workflow asks for transcription.",
+        note: None,
+    },
+    PermissionDef {
+        id: "focus_status",
+        group: SystemPermissionGroup::PersonalData,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_Focus"),
+        usage: "Read Focus status only for workflows that adapt notifications or interruptions.",
+        note: Some("No reliable public per-app status API is available."),
+    },
+    PermissionDef {
+        id: "homekit",
+        group: SystemPermissionGroup::PersonalData,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_HomeKit"),
+        usage: "Access Home data only if future HomeKit workflows are enabled.",
+        note: Some("Hope Agent does not currently use HomeKit workflows."),
+    },
+    PermissionDef {
+        id: "camera",
+        group: SystemPermissionGroup::DeviceNetwork,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_Camera"),
+        usage: "Use the camera for visual input only when explicitly requested.",
+        note: None,
+    },
+    PermissionDef {
+        id: "microphone",
+        group: SystemPermissionGroup::DeviceNetwork,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_Microphone"),
+        usage: "Use the microphone for voice input only when explicitly requested.",
+        note: None,
+    },
+    PermissionDef {
+        id: "bluetooth",
+        group: SystemPermissionGroup::DeviceNetwork,
+        request_mode: SystemPermissionRequestMode::NativePrompt,
+        settings_pane: Some("Privacy_Bluetooth"),
+        usage: "Discover and connect to Bluetooth devices when a workflow needs it.",
+        note: None,
+    },
+    PermissionDef {
+        id: "local_network",
+        group: SystemPermissionGroup::DeviceNetwork,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Privacy_LocalNetwork"),
+        usage: "Discover and connect to devices on the local network.",
+        note: Some("macOS Local Network privacy has no reliable public status API."),
+    },
+    PermissionDef {
+        id: "notifications",
+        group: SystemPermissionGroup::SystemServices,
+        request_mode: SystemPermissionRequestMode::OpenSettings,
+        settings_pane: Some("Notifications"),
+        usage: "Show system notifications. Delivery preferences remain in Notification settings.",
+        note: Some("Notification configuration stays on the Notifications settings page."),
+    },
+];
+
 // ── Platform-specific implementation ─────────────────────────────
 
 #[cfg(target_os = "macos")]
 mod platform {
     use super::*;
+    use std::ffi::CStr;
+    use std::path::Path;
     use std::process::Command;
+    use std::ptr;
+    use std::sync::mpsc;
 
-    // ── Framework bindings (C ABI) ──
+    use block2::RcBlock;
+    use objc2::msg_send;
+    use objc2::rc::Retained;
+    use objc2::runtime::{AnyClass, AnyObject, Bool};
+    use objc2_foundation::NSString;
 
-    extern "C" {
+    #[link(name = "ApplicationServices", kind = "framework")]
+    unsafe extern "C" {
         fn AXIsProcessTrusted() -> bool;
+    }
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    unsafe extern "C" {
         fn CGPreflightScreenCaptureAccess() -> bool;
         fn CGRequestScreenCaptureAccess() -> bool;
+        fn CGPreflightListenEventAccess() -> bool;
+        fn CGRequestListenEventAccess() -> bool;
     }
 
-    // ── Helpers ──
+    #[link(name = "AVFoundation", kind = "framework")]
+    unsafe extern "C" {}
 
-    fn bool_to_state(b: bool) -> PermState {
-        if b {
-            granted()
+    #[link(name = "CoreBluetooth", kind = "framework")]
+    unsafe extern "C" {}
+
+    #[link(name = "CoreLocation", kind = "framework")]
+    unsafe extern "C" {}
+
+    #[link(name = "Contacts", kind = "framework")]
+    unsafe extern "C" {}
+
+    #[link(name = "EventKit", kind = "framework")]
+    unsafe extern "C" {}
+
+    #[link(name = "Photos", kind = "framework")]
+    unsafe extern "C" {}
+
+    #[link(name = "Speech", kind = "framework")]
+    unsafe extern "C" {}
+
+    #[link(name = "UserNotifications", kind = "framework")]
+    unsafe extern "C" {}
+
+    pub fn platform_name() -> &'static str {
+        "macos"
+    }
+
+    pub fn supported() -> bool {
+        true
+    }
+
+    pub fn check_item(id: &str) -> SystemPermissionStatus {
+        match id {
+            "accessibility" => bool_status(unsafe { AXIsProcessTrusted() }),
+            "screen_recording" => bool_status(unsafe { CGPreflightScreenCaptureAccess() }),
+            "input_monitoring" => bool_status(unsafe { CGPreflightListenEventAccess() }),
+            "camera" => av_media_status("vide"),
+            "microphone" => av_media_status("soun"),
+            "location" => location_status(),
+            "contacts" => auth_status_with_entity(c"CNContactStore", 0),
+            "calendar" => auth_status_with_entity(c"EKEventStore", 0),
+            "reminders" => auth_status_with_entity(c"EKEventStore", 1),
+            "photos" => photos_status(),
+            "bluetooth" => objc_auth_status(c"CBCentralManager", "authorization"),
+            "speech_recognition" => speech_status(),
+            "notifications" => notification_status(),
+            "full_disk_access" => full_disk_access_status(),
+            "desktop_folder" => folder_status("Desktop"),
+            "documents_folder" => folder_status("Documents"),
+            "downloads_folder" => folder_status("Downloads"),
+            "homekit" => SystemPermissionStatus::NotUsed,
+            "automation_system_events"
+            | "automation_messages"
+            | "app_management"
+            | "developer_tools"
+            | "system_audio_capture"
+            | "removable_volumes"
+            | "network_volumes"
+            | "media_library"
+            | "focus_status"
+            | "local_network" => SystemPermissionStatus::ManualCheck,
+            _ => SystemPermissionStatus::NotApplicable,
+        }
+    }
+
+    pub fn request_item(def: PermissionDef) -> SystemPermissionStatus {
+        match def.id {
+            "screen_recording" => {
+                let ok = unsafe { CGRequestScreenCaptureAccess() };
+                if !ok {
+                    open_settings_pane(def.settings_pane);
+                }
+                bool_status(ok)
+            }
+            "input_monitoring" => {
+                let ok = unsafe { CGRequestListenEventAccess() };
+                if !ok {
+                    open_settings_pane(def.settings_pane);
+                }
+                bool_status(ok)
+            }
+            "camera" => request_av_media(def, "vide"),
+            "microphone" => request_av_media(def, "soun"),
+            "location" => request_location(def),
+            "contacts" => request_contacts(def),
+            "calendar" => request_eventkit(def, 0),
+            "reminders" => request_eventkit(def, 1),
+            "photos" => request_photos(def),
+            "bluetooth" => request_bluetooth(def),
+            "speech_recognition" => request_speech(def),
+            "automation_system_events" => {
+                trigger_automation_probe("System Events");
+                open_settings_pane(def.settings_pane);
+                check_item(def.id)
+            }
+            "automation_messages" => {
+                trigger_automation_probe("Messages");
+                open_settings_pane(def.settings_pane);
+                check_item(def.id)
+            }
+            _ => {
+                open_settings_pane(def.settings_pane);
+                check_item(def.id)
+            }
+        }
+    }
+
+    fn bool_status(value: bool) -> SystemPermissionStatus {
+        if value {
+            SystemPermissionStatus::Granted
         } else {
-            not_granted()
+            SystemPermissionStatus::NotGranted
         }
     }
 
-    fn run_osascript(args: &[&str]) -> Option<std::process::Output> {
-        Command::new("osascript")
-            .args(args)
-            .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
+    fn map_standard_auth_status(status: isize) -> SystemPermissionStatus {
+        match status {
+            0 => SystemPermissionStatus::NotDetermined,
+            1 => SystemPermissionStatus::Restricted,
+            2 => SystemPermissionStatus::NotGranted,
+            // Some frameworks use 4 for "limited" or "when in use"; both
+            // mean the app has usable access for this permissions overview.
+            3 | 4 => SystemPermissionStatus::Granted,
+            _ => SystemPermissionStatus::ManualCheck,
+        }
+    }
+
+    fn map_speech_auth_status(status: isize) -> SystemPermissionStatus {
+        match status {
+            0 => SystemPermissionStatus::NotDetermined,
+            1 => SystemPermissionStatus::NotGranted,
+            2 => SystemPermissionStatus::Restricted,
+            3 => SystemPermissionStatus::Granted,
+            _ => SystemPermissionStatus::ManualCheck,
+        }
+    }
+
+    fn map_notification_auth_status(status: isize) -> SystemPermissionStatus {
+        match status {
+            0 => SystemPermissionStatus::NotDetermined,
+            1 => SystemPermissionStatus::NotGranted,
+            2..=4 => SystemPermissionStatus::Granted,
+            _ => SystemPermissionStatus::ManualCheck,
+        }
+    }
+
+    fn wait_for_prompt(
+        id: &str,
+        receiver: mpsc::Receiver<SystemPermissionStatus>,
+    ) -> SystemPermissionStatus {
+        receiver
+            .recv_timeout(Duration::from_secs(60))
+            .unwrap_or_else(|_| check_item(id))
+    }
+
+    fn requestable_status_or_open(
+        def: PermissionDef,
+        status: SystemPermissionStatus,
+    ) -> Option<SystemPermissionStatus> {
+        if status == SystemPermissionStatus::NotDetermined {
+            None
+        } else {
+            open_settings_pane(def.settings_pane);
+            Some(status)
+        }
+    }
+
+    fn objc_class(name: &'static CStr) -> Option<&'static AnyClass> {
+        AnyClass::get(name)
+    }
+
+    fn objc_auth_status(class_name: &'static CStr, selector: &str) -> SystemPermissionStatus {
+        let Some(cls) = objc_class(class_name) else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let status: isize = unsafe {
+            match selector {
+                "authorization" => msg_send![cls, authorization],
+                "authorizationStatus" => msg_send![cls, authorizationStatus],
+                _ => return SystemPermissionStatus::NotApplicable,
+            }
+        };
+        map_standard_auth_status(status)
+    }
+
+    fn auth_status_with_entity(
+        class_name: &'static CStr,
+        entity_type: isize,
+    ) -> SystemPermissionStatus {
+        let Some(cls) = objc_class(class_name) else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let status: isize =
+            unsafe { msg_send![cls, authorizationStatusForEntityType: entity_type] };
+        map_standard_auth_status(status)
+    }
+
+    fn av_media_status(raw_media_type: &str) -> SystemPermissionStatus {
+        let Some(cls) = objc_class(c"AVCaptureDevice") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let media_type = NSString::from_str(raw_media_type);
+        let status: isize =
+            unsafe { msg_send![cls, authorizationStatusForMediaType: &*media_type] };
+        map_standard_auth_status(status)
+    }
+
+    fn request_av_media(def: PermissionDef, raw_media_type: &str) -> SystemPermissionStatus {
+        let status = av_media_status(raw_media_type);
+        if let Some(status) = requestable_status_or_open(def, status) {
+            return status;
+        }
+
+        let Some(cls) = objc_class(c"AVCaptureDevice") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let media_type = NSString::from_str(raw_media_type);
+        let (sender, receiver) = mpsc::channel();
+        let block = RcBlock::new(move |granted: Bool| {
+            let _ = sender.send(bool_status(granted.as_bool()));
+        });
+
+        unsafe {
+            let _: () = msg_send![
+                cls,
+                requestAccessForMediaType: &*media_type,
+                completionHandler: &*block
+            ];
+        }
+
+        wait_for_prompt(def.id, receiver)
+    }
+
+    fn location_status() -> SystemPermissionStatus {
+        let Some(cls) = objc_class(c"CLLocationManager") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let status: isize = unsafe { msg_send![cls, authorizationStatus] };
+        match status {
+            0 => SystemPermissionStatus::NotDetermined,
+            1 => SystemPermissionStatus::Restricted,
+            2 => SystemPermissionStatus::NotGranted,
+            3 | 4 => SystemPermissionStatus::Granted,
+            _ => SystemPermissionStatus::ManualCheck,
+        }
+    }
+
+    fn request_location(def: PermissionDef) -> SystemPermissionStatus {
+        let status = location_status();
+        if let Some(status) = requestable_status_or_open(def, status) {
+            return status;
+        }
+
+        let Some(cls) = objc_class(c"CLLocationManager") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let manager: Retained<AnyObject> = unsafe { msg_send![cls, new] };
+        unsafe {
+            let _: () = msg_send![&*manager, requestWhenInUseAuthorization];
+        }
+        std::thread::sleep(Duration::from_millis(500));
+        check_item(def.id)
+    }
+
+    fn request_contacts(def: PermissionDef) -> SystemPermissionStatus {
+        let status = auth_status_with_entity(c"CNContactStore", 0);
+        if let Some(status) = requestable_status_or_open(def, status) {
+            return status;
+        }
+
+        let Some(cls) = objc_class(c"CNContactStore") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let store: Retained<AnyObject> = unsafe { msg_send![cls, new] };
+        let (sender, receiver) = mpsc::channel();
+        let block = RcBlock::new(move |granted: Bool, _error: *mut AnyObject| {
+            let _ = sender.send(bool_status(granted.as_bool()));
+        });
+
+        unsafe {
+            let _: () = msg_send![
+                &*store,
+                requestAccessForEntityType: 0isize,
+                completionHandler: &*block
+            ];
+        }
+
+        wait_for_prompt(def.id, receiver)
+    }
+
+    fn request_eventkit(def: PermissionDef, entity_type: isize) -> SystemPermissionStatus {
+        let status = auth_status_with_entity(c"EKEventStore", entity_type);
+        if let Some(status) = requestable_status_or_open(def, status) {
+            return status;
+        }
+
+        let Some(cls) = objc_class(c"EKEventStore") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let store: Retained<AnyObject> = unsafe { msg_send![cls, new] };
+        let (sender, receiver) = mpsc::channel();
+        let block = RcBlock::new(move |granted: Bool, _error: *mut AnyObject| {
+            let _ = sender.send(bool_status(granted.as_bool()));
+        });
+
+        unsafe {
+            let _: () = msg_send![
+                &*store,
+                requestAccessToEntityType: entity_type,
+                completion: &*block
+            ];
+        }
+
+        wait_for_prompt(def.id, receiver)
+    }
+
+    fn photos_status() -> SystemPermissionStatus {
+        let Some(cls) = objc_class(c"PHPhotoLibrary") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let status: isize = unsafe { msg_send![cls, authorizationStatus] };
+        map_standard_auth_status(status)
+    }
+
+    fn request_photos(def: PermissionDef) -> SystemPermissionStatus {
+        let status = photos_status();
+        if let Some(status) = requestable_status_or_open(def, status) {
+            return status;
+        }
+
+        let Some(cls) = objc_class(c"PHPhotoLibrary") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let (sender, receiver) = mpsc::channel();
+        let block = RcBlock::new(move |status: isize| {
+            let _ = sender.send(map_standard_auth_status(status));
+        });
+
+        unsafe {
+            let _: () = msg_send![cls, requestAuthorization: &*block];
+        }
+
+        wait_for_prompt(def.id, receiver)
+    }
+
+    fn speech_status() -> SystemPermissionStatus {
+        let Some(cls) = objc_class(c"SFSpeechRecognizer") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let status: isize = unsafe { msg_send![cls, authorizationStatus] };
+        map_speech_auth_status(status)
+    }
+
+    fn request_speech(def: PermissionDef) -> SystemPermissionStatus {
+        let status = speech_status();
+        if let Some(status) = requestable_status_or_open(def, status) {
+            return status;
+        }
+
+        let Some(cls) = objc_class(c"SFSpeechRecognizer") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let (sender, receiver) = mpsc::channel();
+        let block = RcBlock::new(move |status: isize| {
+            let _ = sender.send(map_speech_auth_status(status));
+        });
+
+        unsafe {
+            let _: () = msg_send![cls, requestAuthorization: &*block];
+        }
+
+        wait_for_prompt(def.id, receiver)
+    }
+
+    fn request_bluetooth(def: PermissionDef) -> SystemPermissionStatus {
+        let status = objc_auth_status(c"CBCentralManager", "authorization");
+        if let Some(status) = requestable_status_or_open(def, status) {
+            return status;
+        }
+
+        let Some(cls) = objc_class(c"CBCentralManager") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let manager: *mut AnyObject = unsafe { msg_send![cls, alloc] };
+        let manager: *mut AnyObject = unsafe {
+            msg_send![
+                manager,
+                initWithDelegate: ptr::null_mut::<AnyObject>(),
+                queue: ptr::null_mut::<AnyObject>(),
+                options: ptr::null_mut::<AnyObject>()
+            ]
+        };
+        std::thread::sleep(Duration::from_millis(500));
+        if !manager.is_null() {
+            unsafe {
+                let _: () = msg_send![manager, release];
+            }
+        }
+        check_item(def.id)
+    }
+
+    fn notification_status() -> SystemPermissionStatus {
+        let Some(cls) = objc_class(c"UNUserNotificationCenter") else {
+            return SystemPermissionStatus::NotApplicable;
+        };
+        let center: Retained<AnyObject> = unsafe { msg_send![cls, currentNotificationCenter] };
+        let (sender, receiver) = mpsc::channel();
+        let block = RcBlock::new(move |settings: *mut AnyObject| {
+            if settings.is_null() {
+                let _ = sender.send(SystemPermissionStatus::ManualCheck);
+                return;
+            }
+            let status: isize = unsafe { msg_send![settings, authorizationStatus] };
+            let _ = sender.send(map_notification_auth_status(status));
+        });
+
+        unsafe {
+            let _: () = msg_send![&*center, getNotificationSettingsWithCompletionHandler: &*block];
+        }
+
+        receiver
+            .recv_timeout(Duration::from_secs(2))
+            .unwrap_or(SystemPermissionStatus::ManualCheck)
+    }
+
+    fn full_disk_access_status() -> SystemPermissionStatus {
+        let Some(home) = dirs::home_dir() else {
+            return SystemPermissionStatus::ManualCheck;
+        };
+        let probes = [
+            home.join("Library/Safari/Bookmarks.plist"),
+            home.join("Library/Messages/chat.db"),
+        ];
+        if probes.iter().any(|path| std::fs::metadata(path).is_ok()) {
+            SystemPermissionStatus::Granted
+        } else {
+            SystemPermissionStatus::ManualCheck
+        }
+    }
+
+    fn folder_status(folder: &str) -> SystemPermissionStatus {
+        let Some(home) = dirs::home_dir() else {
+            return SystemPermissionStatus::ManualCheck;
+        };
+        let path = home.join(folder);
+        if can_read_dir(&path) {
+            SystemPermissionStatus::Granted
+        } else {
+            SystemPermissionStatus::ManualCheck
+        }
+    }
+
+    fn can_read_dir(path: &Path) -> bool {
+        std::fs::read_dir(path).is_ok()
+    }
+
+    fn trigger_automation_probe(target: &str) {
+        let script = format!("tell application \"{}\" to return name", target);
+        let _ = Command::new("osascript")
+            .args(["-e", &script])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
             .spawn()
-            .ok()?
-            .wait_with_output()
-            .ok()
+            .and_then(|mut child| child.wait());
     }
 
-    fn jxa(script: &str) -> Option<String> {
-        run_osascript(&["-l", "JavaScript", "-e", script])
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-    }
-
-    /// Check a framework authorization status via JXA. Returns granted if status == 3.
-    fn jxa_auth_status(script: &str) -> PermState {
-        bool_to_state(jxa(script).map_or(false, |s| s.trim() == "3"))
-    }
-
-    pub fn open_privacy_pane(pane: &str) {
-        let url = format!(
-            "x-apple.systempreferences:com.apple.preference.security?{}",
-            pane
-        );
-        let _ = Command::new("open").arg(&url).spawn();
-    }
-
-    // ── 1. Accessibility ── (instant, C API)
-
-    pub fn check_accessibility() -> PermState {
-        bool_to_state(unsafe { AXIsProcessTrusted() })
-    }
-
-    pub fn request_accessibility() -> PermState {
-        open_privacy_pane("Privacy_Accessibility");
-        check_accessibility()
-    }
-
-    // ── 2. Screen Recording ── (instant, C API)
-
-    pub fn check_screen_recording() -> PermState {
-        bool_to_state(unsafe { CGPreflightScreenCaptureAccess() })
-    }
-
-    pub fn request_screen_recording() -> PermState {
-        let ok = unsafe { CGRequestScreenCaptureAccess() };
-        if !ok {
-            open_privacy_pane("Privacy_ScreenCapture");
-        }
-        bool_to_state(ok)
-    }
-
-    // ── 3. Automation ── (osascript)
-
-    pub fn check_automation() -> PermState {
-        bool_to_state(
-            run_osascript(&["-e", "tell application \"System Events\" to return name"])
-                .map_or(false, |o| o.status.success()),
-        )
-    }
-
-    pub fn request_automation() -> PermState {
-        let _ = run_osascript(&["-e", "tell application \"System Events\" to return name"]);
-        open_privacy_pane("Privacy_Automation");
-        check_automation()
-    }
-
-    // ── 4. App Management ──
-    // Cannot be reliably detected via filesystem ops (TCC != Unix perms).
-
-    pub fn check_app_management() -> PermState {
-        unknown()
-    }
-
-    pub fn request_app_management() -> PermState {
-        open_privacy_pane("Privacy_AppBundles");
-        unknown()
-    }
-
-    // ── 5. Full Disk Access ── (filesystem heuristic)
-
-    pub fn check_full_disk_access() -> PermState {
-        bool_to_state(dirs::home_dir().map_or(false, |h| {
-            std::fs::metadata(h.join("Library/Safari/Bookmarks.plist")).is_ok()
-        }))
-    }
-
-    pub fn request_full_disk_access() -> PermState {
-        open_privacy_pane("Privacy_AllFiles");
-        check_full_disk_access()
-    }
-
-    // ── 6. Location Services ── (JXA)
-
-    pub fn check_location() -> PermState {
-        bool_to_state(
-            jxa("ObjC.import('CoreLocation'); \
-                 var s = $.CLLocationManager.authorizationStatus; \
-                 s === 3 || s === 4")
-            .map_or(false, |s| s == "true"),
-        )
-    }
-
-    pub fn request_location() -> PermState {
-        open_privacy_pane("Privacy_LocationServices");
-        check_location()
-    }
-
-    // ── 7. Contacts ── (JXA)
-
-    pub fn check_contacts() -> PermState {
-        jxa_auth_status(
-            "ObjC.import('Contacts'); \
-             $.CNContactStore.authorizationStatusForEntityType(0)",
-        )
-    }
-
-    pub fn request_contacts() -> PermState {
-        open_privacy_pane("Privacy_Contacts");
-        check_contacts()
-    }
-
-    // ── 8. Calendar ── (JXA)
-
-    pub fn check_calendar() -> PermState {
-        jxa_auth_status(
-            "ObjC.import('EventKit'); \
-             $.EKEventStore.authorizationStatusForEntityType(0)",
-        )
-    }
-
-    pub fn request_calendar() -> PermState {
-        open_privacy_pane("Privacy_Calendars");
-        check_calendar()
-    }
-
-    // ── 9. Reminders ── (JXA)
-
-    pub fn check_reminders() -> PermState {
-        jxa_auth_status(
-            "ObjC.import('EventKit'); \
-             $.EKEventStore.authorizationStatusForEntityType(1)",
-        )
-    }
-
-    pub fn request_reminders() -> PermState {
-        open_privacy_pane("Privacy_Reminders");
-        check_reminders()
-    }
-
-    // ── 10. Photos ── (JXA)
-
-    pub fn check_photos() -> PermState {
-        jxa_auth_status(
-            "ObjC.import('Photos'); \
-             $.PHPhotoLibrary.authorizationStatus",
-        )
-    }
-
-    pub fn request_photos() -> PermState {
-        open_privacy_pane("Privacy_Photos");
-        check_photos()
-    }
-
-    // ── 11. Camera ── (JXA)
-
-    pub fn check_camera() -> PermState {
-        jxa_auth_status(
-            "ObjC.import('AVFoundation'); \
-             $.AVCaptureDevice.authorizationStatusForMediaType('vide')",
-        )
-    }
-
-    pub fn request_camera() -> PermState {
-        open_privacy_pane("Privacy_Camera");
-        check_camera()
-    }
-
-    // ── 12. Microphone ── (JXA)
-
-    pub fn check_microphone() -> PermState {
-        jxa_auth_status(
-            "ObjC.import('AVFoundation'); \
-             $.AVCaptureDevice.authorizationStatusForMediaType('soun')",
-        )
-    }
-
-    pub fn request_microphone() -> PermState {
-        open_privacy_pane("Privacy_Microphone");
-        check_microphone()
-    }
-
-    // ── 13. Local Network ──
-    // Cannot be reliably detected programmatically on macOS.
-
-    pub fn check_local_network() -> PermState {
-        unknown()
-    }
-
-    pub fn request_local_network() -> PermState {
-        open_privacy_pane("Privacy_LocalNetwork");
-        unknown()
-    }
-
-    // ── 14. Bluetooth ── (JXA)
-
-    pub fn check_bluetooth() -> PermState {
-        bool_to_state(
-            jxa("ObjC.import('CoreBluetooth'); \
-                 var auth = $.CBCentralManager.authorization; \
-                 auth === 3")
-            .map_or(false, |s| s == "true"),
-        )
-    }
-
-    pub fn request_bluetooth() -> PermState {
-        open_privacy_pane("Privacy_Bluetooth");
-        check_bluetooth()
-    }
-
-    // ── 15. Files & Folders ── (filesystem, instant)
-
-    pub fn check_files_and_folders() -> PermState {
-        bool_to_state(dirs::home_dir().map_or(false, |home| {
-            std::fs::read_dir(home.join("Desktop")).is_ok()
-                && std::fs::read_dir(home.join("Documents")).is_ok()
-                && std::fs::read_dir(home.join("Downloads")).is_ok()
-        }))
-    }
-
-    pub fn request_files_and_folders() -> PermState {
-        open_privacy_pane("Privacy_FilesAndFolders");
-        check_files_and_folders()
+    fn open_settings_pane(pane: Option<&str>) {
+        let Some(pane) = pane else {
+            return;
+        };
+        let url = match pane {
+            "Notifications" => {
+                "x-apple.systempreferences:com.apple.preference.notifications".to_string()
+            }
+            pane => format!(
+                "x-apple.systempreferences:com.apple.preference.security?{}",
+                pane
+            ),
+        };
+        let _ = Command::new("open").arg(url).spawn();
     }
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "windows")]
 mod platform {
     use super::*;
 
-    pub fn check_accessibility() -> PermState {
-        granted()
+    pub fn platform_name() -> &'static str {
+        "windows"
     }
-    pub fn request_accessibility() -> PermState {
-        granted()
+
+    pub fn supported() -> bool {
+        false
     }
-    pub fn check_screen_recording() -> PermState {
-        granted()
+
+    pub fn check_item(_id: &str) -> SystemPermissionStatus {
+        SystemPermissionStatus::NotApplicable
     }
-    pub fn request_screen_recording() -> PermState {
-        granted()
+
+    pub fn request_item(_def: PermissionDef) -> SystemPermissionStatus {
+        SystemPermissionStatus::NotApplicable
     }
-    pub fn check_automation() -> PermState {
-        granted()
+}
+
+#[cfg(target_os = "linux")]
+mod platform {
+    use super::*;
+
+    pub fn platform_name() -> &'static str {
+        "linux"
     }
-    pub fn request_automation() -> PermState {
-        granted()
+
+    pub fn supported() -> bool {
+        false
     }
-    pub fn check_app_management() -> PermState {
-        granted()
+
+    pub fn check_item(_id: &str) -> SystemPermissionStatus {
+        SystemPermissionStatus::NotApplicable
     }
-    pub fn request_app_management() -> PermState {
-        granted()
+
+    pub fn request_item(_def: PermissionDef) -> SystemPermissionStatus {
+        SystemPermissionStatus::NotApplicable
     }
-    pub fn check_full_disk_access() -> PermState {
-        granted()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+mod platform {
+    use super::*;
+
+    pub fn platform_name() -> &'static str {
+        "unknown"
     }
-    pub fn request_full_disk_access() -> PermState {
-        granted()
+
+    pub fn supported() -> bool {
+        false
     }
-    pub fn check_location() -> PermState {
-        granted()
+
+    pub fn check_item(_id: &str) -> SystemPermissionStatus {
+        SystemPermissionStatus::NotApplicable
     }
-    pub fn request_location() -> PermState {
-        granted()
-    }
-    pub fn check_contacts() -> PermState {
-        granted()
-    }
-    pub fn request_contacts() -> PermState {
-        granted()
-    }
-    pub fn check_calendar() -> PermState {
-        granted()
-    }
-    pub fn request_calendar() -> PermState {
-        granted()
-    }
-    pub fn check_reminders() -> PermState {
-        granted()
-    }
-    pub fn request_reminders() -> PermState {
-        granted()
-    }
-    pub fn check_photos() -> PermState {
-        granted()
-    }
-    pub fn request_photos() -> PermState {
-        granted()
-    }
-    pub fn check_camera() -> PermState {
-        granted()
-    }
-    pub fn request_camera() -> PermState {
-        granted()
-    }
-    pub fn check_microphone() -> PermState {
-        granted()
-    }
-    pub fn request_microphone() -> PermState {
-        granted()
-    }
-    pub fn check_local_network() -> PermState {
-        granted()
-    }
-    pub fn request_local_network() -> PermState {
-        granted()
-    }
-    pub fn check_bluetooth() -> PermState {
-        granted()
-    }
-    pub fn request_bluetooth() -> PermState {
-        granted()
-    }
-    pub fn check_files_and_folders() -> PermState {
-        granted()
-    }
-    pub fn request_files_and_folders() -> PermState {
-        granted()
+
+    pub fn request_item(_def: PermissionDef) -> SystemPermissionStatus {
+        SystemPermissionStatus::NotApplicable
     }
 }
 
 // ── Async helpers ────────────────────────────────────────────────
 
-/// Run a blocking check function with a timeout. Returns "not_granted" on timeout.
-async fn check_with_timeout<F: FnOnce() -> PermState + Send + 'static>(f: F) -> PermState {
-    match tokio::time::timeout(CHECK_TIMEOUT, tokio::task::spawn_blocking(f)).await {
+async fn blocking_with_timeout<T, F>(timeout: Duration, fallback: T, f: F) -> T
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    match tokio::time::timeout(timeout, tokio::task::spawn_blocking(f)).await {
         Ok(Ok(result)) => result,
-        _ => not_granted(), // timeout or panic → treat as not granted
+        _ => fallback,
     }
 }
 
-// ── Tauri commands (all async) ───────────────────────────────────
+// ── v2 API ───────────────────────────────────────────────────────
+
+pub async fn check_system_permissions() -> SystemPermissionsResponse {
+    blocking_with_timeout(CHECK_TIMEOUT, unsupported_response(), || {
+        let supported = platform::supported();
+        let items = if supported {
+            PERMISSION_DEFS
+                .iter()
+                .map(|def| def.item(platform::check_item(def.id)))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        SystemPermissionsResponse {
+            platform: platform::platform_name().to_string(),
+            supported,
+            items,
+        }
+    })
+    .await
+}
+
+pub async fn request_system_permission(id: String) -> SystemPermissionItem {
+    let fallback = unknown_item(id.clone());
+    blocking_with_timeout(REQUEST_TIMEOUT, fallback, move || {
+        let Some(def) = find_def(&id) else {
+            return unknown_item(id);
+        };
+        let status = if platform::supported() {
+            platform::request_item(def)
+        } else {
+            SystemPermissionStatus::NotApplicable
+        };
+        def.item(status)
+    })
+    .await
+}
+
+fn unsupported_response() -> SystemPermissionsResponse {
+    SystemPermissionsResponse {
+        platform: platform::platform_name().to_string(),
+        supported: false,
+        items: Vec::new(),
+    }
+}
+
+fn find_def(id: &str) -> Option<PermissionDef> {
+    PERMISSION_DEFS.iter().copied().find(|def| def.id == id)
+}
+
+fn unknown_item(id: String) -> SystemPermissionItem {
+    SystemPermissionItem {
+        id,
+        group: SystemPermissionGroup::SystemServices,
+        status: SystemPermissionStatus::NotApplicable,
+        request_mode: SystemPermissionRequestMode::None,
+        settings_pane: None,
+        usage: "This permission is not known by this version of Hope Agent.".to_string(),
+        note: Some("Unknown permission id.".to_string()),
+    }
+}
+
+// ── v1 compatibility wrappers ────────────────────────────────────
 
 pub async fn check_all_permissions() -> AllPermissions {
-    // Run all 15 checks in parallel with timeouts
-    let (
-        accessibility,
-        screen_recording,
-        automation,
-        app_management,
-        full_disk_access,
-        location,
-        contacts,
-        calendar,
-        reminders,
-        photos,
-        camera,
-        microphone,
-        local_network,
-        bluetooth,
-        files_and_folders,
-    ) = tokio::join!(
-        check_with_timeout(platform::check_accessibility),
-        check_with_timeout(platform::check_screen_recording),
-        check_with_timeout(platform::check_automation),
-        check_with_timeout(platform::check_app_management),
-        check_with_timeout(platform::check_full_disk_access),
-        check_with_timeout(platform::check_location),
-        check_with_timeout(platform::check_contacts),
-        check_with_timeout(platform::check_calendar),
-        check_with_timeout(platform::check_reminders),
-        check_with_timeout(platform::check_photos),
-        check_with_timeout(platform::check_camera),
-        check_with_timeout(platform::check_microphone),
-        check_with_timeout(platform::check_local_network),
-        check_with_timeout(platform::check_bluetooth),
-        check_with_timeout(platform::check_files_and_folders),
-    );
-
-    let r = AllPermissions {
-        accessibility,
-        screen_recording,
-        automation,
-        app_management,
-        full_disk_access,
-        location,
-        contacts,
-        calendar,
-        reminders,
-        photos,
-        camera,
-        microphone,
-        local_network,
-        bluetooth,
-        files_and_folders,
-    };
-
+    let response = check_system_permissions().await;
+    let legacy = legacy_from_response(&response);
     crate::app_info!(
         "permissions",
         "check_all",
-        "a11y={} screen={} auto={} appmgmt={} fda={} loc={} contacts={} cal={} remind={} photos={} cam={} mic={} net={} bt={} files={}",
-        r.accessibility, r.screen_recording, r.automation, r.app_management,
-        r.full_disk_access, r.location, r.contacts, r.calendar, r.reminders,
-        r.photos, r.camera, r.microphone, r.local_network, r.bluetooth,
-        r.files_and_folders
+        "platform={} supported={} a11y={} screen={} auto={} appmgmt={} fda={} loc={} contacts={} cal={} remind={} photos={} cam={} mic={} net={} bt={} files={}",
+        response.platform,
+        response.supported,
+        legacy.accessibility,
+        legacy.screen_recording,
+        legacy.automation,
+        legacy.app_management,
+        legacy.full_disk_access,
+        legacy.location,
+        legacy.contacts,
+        legacy.calendar,
+        legacy.reminders,
+        legacy.photos,
+        legacy.camera,
+        legacy.microphone,
+        legacy.local_network,
+        legacy.bluetooth,
+        legacy.files_and_folders
     );
-    r
+    legacy
 }
 
 pub async fn check_permission(id: String) -> PermissionStatus {
-    let id2 = id.clone();
-    let status = check_with_timeout(move || dispatch_check(&id2)).await;
+    let response = check_system_permissions().await;
+    let status = legacy_status_for_id(&response, &id);
     PermissionStatus { id, status }
 }
 
 pub async fn request_permission(id: String) -> PermissionStatus {
     crate::app_info!("permissions", "request", "Requesting: {}", id);
-    let id2 = id.clone();
-    let status = check_with_timeout(move || dispatch_request(&id2)).await;
+    if let Some(request_id) = legacy_request_id(&id) {
+        let _ = request_system_permission(request_id.to_string()).await;
+    }
+    let response = check_system_permissions().await;
+    let status = legacy_status_for_id(&response, &id);
     crate::app_info!("permissions", "request", "{} → {}", id, status);
     PermissionStatus { id, status }
 }
 
-fn dispatch_check(id: &str) -> PermState {
+fn legacy_request_id(id: &str) -> Option<&str> {
     match id {
-        "accessibility" => platform::check_accessibility(),
-        "screen_recording" => platform::check_screen_recording(),
-        "automation" => platform::check_automation(),
-        "app_management" => platform::check_app_management(),
-        "full_disk_access" => platform::check_full_disk_access(),
-        "location" => platform::check_location(),
-        "contacts" => platform::check_contacts(),
-        "calendar" => platform::check_calendar(),
-        "reminders" => platform::check_reminders(),
-        "photos" => platform::check_photos(),
-        "camera" => platform::check_camera(),
-        "microphone" => platform::check_microphone(),
-        "local_network" => platform::check_local_network(),
-        "bluetooth" => platform::check_bluetooth(),
-        "files_and_folders" => platform::check_files_and_folders(),
-        _ => not_granted(),
+        "automation" => Some("automation_system_events"),
+        "files_and_folders" => Some("desktop_folder"),
+        "accessibility" | "screen_recording" | "app_management" | "full_disk_access"
+        | "location" | "contacts" | "calendar" | "reminders" | "photos" | "camera"
+        | "microphone" | "local_network" | "bluetooth" => Some(id),
+        _ => None,
     }
 }
 
-fn dispatch_request(id: &str) -> PermState {
+fn legacy_status_for_id(response: &SystemPermissionsResponse, id: &str) -> PermState {
     match id {
-        "accessibility" => platform::request_accessibility(),
-        "screen_recording" => platform::request_screen_recording(),
-        "automation" => platform::request_automation(),
-        "app_management" => platform::request_app_management(),
-        "full_disk_access" => platform::request_full_disk_access(),
-        "location" => platform::request_location(),
-        "contacts" => platform::request_contacts(),
-        "calendar" => platform::request_calendar(),
-        "reminders" => platform::request_reminders(),
-        "photos" => platform::request_photos(),
-        "camera" => platform::request_camera(),
-        "microphone" => platform::request_microphone(),
-        "local_network" => platform::request_local_network(),
-        "bluetooth" => platform::request_bluetooth(),
-        "files_and_folders" => platform::request_files_and_folders(),
-        _ => not_granted(),
+        "automation" => legacy_item(response, "automation_system_events"),
+        "files_and_folders" => legacy_files_and_folders(response),
+        id => legacy_item(response, id),
+    }
+}
+
+fn legacy_from_response(response: &SystemPermissionsResponse) -> AllPermissions {
+    if !response.supported {
+        return AllPermissions::default();
+    }
+
+    AllPermissions {
+        accessibility: legacy_item(response, "accessibility"),
+        screen_recording: legacy_item(response, "screen_recording"),
+        automation: legacy_item(response, "automation_system_events"),
+        app_management: legacy_item(response, "app_management"),
+        full_disk_access: legacy_item(response, "full_disk_access"),
+        location: legacy_item(response, "location"),
+        contacts: legacy_item(response, "contacts"),
+        calendar: legacy_item(response, "calendar"),
+        reminders: legacy_item(response, "reminders"),
+        photos: legacy_item(response, "photos"),
+        camera: legacy_item(response, "camera"),
+        microphone: legacy_item(response, "microphone"),
+        local_network: legacy_item(response, "local_network"),
+        bluetooth: legacy_item(response, "bluetooth"),
+        files_and_folders: legacy_files_and_folders(response),
+    }
+}
+
+fn legacy_item(response: &SystemPermissionsResponse, id: &str) -> PermState {
+    response
+        .items
+        .iter()
+        .find(|item| item.id == id)
+        .map(|item| legacy_state_for_status(item.status))
+        .unwrap_or_else(unknown)
+}
+
+fn legacy_files_and_folders(response: &SystemPermissionsResponse) -> PermState {
+    let statuses = ["desktop_folder", "documents_folder", "downloads_folder"]
+        .iter()
+        .filter_map(|id| response.items.iter().find(|item| item.id == *id))
+        .map(|item| item.status)
+        .collect::<Vec<_>>();
+
+    if statuses.len() == 3
+        && statuses
+            .iter()
+            .all(|status| *status == SystemPermissionStatus::Granted)
+    {
+        granted()
+    } else if statuses.iter().any(|status| {
+        matches!(
+            status,
+            SystemPermissionStatus::NotGranted
+                | SystemPermissionStatus::NotDetermined
+                | SystemPermissionStatus::Restricted
+        )
+    }) {
+        not_granted()
+    } else {
+        unknown()
+    }
+}
+
+fn legacy_state_for_status(status: SystemPermissionStatus) -> PermState {
+    match status {
+        SystemPermissionStatus::Granted => granted(),
+        SystemPermissionStatus::NotGranted
+        | SystemPermissionStatus::NotDetermined
+        | SystemPermissionStatus::Restricted => not_granted(),
+        SystemPermissionStatus::ManualCheck
+        | SystemPermissionStatus::NotApplicable
+        | SystemPermissionStatus::NotUsed => unknown(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_manual_check_maps_to_unknown() {
+        assert_eq!(
+            legacy_state_for_status(SystemPermissionStatus::ManualCheck),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn legacy_actionable_statuses_map_to_not_granted() {
+        assert_eq!(
+            legacy_state_for_status(SystemPermissionStatus::NotDetermined),
+            "not_granted"
+        );
+        assert_eq!(
+            legacy_state_for_status(SystemPermissionStatus::Restricted),
+            "not_granted"
+        );
+    }
+
+    #[test]
+    fn legacy_permission_ids_map_to_v2_items() {
+        let response = SystemPermissionsResponse {
+            platform: "macos".to_string(),
+            supported: true,
+            items: vec![
+                PermissionDef {
+                    id: "automation_system_events",
+                    group: SystemPermissionGroup::ControlCapture,
+                    request_mode: SystemPermissionRequestMode::TriggerProbe,
+                    settings_pane: None,
+                    usage: "",
+                    note: None,
+                }
+                .item(SystemPermissionStatus::Granted),
+                PermissionDef {
+                    id: "desktop_folder",
+                    group: SystemPermissionGroup::FileAccess,
+                    request_mode: SystemPermissionRequestMode::OpenSettings,
+                    settings_pane: None,
+                    usage: "",
+                    note: None,
+                }
+                .item(SystemPermissionStatus::Granted),
+                PermissionDef {
+                    id: "documents_folder",
+                    group: SystemPermissionGroup::FileAccess,
+                    request_mode: SystemPermissionRequestMode::OpenSettings,
+                    settings_pane: None,
+                    usage: "",
+                    note: None,
+                }
+                .item(SystemPermissionStatus::Granted),
+                PermissionDef {
+                    id: "downloads_folder",
+                    group: SystemPermissionGroup::FileAccess,
+                    request_mode: SystemPermissionRequestMode::OpenSettings,
+                    settings_pane: None,
+                    usage: "",
+                    note: None,
+                }
+                .item(SystemPermissionStatus::Granted),
+            ],
+        };
+
+        assert_eq!(legacy_status_for_id(&response, "automation"), "granted");
+        assert_eq!(
+            legacy_status_for_id(&response, "files_and_folders"),
+            "granted"
+        );
+        assert_eq!(
+            legacy_request_id("automation"),
+            Some("automation_system_events")
+        );
+        assert_eq!(
+            legacy_request_id("files_and_folders"),
+            Some("desktop_folder")
+        );
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[tokio::test]
+    async fn non_macos_system_permissions_are_not_fake_granted() {
+        let response = check_system_permissions().await;
+        assert!(!response.supported);
+        assert!(response.items.is_empty());
+
+        let legacy = check_all_permissions().await;
+        assert!(std::iter::once(&legacy.accessibility)
+            .chain(std::iter::once(&legacy.screen_recording))
+            .chain(std::iter::once(&legacy.automation))
+            .chain(std::iter::once(&legacy.app_management))
+            .chain(std::iter::once(&legacy.full_disk_access))
+            .chain(std::iter::once(&legacy.location))
+            .chain(std::iter::once(&legacy.contacts))
+            .chain(std::iter::once(&legacy.calendar))
+            .chain(std::iter::once(&legacy.reminders))
+            .chain(std::iter::once(&legacy.photos))
+            .chain(std::iter::once(&legacy.camera))
+            .chain(std::iter::once(&legacy.microphone))
+            .chain(std::iter::once(&legacy.local_network))
+            .chain(std::iter::once(&legacy.bluetooth))
+            .chain(std::iter::once(&legacy.files_and_folders))
+            .all(|status| status == "unknown"));
     }
 }

--- a/docs/architecture/api-reference.md
+++ b/docs/architecture/api-reference.md
@@ -921,18 +921,20 @@ Context / Cache 共用单 SQL `get_session_last_assistant_token_row`，避免渲
 
 ## 已知不对齐项
 
-截至 2026-04-28 三端差集稳定为 7 条（§7.3 的 4 条 Desktop-only + `save_avatar` multipart + `fs_list_dir` / `fs_search_files` 两条 query-string GET），没有"HTTP 漏写 COMMAND_MAP"或"HTTP 路由缺失"的破口。COMMAND_MAP 里的每一条都能在 `tauri::generate_handler!` 里找到对应命令；反向差 7 条均已在下表登记。
+截至 2026-05-17 三端差集稳定为 9 条（§7.3 的 6 条 Desktop-only + `save_avatar` multipart + `fs_list_dir` / `fs_search_files` 两条 query-string GET），没有"HTTP 漏写 COMMAND_MAP"或"HTTP 路由缺失"的破口。COMMAND_MAP 里的每一条都能在 `tauri::generate_handler!` 里找到对应命令；反向差 9 条均已在下表登记。
 
-### §7.3 Desktop-only（Tauri 专属，合法缺失，4 条）
+### §7.3 Desktop-only（Tauri 专属，合法缺失，6 条）
 
 | Tauri Command | 说明 |
 |---|---|
-| `check_all_permissions` | `tauri-plugin-permissions` 本地权限查询 |
-| `check_permission` | 同上 |
-| `request_permission` | 同上 |
+| `check_system_permissions` | macOS 系统权限 v2 目录与状态查询 |
+| `request_system_permission` | macOS 系统权限 v2 请求/跳转 |
+| `check_all_permissions` | 权限 v1 兼容包装 |
+| `check_permission` | 权限 v1 兼容包装 |
+| `request_permission` | 权限 v1 兼容包装 |
 | `check_sandbox_available` | Linux bubblewrap 本地探测 |
 
-前端必须在 `supportsLocalFileOps()` 或等价的运行模式判定保护下调用，HTTP 模式应 gate 住相关 UI。
+前端必须在 `supportsLocalFileOps()` / `isTauriMode()` 或等价的运行模式判定保护下调用，HTTP 模式应 gate 住相关 UI。
 
 ### §7.3.1 不进 COMMAND_MAP 的合法非 REST 命令（3 条）
 
@@ -991,8 +993,9 @@ comm -23 \
       grep -oE '::[a-z_][a-zA-Z0-9_]*,?[[:space:]]*$' | tr -d ':, ' | sort -u) \
   <(awk '/^const COMMAND_MAP/,/^};/' src/lib/transport-http.ts | \
       grep -oE '^[[:space:]]+[a-z_][a-zA-Z0-9_]*:' | tr -d ': ' | sort -u)
-# 期望：7 行
-#   check_all_permissions / check_permission / request_permission
+# 期望：9 行
+#   check_system_permissions / request_system_permission
+#   / check_all_permissions / check_permission / request_permission
 #   / check_sandbox_available  （§7.3 Desktop-only）
 #   / save_avatar / fs_list_dir / fs_search_files  （§7.3.1 非 REST 路径）
 ```

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -2,9 +2,55 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Hope Agent needs Apple Events permission to automate selected apps only when a user workflow asks for it.</string>
+    <key>NSAppleMusicUsageDescription</key>
+    <string>Hope Agent needs media library access only when a user explicitly starts a media workflow.</string>
+    <key>NSAudioCaptureUsageDescription</key>
+    <string>Hope Agent needs system audio capture only when a user explicitly starts an audio workflow.</string>
+    <key>NSBluetoothAlwaysUsageDescription</key>
+    <string>Hope Agent needs Bluetooth access only when a user workflow needs to discover or connect nearby devices.</string>
+    <key>NSBluetoothPeripheralUsageDescription</key>
+    <string>Hope Agent needs Bluetooth access only when a user workflow needs to discover or connect nearby devices.</string>
+    <key>NSCalendarsFullAccessUsageDescription</key>
+    <string>Hope Agent needs calendar access only when a user asks it to inspect or manage calendar events.</string>
+    <key>NSCalendarsUsageDescription</key>
+    <string>Hope Agent needs calendar access only when a user asks it to inspect or manage calendar events.</string>
+    <key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+    <string>Hope Agent needs write-only calendar access only when a user asks it to create calendar events.</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Hope Agent needs camera access only when a user explicitly starts a visual input workflow.</string>
+    <key>NSContactsUsageDescription</key>
+    <string>Hope Agent needs contacts access only when a user workflow explicitly asks for contact information.</string>
+    <key>NSDesktopFolderUsageDescription</key>
+    <string>Hope Agent needs Desktop folder access only when a user asks it to work with files there.</string>
+    <key>NSDocumentsFolderUsageDescription</key>
+    <string>Hope Agent needs Documents folder access only when a user asks it to work with files there.</string>
+    <key>NSDownloadsFolderUsageDescription</key>
+    <string>Hope Agent needs Downloads folder access only when a user asks it to work with files there.</string>
+    <key>NSFocusStatusUsageDescription</key>
+    <string>Hope Agent needs Focus status only when a workflow adapts interruptions or notifications.</string>
+    <key>NSHomeKitUsageDescription</key>
+    <string>Hope Agent needs HomeKit access only if a user enables a Home workflow.</string>
     <key>NSLocationUsageDescription</key>
     <string>Hope Agent needs your location to provide local weather information.</string>
     <key>NSLocationWhenInUseUsageDescription</key>
     <string>Hope Agent needs your location to provide local weather information.</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Hope Agent needs local network access to discover and connect to local services only when requested.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Hope Agent needs microphone access only when a user explicitly starts a voice input workflow.</string>
+    <key>NSNetworkVolumesUsageDescription</key>
+    <string>Hope Agent needs network volume access only when a user asks it to work with files there.</string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+    <string>Hope Agent needs permission to add photos only when a user explicitly asks for a photo workflow.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Hope Agent needs photo library access only when a user explicitly asks for a photo workflow.</string>
+    <key>NSRemindersUsageDescription</key>
+    <string>Hope Agent needs reminders access only when a user asks it to inspect or manage reminders.</string>
+    <key>NSRemovableVolumesUsageDescription</key>
+    <string>Hope Agent needs removable volume access only when a user asks it to work with files there.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Hope Agent needs speech recognition only when a user explicitly starts a speech transcription workflow.</string>
 </dict>
 </plist>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -446,8 +446,10 @@ pub fn run() {
             commands::config::set_autostart_enabled,
             // Permissions (thin wrappers over ha-core)
             tauri_wrappers::check_all_permissions,
+            tauri_wrappers::check_system_permissions,
             tauri_wrappers::check_permission,
             tauri_wrappers::request_permission,
+            tauri_wrappers::request_system_permission,
             // Session management
             commands::session::create_session_cmd,
             commands::session::list_sessions_cmd,

--- a/src-tauri/src/tauri_wrappers.rs
+++ b/src-tauri/src/tauri_wrappers.rs
@@ -11,6 +11,11 @@ pub async fn check_all_permissions() -> ha_core::permissions::AllPermissions {
 }
 
 #[tauri::command]
+pub async fn check_system_permissions() -> ha_core::permissions::SystemPermissionsResponse {
+    ha_core::permissions::check_system_permissions().await
+}
+
+#[tauri::command]
 pub async fn check_permission(id: String) -> ha_core::permissions::PermissionStatus {
     ha_core::permissions::check_permission(id).await
 }
@@ -18,6 +23,11 @@ pub async fn check_permission(id: String) -> ha_core::permissions::PermissionSta
 #[tauri::command]
 pub async fn request_permission(id: String) -> ha_core::permissions::PermissionStatus {
     ha_core::permissions::request_permission(id).await
+}
+
+#[tauri::command]
+pub async fn request_system_permission(id: String) -> ha_core::permissions::SystemPermissionItem {
+    ha_core::permissions::request_system_permission(id).await
 }
 
 // ── Sandbox ──────────────────────────────────────────────────────

--- a/src/components/settings/PermissionsPanel.tsx
+++ b/src/components/settings/PermissionsPanel.tsx
@@ -1,195 +1,253 @@
 import { useState, useEffect, useCallback } from "react"
 import { getTransport } from "@/lib/transport-provider"
+import { isTauriMode } from "@/lib/transport"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
 import { Button } from "@/components/ui/button"
 import { IconTip } from "@/components/ui/tooltip"
 import {
-  Hand,
-  Monitor,
-  HardDrive,
-  Workflow,
   AppWindow,
-  MapPin,
+  Bell,
+  Bluetooth,
   BookUser,
   CalendarDays,
-  ListChecks,
-  Image,
   Camera,
-  Mic,
-  Globe,
-  Bluetooth,
-  FolderOpen,
-  ShieldCheck,
-  ShieldAlert,
-  RefreshCw,
+  CheckCircle2,
+  Code2,
   ExternalLink,
+  FolderOpen,
+  Globe,
+  Hand,
+  HardDrive,
+  HelpCircle,
+  Home,
+  Image,
+  Info,
+  Keyboard,
+  ListChecks,
+  MapPin,
+  MessageSquare,
+  Mic,
+  Monitor,
+  Music,
+  RefreshCw,
+  ShieldAlert,
+  ShieldCheck,
+  Volume2,
+  Workflow,
+  type LucideIcon,
 } from "lucide-react"
 
-// "granted" | "not_granted" | "unknown"
-type PermState = string
+type PermissionStatus =
+  | "granted"
+  | "not_granted"
+  | "not_determined"
+  | "restricted"
+  | "manual_check"
+  | "not_applicable"
+  | "not_used"
 
-interface AllPermissions {
-  accessibility: PermState
-  screen_recording: PermState
-  automation: PermState
-  app_management: PermState
-  full_disk_access: PermState
-  location: PermState
-  contacts: PermState
-  calendar: PermState
-  reminders: PermState
-  photos: PermState
-  camera: PermState
-  microphone: PermState
-  local_network: PermState
-  bluetooth: PermState
-  files_and_folders: PermState
+type PermissionRequestMode = "native_prompt" | "open_settings" | "trigger_probe" | "none"
+
+type PermissionGroup =
+  | "control_capture"
+  | "file_access"
+  | "personal_data"
+  | "device_network"
+  | "system_services"
+
+interface SystemPermissionItem {
+  id: string
+  group: PermissionGroup
+  status: PermissionStatus
+  requestMode: PermissionRequestMode
+  settingsPane?: string | null
+  usage: string
+  note?: string | null
 }
 
-interface PermissionItem {
-  id: keyof AllPermissions
-  icon: React.ReactNode
-  labelKey: string
-  descKey: string
+interface SystemPermissionsResponse {
+  platform: string
+  supported: boolean
+  items: SystemPermissionItem[]
 }
 
-const PERMISSION_ITEMS: PermissionItem[] = [
-  // ── Core control ──
-  {
-    id: "accessibility",
-    icon: <Hand className="h-5 w-5" />,
-    labelKey: "settings.permAccessibility",
-    descKey: "settings.permAccessibilityDesc",
-  },
-  {
-    id: "screen_recording",
-    icon: <Monitor className="h-5 w-5" />,
-    labelKey: "settings.permScreenRecording",
-    descKey: "settings.permScreenRecordingDesc",
-  },
-  {
-    id: "automation",
-    icon: <Workflow className="h-5 w-5" />,
-    labelKey: "settings.permAutomation",
-    descKey: "settings.permAutomationDesc",
-  },
-  {
-    id: "app_management",
-    icon: <AppWindow className="h-5 w-5" />,
-    labelKey: "settings.permAppManagement",
-    descKey: "settings.permAppManagementDesc",
-  },
-  {
-    id: "full_disk_access",
-    icon: <HardDrive className="h-5 w-5" />,
-    labelKey: "settings.permFullDiskAccess",
-    descKey: "settings.permFullDiskAccessDesc",
-  },
-  {
-    id: "files_and_folders",
-    icon: <FolderOpen className="h-5 w-5" />,
-    labelKey: "settings.permFilesAndFolders",
-    descKey: "settings.permFilesAndFoldersDesc",
-  },
-  // ── Data access ──
-  {
-    id: "contacts",
-    icon: <BookUser className="h-5 w-5" />,
-    labelKey: "settings.permContacts",
-    descKey: "settings.permContactsDesc",
-  },
-  {
-    id: "calendar",
-    icon: <CalendarDays className="h-5 w-5" />,
-    labelKey: "settings.permCalendar",
-    descKey: "settings.permCalendarDesc",
-  },
-  {
-    id: "reminders",
-    icon: <ListChecks className="h-5 w-5" />,
-    labelKey: "settings.permReminders",
-    descKey: "settings.permRemindersDesc",
-  },
-  {
-    id: "photos",
-    icon: <Image className="h-5 w-5" />,
-    labelKey: "settings.permPhotos",
-    descKey: "settings.permPhotosDesc",
-  },
-  // ── Devices & sensors ──
-  {
-    id: "camera",
-    icon: <Camera className="h-5 w-5" />,
-    labelKey: "settings.permCamera",
-    descKey: "settings.permCameraDesc",
-  },
-  {
-    id: "microphone",
-    icon: <Mic className="h-5 w-5" />,
-    labelKey: "settings.permMicrophone",
-    descKey: "settings.permMicrophoneDesc",
-  },
-  {
-    id: "location",
-    icon: <MapPin className="h-5 w-5" />,
-    labelKey: "settings.permLocation",
-    descKey: "settings.permLocationDesc",
-  },
-  {
-    id: "local_network",
-    icon: <Globe className="h-5 w-5" />,
-    labelKey: "settings.permLocalNetwork",
-    descKey: "settings.permLocalNetworkDesc",
-  },
-  {
-    id: "bluetooth",
-    icon: <Bluetooth className="h-5 w-5" />,
-    labelKey: "settings.permBluetooth",
-    descKey: "settings.permBluetoothDesc",
-  },
+const GROUP_ORDER: PermissionGroup[] = [
+  "control_capture",
+  "file_access",
+  "personal_data",
+  "device_network",
+  "system_services",
 ]
 
-// ── Style helpers for three states ──
+const GROUP_META: Record<PermissionGroup, { icon: LucideIcon; labelKey: string; fallback: string }> = {
+  control_capture: {
+    icon: Hand,
+    labelKey: "settings.permissionGroups.controlCapture",
+    fallback: "Control & Capture",
+  },
+  file_access: {
+    icon: FolderOpen,
+    labelKey: "settings.permissionGroups.fileAccess",
+    fallback: "File Access",
+  },
+  personal_data: {
+    icon: BookUser,
+    labelKey: "settings.permissionGroups.personalData",
+    fallback: "Personal Data",
+  },
+  device_network: {
+    icon: Camera,
+    labelKey: "settings.permissionGroups.deviceNetwork",
+    fallback: "Devices & Network",
+  },
+  system_services: {
+    icon: Bell,
+    labelKey: "settings.permissionGroups.systemServices",
+    fallback: "System Services",
+  },
+}
 
-function stateBorder(state: PermState) {
+const ITEM_ICONS: Record<string, LucideIcon> = {
+  accessibility: Hand,
+  screen_recording: Monitor,
+  system_audio_capture: Volume2,
+  input_monitoring: Keyboard,
+  automation_system_events: Workflow,
+  automation_messages: MessageSquare,
+  app_management: AppWindow,
+  developer_tools: Code2,
+  full_disk_access: HardDrive,
+  desktop_folder: FolderOpen,
+  documents_folder: FolderOpen,
+  downloads_folder: FolderOpen,
+  removable_volumes: HardDrive,
+  network_volumes: Globe,
+  location: MapPin,
+  contacts: BookUser,
+  calendar: CalendarDays,
+  reminders: ListChecks,
+  photos: Image,
+  media_library: Music,
+  speech_recognition: Mic,
+  focus_status: Info,
+  homekit: Home,
+  camera: Camera,
+  microphone: Mic,
+  bluetooth: Bluetooth,
+  local_network: Globe,
+  notifications: Bell,
+}
+
+const STATUS_LABEL_KEYS: Record<PermissionStatus, string> = {
+  granted: "settings.permissionStatuses.granted",
+  not_granted: "settings.permissionStatuses.notGranted",
+  not_determined: "settings.permissionStatuses.notDetermined",
+  restricted: "settings.permissionStatuses.restricted",
+  manual_check: "settings.permissionStatuses.manualCheck",
+  not_applicable: "settings.permissionStatuses.notApplicable",
+  not_used: "settings.permissionStatuses.notUsed",
+}
+
+const STATUS_FALLBACKS: Record<PermissionStatus, string> = {
+  granted: "Granted",
+  not_granted: "Not granted",
+  not_determined: "Not determined",
+  restricted: "Restricted",
+  manual_check: "Manual check",
+  not_applicable: "Not applicable",
+  not_used: "Not used",
+}
+
+function stateBorder(state: PermissionStatus) {
   if (state === "granted") return "border-green-500/20 bg-green-500/5"
-  if (state === "unknown") return "border-muted-foreground/20 bg-muted/30"
+  if (state === "manual_check") return "border-sky-500/20 bg-sky-500/5"
+  if (state === "not_applicable" || state === "not_used") return "border-muted-foreground/15 bg-muted/20"
   return "border-amber-500/20 bg-amber-500/5"
 }
 
-function stateIconColor(state: PermState) {
+function stateIconColor(state: PermissionStatus) {
   if (state === "granted") return "text-green-500"
-  if (state === "unknown") return "text-muted-foreground"
+  if (state === "manual_check") return "text-sky-500"
+  if (state === "not_applicable" || state === "not_used") return "text-muted-foreground"
   return "text-amber-500"
 }
 
-function stateBadgeClass(state: PermState) {
+function stateBadgeClass(state: PermissionStatus) {
   if (state === "granted") return "bg-green-500/15 text-green-600 dark:text-green-400"
-  if (state === "unknown") return "bg-muted text-muted-foreground"
+  if (state === "manual_check") return "bg-sky-500/15 text-sky-600 dark:text-sky-400"
+  if (state === "not_applicable" || state === "not_used") return "bg-muted text-muted-foreground"
   return "bg-amber-500/15 text-amber-600 dark:text-amber-400"
 }
 
-function stateBadgeKey(state: PermState) {
-  if (state === "granted") return "settings.permGranted"
-  if (state === "unknown") return "settings.permUnknown"
-  return "settings.permNotGranted"
+function isActionable(state: PermissionStatus) {
+  return state === "not_granted" || state === "not_determined" || state === "restricted"
+}
+
+function canRequest(item: SystemPermissionItem) {
+  return (
+    item.requestMode !== "none" &&
+    item.status !== "granted" &&
+    item.status !== "not_applicable" &&
+    item.status !== "not_used"
+  )
+}
+
+function itemTextKey(id: string, field: "label" | "usage" | "note") {
+  return `settings.permissionItems.${id}.${field}`
+}
+
+function fallbackLabel(id: string) {
+  return id
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+function DisabledPermissionsPage() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex-1 overflow-y-auto p-6">
+      <div className="max-w-2xl rounded-lg border border-muted-foreground/20 bg-muted/20 p-5">
+        <div className="mb-2 flex items-center gap-3">
+          <ShieldAlert className="h-5 w-5 text-muted-foreground" />
+          <h3 className="text-sm font-semibold text-foreground">
+            {t("settings.permUnsupportedTitle", "System permissions are macOS-only for now")}
+          </h3>
+        </div>
+        <p className="text-xs leading-5 text-muted-foreground">
+          {t(
+            "settings.permUnsupportedDesc",
+            "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get a separate permissions implementation later.",
+          )}
+        </p>
+      </div>
+    </div>
+  )
 }
 
 export default function PermissionsPanel() {
   const { t } = useTranslation()
-  const [permissions, setPermissions] = useState<AllPermissions | null>(null)
+  const [response, setResponse] = useState<SystemPermissionsResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [requesting, setRequesting] = useState<string | null>(null)
 
   const fetchPermissions = useCallback(async () => {
+    if (!isTauriMode()) {
+      setLoading(false)
+      return
+    }
+
     try {
       setLoading(true)
-      const result = await getTransport().call<AllPermissions>("check_all_permissions")
-      setPermissions(result)
+      const result = await getTransport().call<SystemPermissionsResponse>("check_system_permissions")
+      setResponse(result)
     } catch (e) {
       logger.error("settings", "PermissionsPanel::fetch", "Failed to check permissions", e)
+      setResponse({ platform: "unknown", supported: false, items: [] })
     } finally {
       setLoading(false)
     }
@@ -199,7 +257,6 @@ export default function PermissionsPanel() {
     fetchPermissions()
   }, [fetchPermissions])
 
-  // Re-check when window regains focus
   useEffect(() => {
     const onFocus = () => fetchPermissions()
     window.addEventListener("focus", onFocus)
@@ -209,8 +266,15 @@ export default function PermissionsPanel() {
   const handleRequest = async (id: string) => {
     setRequesting(id)
     try {
-      const result = await getTransport().call<{ id: string; status: PermState }>("request_permission", { id })
-      setPermissions((prev) => (prev ? { ...prev, [result.id]: result.status } : prev))
+      const result = await getTransport().call<SystemPermissionItem>("request_system_permission", { id })
+      setResponse((prev) =>
+        prev
+          ? {
+              ...prev,
+              items: prev.items.map((item) => (item.id === result.id ? result : item)),
+            }
+          : prev,
+      )
     } catch (e) {
       logger.error("settings", "PermissionsPanel::request", `Failed to request ${id}`, e)
     } finally {
@@ -218,90 +282,139 @@ export default function PermissionsPanel() {
     }
   }
 
-  const grantedCount = permissions
-    ? Object.values(permissions).filter((s) => s === "granted").length
-    : 0
-  const detectableCount = permissions
-    ? Object.values(permissions).filter((s) => s !== "unknown").length
-    : 0
-  const allDetectableGranted = permissions
-    ? Object.values(permissions).every((s) => s === "granted" || s === "unknown")
-    : false
+  if (!isTauriMode()) {
+    return <DisabledPermissionsPage />
+  }
+
+  if (!loading && response && !response.supported) {
+    return <DisabledPermissionsPage />
+  }
+
+  const items = response?.items ?? []
+  const groups = GROUP_ORDER.map((group) => ({
+    group,
+    items: items.filter((item) => item.group === group),
+  })).filter((entry) => entry.items.length > 0)
+
+  const summary = {
+    granted: items.filter((item) => item.status === "granted").length,
+    needsAction: items.filter((item) => isActionable(item.status)).length,
+    manual: items.filter((item) => item.status === "manual_check").length,
+    inactive: items.filter((item) => item.status === "not_applicable" || item.status === "not_used").length,
+  }
+  const allClear = items.length > 0 && summary.needsAction === 0 && summary.manual === 0
 
   return (
     <div className="flex-1 overflow-y-auto p-6">
-      {/* Header summary */}
-      <div className="flex items-center gap-3 mb-2">
-        {allDetectableGranted && permissions ? (
+      <div className="mb-2 flex items-center gap-3">
+        {allClear ? (
           <ShieldCheck className="h-5 w-5 text-green-500" />
         ) : (
           <ShieldAlert className="h-5 w-5 text-amber-500" />
         )}
         <h3 className="text-sm font-semibold text-foreground">{t("settings.permTitle")}</h3>
       </div>
-      <p className="text-xs text-muted-foreground mb-1">{t("settings.permDesc")}</p>
-      {permissions && (
-        <p className="text-xs text-muted-foreground mb-6">
-          {t("settings.permSummary", { granted: grantedCount, total: detectableCount })}
-        </p>
-      )}
+      <p className="mb-1 text-xs text-muted-foreground">
+        {t(
+          "settings.permDesc",
+          "Hope Agent shows the macOS permissions it may need. Items without reliable public status APIs are marked for manual confirmation.",
+        )}
+      </p>
+      <p className="mb-6 text-xs text-muted-foreground">
+        {loading
+          ? t("settings.permLoading", "Checking permissions...")
+          : t("settings.permSummaryV2", {
+              granted: summary.granted,
+              needsAction: summary.needsAction,
+              manual: summary.manual,
+              inactive: summary.inactive,
+            })}
+      </p>
 
-      {/* Permission list */}
-      <div className="space-y-2">
-        {PERMISSION_ITEMS.map((item) => {
-          const state = permissions?.[item.id] ?? "not_granted"
-          const isRequesting = requesting === item.id
+      <div className="space-y-6">
+        {groups.map(({ group, items: groupItems }) => {
+          const meta = GROUP_META[group]
+          const GroupIcon = meta.icon
 
           return (
-            <div
-              key={item.id}
-              className={cn(
-                "flex items-center gap-4 px-4 py-4 rounded-lg border transition-colors",
-                stateBorder(state),
-              )}
-            >
-              {/* Icon */}
-              <span className={cn("shrink-0", stateIconColor(state))}>{item.icon}</span>
-
-              {/* Label & description */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="text-sm font-medium text-foreground">{t(item.labelKey)}</span>
-                  <span
-                    className={cn(
-                      "text-[10px] font-medium px-1.5 py-0.5 rounded-full",
-                      stateBadgeClass(state),
-                    )}
-                  >
-                    {t(stateBadgeKey(state))}
-                  </span>
-                </div>
-                <p className="text-xs text-muted-foreground mt-0.5">{t(item.descKey)}</p>
+            <section key={group} className="space-y-2">
+              <div className="flex items-center gap-2">
+                <GroupIcon className="h-4 w-4 text-muted-foreground" />
+                <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+                  {t(meta.labelKey, meta.fallback)}
+                </h4>
               </div>
 
-              {/* Action button — show for not_granted and unknown */}
-              {state !== "granted" && !loading && (
-                <IconTip label={t("settings.permGrantTooltip")}>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={isRequesting}
-                      onClick={() => handleRequest(item.id)}
-                      className="shrink-0 gap-1.5"
-                    >
-                      <ExternalLink className="h-3.5 w-3.5" />
-                      {state === "unknown" ? t("settings.permCheck") : t("settings.permGrant")}
-                    </Button>
-                  </IconTip>
-              )}
+              <div className="space-y-2">
+                {groupItems.map((item) => {
+                  const Icon = ITEM_ICONS[item.id] ?? meta.icon
+                  const isRequesting = requesting === item.id
+                  const label = t(itemTextKey(item.id, "label"), fallbackLabel(item.id))
+                  const usage = t(itemTextKey(item.id, "usage"), item.usage)
+                  const note = item.note ? t(itemTextKey(item.id, "note"), item.note) : null
 
-              {state === "granted" && <ShieldCheck className="h-4 w-4 text-green-500 shrink-0" />}
-            </div>
+                  return (
+                    <div
+                      key={item.id}
+                      className={cn(
+                        "flex items-start gap-4 rounded-lg border px-4 py-4 transition-colors",
+                        stateBorder(item.status),
+                      )}
+                    >
+                      <span className={cn("mt-0.5 shrink-0", stateIconColor(item.status))}>
+                        <Icon className="h-5 w-5" />
+                      </span>
+
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-sm font-medium text-foreground">{label}</span>
+                          <span
+                            className={cn(
+                              "rounded-full px-1.5 py-0.5 text-[10px] font-medium",
+                              stateBadgeClass(item.status),
+                            )}
+                          >
+                            {t(STATUS_LABEL_KEYS[item.status], STATUS_FALLBACKS[item.status])}
+                          </span>
+                        </div>
+                        <p className="mt-0.5 text-xs leading-5 text-muted-foreground">{usage}</p>
+                        {note && <p className="mt-1 text-[11px] leading-4 text-muted-foreground">{note}</p>}
+                      </div>
+
+                      {canRequest(item) && !loading && (
+                        <IconTip label={t("settings.permGrantTooltip")}>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={isRequesting}
+                            onClick={() => handleRequest(item.id)}
+                            className="shrink-0 gap-1.5"
+                          >
+                            {item.requestMode === "native_prompt" ? (
+                              <ShieldCheck className="h-3.5 w-3.5" />
+                            ) : (
+                              <ExternalLink className="h-3.5 w-3.5" />
+                            )}
+                            {item.requestMode === "native_prompt"
+                              ? t("settings.permGrant")
+                              : t("settings.permCheck")}
+                          </Button>
+                        </IconTip>
+                      )}
+
+                      {item.status === "granted" && <CheckCircle2 className="h-4 w-4 shrink-0 text-green-500" />}
+                      {(item.status === "not_applicable" || item.status === "not_used") && (
+                        <HelpCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </section>
           )
         })}
       </div>
 
-      {/* Refresh button */}
       <div className="mt-6 flex items-center gap-3">
         <Button
           variant="outline"

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "تسجيل الشاشة",
     "permScreenRecordingDesc": "التقاط محتوى الشاشة والتعرف على عناصر واجهة المستخدم",
     "permSummary": "{{granted}} / {{total}} ممنوحة",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "صلاحيات النظام",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "تحقق يدوياً",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "الصلاحيات",
     "personaModeDesc": "املأ الحقول المنظَّمة أو اكتب ملف SOUL.md مباشرة. ملف SOUL.md مشترك مع وضع توافق openclaw.",
     "personaModeLabel": "سطح تحرير الشخصية",
@@ -3490,6 +3639,16 @@
         "title": "Recent reject reasons",
         "empty": "No rejections recorded yet. Whenever any gate stops a review from producing a draft, the reason lands here."
       },
+      "curator": {
+        "title": "Draft consolidation",
+        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
+        "run": "Scan",
+        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
+        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
+        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
+        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
+        "apply": "Keep this, discard the other {{n}}"
+      },
       "resetAll": {
         "label": "Reset everything",
         "confirm": "Reset every custom field to defaults?",
@@ -3594,16 +3753,6 @@
           "label": "Override review system prompt",
           "help": "Replaces the built-in review system prompt verbatim; leave empty to use the built-in. Backend hard floors still apply."
         }
-      },
-      "curator": {
-        "title": "Draft consolidation",
-        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
-        "run": "Scan",
-        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
-        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
-        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
-        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
-        "apply": "Keep this, discard the other {{n}}"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "Screen Recording",
     "permScreenRecordingDesc": "Capture screen content and recognize UI elements",
     "permSummary": "{{granted}} / {{total}} granted",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "System Permissions",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "Verify Manually",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "Permissions",
     "personaModeDesc": "Fill in structured fields, or write a SOUL.md markdown directly. The SOUL.md file is shared with openclaw compatibility mode.",
     "personaModeLabel": "Persona authoring surface",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "Grabación de pantalla",
     "permScreenRecordingDesc": "Capturar contenido de pantalla y reconocer elementos de la UI",
     "permSummary": "{{granted}} / {{total}} concedidos",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "Permisos del sistema",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "Verificar manualmente",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "Permisos",
     "personaModeDesc": "Rellena los campos estructurados o escribe directamente un markdown SOUL.md. El archivo SOUL.md se comparte con el modo de compatibilidad openclaw.",
     "personaModeLabel": "Superficie de edición de persona",
@@ -3490,6 +3639,16 @@
         "title": "Recent reject reasons",
         "empty": "No rejections recorded yet. Whenever any gate stops a review from producing a draft, the reason lands here."
       },
+      "curator": {
+        "title": "Draft consolidation",
+        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
+        "run": "Scan",
+        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
+        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
+        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
+        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
+        "apply": "Keep this, discard the other {{n}}"
+      },
       "resetAll": {
         "label": "Reset everything",
         "confirm": "Reset every custom field to defaults?",
@@ -3594,16 +3753,6 @@
           "label": "Override review system prompt",
           "help": "Replaces the built-in review system prompt verbatim; leave empty to use the built-in. Backend hard floors still apply."
         }
-      },
-      "curator": {
-        "title": "Draft consolidation",
-        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
-        "run": "Scan",
-        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
-        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
-        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
-        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
-        "apply": "Keep this, discard the other {{n}}"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "画面収録",
     "permScreenRecordingDesc": "画面コンテンツを取得し UI 要素を認識",
     "permSummary": "{{granted}} / {{total}} 許可済み",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "システム権限",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "手動で確認",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "システム権限",
     "personaModeDesc": "構造化フィールドに入力するか、SOUL.md マークダウンを直接書き込みます。SOUL.md ファイルは openclaw 互換モードと共有されます。",
     "personaModeLabel": "ペルソナ編集方式",
@@ -3490,6 +3639,16 @@
         "title": "Recent reject reasons",
         "empty": "No rejections recorded yet. Whenever any gate stops a review from producing a draft, the reason lands here."
       },
+      "curator": {
+        "title": "Draft consolidation",
+        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
+        "run": "Scan",
+        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
+        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
+        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
+        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
+        "apply": "Keep this, discard the other {{n}}"
+      },
       "resetAll": {
         "label": "Reset everything",
         "confirm": "Reset every custom field to defaults?",
@@ -3594,16 +3753,6 @@
           "label": "Override review system prompt",
           "help": "Replaces the built-in review system prompt verbatim; leave empty to use the built-in. Backend hard floors still apply."
         }
-      },
-      "curator": {
-        "title": "Draft consolidation",
-        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
-        "run": "Scan",
-        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
-        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
-        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
-        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
-        "apply": "Keep this, discard the other {{n}}"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "화면 기록",
     "permScreenRecordingDesc": "화면 콘텐츠를 캡처하고 UI 요소 인식",
     "permSummary": "{{granted}} / {{total}} 부여됨",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "시스템 권한",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "수동 확인",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "시스템 권한",
     "personaModeDesc": "구조화된 필드를 채우거나 SOUL.md 마크다운을 직접 작성하세요. SOUL.md 파일은 openclaw 호환 모드와 공유됩니다.",
     "personaModeLabel": "페르소나 작성 방식",
@@ -3490,6 +3639,16 @@
         "title": "Recent reject reasons",
         "empty": "No rejections recorded yet. Whenever any gate stops a review from producing a draft, the reason lands here."
       },
+      "curator": {
+        "title": "Draft consolidation",
+        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
+        "run": "Scan",
+        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
+        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
+        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
+        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
+        "apply": "Keep this, discard the other {{n}}"
+      },
       "resetAll": {
         "label": "Reset everything",
         "confirm": "Reset every custom field to defaults?",
@@ -3594,16 +3753,6 @@
           "label": "Override review system prompt",
           "help": "Replaces the built-in review system prompt verbatim; leave empty to use the built-in. Backend hard floors still apply."
         }
-      },
-      "curator": {
-        "title": "Draft consolidation",
-        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
-        "run": "Scan",
-        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
-        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
-        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
-        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
-        "apply": "Keep this, discard the other {{n}}"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "Rakaman skrin",
     "permScreenRecordingDesc": "Tangkap kandungan skrin dan kenali elemen UI",
     "permSummary": "{{granted}} / {{total}} diberikan",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "Kebenaran sistem",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "Sahkan secara manual",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "Kebenaran",
     "personaModeDesc": "Isikan medan berstruktur, atau tulis markdown SOUL.md secara terus. Fail SOUL.md dikongsi dengan mod keserasian openclaw.",
     "personaModeLabel": "Permukaan tulisan persona",
@@ -3490,6 +3639,16 @@
         "title": "Recent reject reasons",
         "empty": "No rejections recorded yet. Whenever any gate stops a review from producing a draft, the reason lands here."
       },
+      "curator": {
+        "title": "Draft consolidation",
+        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
+        "run": "Scan",
+        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
+        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
+        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
+        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
+        "apply": "Keep this, discard the other {{n}}"
+      },
       "resetAll": {
         "label": "Reset everything",
         "confirm": "Reset every custom field to defaults?",
@@ -3594,16 +3753,6 @@
           "label": "Override review system prompt",
           "help": "Replaces the built-in review system prompt verbatim; leave empty to use the built-in. Backend hard floors still apply."
         }
-      },
-      "curator": {
-        "title": "Draft consolidation",
-        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
-        "run": "Scan",
-        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
-        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
-        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
-        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
-        "apply": "Keep this, discard the other {{n}}"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "Gravação de tela",
     "permScreenRecordingDesc": "Capturar conteúdo da tela e reconhecer elementos da UI",
     "permSummary": "{{granted}} / {{total}} concedidas",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "Permissões do sistema",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "Verificar manualmente",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "Permissões",
     "personaModeDesc": "Preencha os campos estruturados ou escreva um markdown SOUL.md diretamente. O arquivo SOUL.md é compartilhado com o modo de compatibilidade openclaw.",
     "personaModeLabel": "Superfície de autoria de persona",
@@ -3490,6 +3639,16 @@
         "title": "Recent reject reasons",
         "empty": "No rejections recorded yet. Whenever any gate stops a review from producing a draft, the reason lands here."
       },
+      "curator": {
+        "title": "Draft consolidation",
+        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
+        "run": "Scan",
+        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
+        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
+        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
+        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
+        "apply": "Keep this, discard the other {{n}}"
+      },
       "resetAll": {
         "label": "Reset everything",
         "confirm": "Reset every custom field to defaults?",
@@ -3594,16 +3753,6 @@
           "label": "Override review system prompt",
           "help": "Replaces the built-in review system prompt verbatim; leave empty to use the built-in. Backend hard floors still apply."
         }
-      },
-      "curator": {
-        "title": "Draft consolidation",
-        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
-        "run": "Scan",
-        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
-        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
-        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
-        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
-        "apply": "Keep this, discard the other {{n}}"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "Запись экрана",
     "permScreenRecordingDesc": "Захват содержимого экрана и распознавание элементов UI",
     "permSummary": "{{granted}} / {{total}} предоставлено",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "Системные разрешения",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "Проверить вручную",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "Разрешения",
     "personaModeDesc": "Заполните структурированные поля или напишите markdown SOUL.md напрямую. Файл SOUL.md общий с режимом совместимости openclaw.",
     "personaModeLabel": "Способ редактирования персоны",
@@ -3490,6 +3639,16 @@
         "title": "Recent reject reasons",
         "empty": "No rejections recorded yet. Whenever any gate stops a review from producing a draft, the reason lands here."
       },
+      "curator": {
+        "title": "Draft consolidation",
+        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
+        "run": "Scan",
+        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
+        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
+        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
+        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
+        "apply": "Keep this, discard the other {{n}}"
+      },
       "resetAll": {
         "label": "Reset everything",
         "confirm": "Reset every custom field to defaults?",
@@ -3594,16 +3753,6 @@
           "label": "Override review system prompt",
           "help": "Replaces the built-in review system prompt verbatim; leave empty to use the built-in. Backend hard floors still apply."
         }
-      },
-      "curator": {
-        "title": "Draft consolidation",
-        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
-        "run": "Scan",
-        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
-        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
-        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
-        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
-        "apply": "Keep this, discard the other {{n}}"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "Ekran kaydı",
     "permScreenRecordingDesc": "Ekran içeriğini yakala ve UI öğelerini tanı",
     "permSummary": "{{granted}} / {{total}} verildi",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "Sistem izinleri",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "Manuel doğrula",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "İzinler",
     "personaModeDesc": "Yapılandırılmış alanları doldurun veya doğrudan bir SOUL.md markdown yazın. SOUL.md dosyası openclaw uyumluluk moduyla paylaşılır.",
     "personaModeLabel": "Persona yazım yüzeyi",
@@ -3490,6 +3639,16 @@
         "title": "Recent reject reasons",
         "empty": "No rejections recorded yet. Whenever any gate stops a review from producing a draft, the reason lands here."
       },
+      "curator": {
+        "title": "Draft consolidation",
+        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
+        "run": "Scan",
+        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
+        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
+        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
+        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
+        "apply": "Keep this, discard the other {{n}}"
+      },
       "resetAll": {
         "label": "Reset everything",
         "confirm": "Reset every custom field to defaults?",
@@ -3594,16 +3753,6 @@
           "label": "Override review system prompt",
           "help": "Replaces the built-in review system prompt verbatim; leave empty to use the built-in. Backend hard floors still apply."
         }
-      },
-      "curator": {
-        "title": "Draft consolidation",
-        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
-        "run": "Scan",
-        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
-        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
-        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
-        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
-        "apply": "Keep this, discard the other {{n}}"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "Ghi màn hình",
     "permScreenRecordingDesc": "Chụp nội dung màn hình và nhận diện các phần tử UI",
     "permSummary": "{{granted}} / {{total}} đã cấp",
+    "permSummaryV2": "{{granted}} granted · {{needsAction}} need action · {{manual}} manual checks · {{inactive}} unused/not applicable",
     "permTitle": "Quyền hệ thống",
+    "permUnsupportedDesc": "This page currently supports the macOS desktop app only. Windows, Linux, and HTTP/server mode will get their own permissions implementation later.",
+    "permUnsupportedTitle": "System permissions are macOS-only for now",
     "permUnknown": "Xác minh thủ công",
+    "permissionGroups": {
+      "controlCapture": "Control & Capture",
+      "deviceNetwork": "Devices & Network",
+      "fileAccess": "File Access",
+      "personalData": "Personal Data",
+      "systemServices": "System Services"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "Accessibility",
+        "usage": "Control the mouse, keyboard, and other application windows."
+      },
+      "app_management": {
+        "label": "App Management",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Manage or update other applications only when a tool explicitly needs it."
+      },
+      "automation_messages": {
+        "label": "Automation: Messages",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of Messages when messaging workflows need it."
+      },
+      "automation_system_events": {
+        "label": "Automation: System Events",
+        "note": "Automation consent is stored per target app; System Settings is the most reliable source of truth.",
+        "usage": "Allow Apple Events automation of System Events."
+      },
+      "bluetooth": {
+        "label": "Bluetooth",
+        "usage": "Discover and connect to Bluetooth devices when a workflow needs it."
+      },
+      "calendar": {
+        "label": "Calendars",
+        "usage": "Read or write calendar events when scheduling workflows need it."
+      },
+      "camera": {
+        "label": "Camera",
+        "usage": "Use the camera for visual input only when explicitly requested."
+      },
+      "contacts": {
+        "label": "Contacts",
+        "usage": "Read contacts only when a user workflow explicitly asks for it."
+      },
+      "desktop_folder": {
+        "label": "Desktop Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files on the Desktop when requested by the user."
+      },
+      "developer_tools": {
+        "label": "Developer Tools",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Use developer tooling that macOS protects behind Developer Tools consent."
+      },
+      "documents_folder": {
+        "label": "Documents Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Documents when requested by the user."
+      },
+      "downloads_folder": {
+        "label": "Downloads Folder",
+        "note": "macOS exposes this through Files & Folders; status is probed.",
+        "usage": "Read and write files in Downloads when requested by the user."
+      },
+      "focus_status": {
+        "label": "Focus Status",
+        "note": "macOS does not expose a reliable public per-app status API.",
+        "usage": "Read Focus status only for workflows that adapt notifications or interruptions."
+      },
+      "full_disk_access": {
+        "label": "Full Disk Access",
+        "note": "Detected with a conservative filesystem probe; absence is shown as manual confirmation.",
+        "usage": "Read protected files that normal Files & Folders consent does not cover."
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent does not currently use HomeKit workflows.",
+        "usage": "Access Home data only if future HomeKit workflows are enabled."
+      },
+      "input_monitoring": {
+        "label": "Input Monitoring",
+        "usage": "Listen for keyboard and pointer events needed by desktop automation."
+      },
+      "local_network": {
+        "label": "Local Network",
+        "note": "macOS Local Network privacy has no reliable public status API.",
+        "usage": "Discover and connect to devices on the local network."
+      },
+      "location": {
+        "label": "Location Services",
+        "usage": "Use device location for local weather and location-aware workflows."
+      },
+      "media_library": {
+        "label": "Media Library",
+        "note": "No reliable public status API is available for this app surface.",
+        "usage": "Access the media library only when a media workflow explicitly needs it."
+      },
+      "microphone": {
+        "label": "Microphone",
+        "usage": "Use the microphone for voice input only when explicitly requested."
+      },
+      "network_volumes": {
+        "label": "Network Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access mounted network volumes when the user asks the app to work there."
+      },
+      "notifications": {
+        "label": "Notifications",
+        "note": "Notification configuration stays on the Notifications settings page.",
+        "usage": "Show system notifications."
+      },
+      "photos": {
+        "label": "Photos",
+        "usage": "Access the Photos library only when the user asks for photo workflows."
+      },
+      "reminders": {
+        "label": "Reminders",
+        "usage": "Read or write reminders when planning workflows need it."
+      },
+      "removable_volumes": {
+        "label": "Removable Volumes",
+        "note": "No reliable public per-volume status API is available.",
+        "usage": "Access removable drives when the user asks the app to work there."
+      },
+      "screen_recording": {
+        "label": "Screen Recording",
+        "usage": "Capture screen contents for visual understanding and UI automation."
+      },
+      "speech_recognition": {
+        "label": "Speech Recognition",
+        "usage": "Use speech recognition when a voice workflow asks for transcription."
+      },
+      "system_audio_capture": {
+        "label": "System Audio Capture",
+        "note": "macOS does not expose a reliable public preflight API for this permission.",
+        "usage": "Capture system audio when a future workflow explicitly needs it."
+      }
+    },
+    "permissionStatuses": {
+      "granted": "Granted",
+      "manualCheck": "Manual check",
+      "notApplicable": "Not applicable",
+      "notDetermined": "Not determined",
+      "notGranted": "Not granted",
+      "notUsed": "Not used",
+      "restricted": "Restricted"
+    },
     "permissions": "Quyền",
     "personaModeDesc": "Điền các trường có cấu trúc, hoặc viết trực tiếp một SOUL.md markdown. Tệp SOUL.md dùng chung với chế độ tương thích openclaw.",
     "personaModeLabel": "Bề mặt chỉnh sửa persona",
@@ -3490,6 +3639,16 @@
         "title": "Recent reject reasons",
         "empty": "No rejections recorded yet. Whenever any gate stops a review from producing a draft, the reason lands here."
       },
+      "curator": {
+        "title": "Draft consolidation",
+        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
+        "run": "Scan",
+        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
+        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
+        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
+        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
+        "apply": "Keep this, discard the other {{n}}"
+      },
       "resetAll": {
         "label": "Reset everything",
         "confirm": "Reset every custom field to defaults?",
@@ -3594,16 +3753,6 @@
           "label": "Override review system prompt",
           "help": "Replaces the built-in review system prompt verbatim; leave empty to use the built-in. Backend hard floors still apply."
         }
-      },
-      "curator": {
-        "title": "Draft consolidation",
-        "help": "Find clusters of draft skills that overlap topically and merge them in one click — keep one, discard the rest. Read-only scan, no LLM call.",
-        "run": "Scan",
-        "idle": "Not scanned yet. Click \"Scan\" to look for overlapping drafts.",
-        "noClusters": "Scanned {{count}} drafts. No obvious overlap found.",
-        "foundN": "Found {{proposals}} overlap cluster(s) across {{scanned}} drafts.",
-        "clusterMeta": "{{members}} drafts · min similarity {{similarity}}",
-        "apply": "Keep this, discard the other {{n}}"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "屏幕錄制",
     "permScreenRecordingDesc": "允許截取屏幕內容，識別界面元素",
     "permSummary": "已授權 {{granted}} / {{total}} 項",
+    "permSummaryV2": "已授权 {{granted}} 项 · 需处理 {{needsAction}} 项 · 手动确认 {{manual}} 项 · 未使用/不适用 {{inactive}} 项",
     "permTitle": "系統權限",
+    "permUnsupportedDesc": "本页当前仅支持 macOS 桌面应用。Windows、Linux 和 HTTP/server 模式会在后续版本提供各自的权限适配。",
+    "permUnsupportedTitle": "系统权限页当前仅支持 macOS",
     "permUnknown": "請手動確認",
+    "permissionGroups": {
+      "controlCapture": "控制与捕获",
+      "deviceNetwork": "设备与网络",
+      "fileAccess": "文件访问",
+      "personalData": "个人数据",
+      "systemServices": "系统服务"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "辅助功能",
+        "usage": "允许控制鼠标、键盘和其他应用窗口。"
+      },
+      "app_management": {
+        "label": "应用管理",
+        "note": "macOS 没有可靠的公开接口可读取此项的逐 App 状态。",
+        "usage": "仅在工具明确需要时管理或更新其他应用。"
+      },
+      "automation_messages": {
+        "label": "自动化：Messages",
+        "note": "自动化授权按目标应用记录，最可靠的状态来源是系统设置。",
+        "usage": "在消息工作流需要时允许通过 Apple Events 自动化 Messages。"
+      },
+      "automation_system_events": {
+        "label": "自动化：System Events",
+        "note": "自动化授权按目标应用记录，最可靠的状态来源是系统设置。",
+        "usage": "允许通过 Apple Events 自动化 System Events。"
+      },
+      "bluetooth": {
+        "label": "蓝牙",
+        "usage": "在工作流需要时发现和连接蓝牙设备。"
+      },
+      "calendar": {
+        "label": "日历",
+        "usage": "在日程工作流需要时读取或写入日历事件。"
+      },
+      "camera": {
+        "label": "相机",
+        "usage": "仅在用户明确请求视觉输入时使用相机。"
+      },
+      "contacts": {
+        "label": "通讯录",
+        "usage": "仅在用户工作流明确需要联系人信息时读取通讯录。"
+      },
+      "desktop_folder": {
+        "label": "桌面文件夹",
+        "note": "macOS 将此项放在“文件与文件夹”中；这里通过探测展示。",
+        "usage": "在用户要求处理桌面文件时读写桌面。"
+      },
+      "developer_tools": {
+        "label": "开发者工具",
+        "note": "macOS 没有可靠的公开接口可读取此项的逐 App 状态。",
+        "usage": "使用 macOS 受开发者工具授权保护的调试或开发能力。"
+      },
+      "documents_folder": {
+        "label": "文稿文件夹",
+        "note": "macOS 将此项放在“文件与文件夹”中；这里通过探测展示。",
+        "usage": "在用户要求处理文稿文件时读写文稿。"
+      },
+      "downloads_folder": {
+        "label": "下载文件夹",
+        "note": "macOS 将此项放在“文件与文件夹”中；这里通过探测展示。",
+        "usage": "在用户要求处理下载文件时读写下载目录。"
+      },
+      "focus_status": {
+        "label": "专注状态",
+        "note": "macOS 没有可靠的公开接口可读取此项的逐 App 状态。",
+        "usage": "仅在工作流需要适配通知或打扰策略时读取专注状态。"
+      },
+      "full_disk_access": {
+        "label": "完全磁盘访问",
+        "note": "这里使用保守文件探测；未探测到时需要手动确认。",
+        "usage": "读取“文件与文件夹”授权无法覆盖的受保护文件。"
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent 当前未使用 HomeKit 工作流。",
+        "usage": "仅当后续启用家庭工作流时访问家庭数据。"
+      },
+      "input_monitoring": {
+        "label": "输入监控",
+        "usage": "监听桌面自动化所需的键盘和指针事件。"
+      },
+      "local_network": {
+        "label": "本地网络",
+        "note": "macOS 本地网络权限没有可靠的公开状态读取接口。",
+        "usage": "发现并连接本地网络中的设备和服务。"
+      },
+      "location": {
+        "label": "定位服务",
+        "usage": "用于本地天气和用户明确请求的定位相关工作流。"
+      },
+      "media_library": {
+        "label": "媒体资料库",
+        "note": "该 App 场景没有可靠的公开状态读取接口。",
+        "usage": "仅在媒体工作流明确需要时访问媒体资料库。"
+      },
+      "microphone": {
+        "label": "麦克风",
+        "usage": "仅在用户明确请求语音输入时使用麦克风。"
+      },
+      "network_volumes": {
+        "label": "网络卷",
+        "note": "macOS 没有可靠的公开接口可读取逐卷授权状态。",
+        "usage": "在用户要求处理网络卷文件时访问已挂载的网络卷。"
+      },
+      "notifications": {
+        "label": "通知",
+        "note": "通知的开关配置仍保留在通知设置页。",
+        "usage": "显示系统通知。"
+      },
+      "photos": {
+        "label": "照片",
+        "usage": "仅在用户明确请求照片工作流时访问照片图库。"
+      },
+      "reminders": {
+        "label": "提醒事项",
+        "usage": "在计划工作流需要时读取或写入提醒事项。"
+      },
+      "removable_volumes": {
+        "label": "可移动卷",
+        "note": "macOS 没有可靠的公开接口可读取逐卷授权状态。",
+        "usage": "在用户要求处理外置磁盘文件时访问可移动卷。"
+      },
+      "screen_recording": {
+        "label": "屏幕录制",
+        "usage": "截取屏幕内容，用于视觉理解和界面自动化。"
+      },
+      "speech_recognition": {
+        "label": "语音识别",
+        "usage": "仅在用户明确请求语音转写时使用语音识别。"
+      },
+      "system_audio_capture": {
+        "label": "系统音频捕获",
+        "note": "macOS 没有可靠的公开预检查接口可读取此项状态。",
+        "usage": "仅在后续工作流明确需要时捕获系统音频。"
+      }
+    },
+    "permissionStatuses": {
+      "granted": "已授权",
+      "manualCheck": "手动确认",
+      "notApplicable": "不适用",
+      "notDetermined": "未决定",
+      "notGranted": "未授权",
+      "notUsed": "未使用",
+      "restricted": "受限"
+    },
     "permissions": "系統權限",
     "personaModeDesc": "填寫結構化欄位，或直接撰寫 SOUL.md 自由文字。SOUL.md 與 openclaw 相容模式共用同一份檔案。",
     "personaModeLabel": "人格編輯方式",
@@ -3490,6 +3639,16 @@
         "title": "最近的拒绝原因",
         "empty": "暂无被拒记录。系统会在每次审核被任意一道闸拦下时记录原因。"
       },
+      "curator": {
+        "title": "草稿合并建议",
+        "help": "在所有草稿技能中查找主题重叠的聚类，让你一键保留一个、清理其余。不调用 LLM、只读扫描。",
+        "run": "扫描",
+        "idle": "尚未扫描。点击右上「扫描」检查现有草稿是否存在重叠。",
+        "noClusters": "已扫描 {{count}} 条草稿，未发现明显重叠。",
+        "foundN": "在 {{scanned}} 条草稿中发现 {{proposals}} 组潜在重叠。",
+        "clusterMeta": "{{members}} 条草稿 · 最低相似度 {{similarity}}",
+        "apply": "保留这一条、删除其余 {{n}} 条"
+      },
       "resetAll": {
         "label": "全部恢复默认",
         "confirm": "确定重置所有自定义配置？",
@@ -3594,16 +3753,6 @@
           "label": "覆盖审核 Prompt",
           "help": "完全替换内置审核系统提示词；留空则用内置版本。后端硬阈值仍会生效。"
         }
-      },
-      "curator": {
-        "title": "草稿合并建议",
-        "help": "在所有草稿技能中查找主题重叠的聚类，让你一键保留一个、清理其余。不调用 LLM、只读扫描。",
-        "run": "扫描",
-        "idle": "尚未扫描。点击右上「扫描」检查现有草稿是否存在重叠。",
-        "noClusters": "已扫描 {{count}} 条草稿，未发现明显重叠。",
-        "foundN": "在 {{scanned}} 条草稿中发现 {{proposals}} 组潜在重叠。",
-        "clusterMeta": "{{members}} 条草稿 · 最低相似度 {{similarity}}",
-        "apply": "保留这一条、删除其余 {{n}} 条"
       }
     },
     "skillsEvolutionHero": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -3271,8 +3271,157 @@
     "permScreenRecording": "屏幕录制",
     "permScreenRecordingDesc": "允许截取屏幕内容，识别界面元素",
     "permSummary": "已授权 {{granted}} / {{total}} 项",
+    "permSummaryV2": "已授权 {{granted}} 项 · 需处理 {{needsAction}} 项 · 手动确认 {{manual}} 项 · 未使用/不适用 {{inactive}} 项",
     "permTitle": "系统权限",
+    "permUnsupportedDesc": "本页当前仅支持 macOS 桌面应用。Windows、Linux 和 HTTP/server 模式会在后续版本提供各自的权限适配。",
+    "permUnsupportedTitle": "系统权限页当前仅支持 macOS",
     "permUnknown": "请手动确认",
+    "permissionGroups": {
+      "controlCapture": "控制与捕获",
+      "deviceNetwork": "设备与网络",
+      "fileAccess": "文件访问",
+      "personalData": "个人数据",
+      "systemServices": "系统服务"
+    },
+    "permissionItems": {
+      "accessibility": {
+        "label": "辅助功能",
+        "usage": "允许控制鼠标、键盘和其他应用窗口。"
+      },
+      "app_management": {
+        "label": "应用管理",
+        "note": "macOS 没有可靠的公开接口可读取此项的逐 App 状态。",
+        "usage": "仅在工具明确需要时管理或更新其他应用。"
+      },
+      "automation_messages": {
+        "label": "自动化：Messages",
+        "note": "自动化授权按目标应用记录，最可靠的状态来源是系统设置。",
+        "usage": "在消息工作流需要时允许通过 Apple Events 自动化 Messages。"
+      },
+      "automation_system_events": {
+        "label": "自动化：System Events",
+        "note": "自动化授权按目标应用记录，最可靠的状态来源是系统设置。",
+        "usage": "允许通过 Apple Events 自动化 System Events。"
+      },
+      "bluetooth": {
+        "label": "蓝牙",
+        "usage": "在工作流需要时发现和连接蓝牙设备。"
+      },
+      "calendar": {
+        "label": "日历",
+        "usage": "在日程工作流需要时读取或写入日历事件。"
+      },
+      "camera": {
+        "label": "相机",
+        "usage": "仅在用户明确请求视觉输入时使用相机。"
+      },
+      "contacts": {
+        "label": "通讯录",
+        "usage": "仅在用户工作流明确需要联系人信息时读取通讯录。"
+      },
+      "desktop_folder": {
+        "label": "桌面文件夹",
+        "note": "macOS 将此项放在“文件与文件夹”中；这里通过探测展示。",
+        "usage": "在用户要求处理桌面文件时读写桌面。"
+      },
+      "developer_tools": {
+        "label": "开发者工具",
+        "note": "macOS 没有可靠的公开接口可读取此项的逐 App 状态。",
+        "usage": "使用 macOS 受开发者工具授权保护的调试或开发能力。"
+      },
+      "documents_folder": {
+        "label": "文稿文件夹",
+        "note": "macOS 将此项放在“文件与文件夹”中；这里通过探测展示。",
+        "usage": "在用户要求处理文稿文件时读写文稿。"
+      },
+      "downloads_folder": {
+        "label": "下载文件夹",
+        "note": "macOS 将此项放在“文件与文件夹”中；这里通过探测展示。",
+        "usage": "在用户要求处理下载文件时读写下载目录。"
+      },
+      "focus_status": {
+        "label": "专注状态",
+        "note": "macOS 没有可靠的公开接口可读取此项的逐 App 状态。",
+        "usage": "仅在工作流需要适配通知或打扰策略时读取专注状态。"
+      },
+      "full_disk_access": {
+        "label": "完全磁盘访问",
+        "note": "这里使用保守文件探测；未探测到时需要手动确认。",
+        "usage": "读取“文件与文件夹”授权无法覆盖的受保护文件。"
+      },
+      "homekit": {
+        "label": "HomeKit",
+        "note": "Hope Agent 当前未使用 HomeKit 工作流。",
+        "usage": "仅当后续启用家庭工作流时访问家庭数据。"
+      },
+      "input_monitoring": {
+        "label": "输入监控",
+        "usage": "监听桌面自动化所需的键盘和指针事件。"
+      },
+      "local_network": {
+        "label": "本地网络",
+        "note": "macOS 本地网络权限没有可靠的公开状态读取接口。",
+        "usage": "发现并连接本地网络中的设备和服务。"
+      },
+      "location": {
+        "label": "定位服务",
+        "usage": "用于本地天气和用户明确请求的定位相关工作流。"
+      },
+      "media_library": {
+        "label": "媒体资料库",
+        "note": "该 App 场景没有可靠的公开状态读取接口。",
+        "usage": "仅在媒体工作流明确需要时访问媒体资料库。"
+      },
+      "microphone": {
+        "label": "麦克风",
+        "usage": "仅在用户明确请求语音输入时使用麦克风。"
+      },
+      "network_volumes": {
+        "label": "网络卷",
+        "note": "macOS 没有可靠的公开接口可读取逐卷授权状态。",
+        "usage": "在用户要求处理网络卷文件时访问已挂载的网络卷。"
+      },
+      "notifications": {
+        "label": "通知",
+        "note": "通知的开关配置仍保留在通知设置页。",
+        "usage": "显示系统通知。"
+      },
+      "photos": {
+        "label": "照片",
+        "usage": "仅在用户明确请求照片工作流时访问照片图库。"
+      },
+      "reminders": {
+        "label": "提醒事项",
+        "usage": "在计划工作流需要时读取或写入提醒事项。"
+      },
+      "removable_volumes": {
+        "label": "可移动卷",
+        "note": "macOS 没有可靠的公开接口可读取逐卷授权状态。",
+        "usage": "在用户要求处理外置磁盘文件时访问可移动卷。"
+      },
+      "screen_recording": {
+        "label": "屏幕录制",
+        "usage": "截取屏幕内容，用于视觉理解和界面自动化。"
+      },
+      "speech_recognition": {
+        "label": "语音识别",
+        "usage": "仅在用户明确请求语音转写时使用语音识别。"
+      },
+      "system_audio_capture": {
+        "label": "系统音频捕获",
+        "note": "macOS 没有可靠的公开预检查接口可读取此项状态。",
+        "usage": "仅在后续工作流明确需要时捕获系统音频。"
+      }
+    },
+    "permissionStatuses": {
+      "granted": "已授权",
+      "manualCheck": "手动确认",
+      "notApplicable": "不适用",
+      "notDetermined": "未决定",
+      "notGranted": "未授权",
+      "notUsed": "未使用",
+      "restricted": "受限"
+    },
     "permissions": "系统权限",
     "personaModeDesc": "结构化字段填空，或直接写 SOUL.md 自由文本。SOUL.md 与 openclaw 兼容模式共用同一份文件。",
     "personaModeLabel": "人格编辑方式",


### PR DESCRIPTION
## Summary

- 新增系统权限 v2 数据模型与 Tauri 命令，macOS 权限页改为完整分组目录。
- macOS 可原生检测/请求的权限走系统 API；无法可靠检测的权限明确标为手动确认并提供系统设置入口。
- Windows / Linux / HTTP 模式暂显示禁用说明，避免继续返回假授权状态。
- 补齐 `Info.plist` 隐私 usage description、通知授权读取、v1 权限命令兼容包装、前端状态/i18n/架构文档与 changelog。

## Validation

- `cargo check -p ha-core`
- `cargo check -p hope-agent`
- `cargo check -p ha-core --tests`
- `pnpm typecheck`
- `node scripts/sync-i18n.mjs --check`
- `git diff --check`
- pre-push: `cargo fmt --all --check`
- pre-push: `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- pre-push: `pnpm typecheck`
- pre-push: `pnpm lint`
- pre-push: `pnpm test`
- pre-push: `cargo test -p ha-core -p ha-server --locked`