### PR TITLE
[codex] 🦭 Persist sidebar section state

### DIFF
--- a/src/components/chat/project/ProjectSection.tsx
+++ b/src/components/chat/project/ProjectSection.tsx
@@ -14,7 +14,6 @@
 import { useCallback, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
-  ChevronDown,
   ChevronRight,
   MessageSquarePlus,
   Plus,
@@ -41,6 +40,7 @@ import type {
   SessionMeta,
 } from "@/types/chat"
 import SessionItem from "../sidebar/SessionItem"
+import SidebarSectionHeader from "../sidebar/SidebarSectionHeader"
 import ProjectIcon from "./ProjectIcon"
 
 interface ProjectSectionProps {
@@ -72,6 +72,26 @@ interface ProjectSectionProps {
 }
 
 const EXPANDED_STORAGE_KEY = "ha:project-expanded"
+const ARCHIVED_EXPANDED_STORAGE_KEY = "ha:project-archived-expanded"
+
+function readStoredBoolean(key: string, fallback: boolean): boolean {
+  try {
+    if (typeof window === "undefined") return fallback
+    const raw = window.localStorage.getItem(key)
+    if (raw === null) return fallback
+    return raw === "true"
+  } catch {
+    return fallback
+  }
+}
+
+function writeStoredBoolean(key: string, value: boolean) {
+  try {
+    window.localStorage.setItem(key, String(value))
+  } catch {
+    // localStorage may be unavailable in restricted browser modes.
+  }
+}
 
 function isUnreadChatSession(session: SessionMeta): boolean {
   return !session.channelInfo && !session.parentSessionId && session.unreadCount > 0
@@ -88,7 +108,14 @@ export default function ProjectSection(props: ProjectSectionProps) {
   } = props
   const visibleProjects = useMemo(() => projects.filter((p) => !p.archived), [projects])
   const archivedProjects = useMemo(() => projects.filter((p) => p.archived), [projects])
-  const [archivedExpanded, setArchivedExpanded] = useState(false)
+  const [archivedExpanded, setArchivedExpandedState] = useState(() =>
+    readStoredBoolean(ARCHIVED_EXPANDED_STORAGE_KEY, false),
+  )
+
+  const setArchivedExpanded = useCallback((expanded: boolean) => {
+    setArchivedExpandedState(expanded)
+    writeStoredBoolean(ARCHIVED_EXPANDED_STORAGE_KEY, expanded)
+  }, [])
 
   // Single localStorage entry for all project expansion states. Loaded once,
   // persisted on toggle. Stale keys for deleted projects are harmless and
@@ -129,22 +156,12 @@ export default function ProjectSection(props: ProjectSectionProps) {
 
   return (
     <div className="px-3 pt-3 pb-1">
-      <div className="flex items-center gap-1 mb-2">
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/80 hover:text-foreground transition-colors"
-        >
-          {expanded ? (
-            <ChevronDown className="h-3 w-3" />
-          ) : (
-            <ChevronRight className="h-3 w-3" />
-          )}
-          {t("project.projects")}
-          {visibleProjects.length > 0 && (
-            <span className="ml-1 text-muted-foreground/60">· {visibleProjects.length}</span>
-          )}
-        </button>
-        <div className="ml-auto">
+      <SidebarSectionHeader
+        title={t("project.projects")}
+        count={visibleProjects.length > 0 ? visibleProjects.length : undefined}
+        expanded={expanded}
+        onToggle={() => setExpanded(!expanded)}
+        action={
           <IconTip label={t("project.newProject")}>
             <button
               onClick={onAddProject}
@@ -153,8 +170,8 @@ export default function ProjectSection(props: ProjectSectionProps) {
               <Plus className="h-3.5 w-3.5" />
             </button>
           </IconTip>
-        </div>
-      </div>
+        }
+      />
 
       {expanded && (
         <div className="space-y-0.5">
@@ -181,14 +198,15 @@ export default function ProjectSection(props: ProjectSectionProps) {
           {archivedProjects.length > 0 && (
             <div className="mt-2 border-t border-border/40 pt-2">
               <button
-                onClick={() => setArchivedExpanded((prev) => !prev)}
-                className="flex w-full items-center gap-1.5 px-2 py-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/70 hover:text-foreground transition-colors"
+                onClick={() => setArchivedExpanded(!archivedExpanded)}
+                className="flex w-full items-center gap-1.5 px-2 py-1 text-[11px] font-semibold tracking-normal text-muted-foreground/70 hover:text-foreground transition-colors"
               >
-                {archivedExpanded ? (
-                  <ChevronDown className="h-3 w-3" />
-                ) : (
-                  <ChevronRight className="h-3 w-3" />
-                )}
+                <ChevronRight
+                  className={cn(
+                    "h-3 w-3 transition-transform duration-200",
+                    archivedExpanded && "rotate-90",
+                  )}
+                />
                 <Archive className="h-3 w-3" />
                 <span className="truncate">{t("project.archivedProjects")}</span>
                 <span className="ml-auto text-muted-foreground/60">

--- a/src/components/chat/sidebar/AgentSection.tsx
+++ b/src/components/chat/sidebar/AgentSection.tsx
@@ -10,13 +10,13 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
 import {
-  ChevronRight,
   Bot,
   Ghost,
   MessageSquarePlus,
   Settings,
 } from "lucide-react"
 import type { AgentSummaryForSidebar } from "@/types/chat"
+import SidebarSectionHeader from "./SidebarSectionHeader"
 
 interface AgentSectionProps {
   agents: AgentSummaryForSidebar[]
@@ -43,24 +43,13 @@ export default function AgentSection({
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   return (
-    <div className="border-b border-border/50">
-      <div className="flex items-center">
-        <button
-          className="flex items-center gap-1.5 flex-1 px-4 py-2 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider hover:text-foreground transition-colors"
-          onClick={() => setAgentsExpanded(!agentsExpanded)}
-        >
-          <ChevronRight
-            className={cn(
-              "h-3 w-3 transition-transform duration-200",
-              agentsExpanded && "rotate-90",
-            )}
-          />
-          <span>Agents</span>
-          <span className="font-normal normal-case text-muted-foreground/60 ml-0.5">
-            ({agents.length})
-          </span>
-        </button>
-      </div>
+    <div className="border-b border-border/50 px-3 pt-3 pb-1">
+      <SidebarSectionHeader
+        title={t("settings.agents")}
+        count={agents.length}
+        expanded={agentsExpanded}
+        onToggle={() => setAgentsExpanded(!agentsExpanded)}
+      />
       <div
         className={cn(
           "overflow-hidden transition-all duration-200 ease-out",
@@ -69,7 +58,7 @@ export default function AgentSection({
       >
         <div
           className={cn(
-            "px-2 pb-2 grid gap-1",
+            "pb-2 grid gap-1",
             panelWidth >= 280 ? "grid-cols-2" : "grid-cols-1",
           )}
         >

--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -28,6 +28,28 @@ import AgentSection from "./AgentSection"
 import SessionList from "./SessionList"
 import ProjectSection from "../project/ProjectSection"
 
+const AGENTS_EXPANDED_STORAGE_KEY = "hope.chatSidebarAgentsExpanded"
+const PROJECTS_EXPANDED_STORAGE_KEY = "hope.chatSidebarProjectsExpanded"
+
+function readStoredBoolean(key: string, fallback: boolean): boolean {
+  try {
+    if (typeof window === "undefined") return fallback
+    const raw = window.localStorage.getItem(key)
+    if (raw === null) return fallback
+    return raw === "true"
+  } catch {
+    return fallback
+  }
+}
+
+function writeStoredBoolean(key: string, value: boolean) {
+  try {
+    window.localStorage.setItem(key, String(value))
+  } catch {
+    // localStorage may be unavailable in restricted browser modes.
+  }
+}
+
 export default function ChatSidebar({
   sessions,
   agents,
@@ -55,11 +77,25 @@ export default function ChatSidebar({
   searchFocusSignal,
 }: ChatSidebarProps) {
   const { t } = useTranslation()
-  const [agentsExpanded, setAgentsExpanded] = useState(true)
-  const [projectsExpanded, setProjectsExpanded] = useState(true)
+  const [agentsExpanded, setAgentsExpandedState] = useState(() =>
+    readStoredBoolean(AGENTS_EXPANDED_STORAGE_KEY, true),
+  )
+  const [projectsExpanded, setProjectsExpandedState] = useState(() =>
+    readStoredBoolean(PROJECTS_EXPANDED_STORAGE_KEY, true),
+  )
   const [showNewChatMenu, setShowNewChatMenu] = useState(false)
   const newChatMenuRef = useRef<HTMLDivElement>(null)
   const [deleteConfirmSessionId, setDeleteConfirmSessionId] = useState<string | null>(null)
+
+  const setAgentsExpanded = useCallback((expanded: boolean) => {
+    setAgentsExpandedState(expanded)
+    writeStoredBoolean(AGENTS_EXPANDED_STORAGE_KEY, expanded)
+  }, [])
+
+  const setProjectsExpanded = useCallback((expanded: boolean) => {
+    setProjectsExpandedState(expanded)
+    writeStoredBoolean(PROJECTS_EXPANDED_STORAGE_KEY, expanded)
+  }, [])
 
   // Inline rename state
   const [renamingSessionId, setRenamingSessionId] = useState<string | null>(null)

--- a/src/components/chat/sidebar/SidebarSectionHeader.tsx
+++ b/src/components/chat/sidebar/SidebarSectionHeader.tsx
@@ -1,0 +1,43 @@
+import { ChevronRight } from "lucide-react"
+import type { ReactNode } from "react"
+
+import { cn } from "@/lib/utils"
+
+interface SidebarSectionHeaderProps {
+  title: string
+  count?: number
+  expanded: boolean
+  onToggle: () => void
+  action?: ReactNode
+  className?: string
+}
+
+export default function SidebarSectionHeader({
+  title,
+  count,
+  expanded,
+  onToggle,
+  action,
+  className,
+}: SidebarSectionHeaderProps) {
+  return (
+    <div className={cn("mb-2 flex items-center gap-1", className)}>
+      <button
+        onClick={onToggle}
+        className="flex min-w-0 flex-1 items-center gap-1.5 text-[11px] font-semibold tracking-normal text-muted-foreground/80 transition-colors hover:text-foreground"
+      >
+        <ChevronRight
+          className={cn(
+            "h-3 w-3 shrink-0 transition-transform duration-200",
+            expanded && "rotate-90",
+          )}
+        />
+        <span className="truncate">{title}</span>
+        {count !== undefined && (
+          <span className="shrink-0 font-normal text-muted-foreground/60">· {count}</span>
+        )}
+      </button>
+      {action && <div className="ml-auto flex items-center">{action}</div>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 🦭 Added a shared sidebar section header so Project and Agent sections use the same typography, spacing, count format, and chevron behavior.
- Persisted top-level Project and Agent section expansion state in localStorage.
- Persisted the archived-projects expansion state alongside the existing per-project expansion storage.

## Why
The Project and Agent sidebar headers had drifted visually, and user collapse/expand choices were reset after restart. This keeps the UI consistent and preserves the user's sidebar preferences.

## Validation
- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `cargo test -p ha-core -p ha-server --locked`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`

Note: Vitest emitted two existing `Could not parse CSS stylesheet` messages, but all tests passed.