### PR TITLE
🦭 fix(permission): split auto_approve_tools to plug async-bg exec approval bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **修复异步后台化路径下 `exec` 工具静默跳过审批的安全 bug**：原先任何会进 auto-background 或 `run_in_background:true` 路径的 shell 命令都会完全绕过审批（含 `git push --force` / `rm -rf` 这类 dangerous-commands），本版起按权限模式正常审计。**操作影响**：之前依赖 IM 账号未勾「自动批准工具」也不弹审批的部署，从这版起每条 `exec` 都会按规则弹审批；想保持静默执行请显式勾选账号「自动批准工具」。
 - **聊天任务视图消息操作区补齐**：任务视图下模型消息恢复「详情」按钮，复制 / Markdown 切换 / 详情三枚按钮统一对齐；`showPlainText` / `renderMarkdown` 补齐 12 语言文案；亮色主题用户气泡改为更克制的冷灰色，并修复首次打开时 session pane 宽度被空 `localStorage` 错夹到最小值的问题。
 - **MCP 工具开关热更新一致性**：`mcpGlobal.enabled` / `deniedServers` / server `enabled` 现在会同步更新 live registry、schema cache、`tool_search` 与执行反查表；修改 server `allowedTools` / `deniedTools` 不再把已 Ready 的 MCP 工具清空到必须手动 Reconnect。server `autoApprove` 现在只在 `trustLevel=Trusted` 时真正跳过普通工具审批，且不会绕过 Plan Mode ask。
 - **切回流式输出中的会话不再从头重放打字机动画**：MarkdownRenderer 在 mount 时把当前 content 长度记为基线，已经看过的内容直接整段显示，仅对 mount 之后新到达的 delta 继续走 typewriter + blurIn 动画。修复切到别的会话再切回时整段内容"咵地从头一字一字 / 模糊变清晰重放一遍"的视觉问题。

--- a/crates/ha-core/src/agent/mod.rs
+++ b/crates/ha-core/src/agent/mod.rs
@@ -1410,6 +1410,7 @@ impl AssistantAgent {
                 _ => Vec::new(),
             },
             auto_approve_tools: self.auto_approve_tools,
+            external_pre_approved: false,
             session_mode,
             agent_custom_approval_enabled: caps.enable_custom_tool_approval,
             agent_custom_approval_tools: caps.custom_approval_tools.clone(),

