### PR TITLE
🦭 feat(server): --auto-approve-tools flag for headless / Docker deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **IM 文本审批可用性增强（无按钮渠道：WeChat / Signal / iMessage / IRC / WhatsApp）**：审批回复 parsing 从「只接 `1`/`2`/`3`」扩到大小写无关 + 中英自然语言白名单（`yes` / `y` / `ok` / `allow` / `好` / `同意` / `允许` / `2` / `always` / `总是` / `永远` / `3` / `no` / `n` / `deny` / `拒绝` / `取消` 等）；审批 prompt 渲染 `#tag` 6 字符短前缀，多个 pending 时可用 `yes#abc123` 精准定位（不限于 LIFO 栈顶）；超时不再 IM 端静默 —— 走新的 `approval_timed_out` EventBus 事件给 chat 发一条「⏱ approval timed out」通知；pending 期间用户发非审批消息时 1 分钟节流提示一次「你有 N 个待审批，回 1/2/3 或 yes/no」，照常进入新 turn 不绑架用户。
+- **`hope-agent server` 新增 `--auto-approve-tools` flag / `HA_SERVER_AUTO_APPROVE_TOOLS=1` env**：headless 部署（CI / Docker / pipeline）下 HTTP 客户端通常不接审批 UI，所有工具调用会等满 5 分钟超时再被 deny。新开关让 HTTP 入口的 chat 全部按「自动批准工具」处理（permission engine 的 dangerous-commands / protected-paths / Plan Mode ask 仍执行），等同桌面 IM 渠道账号勾「auto-approve tools」。进程态、不持久化、启动 stderr 红字 banner 提醒。比 `--dangerously-skip-all-approvals` 更窄；常规 headless 推荐用这个。
 - **聊天工作台视觉与布局改造**：主界面切成全局 rail + 会话 pane 两层导航，右侧 Browser / Plan / Diff / Canvas / Team 面板统一为共享 shell；空会话时输入框居中加宽并显示品牌 Logo，有消息后回到底部；应用默认窗口尺寸放大到更适合双栏工作台的 1360×860。
 - **macOS 系统权限页 v2**：权限设置切到 macOS 全量权限目录与 v2 数据模型，覆盖辅助功能、屏幕录制、输入监控、媒体/个人数据/文件访问/自动化/通知等类别；可原生检测或请求的权限走 macOS API，无法可靠检测的权限标记为「手动确认」并跳转系统设置。Windows / Linux / HTTP 模式本期显示禁用说明；旧权限命令保留兼容包装，`Info.plist` 补齐本期隐私 usage description。
 - **聊天界面窄栏自适应整理**：输入框工作目录入口改为纯图标 + 「设置工作目录」提示，统一工具条图标尺寸；无痕模式入口移至顶部标题栏；右侧 Browser / Plan / Diff / Canvas / Team 面板打开时自动收起左侧 session 列表，用户仍可手动展开；输入框溢出菜单改为按容器宽度触发，修复右侧面板压缩聊天列时「+」菜单不出现。

--- a/crates/ha-server/src/auto_approve.rs
+++ b/crates/ha-server/src/auto_approve.rs
@@ -1,0 +1,71 @@
+//! Headless-server tool auto-approve switch.
+//!
+//! `hope-agent server` exposes the chat API over HTTP/WS. Tool approval
+//! prompts are emitted as EventBus events and only the desktop / browser UI
+//! (or an IM channel listener) knows how to surface them. Plain HTTP clients
+//! that don't subscribe to those events end up with every approval waiting
+//! out the 5-minute timeout and then being denied — which appears to the
+//! caller as "the model can't run any shell command".
+//!
+//! For container / CI / pipeline deployments where the operator already
+//! trusts whatever runs in their tenant, this module exposes a process-
+//! scoped switch that flips every `auto_approve_tools` boolean on the HTTP
+//! chat entry point to `true`. Set by either:
+//!
+//! 1. CLI flag `--auto-approve-tools` on `hope-agent server`.
+//! 2. Env var `HA_SERVER_AUTO_APPROVE_TOOLS=1` (Docker-friendly).
+//!
+//! Neither persists to disk. Narrower than [`ha_core::security::dangerous`]:
+//! that one skips protected-paths + dangerous-commands too; this one only
+//! flips the per-chat `auto_approve_tools` flag, leaving the full permission
+//! engine wired up the same way as an IM auto-approve account.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static SERVER_AUTO_APPROVE: AtomicBool = AtomicBool::new(false);
+
+/// CLI flag the user passes to `hope-agent server`.
+pub const FLAG: &str = "--auto-approve-tools";
+
+/// Env-var equivalent of [`FLAG`]. Anything truthy (`"1"`, `"true"`, `"yes"`,
+/// case-insensitive) enables auto-approve mode. Anything else — including
+/// an empty value — leaves it off.
+pub const ENV_VAR: &str = "HA_SERVER_AUTO_APPROVE_TOOLS";
+
+pub fn set_cli_flag(v: bool) {
+    SERVER_AUTO_APPROVE.store(v, Ordering::Relaxed);
+}
+
+/// Snapshot of the current flag. Read by HTTP route handlers when building
+/// `ChatEngineParams.auto_approve_tools`.
+pub fn cli_flag_active() -> bool {
+    SERVER_AUTO_APPROVE.load(Ordering::Relaxed)
+}
+
+/// Parse the env var to a boolean. Truthy: `1` / `true` / `yes` / `on`
+/// (case-insensitive). Everything else (including empty / unset) is false.
+pub fn env_truthy(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_truthy_matches_common_yes_values() {
+        for v in ["1", "true", "TRUE", "yes", "YES", "on", " true "] {
+            assert!(env_truthy(v), "expected truthy: {v:?}");
+        }
+    }
+
+    #[test]
+    fn env_truthy_rejects_falsy_and_garbage() {
+        for v in ["", " ", "0", "false", "no", "off", "maybe", "1.0"] {
+            assert!(!env_truthy(v), "expected falsy: {v:?}");
+        }
+    }
+}

