### PR TITLE
[codex] Preserve async job refs during compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **异步任务结果引用在上下文压缩后稳定保留**：后台工具完成后的 `task-id` / `output-file` 会作为可恢复引用进入摘要，避免长对话压缩后模型忘记如何继续查看任务结果。 (#221)
 - **聊天任务视图消息操作区补齐**：任务视图下模型消息恢复「详情」按钮，复制 / Markdown 切换 / 详情三枚按钮统一对齐；`showPlainText` / `renderMarkdown` 补齐 12 语言文案；亮色主题用户气泡改为更克制的冷灰色，并修复首次打开时 session pane 宽度被空 `localStorage` 错夹到最小值的问题。
 - **MCP 工具开关热更新一致性**：`mcpGlobal.enabled` / `deniedServers` / server `enabled` 现在会同步更新 live registry、schema cache、`tool_search` 与执行反查表；修改 server `allowedTools` / `deniedTools` 不再把已 Ready 的 MCP 工具清空到必须手动 Reconnect。server `autoApprove` 现在只在 `trustLevel=Trusted` 时真正跳过普通工具审批，且不会绕过 Plan Mode ask。
 - **切回流式输出中的会话不再从头重放打字机动画**：MarkdownRenderer 在 mount 时把当前 content 长度记为基线，已经看过的内容直接整段显示，仅对 mount 之后新到达的 delta 继续走 typewriter + blurIn 动画。修复切到别的会话再切回时整段内容"咵地从头一字一字 / 模糊变清晰重放一遍"的视觉问题。

--- a/crates/ha-core/src/context_compact/compact.rs
+++ b/crates/ha-core/src/context_compact/compact.rs
@@ -8,6 +8,9 @@ use super::estimation::{
     is_tool_result, is_user_message, set_tool_result_text,
 };
 use super::pruning::prune_old_context;
+use super::task_notification::{
+    collect_async_job_references_from_messages, render_async_job_reference_section,
+};
 use super::truncation::truncate_tool_results;
 use super::types::{CompactDetails, CompactResult};
 use serde_json::Value;
@@ -178,8 +181,19 @@ pub fn emergency_compact(messages: &mut Vec<Value>, config: &CompactConfig) -> C
     keep_from = super::round_grouping::find_round_safe_boundary_forward(messages, keep_from);
 
     if keep_from > 0 && keep_from < messages.len() {
+        let async_refs = collect_async_job_references_from_messages(&messages[..keep_from]);
         let removed = keep_from;
         messages.drain(..keep_from);
+        let reference_section = render_async_job_reference_section(&async_refs);
+        if !reference_section.is_empty() {
+            messages.insert(
+                0,
+                serde_json::json!({
+                    "role": "user",
+                    "content": format!("[Previous conversation summary]\n{}", reference_section)
+                }),
+            );
+        }
         affected += removed;
     }
 
@@ -341,5 +355,42 @@ pub fn compact_if_needed(
         messages_affected: 0,
         description: "no_action_needed".to_string(),
         details: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn emergency_compact_preserves_async_job_references_from_removed_history() {
+        let config = CompactConfig {
+            preserve_recent_turns: 2,
+            ..CompactConfig::default()
+        };
+        let mut messages = vec![
+            json!({
+                "role": "user",
+                "content": "<task-notification>\n<task-id>job_old</task-id>\n<tool>exec</tool>\n<status>completed</status>\n<output-file>/tmp/out.txt</output-file>\n</task-notification>"
+            }),
+            json!({"role": "assistant", "content": "noted"}),
+            json!({"role": "user", "content": "recent 1"}),
+            json!({"role": "assistant", "content": "ok"}),
+            json!({"role": "user", "content": "recent 2"}),
+        ];
+
+        emergency_compact(&mut messages, &config);
+
+        let joined = messages
+            .iter()
+            .filter_map(|m| m.get("content").and_then(|c| c.as_str()))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(joined.contains("<async-job-reference>"));
+        assert!(joined.contains("<task-id>job_old</task-id>"));
+        assert!(joined.contains("<output-file>/tmp/out.txt</output-file>"));
+        assert!(joined.contains("recent 1"));
+        assert!(joined.contains("recent 2"));
     }
 }

--- a/crates/ha-core/src/context_compact/mod.rs
+++ b/crates/ha-core/src/context_compact/mod.rs
@@ -17,6 +17,7 @@ mod pruning;
 pub(crate) mod recovery;
 pub(crate) mod round_grouping;
 mod summarization;
+mod task_notification;
 mod truncation;
 mod types;
 
@@ -89,6 +90,7 @@ MUST PRESERVE:
 - Decisions made and their rationale
 - TODOs, open questions, and constraints
 - Any commitments or follow-ups promised
+- Async job references, preserving task-id, tool-use-id, tool, status, output-file, error, and summary exactly
 
 PRIORITIZE recent context over older history."#;
 

--- a/crates/ha-core/src/context_compact/summarization.rs
+++ b/crates/ha-core/src/context_compact/summarization.rs
@@ -2,10 +2,14 @@
 
 use super::config::CompactConfig;
 use super::estimation::{estimate_tokens, get_tool_result_text, is_tool_result, is_user_message};
+use super::task_notification::{
+    build_summary_with_async_job_references, collect_async_job_references_from_message,
+    collect_async_job_references_from_messages, render_async_job_reference_section,
+    text_without_async_job_references,
+};
 use super::types::SummarizationSplit;
 use super::{
     BASE_CHUNK_RATIO, IDENTIFIER_PRESERVATION_INSTRUCTIONS, MIN_CHUNK_RATIO, SAFETY_MARGIN,
-    SUMMARY_TRUNCATED_MARKER,
 };
 use serde_json::Value;
 
@@ -22,6 +26,7 @@ MUST PRESERVE:
 - TODOs, open questions, and constraints
 - Any commitments or follow-ups promised
 - All file paths, function names, and code references mentioned
+- Async job notification references, preserving task-id, tool-use-id, tool, status, output-file, error, and summary exactly
 
 PRIORITIZE recent context over older history. The agent needs to know what it was doing, not just what was discussed.
 
@@ -99,6 +104,13 @@ pub fn build_summarization_prompt(
     // Serialize messages in a readable format
     for msg in messages_to_summarize {
         let msg_type = msg.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        let async_refs = collect_async_job_references_from_message(msg);
+        let has_async_refs = !async_refs.is_empty();
+        if has_async_refs {
+            prompt.push_str("[async_job_reference]:");
+            prompt.push_str(&render_async_job_reference_section(&async_refs));
+            prompt.push('\n');
+        }
 
         // Skip encrypted reasoning items (not human-readable)
         if msg_type == "reasoning" {
@@ -127,14 +139,18 @@ pub fn build_summarization_prompt(
         // Responses API function_call_output → readable tool result
         if msg_type == "function_call_output" {
             let output = msg.get("output").and_then(|o| o.as_str()).unwrap_or("");
+            let output = prompt_text_without_async_refs(output, has_async_refs);
+            if output.trim().is_empty() {
+                continue;
+            }
             let preview = if output.len() > 500 {
                 format!(
                     "{}... [{}+ chars]",
-                    crate::truncate_utf8(output, 500),
+                    crate::truncate_utf8(&output, 500),
                     output.len()
                 )
             } else {
-                output.to_string()
+                output
             };
             prompt.push_str(&format!("[tool_result]: {}\n", preview));
             continue;
@@ -147,6 +163,10 @@ pub fn build_summarization_prompt(
 
         if is_tool_result(msg) {
             if let Some(text) = get_tool_result_text(msg) {
+                let text = prompt_text_without_async_refs(&text, has_async_refs);
+                if text.trim().is_empty() {
+                    continue;
+                }
                 let preview = if text.len() > 500 {
                     format!(
                         "{}... [{}+ chars]",
@@ -164,14 +184,14 @@ pub fn build_summarization_prompt(
                 for part in parts {
                     if part.get("type").and_then(|t| t.as_str()) == Some("output_text") {
                         if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
-                            prompt.push_str(&format!("[{}]: {}\n", role, text));
+                            push_role_text(&mut prompt, role, text, has_async_refs);
                         }
                     }
                 }
             }
         } else if let Some(content) = msg.get("content").and_then(|c| c.as_str()) {
             // Simple string content (Chat Completions / Anthropic simple format)
-            prompt.push_str(&format!("[{}]: {}\n", role, content));
+            push_role_text(&mut prompt, role, content, has_async_refs);
         } else if let Some(content_arr) = msg.get("content").and_then(|c| c.as_array()) {
             // Array content (Anthropic format with thinking + text blocks)
             for block in content_arr {
@@ -179,7 +199,7 @@ pub fn build_summarization_prompt(
                 match block_type {
                     "text" => {
                         if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
-                            prompt.push_str(&format!("[{}]: {}\n", role, text));
+                            push_role_text(&mut prompt, role, text, has_async_refs);
                         }
                     }
                     "thinking" => {
@@ -233,6 +253,21 @@ pub fn build_summarization_prompt(
     prompt
 }
 
+fn push_role_text(prompt: &mut String, role: &str, text: &str, strip_async_refs: bool) {
+    let text = prompt_text_without_async_refs(text, strip_async_refs);
+    if !text.trim().is_empty() {
+        prompt.push_str(&format!("[{}]: {}\n", role, text));
+    }
+}
+
+fn prompt_text_without_async_refs(text: &str, strip_async_refs: bool) -> String {
+    if strip_async_refs {
+        text_without_async_job_references(text).trim().to_string()
+    } else {
+        text.to_string()
+    }
+}
+
 /// Apply a summary: replace old messages with a summary message + preserved messages.
 pub fn apply_summary(
     messages: &mut Vec<Value>,
@@ -242,16 +277,13 @@ pub fn apply_summary(
 ) {
     // Cap summary length (configurable, clamped to 4000–64000)
     let max_summary_chars = config.max_compaction_summary_chars.clamp(4_000, 64_000);
-    let capped_summary = if summary.len() > max_summary_chars {
-        let budget = max_summary_chars.saturating_sub(SUMMARY_TRUNCATED_MARKER.len());
-        format!(
-            "{}{}",
-            crate::truncate_utf8(summary, budget),
-            SUMMARY_TRUNCATED_MARKER
-        )
+    let async_refs = if preserved_start_index <= messages.len() {
+        collect_async_job_references_from_messages(&messages[..preserved_start_index])
     } else {
-        summary.to_string()
+        Vec::new()
     };
+    let capped_summary =
+        build_summary_with_async_job_references(summary, &async_refs, max_summary_chars);
 
     // Build summary message
     let summary_msg = serde_json::json!({
@@ -335,4 +367,61 @@ pub fn split_messages_by_token_share(messages: &[Value], parts: usize) -> Vec<Ve
     }
 
     chunks
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn summarization_prompt_canonicalizes_task_notifications() {
+        let config = CompactConfig::default();
+        let messages = vec![json!({
+            "role": "user",
+            "content": "<task-notification>\n<task-id>job_123</task-id>\n<tool-use-id>call_123</tool-use-id>\n<tool>exec</tool>\n<status>completed</status>\n<output-file>/tmp/output.txt</output-file>\n<output-preview>large content that should not be copied</output-preview>\n<summary>done</summary>\n</task-notification>"
+        })];
+
+        let prompt = build_summarization_prompt(&messages, None, &config);
+        assert!(prompt.contains("[async_job_reference]:"));
+        assert!(prompt.contains("<task-id>job_123</task-id>"));
+        assert!(prompt.contains("<output-file>/tmp/output.txt</output-file>"));
+        assert!(!prompt.contains("large content that should not be copied"));
+    }
+
+    #[test]
+    fn summarization_prompt_preserves_summary_body_with_async_references() {
+        let config = CompactConfig::default();
+        let messages = vec![json!({
+            "role": "user",
+            "content": "[Previous conversation summary]\n\n## Decisions\n- Store async outputs on disk.\n\n## Async job references\n<async-job-reference>\n<task-id>job_123</task-id>\n<tool>exec</tool>\n<status>completed</status>\n<output-file>/tmp/output.txt</output-file>\n</async-job-reference>"
+        })];
+
+        let prompt = build_summarization_prompt(&messages, None, &config);
+        assert!(prompt.contains("[async_job_reference]:"));
+        assert!(prompt.contains("<task-id>job_123</task-id>"));
+        assert!(prompt.contains("[user]: [Previous conversation summary]"));
+        assert!(prompt.contains("- Store async outputs on disk."));
+    }
+
+    #[test]
+    fn apply_summary_preserves_async_job_reference_when_model_omits_it() {
+        let config = CompactConfig::default();
+        let mut messages = vec![
+            json!({
+                "role": "user",
+                "content": "<task-notification>\n<task-id>job_keep</task-id>\n<tool>exec</tool>\n<status>completed</status>\n<output-file>/tmp/result.txt</output-file>\n<summary>done</summary>\n</task-notification>"
+            }),
+            json!({"role": "user", "content": "recent"}),
+        ];
+
+        apply_summary(&mut messages, "Old discussion.", 1, &config);
+
+        let summary = messages[0]["content"].as_str().unwrap();
+        assert!(summary.contains("Old discussion."));
+        assert!(summary.contains("<async-job-reference>"));
+        assert!(summary.contains("<task-id>job_keep</task-id>"));
+        assert!(summary.contains("<output-file>/tmp/result.txt</output-file>"));
+        assert_eq!(messages[1]["content"].as_str(), Some("recent"));
+    }
 }

--- a/crates/ha-core/src/context_compact/task_notification.rs
+++ b/crates/ha-core/src/context_compact/task_notification.rs
@@ -1,0 +1,488 @@
+use serde_json::Value;
+
+use super::SUMMARY_TRUNCATED_MARKER;
+
+const TASK_NOTIFICATION_TAG: &str = "task-notification";
+const ASYNC_JOB_REFERENCE_TAG: &str = "async-job-reference";
+const ASYNC_JOB_REFERENCE_HEADING: &str = "## Async job references";
+const MAX_RENDERED_REFS: usize = 32;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AsyncJobReference {
+    task_id: String,
+    tool_use_id: Option<String>,
+    tool: Option<String>,
+    status: Option<String>,
+    output_file: Option<String>,
+    media_items_json: Option<String>,
+    output_preview: Option<String>,
+    error: Option<String>,
+    summary: Option<String>,
+}
+
+impl AsyncJobReference {
+    fn merge_from(&mut self, newer: Self) {
+        self.tool_use_id = prefer_non_empty(newer.tool_use_id, self.tool_use_id.take());
+        self.tool = prefer_non_empty(newer.tool, self.tool.take());
+        self.status = prefer_non_empty(newer.status, self.status.take());
+        self.output_file = prefer_non_empty(newer.output_file, self.output_file.take());
+        self.media_items_json =
+            prefer_non_empty(newer.media_items_json, self.media_items_json.take());
+        self.output_preview = prefer_non_empty(newer.output_preview, self.output_preview.take());
+        self.error = prefer_non_empty(newer.error, self.error.take());
+        self.summary = prefer_non_empty(newer.summary, self.summary.take());
+    }
+}
+
+pub(crate) fn collect_async_job_references_from_messages(
+    messages: &[Value],
+) -> Vec<AsyncJobReference> {
+    let mut refs = Vec::new();
+    for msg in messages {
+        merge_many(&mut refs, collect_async_job_references_from_message(msg));
+    }
+    refs
+}
+
+pub(crate) fn collect_async_job_references_from_message(msg: &Value) -> Vec<AsyncJobReference> {
+    let mut refs = Vec::new();
+
+    if let Some(content) = msg.get("content").and_then(|c| c.as_str()) {
+        merge_many(&mut refs, collect_async_job_references_from_text(content));
+    }
+
+    if let Some(parts) = msg.get("content").and_then(|c| c.as_array()) {
+        for part in parts {
+            for key in ["text", "output_text", "content"] {
+                if let Some(text) = part.get(key).and_then(|v| v.as_str()) {
+                    merge_many(&mut refs, collect_async_job_references_from_text(text));
+                }
+            }
+        }
+    }
+
+    refs
+}
+
+pub(crate) fn collect_async_job_references_from_text(text: &str) -> Vec<AsyncJobReference> {
+    let mut refs = Vec::new();
+    for block in extract_reference_blocks_in_order(text) {
+        if let Some(reference) = parse_reference_block(block) {
+            merge_reference(&mut refs, reference);
+        }
+    }
+    refs
+}
+
+pub(crate) fn text_without_async_job_references(text: &str) -> String {
+    let without_notifications = strip_tagged_blocks(text, TASK_NOTIFICATION_TAG);
+    let without_refs = strip_tagged_blocks(&without_notifications, ASYNC_JOB_REFERENCE_TAG);
+    without_refs
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            trimmed != ASYNC_JOB_REFERENCE_HEADING
+                && !trimmed.starts_with("<omitted-older-async-job-references>")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub(crate) fn render_async_job_reference_section(refs: &[AsyncJobReference]) -> String {
+    if refs.is_empty() {
+        return String::new();
+    }
+
+    let total = refs.len();
+    let start = total.saturating_sub(MAX_RENDERED_REFS);
+    render_reference_section_from(&refs[start..], start)
+}
+
+fn render_async_job_reference_section_to_fit(
+    refs: &[AsyncJobReference],
+    max_chars: usize,
+) -> String {
+    if refs.is_empty() {
+        return String::new();
+    }
+
+    let total = refs.len();
+    let mut keep = total.min(MAX_RENDERED_REFS);
+    loop {
+        let start = total.saturating_sub(keep);
+        let section = render_reference_section_from(&refs[start..], start);
+        if section.len() <= max_chars || keep <= 1 {
+            return section;
+        }
+        keep -= 1;
+    }
+}
+
+fn render_reference_section_from(rendered: &[AsyncJobReference], omitted_older: usize) -> String {
+    let mut out = String::new();
+    out.push_str("\n\n");
+    out.push_str(ASYNC_JOB_REFERENCE_HEADING);
+    out.push('\n');
+    if omitted_older > 0 {
+        out.push_str(&format!(
+            "<omitted-older-async-job-references>{}</omitted-older-async-job-references>\n",
+            omitted_older
+        ));
+    }
+
+    for reference in rendered {
+        out.push_str("<async-job-reference>\n");
+        push_required_tag(&mut out, "task-id", &reference.task_id, 256);
+        push_optional_tag(
+            &mut out,
+            "tool-use-id",
+            reference.tool_use_id.as_deref(),
+            256,
+        );
+        push_optional_tag(&mut out, "tool", reference.tool.as_deref(), 128);
+        push_optional_tag(&mut out, "status", reference.status.as_deref(), 64);
+        push_optional_tag(
+            &mut out,
+            "output-file",
+            reference.output_file.as_deref(),
+            1024,
+        );
+        push_optional_tag(
+            &mut out,
+            "media-items-json",
+            reference.media_items_json.as_deref(),
+            512,
+        );
+        if reference.output_file.is_none() {
+            push_optional_tag(
+                &mut out,
+                "output-preview",
+                reference.output_preview.as_deref(),
+                512,
+            );
+        }
+        push_optional_tag(&mut out, "error", reference.error.as_deref(), 512);
+        push_optional_tag(&mut out, "summary", reference.summary.as_deref(), 512);
+        out.push_str("</async-job-reference>\n");
+    }
+
+    out
+}
+
+pub(crate) fn build_summary_with_async_job_references(
+    summary: &str,
+    source_refs: &[AsyncJobReference],
+    max_chars: usize,
+) -> String {
+    let mut refs = collect_async_job_references_from_text(summary);
+    merge_many(&mut refs, source_refs.to_vec());
+
+    let section = render_async_job_reference_section_to_fit(&refs, max_chars);
+    let body = if section.is_empty() {
+        summary.to_string()
+    } else {
+        text_without_async_job_references(summary)
+            .trim_end()
+            .to_string()
+    };
+
+    cap_summary_preserving_suffix(&body, &section, max_chars)
+}
+
+fn parse_reference_block(block: &str) -> Option<AsyncJobReference> {
+    let task_id = field(block, "task-id")?;
+    if task_id.trim().is_empty() {
+        return None;
+    }
+
+    Some(AsyncJobReference {
+        task_id,
+        tool_use_id: field(block, "tool-use-id"),
+        tool: field(block, "tool"),
+        status: field(block, "status"),
+        output_file: field(block, "output-file"),
+        media_items_json: field(block, "media-items-json"),
+        output_preview: field(block, "output-preview"),
+        error: field(block, "error"),
+        summary: field(block, "summary"),
+    })
+}
+
+fn field(block: &str, tag: &str) -> Option<String> {
+    let raw = extract_first(block, tag)?;
+    let value = unescape_xml_text(raw.trim()).trim().to_string();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+fn extract_blocks<'a>(text: &'a str, tag: &str) -> Vec<&'a str> {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let mut out = Vec::new();
+    let mut rest = text;
+
+    while let Some(start) = rest.find(&open) {
+        let after_open = &rest[start + open.len()..];
+        let Some(end) = after_open.find(&close) else {
+            break;
+        };
+        out.push(&after_open[..end]);
+        rest = &after_open[end + close.len()..];
+    }
+
+    out
+}
+
+fn extract_reference_blocks_in_order(text: &str) -> Vec<&str> {
+    let mut blocks = Vec::new();
+    for tag in [TASK_NOTIFICATION_TAG, ASYNC_JOB_REFERENCE_TAG] {
+        for (start, block) in extract_blocks_with_start(text, tag) {
+            blocks.push((start, block));
+        }
+    }
+    blocks.sort_by_key(|(start, _)| *start);
+    blocks.into_iter().map(|(_, block)| block).collect()
+}
+
+fn extract_blocks_with_start<'a>(text: &'a str, tag: &str) -> Vec<(usize, &'a str)> {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let mut out = Vec::new();
+    let mut search_from = 0;
+
+    while search_from < text.len() {
+        let Some(relative_start) = text[search_from..].find(&open) else {
+            break;
+        };
+        let start = search_from + relative_start;
+        let body_start = start + open.len();
+        let Some(relative_end) = text[body_start..].find(&close) else {
+            break;
+        };
+        let body_end = body_start + relative_end;
+        out.push((start, &text[body_start..body_end]));
+        search_from = body_end + close.len();
+    }
+
+    out
+}
+
+fn extract_first<'a>(text: &'a str, tag: &str) -> Option<&'a str> {
+    extract_blocks(text, tag).into_iter().next()
+}
+
+fn merge_many(refs: &mut Vec<AsyncJobReference>, incoming: Vec<AsyncJobReference>) {
+    for reference in incoming {
+        merge_reference(refs, reference);
+    }
+}
+
+fn merge_reference(refs: &mut Vec<AsyncJobReference>, reference: AsyncJobReference) {
+    if let Some(pos) = refs.iter().position(|r| r.task_id == reference.task_id) {
+        let mut existing = refs.remove(pos);
+        existing.merge_from(reference);
+        refs.push(existing);
+    } else {
+        refs.push(reference);
+    }
+}
+
+fn prefer_non_empty(newer: Option<String>, older: Option<String>) -> Option<String> {
+    match newer {
+        Some(value) if !value.trim().is_empty() => Some(value),
+        _ => older,
+    }
+}
+
+fn push_required_tag(out: &mut String, tag: &str, value: &str, max_chars: usize) {
+    push_tag(out, tag, value, max_chars);
+}
+
+fn push_optional_tag(out: &mut String, tag: &str, value: Option<&str>, max_chars: usize) {
+    if let Some(value) = value {
+        if !value.trim().is_empty() {
+            push_tag(out, tag, value, max_chars);
+        }
+    }
+}
+
+fn push_tag(out: &mut String, tag: &str, value: &str, max_chars: usize) {
+    let value = limit_field(value, max_chars);
+    out.push_str(&format!("<{}>{}</{}>\n", tag, escape_xml_text(&value), tag));
+}
+
+fn limit_field(value: &str, max_chars: usize) -> String {
+    if value.len() <= max_chars {
+        value.to_string()
+    } else {
+        format!("{}... [truncated]", crate::truncate_utf8(value, max_chars))
+    }
+}
+
+fn strip_tagged_blocks(text: &str, tag: &str) -> String {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let mut out = String::new();
+    let mut rest = text;
+
+    while let Some(start) = rest.find(&open) {
+        out.push_str(&rest[..start]);
+        let after_open = &rest[start + open.len()..];
+        let Some(end) = after_open.find(&close) else {
+            out.push_str(rest);
+            return out;
+        };
+        rest = &after_open[end + close.len()..];
+    }
+    out.push_str(rest);
+    out
+}
+
+fn cap_summary_preserving_suffix(body: &str, suffix: &str, max_chars: usize) -> String {
+    let max_chars = max_chars.max(1);
+    if suffix.is_empty() {
+        return cap_text(body, max_chars);
+    }
+
+    if suffix.len() >= max_chars {
+        return cap_text(suffix, max_chars);
+    }
+
+    let available_for_body = max_chars - suffix.len();
+    if body.len() <= available_for_body {
+        return format!("{}{}", body, suffix);
+    }
+
+    let body_budget = available_for_body.saturating_sub(SUMMARY_TRUNCATED_MARKER.len());
+    format!(
+        "{}{}{}",
+        crate::truncate_utf8(body, body_budget),
+        SUMMARY_TRUNCATED_MARKER,
+        suffix
+    )
+}
+
+fn cap_text(text: &str, max_chars: usize) -> String {
+    if text.len() <= max_chars {
+        text.to_string()
+    } else {
+        let budget = max_chars.saturating_sub(SUMMARY_TRUNCATED_MARKER.len());
+        format!(
+            "{}{}",
+            crate::truncate_utf8(text, budget),
+            SUMMARY_TRUNCATED_MARKER
+        )
+    }
+}
+
+fn escape_xml_text(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn unescape_xml_text(input: &str) -> String {
+    input
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_task_notification_and_renders_reference() {
+        let text = r#"<task-notification>
+<task-id>job_123</task-id>
+<tool-use-id>call_456</tool-use-id>
+<tool>exec</tool>
+<status>completed</status>
+<output-file>/tmp/out&amp;1.txt</output-file>
+<summary>done</summary>
+</task-notification>"#;
+
+        let refs = collect_async_job_references_from_text(text);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].task_id, "job_123");
+        assert_eq!(refs[0].output_file.as_deref(), Some("/tmp/out&1.txt"));
+
+        let rendered = render_async_job_reference_section(&refs);
+        assert!(rendered.contains("<async-job-reference>"));
+        assert!(rendered.contains("<task-id>job_123</task-id>"));
+        assert!(rendered.contains("<output-file>/tmp/out&amp;1.txt</output-file>"));
+    }
+
+    #[test]
+    fn later_references_update_existing_task_status() {
+        let text = r#"<async-job-reference>
+<task-id>job_1</task-id>
+<status>running</status>
+</async-job-reference>
+<task-notification>
+<task-id>job_1</task-id>
+<status>completed</status>
+<output-file>/tmp/result.txt</output-file>
+</task-notification>"#;
+
+        let refs = collect_async_job_references_from_text(text);
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0].status.as_deref(), Some("completed"));
+        assert_eq!(refs[0].output_file.as_deref(), Some("/tmp/result.txt"));
+    }
+
+    #[test]
+    fn updated_reference_is_treated_as_recent_when_rendering_limit_applies() {
+        let mut text = String::new();
+        text.push_str("<async-job-reference>\n<task-id>job_0</task-id>\n<status>running</status>\n</async-job-reference>\n");
+        for i in 1..=32 {
+            text.push_str(&format!(
+                "<async-job-reference>\n<task-id>job_{}</task-id>\n<status>completed</status>\n</async-job-reference>\n",
+                i
+            ));
+        }
+        text.push_str("<task-notification>\n<task-id>job_0</task-id>\n<status>completed</status>\n<output-file>/tmp/job0.txt</output-file>\n</task-notification>\n");
+
+        let refs = collect_async_job_references_from_text(&text);
+        let rendered = render_async_job_reference_section(&refs);
+
+        assert!(rendered.contains("<task-id>job_0</task-id>"));
+        assert!(rendered.contains("<output-file>/tmp/job0.txt</output-file>"));
+        assert!(!rendered.contains("<task-id>job_1</task-id>"));
+    }
+
+    #[test]
+    fn strips_reference_blocks_without_dropping_surrounding_summary() {
+        let text = "Decision: keep output on disk.\n\n## Async job references\n<async-job-reference>\n<task-id>job_1</task-id>\n</async-job-reference>\nNext step: inspect output.";
+
+        let stripped = text_without_async_job_references(text);
+
+        assert!(stripped.contains("Decision: keep output on disk."));
+        assert!(stripped.contains("Next step: inspect output."));
+        assert!(!stripped.contains("<async-job-reference>"));
+        assert!(!stripped.contains("## Async job references"));
+    }
+
+    #[test]
+    fn summary_cap_keeps_async_reference_suffix() {
+        let refs = collect_async_job_references_from_text(
+            r#"<task-notification>
+<task-id>job_keep</task-id>
+<tool>exec</tool>
+<status>completed</status>
+<output-file>/tmp/result.txt</output-file>
+</task-notification>"#,
+        );
+
+        let summary = "x".repeat(5000);
+        let compacted = build_summary_with_async_job_references(&summary, &refs, 4096);
+        assert!(compacted.contains(SUMMARY_TRUNCATED_MARKER));
+        assert!(compacted.contains("<task-id>job_keep</task-id>"));
+        assert!(compacted.contains("<output-file>/tmp/result.txt</output-file>"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add compaction-aware parsing/rendering for async job notifications.
- Preserve task-id, tool-use-id, status, output-file, error, and summary as durable async job references during Tier 3 summarization and Tier 4 emergency compaction.
- Keep large async outputs out of model context while retaining enough pointers for later `job_status` or output-file inspection.

## Why
Async tool results are persisted to disk/DB, but the injected `<task-notification>` pointer could be summarized away or dropped during emergency compaction. This keeps the durable reference stable across compaction passes.

## Validation
- cargo fmt --all --check
- cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings
- cargo test -p ha-core -p ha-server --locked
- pnpm typecheck
- pnpm lint
- pnpm test
- git diff --check

Note: `pnpm test` emits the existing `Could not parse CSS stylesheet` warnings but exits successfully.