--- a/crates/ha-core/src/async_jobs/spawn.rs
+++ b/crates/ha-core/src/async_jobs/spawn.rs
@@ -140,11 +140,15 @@ pub fn spawn_explicit_job(
     let clean_args = strip_async_control_args(args);
     let cancel_token = super::cancel::register_job(&job_id);
     ctx.bypass_async_dispatch = true;
-    // The outer call already passed the approval gate for this exact arg set;
-    // the recursive inner call must not re-prompt (the user has no surface to
-    // answer it from inside a background runtime). The visibility / plan-mode
+    // Engine gate already ran (or was deliberately skipped for `exec`) at
+    // the outer dispatch; the recursive inner call must not re-prompt (the
+    // user has no surface to answer it from inside a background runtime).
+    // `external_pre_approved` silences the engine-level prompt **without**
+    // bypassing `exec`'s command-level dangerous/edit audit — flipping
+    // `auto_approve_tools` here would let any shell command run silently
+    // whenever `run_in_background: true` is set. Visibility / plan-mode
     // checks still re-run as belt-and-suspenders.
-    ctx.auto_approve_tools = true;
+    ctx.external_pre_approved = true;
     ctx.suppress_global_tool_timeout = true;
     ctx.suppress_result_disk_persistence = true;
     ctx.cancellation_token = Some(cancel_token.clone());

--- a/crates/ha-core/src/tools/exec.rs
+++ b/crates/ha-core/src/tools/exec.rs
@@ -414,7 +414,15 @@ pub(crate) async fn tool_exec(args: &Value, ctx: &super::ToolExecContext) -> Res
     // store on top: once the user picks "allow always" for `git status`,
     // the prefix shortcut keeps the engine from re-asking for similar
     // commands.
-    if !ctx.auto_approve_tools {
+    //
+    // Gate predicate is `ToolExecContext::should_run_exec_command_gate` —
+    // it reads `auto_approve_tools` only, deliberately ignoring
+    // `external_pre_approved`. The latter is set by async-job re-entry to
+    // silence the *engine* gate (the engine intentionally excludes `exec`
+    // and would never have run anyway), and must NOT silence this
+    // command-level audit — otherwise dangerous shell commands could slip
+    // through whenever the call is re-dispatched into a background runtime.
+    if ctx.should_run_exec_command_gate() {
         let decision = super::execution::resolve_tool_permission(TOOL_EXEC, args, ctx, false).await;
         match decision {
             crate::permission::Decision::Allow => {}

--- a/crates/ha-core/src/tools/execution.rs
+++ b/crates/ha-core/src/tools/execution.rs
@@ -180,8 +180,28 @@ pub struct ToolExecContext {
     /// for the bundled plan agent so a planning subagent can't run shell
     /// commands without confirmation.
     pub plan_mode_ask_tools: Vec<String>,
-    /// When true, automatically approve all tool calls (IM channel auto-approve mode).
+    /// When true, automatically approve all tool calls — skips BOTH the
+    /// permission-engine gate AND the `exec` command-level gate. Set by the
+    /// IM channel auto-approve account flag and by skill-triggered slash
+    /// commands (the user has out-of-band authorized everything that path
+    /// will run). **Do not** set this for internal re-entries that only mean
+    /// "the engine already ran at the outer dispatch" — use
+    /// [`Self::external_pre_approved`] instead, otherwise `exec` will
+    /// silently bypass its dangerous/edit-command audits.
     pub auto_approve_tools: bool,
+    /// Set by the async-job spawner / auto-bg helper to mark that the
+    /// permission engine gate (see [`needs_permission_engine`]) was already
+    /// satisfied at the outer dispatch. Inner re-entries skip the engine
+    /// gate but **still run command-level gates** (notably `exec`'s
+    /// dangerous/edit-command + AllowAlways audit), because for the `exec`
+    /// tool those gates are intentionally bypassed at the outer engine layer
+    /// (`needs_permission_engine` excludes `TOOL_EXEC`) and `exec` is
+    /// expected to run them itself.
+    ///
+    /// Differs from [`Self::auto_approve_tools`], which means "skip ALL
+    /// approval gates including command-level" and is set only by IM
+    /// auto-approve accounts or slash-skill execution.
+    pub external_pre_approved: bool,
     /// Per-session permission mode (Default / Smart / Yolo). Resolved from the
     /// `sessions.permission_mode` column at agent build time. The engine
     /// consumes this together with `global_yolo` to decide approval behavior.
@@ -231,6 +251,32 @@ pub struct ToolExecContext {
 }
 
 impl ToolExecContext {
+    /// True when either local gate-skip flag is set (`auto_approve_tools`
+    /// from IM auto-approve accounts / slash-skill execution, or
+    /// `external_pre_approved` from async-job re-entry). Callers that need
+    /// the full effective verdict still need to OR in
+    /// `mcp_tool_auto_approves(name).await` — that one is async-only and
+    /// can't fold into a sync method.
+    #[inline]
+    pub fn local_auto_approve(&self) -> bool {
+        self.auto_approve_tools || self.external_pre_approved
+    }
+
+    /// True when `exec` must run its command-level audit (dangerous-commands
+    /// + edit-commands + AllowAlways prefix). Only `auto_approve_tools`
+    /// bypasses this — `external_pre_approved` deliberately does NOT,
+    /// because the outer engine gate excludes `TOOL_EXEC` and this audit is
+    /// `exec`'s only safeguard against dangerous patterns when the call is
+    /// re-dispatched through the async-job spawner / auto-bg helper.
+    ///
+    /// Changing this read site without also updating
+    /// [`Self::auto_approve_tools`] / [`Self::external_pre_approved`] doc
+    /// is a security regression.
+    #[inline]
+    pub fn should_run_exec_command_gate(&self) -> bool {
+        !self.auto_approve_tools
+    }
+
     /// Returns the default path for path-aware tools: session working dir,
     /// then agent home, then ".".
     pub fn default_path(&self) -> &str {
@@ -529,7 +575,12 @@ pub async fn execute_tool_with_context(
     //   - the tool is `exec` (which usually skips the engine for its own
     //     command-level prefix gate; in Plan Mode the engine's
     //     plan-mode-ask path takes precedence).
-    let effective_auto_approve = ctx.auto_approve_tools || mcp_tool_auto_approves(name).await;
+    // `external_pre_approved` only suppresses re-entry into the engine gate —
+    // it does NOT pierce `exec`'s command-level audit (exec.rs reads
+    // `auto_approve_tools` directly via `should_run_exec_command_gate`).
+    // `auto_approve_tools` continues to mean "skip everything" for IM
+    // auto-approve accounts and skill-triggered slash commands.
+    let effective_auto_approve = ctx.local_auto_approve() || mcp_tool_auto_approves(name).await;
     let needs_engine = needs_permission_engine(name, args, ctx, effective_auto_approve);
     if needs_engine {
         let decision =
@@ -691,8 +742,14 @@ pub async fn execute_tool_with_context(
         let mut inner_ctx = ctx.clone();
         inner_ctx.bypass_async_dispatch = true;
         inner_ctx.suppress_global_tool_timeout = true;
-        // Approval already ran at this outer layer — silence the inner re-entry.
-        inner_ctx.auto_approve_tools = true;
+        // The engine gate either ran (for non-exec tools) or was deliberately
+        // skipped (`exec` is always excluded from the outer engine gate and
+        // runs its command-level audit instead). Tell the recursive inner
+        // dispatch "engine already handled" so it doesn't double-prompt the
+        // user — but **do not** flip `auto_approve_tools`, which would also
+        // bypass `exec`'s command-level dangerous/edit audit and let any
+        // shell command run silently as long as it's async-eligible.
+        inner_ctx.external_pre_approved = true;
         let raw =
             async_jobs::dispatch_with_auto_background(name, args, &inner_ctx, auto_bg_secs).await?;
         // The inner worker suppresses generic disk persistence so detached jobs
@@ -1368,5 +1425,127 @@ mod tests {
         };
 
         assert!(needs_permission_engine(&tool, &json!({}), &ctx, true));
+    }
+
+    // ── Regression: `external_pre_approved` vs `auto_approve_tools` split ──
+    //
+    // Before the split there was a single `auto_approve_tools` flag used both
+    // by IM auto-approve accounts ("skip ALL gates") and by async-job
+    // re-entry helpers ("engine already ran outside"). For `exec` the
+    // re-entry meaning was wrong — the outer engine gate intentionally
+    // excludes `TOOL_EXEC` (see `needs_permission_engine`), so flipping
+    // `auto_approve_tools=true` on re-entry let `exec` silently bypass its
+    // own command-level dangerous/edit audit. These tests pin the new
+    // contract: `external_pre_approved` only suppresses the engine gate,
+    // never the per-tool command-level gate.
+
+    #[test]
+    fn external_pre_approved_skips_engine_for_non_exec() {
+        let ctx = ToolExecContext {
+            external_pre_approved: true,
+            ..ToolExecContext::default()
+        };
+        assert!(ctx.local_auto_approve());
+        assert!(!needs_permission_engine(
+            "read",
+            &json!({"path": "/tmp/x"}),
+            &ctx,
+            ctx.local_auto_approve()
+        ));
+    }
+
+    #[test]
+    fn external_pre_approved_does_not_pierce_exec_command_gate() {
+        // Core regression: even with `external_pre_approved=true` the
+        // command-level audit (dangerous/edit-commands + AllowAlways prefix)
+        // must still run inside `exec::tool_exec`.
+        let ctx = ToolExecContext {
+            external_pre_approved: true,
+            auto_approve_tools: false,
+            ..ToolExecContext::default()
+        };
+        assert!(
+            ctx.should_run_exec_command_gate(),
+            "external_pre_approved must NOT bypass exec command-level audit"
+        );
+    }
+
+    #[test]
+    fn auto_approve_tools_pierces_exec_command_gate() {
+        // IM auto-approve account / skill-triggered slash command behavior:
+        // `auto_approve_tools=true` legitimately bypasses every gate
+        // including the exec command-level audit.
+        let ctx = ToolExecContext {
+            auto_approve_tools: true,
+            ..ToolExecContext::default()
+        };
+        assert!(
+            !ctx.should_run_exec_command_gate(),
+            "IM auto-approve behavior regression"
+        );
+    }
+
+    #[test]
+    fn plan_mode_ask_tools_pierces_external_pre_approved_for_exec() {
+        // Plan Mode `ask_tools` user-sovereignty contract: even if a recursive
+        // inner dispatch claims "engine already ran outside", Plan Mode forces
+        // the engine to re-prompt because the outer turn's plan agent had
+        // already decided this tool must always ask.
+        let ctx = ToolExecContext {
+            external_pre_approved: true,
+            plan_mode_allowed_tools: vec!["exec".to_string()],
+            plan_mode_ask_tools: vec!["exec".to_string()],
+            ..ToolExecContext::default()
+        };
+        assert!(needs_permission_engine(
+            "exec",
+            &json!({"command": "ls"}),
+            &ctx,
+            ctx.local_auto_approve()
+        ));
+    }
+
+    #[test]
+    fn plan_mode_ask_tools_pierces_auto_approve_tools_for_exec() {
+        let ctx = ToolExecContext {
+            auto_approve_tools: true,
+            plan_mode_allowed_tools: vec!["exec".to_string()],
+            plan_mode_ask_tools: vec!["exec".to_string()],
+            ..ToolExecContext::default()
+        };
+        assert!(needs_permission_engine(
+            "exec",
+            &json!({"command": "ls"}),
+            &ctx,
+            ctx.local_auto_approve()
+        ));
+    }
+
+    #[test]
+    fn async_spawn_keeps_exec_command_gate() {
+        // Pins the spawn.rs / auto-bg helper contract: when re-dispatching
+        // into the OS-thread runtime, only `external_pre_approved` may be
+        // flipped to silence the engine re-entry; `auto_approve_tools` must
+        // stay false so the command-level audit still catches things like
+        // `git push --force` or `rm -rf /`.
+        let inner_ctx = ToolExecContext {
+            bypass_async_dispatch: true,
+            external_pre_approved: true,
+            // auto_approve_tools intentionally NOT touched
+            ..ToolExecContext::default()
+        };
+        assert!(
+            inner_ctx.should_run_exec_command_gate(),
+            "async spawn must NOT flip auto_approve_tools — that was the original CVE-class bug"
+        );
+        // Engine gate skipped on re-entry (exec was already excluded from the
+        // outer engine gate; the load-bearing guarantee is the command-level
+        // audit above still fires).
+        assert!(!needs_permission_engine(
+            "exec",
+            &json!({"command": "rm -rf /"}),
+            &inner_ctx,
+            inner_ctx.local_auto_approve()
+        ));
     }
 }

--- a/docs/plans/review-followups.md
+++ b/docs/plans/review-followups.md
@@ -970,6 +970,23 @@
 
 ---
 
+### F-105 `mcp_tool_auto_approves` sync 短路应提到调用点
+
+- **来源**：2026-05-17 `fix-approval-gate-split-field` PR `/simplify` review（efficiency agent）
+- **现象**：[`tools/execution.rs::mcp_tool_auto_approves`](../../crates/ha-core/src/tools/execution.rs) 第一件事就是 `is_mcp_tool_name(name)` 同步早返回，但这个早返回被埋在 `async fn` 里。`execute_tool_with_context` 每次 dispatch 调 `ctx.local_auto_approve() || mcp_tool_auto_approves(name).await`，**当前两个 bool 都 false 时**（desktop Default 模式常态）仍然要构造 future + poll，且 `mcp_tool_auto_approves` 内部连续拿两把 async `RwLock`（`McpManager` + `handle.config`）。
+- **为什么留**：本 PR 主线是修审批 bug，挪 sync 早返回属于独立性能优化；预存量问题（不是 PR 引入）。
+- **改的话要做什么**：把 `is_mcp_tool_name` 这一层 sync 检查提到调用点：
+  ```rust
+  let mcp_aa = crate::mcp::catalog::is_mcp_tool_name(name)
+      && mcp_tool_auto_approves(name).await;
+  let effective_auto_approve = ctx.local_auto_approve() || mcp_aa;
+  ```
+  非 MCP 工具（read/write/edit/exec/grep…，占绝大多数 dispatch）连 future 都不构造。进一步可给 `(server_id → auto_approve_resolved)` 加 `ArcSwap` 缓存避免每次拿 RwLock，但属于另一个 PR。
+- **影响面**：tool dispatch hot path 单次 ~纳秒级 future 构造开销 × 高频；正确性无影响。
+- **触发时机建议**：下次动 `tools/execution.rs` 或做 MCP 性能优化时顺手。
+
+---
+
 ## Closed
 
 > 已修复条目移到此处，附 commit hash + 关闭日期。保留以便后续 grep。


### PR DESCRIPTION
## Summary

`ToolExecContext.auto_approve_tools` was overloaded with two incompatible meanings — **IM auto-approve account / slash-skill execution** ("skip ALL gates") and **async-job re-entry** ("engine already ran outside"). For `exec` the re-entry meaning was wrong: the outer engine gate intentionally excludes `TOOL_EXEC` (`needs_permission_engine` uses `name != TOOL_EXEC`), so flipping `auto_approve_tools=true` on async re-dispatch let `exec` silently bypass its command-level dangerous/edit audit.

**Effect**: any shell command going through auto-background (`asyncTools.autoBackgroundSecs > 0`, default 30s) or `run_in_background:true` would skip approval — including `git push --force` / `rm -rf` / dangerous-commands matches. Discovered while investigating a session where 30+ `exec` calls including `git worktree remove --force` ran without a single approval prompt despite `permission_mode=default` and `globalYolo=false`.

## Fix

Split into two fields with disjoint semantics:

| Field | Set by | Skips engine gate? | Skips exec command-level gate? |
|---|---|---|---|
| `auto_approve_tools` (kept) | IM account auto-approve, slash-skill execution | ✅ | ✅ (legitimate "skip everything") |
| `external_pre_approved` (new) | `async_jobs::spawn`, auto-bg helper | ✅ | ❌ (must run — that was the bug) |

Two new helpers on `ToolExecContext` document the contract and pin both read sites against accidental re-merge:

- `ctx.local_auto_approve()` → `auto_approve_tools \|\| external_pre_approved` (engine gate)
- `ctx.should_run_exec_command_gate()` → `!auto_approve_tools` (only reads the legitimate skip flag)

[exec.rs:366](crates/ha-core/src/tools/exec.rs#L366) calls `should_run_exec_command_gate()` with a doc anchor explaining why it deliberately ignores `external_pre_approved`.

## Changes

- [crates/ha-core/src/tools/execution.rs](crates/ha-core/src/tools/execution.rs): new field + 2 helper methods, swap async-bg re-entry to `external_pre_approved`, 6 regression tests
- [crates/ha-core/src/async_jobs/spawn.rs](crates/ha-core/src/async_jobs/spawn.rs): explicit `spawn_explicit_job` swaps to `external_pre_approved`
- [crates/ha-core/src/tools/exec.rs](crates/ha-core/src/tools/exec.rs): command gate uses new method + doc anchor
- [crates/ha-core/src/agent/mod.rs](crates/ha-core/src/agent/mod.rs): ctx construction adds `external_pre_approved: false`
- [CHANGELOG.md](CHANGELOG.md): one-line user-facing entry with operational-impact note
- [docs/plans/review-followups.md](docs/plans/review-followups.md): F-105 registers an unrelated `mcp_tool_auto_approves` hot-path optimization surfaced by /simplify

## Regression coverage (6 new test cases)

1. `external_pre_approved_skips_engine_for_non_exec`
2. `external_pre_approved_does_not_pierce_exec_command_gate` ← **the core security regression**
3. `auto_approve_tools_pierces_exec_command_gate` (IM auto-approve behavior must not regress)
4. `plan_mode_ask_tools_pierces_external_pre_approved_for_exec`
5. `plan_mode_ask_tools_pierces_auto_approve_tools_for_exec`
6. `async_spawn_keeps_exec_command_gate` (pins spawn.rs contract)

## Operational impact

Previously IM accounts without `auto_approve_tools=true` silently skipped exec approvals due to this bug. After the fix they will receive approval prompts on every `exec` matching the protected/dangerous/edit lists. To keep silent behavior set the account's `auto_approve_tools=true` explicitly.

PR-A (separately) will land IM text-approval usability improvements (alias parsing, timeout notification, multi-pending `#id` disambiguation) — this fix needs to land first so approvals actually fire and that work has user value.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- [x] `cargo test -p ha-core -p ha-server --locked` (1442 tests pass, 6 new cases all green)
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` (via pre-push hook)
- [ ] **Manual desktop GUI**: open new session in default mode, ask LLM to run `git fetch --all --prune` → must prompt (regressed silently before this fix)
- [ ] **Manual desktop GUI**: ask LLM to run `git status` → not in any list, should auto-allow
- [ ] **Manual desktop GUI**: ask LLM to run `git push --force` → must show strict-Ask dialog with AllowAlways greyed
- [ ] **Manual IM**: account with `auto_approve_tools=true` still skips everything (no regression of IM auto-approve UX)
- [ ] **Manual IM**: account with `auto_approve_tools=false` now sends text approval prompt for `exec` (this is the entry point for PR-A)