--- a/crates/ha-server/src/bin/hope-agent.rs
+++ b/crates/ha-server/src/bin/hope-agent.rs
@@ -30,6 +30,25 @@ fn main() {
         );
     }
 
+    // Headless auto-approve: same effect as ticking "auto approve tools" on
+    // every chat the HTTP route opens — the permission engine still runs
+    // (so dangerous-commands, plan-mode ask, protected paths all stay
+    // enforced), just the `auto_approve_tools` switch goes through. Narrower
+    // than `--dangerously-skip-all-approvals`. Env var lets Docker /
+    // systemd users opt in without rewriting the entrypoint.
+    let env_enabled = std::env::var(ha_server::auto_approve::ENV_VAR)
+        .map(|v| ha_server::auto_approve::env_truthy(&v))
+        .unwrap_or(false);
+    let cli_enabled = args.iter().any(|a| a == ha_server::auto_approve::FLAG);
+    if env_enabled || cli_enabled {
+        ha_server::auto_approve::set_cli_flag(true);
+        let source = if cli_enabled { "CLI flag" } else { "env" };
+        eprintln!(
+            "[!] AUTO-APPROVE MODE ({source}): HTTP chat will auto-approve every tool call \
+             (engine gates still enforced; this launch only)"
+        );
+    }
+
     if args.iter().any(|a| a == "--version") {
         println!("hope-agent {}", env!("CARGO_PKG_VERSION"));
         return;
@@ -84,6 +103,12 @@ fn print_top_help() {
     println!("Options:");
     println!("  --bind, -b ADDR                   Bind address (default: 127.0.0.1:8420)");
     println!("  --api-key KEY                     Bearer token for HTTP/WS auth");
+    println!(
+        "  --auto-approve-tools              Auto-approve every tool call on HTTP chat (engine"
+    );
+    println!(
+        "                                    gates still enforced; or set HA_SERVER_AUTO_APPROVE_TOOLS=1)"
+    );
     println!("  --dangerously-skip-all-approvals  Skip every tool approval (this launch only)");
     println!("  --version                         Print version and exit");
     println!("  --help, -h                        Print help and exit");
@@ -247,6 +272,9 @@ fn parse_server_args(args: &[String]) -> Option<(String, Option<String>)> {
                 api_key = Some(s["--api-key=".len()..].to_string());
             }
             "--dangerously-skip-all-approvals" => {}
+            // Already consumed in `main()`; ignore here so it doesn't fall
+            // through to the unknown-arg branch and stripe the help text.
+            s if s == ha_server::auto_approve::FLAG => {}
             "--version" => {
                 println!("hope-agent {}", env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);

--- a/crates/ha-server/src/lib.rs
+++ b/crates/ha-server/src/lib.rs
@@ -14,6 +14,7 @@ use ha_core::event_bus::EventBus;
 use ha_core::project::ProjectDB;
 use ha_core::session::SessionDB;
 
+pub mod auto_approve;
 pub mod banner;
 pub mod config;
 pub mod error;

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -373,7 +373,12 @@ pub async fn chat(
         denied_tools: Vec::new(),
         subagent_depth: 0,
         steer_run_id: None,
-        auto_approve_tools: false,
+        // Honors `--auto-approve-tools` / `HA_SERVER_AUTO_APPROVE_TOOLS=1`
+        // for headless / Docker deployments where the HTTP client doesn't
+        // implement an approval handler. Engine gates (dangerous-commands,
+        // protected paths, plan-mode ask) still run; this just flips the
+        // same switch IM auto-approve accounts use.
+        auto_approve_tools: crate::auto_approve::cli_flag_active(),
         follow_global_reasoning_effort: true,
         post_turn_effects: true,
         abort_on_cancel: false,

--- a/docs/architecture/transport-modes.md
+++ b/docs/architecture/transport-modes.md
@@ -14,6 +14,21 @@
 
 三种模式共享 `ha-core` 业务逻辑和 `EventBus` 抽象。Tauri 与 HTTP 只是把同一批核心能力分别桥接成 IPC 或 REST/WS；ACP 是另一条协议入口，不参与前端 Transport 选择。
 
+### Server 模式的工具审批
+
+HTTP 入口的 `ChatEngineParams.auto_approve_tools` 在桌面 Web GUI 客户端下默认 `false`（跟桌面 GUI 一致），审批通过 EventBus `approval_required` 事件等浏览器侧 UI 响应。但 headless 客户端（curl / pipeline / Docker entrypoint）通常不会订阅这个事件，工具调用会卡到 5 分钟超时再被 deny —— 表现就是「模型一个 shell 命令都跑不了」。
+
+提供两个 opt-in 开关给 headless 部署：
+
+- **CLI flag** `hope-agent server start --auto-approve-tools`
+- **Env var** `HA_SERVER_AUTO_APPROVE_TOOLS=1`（Docker 友好；接受 `1` / `true` / `yes` / `on` 任一值）
+
+任一启用后，[`ha_server::auto_approve::cli_flag_active()`](../../crates/ha-server/src/auto_approve.rs) 返回 `true`，HTTP chat 路由把 `auto_approve_tools=true` 透传给 chat engine —— 等同于 IM 渠道账号勾上「auto-approve tools」。**只跳过 chat 入口的工具审批**：permission engine 的 dangerous-commands / protected-paths / Plan Mode ask 仍然生效。
+
+要更激进地跳过一切（包括 dangerous-commands），用 `--dangerously-skip-all-approvals`（即 global YOLO）。两个 flag 是正交的；常规 headless 推荐 `--auto-approve-tools` 即可。
+
+进程态、不持久化，启动时 stderr 打一行红字 banner 提醒。
+
 ```mermaid
 flowchart TD
     UI["React UI"] --> TP["getTransport()"]
@@ -123,6 +138,7 @@ Tauri 桌面没有 `/ws/events`，但同一个 EventBus 会在 `src-tauri/src/se
 | Channel | `channel:stream_start` / `channel:stream_delta` / `channel:stream_end` | IM 渠道会话的流式状态和增量。 |
 | Channel | `channel:message_update` | IM 渠道消息落库后通知 UI 刷新。 |
 | Approval | `approval_required` | 工具审批请求。 |
+| Approval | `approval_timed_out` | 审批 5 分钟超时通知。IM 渠道侧用来给用户发「已超时被拒」消息；桌面 UI 自身有倒计时圆环，不依赖此事件。 |
 | Approval | `session_pending_interactions_changed` | 会话 pending 审批和 ask_user 数量变化。 |
 | Ask User | `ask_user_request` | 结构化问答请求，Plan Mode 和普通工具路径共用。 |
 | Plan Mode | `plan_mode_changed` / `plan_content_updated` / `plan_step_updated` | 计划状态、内容、步骤变化。 |

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -47,6 +47,7 @@ docker compose logs -f hope-agent
 | --- | --- | --- |
 | `HA_BIND` | `0.0.0.0:8420` | server 监听地址。容器内必须是 `0.0.0.0`（loopback 会拒绝外部连接）。entrypoint 自动翻译为 `--bind` |
 | `HA_API_KEY` | _未设置_ | HTTP/WS Bearer Token。设了之后从浏览器打开会弹「需要服务器鉴权」对话框，粘贴 token 即可继续；也支持 `https://host:8420/?token=XXX` 一次性传 token —— 前端会自动捕获到 localStorage 并把 URL 清掉。entrypoint 自动翻译为 `--api-key` |
+| `HA_SERVER_AUTO_APPROVE_TOOLS` | _未设置_ | 设为 `1` / `true` / `yes` 让 HTTP 入口的每条 chat 都按「自动批准工具」处理 —— 等同于桌面端 IM 渠道账号勾上「auto-approve tools」。**只跳过 chat 入口的工具审批**：dangerous-commands / protected-paths / Plan Mode ask 等 engine 层规则照常执行（要全跳走 `--dangerously-skip-all-approvals`）。无人值守 / CI / pipeline 部署且客户端没接审批 UI 时必开，否则每条 `exec` 都会等满 5 分钟超时 → deny |
 | `HA_DATA_DIR` | `/data` | 数据根目录，所有持久化文件（`config.json` / `sessions.db` / `memory.db` / 凭据 / 项目 / 附件等）都在此目录下 |
 | `HA_DEPLOYMENT` | `docker` | 给 updater 的部署形态提示。**不要改**，否则 `app_update install` 会尝试在容器内做 binary swap |
 | `TZ` | `UTC` | 时区。影响 cron 调度与时间戳格式 |


### PR DESCRIPTION
## Summary

Follow-up to #217 + #218 for headless deployments.

After the approval bug fix (#217) the HTTP entry point's `auto_approve_tools` defaulted to `false`, matching the desktop GUI which has its own approval modal. That exposes a UX cliff for headless clients (curl / pipeline / Docker entrypoint): they don't subscribe to the `approval_required` EventBus event, so every shell command waits out the 5-minute timeout and gets denied. Operators saw "the model can't run any tool" with no obvious fix short of `--dangerously-skip-all-approvals` — which is much broader (also skips protected-paths + dangerous-commands).

PR-A (#218) helped users on button-less IM channels respond in natural language, but headless HTTP has no chat surface to respond from at all.

## What changes

New narrower opt-in switches:

- **CLI flag** `--auto-approve-tools` on `hope-agent server`
- **Env var** `HA_SERVER_AUTO_APPROVE_TOOLS=1` / `true` / `yes` / `on` (Docker-friendly)

When active, the HTTP chat route passes `auto_approve_tools=true` to `ChatEngineParams` — equivalent to ticking "auto-approve tools" on an IM account. The full permission engine still runs: **dangerous-commands / protected-paths / Plan Mode ask all stay enforced**. We just flip the per-chat switch IM accounts already use.

Process-scoped via [`ha_server::auto_approve::SERVER_AUTO_APPROVE`](crates/ha-server/src/auto_approve.rs) AtomicBool, modeled on [`ha_core::security::dangerous::DANGEROUS_SKIP_CLI`](crates/ha-core/src/security/dangerous.rs). Not persisted to disk. Startup logs a red `[!] AUTO-APPROVE MODE (CLI flag|env)` banner to stderr so operators can't miss it in `docker logs` / `journalctl`.

Help text and `docs/deployment/docker.md` env-var table also updated.

## Files

- [crates/ha-server/src/auto_approve.rs](crates/ha-server/src/auto_approve.rs) — new module with `set_cli_flag` / `cli_flag_active` / `env_truthy` (mirrors `security::dangerous` pattern). 2 unit tests for env parsing.
- [crates/ha-server/src/lib.rs](crates/ha-server/src/lib.rs) — `pub mod auto_approve`
- [crates/ha-server/src/bin/hope-agent.rs](crates/ha-server/src/bin/hope-agent.rs) — parse CLI flag + env var early in `main`, swallow flag in `parse_server_args`, update help text
- [crates/ha-server/src/routes/chat.rs](crates/ha-server/src/routes/chat.rs) — read `cli_flag_active()` into `ChatEngineParams.auto_approve_tools`
- [docs/deployment/docker.md](docs/deployment/docker.md) — env-var table entry
- [docs/architecture/transport-modes.md](docs/architecture/transport-modes.md) — new "Server 模式的工具审批" subsection; also documents the `approval_timed_out` EventBus event introduced in #218

## Decision rationale

Why narrower than `--dangerously-skip-all-approvals`:

| | `--dangerously-skip-all-approvals` | `--auto-approve-tools` (this PR) |
|---|---|---|
| dangerous-commands list | ❌ skipped | ✅ enforced |
| protected-paths list | ❌ skipped | ✅ enforced |
| Plan Mode `ask_tools` | ❌ skipped | ✅ enforced |
| Per-chat approval prompts | ❌ skipped | ❌ skipped (this is the point) |

Operators who want "model can run things, but don't let it `git push --force`" got no good answer before. This is that answer.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- [x] `cargo test -p ha-core -p ha-server --locked` — 1450+ tests pass (added 2 for `env_truthy`)
- [ ] Manual: `hope-agent server start` (no flag) — verify HTTP chat still gets blocked on approval (no regression of the safety contract for browser-UI deployments)
- [ ] Manual: `hope-agent server start --auto-approve-tools` — verify banner prints and curl-driven chat runs `exec` without timeout
- [ ] Manual: `HA_SERVER_AUTO_APPROVE_TOOLS=1 hope-agent server start` — same as above but env-driven
- [ ] Manual: `HA_SERVER_AUTO_APPROVE_TOOLS=maybe hope-agent server start` — verify it's treated as falsy
- [ ] Manual (regression): with `--auto-approve-tools` active, ask LLM to run `git push --force` — must still trigger strict-Ask path via permission engine (this is the narrower-than-YOLO contract)