### PR TITLE
[codex] 🦭 Fix chat stop cancellation

### DIFF
--- a/crates/ha-core/src/agent/providers/anthropic_adapter.rs
+++ b/crates/ha-core/src/agent/providers/anthropic_adapter.rs
@@ -7,7 +7,7 @@
 //! Phase 2 of the LLM call unification — the public tool loop lives in
 //! [`super::super::streaming_loop`]. See `docs/architecture/side-query.md`.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -170,15 +170,17 @@ impl<'a> StreamingChatAdapter for AnthropicStreamingAdapter<'a> {
 
         // ── Send.
         let request_start = std::time::Instant::now();
-        let resp = client
+        let request = client
             .post(&api_url)
             .header("x-api-key", self.api_key)
             .header("anthropic-version", ANTHROPIC_API_VERSION)
             .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| anyhow::anyhow!("Anthropic API request failed: {}", e))?;
+            .json(&body);
+        let resp = match super::cancel::send_with_cancel(request, cancel).await {
+            Ok(Some(resp)) => resp,
+            Ok(None) => return Ok(super::cancel::cancelled_round_outcome()),
+            Err(e) => return Err(anyhow::anyhow!("Anthropic API request failed: {}", e)),
+        };
 
         // ── Log response status with rate-limit headers for debugging.
         if let Some(logger) = crate::get_logger() {
@@ -227,7 +229,11 @@ impl<'a> StreamingChatAdapter for AnthropicStreamingAdapter<'a> {
 
         if !resp.status().is_success() {
             let status = resp.status().as_u16();
-            let error_text = resp.text().await.unwrap_or_default();
+            let error_text = match super::cancel::read_text_with_cancel(resp, cancel).await {
+                Ok(Some(text)) => text,
+                Ok(None) => return Ok(super::cancel::cancelled_round_outcome()),
+                Err(_) => String::new(),
+            };
             if let Some(logger) = crate::get_logger() {
                 let error_preview = if error_text.len() > 500 {
                     format!("{}...", crate::truncate_utf8(&error_text, 500))
@@ -403,8 +409,6 @@ async fn parse_anthropic_sse(
     String,
     Option<u64>,
 )> {
-    use futures_util::StreamExt;
-
     let mut collected_text = String::new();
     let mut collected_thinking = String::new();
     let mut tool_calls: Vec<FunctionCallItem> = Vec::new();
@@ -419,11 +423,7 @@ async fn parse_anthropic_sse(
     let mut stream = resp.bytes_stream();
     let mut buffer = String::new();
 
-    while let Some(chunk) = stream.next().await {
-        if cancel.load(Ordering::SeqCst) {
-            stop_reason = Some("cancelled".to_string());
-            break;
-        }
+    while let Some(chunk) = super::cancel::next_chunk_or_cancel(&mut stream, cancel).await {
         let chunk = chunk?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
 
@@ -553,6 +553,12 @@ async fn parse_anthropic_sse(
                 }
             }
         }
+    }
+
+    if cancel.load(std::sync::atomic::Ordering::SeqCst) {
+        stop_reason = Some("cancelled".to_string());
+        let _ = current_tool.take();
+        tool_calls.clear();
     }
 
     if let Some(logger) = crate::get_logger() {

--- a/crates/ha-core/src/agent/providers/cancel.rs
+++ b/crates/ha-core/src/agent/providers/cancel.rs
@@ -1,0 +1,114 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use super::super::streaming_adapter::RoundOutcome;
+
+const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+pub(super) async fn wait_for_cancel(cancel: &Arc<AtomicBool>) {
+    wait_for_cancel_flag(cancel.as_ref()).await;
+}
+
+pub(super) async fn wait_for_cancel_flag(cancel: &AtomicBool) {
+    loop {
+        if cancel.load(Ordering::SeqCst) {
+            return;
+        }
+        tokio::time::sleep(CANCEL_POLL_INTERVAL).await;
+    }
+}
+
+pub(super) async fn sleep_or_cancel(duration: Duration, cancel: &Arc<AtomicBool>) -> bool {
+    if cancel.load(Ordering::SeqCst) {
+        return true;
+    }
+    tokio::select! {
+        biased;
+        _ = wait_for_cancel(cancel) => true,
+        _ = tokio::time::sleep(duration) => cancel.load(Ordering::SeqCst),
+    }
+}
+
+pub(super) async fn next_chunk_or_cancel<S>(
+    stream: &mut S,
+    cancel: &Arc<AtomicBool>,
+) -> Option<S::Item>
+where
+    S: futures_util::Stream + Unpin,
+{
+    next_chunk_or_cancel_flag(stream, cancel.as_ref()).await
+}
+
+pub(super) async fn next_chunk_or_cancel_flag<S>(
+    stream: &mut S,
+    cancel: &AtomicBool,
+) -> Option<S::Item>
+where
+    S: futures_util::Stream + Unpin,
+{
+    use futures_util::StreamExt;
+
+    if cancel.load(Ordering::SeqCst) {
+        return None;
+    }
+    let next = tokio::select! {
+        biased;
+        _ = wait_for_cancel_flag(cancel) => return None,
+        chunk = stream.next() => chunk,
+    };
+    if cancel.load(Ordering::SeqCst) {
+        return None;
+    }
+    next
+}
+
+pub(super) async fn send_with_cancel(
+    request: reqwest::RequestBuilder,
+    cancel: &Arc<AtomicBool>,
+) -> Result<Option<reqwest::Response>, reqwest::Error> {
+    if cancel.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
+    tokio::select! {
+        biased;
+        _ = wait_for_cancel(cancel) => Ok(None),
+        response = request.send() => {
+            if cancel.load(Ordering::SeqCst) {
+                Ok(None)
+            } else {
+                response.map(Some)
+            }
+        },
+    }
+}
+
+pub(super) async fn read_text_with_cancel(
+    response: reqwest::Response,
+    cancel: &Arc<AtomicBool>,
+) -> Result<Option<String>, reqwest::Error> {
+    if cancel.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
+    let text = tokio::select! {
+        biased;
+        _ = wait_for_cancel(cancel) => return Ok(None),
+        text = response.text() => text,
+    };
+    if cancel.load(Ordering::SeqCst) {
+        Ok(None)
+    } else {
+        text.map(Some)
+    }
+}
+
+pub(super) fn cancelled_round_outcome() -> RoundOutcome {
+    RoundOutcome {
+        text: String::new(),
+        thinking: String::new(),
+        tool_calls: Vec::new(),
+        usage: Default::default(),
+        ttft_ms: None,
+        stop_reason: Some("cancelled".to_string()),
+    }
+}

--- a/crates/ha-core/src/agent/providers/codex_adapter.rs
+++ b/crates/ha-core/src/agent/providers/codex_adapter.rs
@@ -183,10 +183,11 @@ impl<'a> StreamingChatAdapter for CodexStreamingAdapter<'a> {
                 self.account_id,
                 codex_user_agent(),
             );
-            let response = builder.body(body_json.clone()).send().await;
+            let response =
+                super::cancel::send_with_cancel(builder.body(body_json.clone()), cancel).await;
 
             match response {
-                Ok(resp) => {
+                Ok(Some(resp)) => {
                     if resp.status().is_success() {
                         if let Some(logger) = crate::get_logger() {
                             let ttfb_ms = request_start.elapsed().as_millis() as u64;
@@ -222,7 +223,12 @@ impl<'a> StreamingChatAdapter for CodexStreamingAdapter<'a> {
                     }
 
                     let status = resp.status().as_u16();
-                    let error_text = resp.text().await.unwrap_or_default();
+                    let error_text = match super::cancel::read_text_with_cancel(resp, cancel).await
+                    {
+                        Ok(Some(text)) => text,
+                        Ok(None) => return Ok(super::cancel::cancelled_round_outcome()),
+                        Err(_) => String::new(),
+                    };
 
                     if attempt < MAX_RETRIES && is_retryable_error(status, &error_text) {
                         let delay = BASE_DELAY_MS * 2u64.pow(attempt);
@@ -241,7 +247,14 @@ impl<'a> StreamingChatAdapter for CodexStreamingAdapter<'a> {
                                 Some(json!({"status": status, "attempt": attempt + 1, "delay_ms": delay, "error": &error_text}).to_string()),
                                 None, None);
                         }
-                        tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                        if super::cancel::sleep_or_cancel(
+                            std::time::Duration::from_millis(delay),
+                            cancel,
+                        )
+                        .await
+                        {
+                            return Ok(super::cancel::cancelled_round_outcome());
+                        }
                         last_error = Some(error_text);
                         continue;
                     }
@@ -268,6 +281,9 @@ impl<'a> StreamingChatAdapter for CodexStreamingAdapter<'a> {
                     let friendly = parse_error_response(status, &error_text);
                     return Err(anyhow::anyhow!("{}", friendly));
                 }
+                Ok(None) => {
+                    return Ok(super::cancel::cancelled_round_outcome());
+                }
                 Err(e) => {
                     if attempt < MAX_RETRIES {
                         let delay = BASE_DELAY_MS * 2u64.pow(attempt);
@@ -286,7 +302,14 @@ impl<'a> StreamingChatAdapter for CodexStreamingAdapter<'a> {
                                 Some(json!({"attempt": attempt + 1, "delay_ms": delay, "error": e.to_string()}).to_string()),
                                 None, None);
                         }
-                        tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                        if super::cancel::sleep_or_cancel(
+                            std::time::Duration::from_millis(delay),
+                            cancel,
+                        )
+                        .await
+                        {
+                            return Ok(super::cancel::cancelled_round_outcome());
+                        }
                         last_error = Some(e.to_string());
                         continue;
                     }

--- a/crates/ha-core/src/agent/providers/mod.rs
+++ b/crates/ha-core/src/agent/providers/mod.rs
@@ -1,5 +1,6 @@
 pub(super) mod anthropic;
 pub(super) mod anthropic_adapter;
+pub(super) mod cancel;
 pub(super) mod codex;
 pub(super) mod codex_adapter;
 pub(super) mod openai_chat;

--- a/crates/ha-core/src/agent/providers/openai_chat_adapter.rs
+++ b/crates/ha-core/src/agent/providers/openai_chat_adapter.rs
@@ -5,7 +5,7 @@
 //! `tool_calls[]` index accumulation + `<think>` tag filtering), and history
 //! persistence in Chat Completions' `tool_calls` + `role=tool` shape.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -372,7 +372,8 @@ async fn send_chat_request(
     api_key: &str,
     body: &Value,
     round: u32,
-) -> Result<reqwest::Response> {
+    cancel: &Arc<AtomicBool>,
+) -> Result<Option<reqwest::Response>> {
     let mut http_req = client
         .post(api_url)
         .header("Content-Type", "application/json");
@@ -380,13 +381,14 @@ async fn send_chat_request(
         http_req = http_req.header("Authorization", format!("Bearer {}", api_key));
     }
     let request_start = std::time::Instant::now();
-    let resp = http_req
-        .json(body)
-        .send()
+    let Some(resp) = super::cancel::send_with_cancel(http_req.json(body), cancel)
         .await
-        .map_err(|e| anyhow::anyhow!("OpenAI Chat API request failed: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("OpenAI Chat API request failed: {}", e))?
+    else {
+        return Ok(None);
+    };
     log_openai_chat_response(&resp, request_start, round);
-    Ok(resp)
+    Ok(Some(resp))
 }
 
 #[async_trait]
@@ -426,11 +428,19 @@ impl<'a> StreamingChatAdapter for OpenAIChatStreamingAdapter<'a> {
             &body,
         );
         let mut request_start = std::time::Instant::now();
-        let mut resp = send_chat_request(client, &api_url, self.api_key, &body, req.round).await?;
+        let Some(mut resp) =
+            send_chat_request(client, &api_url, self.api_key, &body, req.round, cancel).await?
+        else {
+            return Ok(super::cancel::cancelled_round_outcome());
+        };
 
         if !resp.status().is_success() {
             let status = resp.status().as_u16();
-            let error_text = resp.text().await.unwrap_or_default();
+            let error_text = match super::cancel::read_text_with_cancel(resp, cancel).await {
+                Ok(Some(text)) => text,
+                Ok(None) => return Ok(super::cancel::cancelled_round_outcome()),
+                Err(_) => String::new(),
+            };
             log_openai_chat_error(status, &error_text, req.round);
 
             if let Some(autofix) = maybe_auto_disable_thinking(
@@ -453,11 +463,27 @@ impl<'a> StreamingChatAdapter for OpenAIChatStreamingAdapter<'a> {
                     &retry_body,
                 );
                 request_start = std::time::Instant::now();
-                resp = send_chat_request(client, &api_url, self.api_key, &retry_body, req.round)
-                    .await?;
+                let Some(retry_resp) = send_chat_request(
+                    client,
+                    &api_url,
+                    self.api_key,
+                    &retry_body,
+                    req.round,
+                    cancel,
+                )
+                .await?
+                else {
+                    return Ok(super::cancel::cancelled_round_outcome());
+                };
+                resp = retry_resp;
                 if !resp.status().is_success() {
                     let retry_status = resp.status().as_u16();
-                    let retry_error = resp.text().await.unwrap_or_default();
+                    let retry_error = match super::cancel::read_text_with_cancel(resp, cancel).await
+                    {
+                        Ok(Some(text)) => text,
+                        Ok(None) => return Ok(super::cancel::cancelled_round_outcome()),
+                        Err(_) => String::new(),
+                    };
                     log_openai_chat_error(retry_status, &retry_error, req.round);
                     return Err(anyhow::anyhow!(
                         "OpenAI Chat API error ({}): {}",
@@ -492,11 +518,27 @@ impl<'a> StreamingChatAdapter for OpenAIChatStreamingAdapter<'a> {
                     &retry_body,
                 );
                 request_start = std::time::Instant::now();
-                resp = send_chat_request(client, &api_url, self.api_key, &retry_body, req.round)
-                    .await?;
+                let Some(retry_resp) = send_chat_request(
+                    client,
+                    &api_url,
+                    self.api_key,
+                    &retry_body,
+                    req.round,
+                    cancel,
+                )
+                .await?
+                else {
+                    return Ok(super::cancel::cancelled_round_outcome());
+                };
+                resp = retry_resp;
                 if !resp.status().is_success() {
                     let retry_status = resp.status().as_u16();
-                    let retry_error = resp.text().await.unwrap_or_default();
+                    let retry_error = match super::cancel::read_text_with_cancel(resp, cancel).await
+                    {
+                        Ok(Some(text)) => text,
+                        Ok(None) => return Ok(super::cancel::cancelled_round_outcome()),
+                        Err(_) => String::new(),
+                    };
                     log_openai_chat_error(retry_status, &retry_error, req.round);
                     return Err(anyhow::anyhow!(
                         "OpenAI Chat API error ({}): {}",
@@ -637,8 +679,6 @@ async fn parse_chat_completions_sse(
     String,
     Option<u64>,
 )> {
-    use futures_util::StreamExt;
-
     let mut collected_text = String::new();
     let mut collected_thinking = String::new();
     let mut tool_calls: Vec<FunctionCallItem> = Vec::new();
@@ -651,10 +691,7 @@ async fn parse_chat_completions_sse(
     let mut stream = resp.bytes_stream();
     let mut buffer = String::new();
 
-    while let Some(chunk) = stream.next().await {
-        if cancel.load(Ordering::SeqCst) {
-            break;
-        }
+    while let Some(chunk) = super::cancel::next_chunk_or_cancel(&mut stream, cancel).await {
         let chunk = chunk?;
         buffer.push_str(&String::from_utf8_lossy(&chunk));
 
@@ -788,12 +825,17 @@ async fn parse_chat_completions_sse(
         }
     }
 
-    // Move pending calls to final list, ordered by index.
-    let mut sorted_keys: Vec<usize> = pending_calls.keys().cloned().collect();
-    sorted_keys.sort();
-    for key in sorted_keys {
-        if let Some(tc) = pending_calls.remove(&key) {
-            tool_calls.push(tc);
+    if cancel.load(std::sync::atomic::Ordering::SeqCst) {
+        pending_calls.clear();
+        tool_calls.clear();
+    } else {
+        // Move pending calls to final list, ordered by index.
+        let mut sorted_keys: Vec<usize> = pending_calls.keys().cloned().collect();
+        sorted_keys.sort();
+        for key in sorted_keys {
+            if let Some(tc) = pending_calls.remove(&key) {
+                tool_calls.push(tc);
+            }
         }
     }
 

--- a/crates/ha-core/src/agent/providers/openai_responses_adapter.rs
+++ b/crates/ha-core/src/agent/providers/openai_responses_adapter.rs
@@ -11,7 +11,7 @@
 //! The SSE parser ([`parse_openai_sse`]) is shared with the Codex adapter
 //! since they speak the same protocol — only auth header and endpoint differ.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -601,11 +601,16 @@ impl<'a> StreamingChatAdapter for OpenAIResponsesStreamingAdapter<'a> {
             http_req = http_req.header("Authorization", format!("Bearer {}", self.api_key));
         }
         let request_start = std::time::Instant::now();
-        let resp = http_req
-            .json(&request)
-            .send()
-            .await
-            .map_err(|e| anyhow::anyhow!("OpenAI Responses API request failed: {}", e))?;
+        let resp = match super::cancel::send_with_cancel(http_req.json(&request), cancel).await {
+            Ok(Some(resp)) => resp,
+            Ok(None) => return Ok(super::cancel::cancelled_round_outcome()),
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "OpenAI Responses API request failed: {}",
+                    e
+                ))
+            }
+        };
 
         if let Some(logger) = crate::get_logger() {
             let status = resp.status().as_u16();
@@ -655,7 +660,11 @@ impl<'a> StreamingChatAdapter for OpenAIResponsesStreamingAdapter<'a> {
 
         if !resp.status().is_success() {
             let status = resp.status().as_u16();
-            let error_text = resp.text().await.unwrap_or_default();
+            let error_text = match super::cancel::read_text_with_cancel(resp, cancel).await {
+                Ok(Some(text)) => text,
+                Ok(None) => return Ok(super::cancel::cancelled_round_outcome()),
+                Err(_) => String::new(),
+            };
             if let Some(logger) = crate::get_logger() {
                 let error_preview = if error_text.len() > 500 {
                     format!("{}...", crate::truncate_utf8(&error_text, 500))
@@ -793,8 +802,6 @@ pub(in crate::agent) async fn parse_openai_sse(
     String,
     Option<u64>,
 )> {
-    use futures_util::StreamExt;
-
     let request_id = sse_request_id(&resp);
     let mut collected_text = String::new();
     let mut collected_thinking = String::new();
@@ -808,10 +815,7 @@ pub(in crate::agent) async fn parse_openai_sse(
     let mut buffer = String::new();
     let mut saw_stream_error = false;
 
-    while let Some(chunk) = stream.next().await {
-        if cancel.load(Ordering::SeqCst) {
-            break;
-        }
+    while let Some(chunk) = super::cancel::next_chunk_or_cancel_flag(&mut stream, cancel).await {
         let chunk = match chunk {
             Ok(chunk) => chunk,
             Err(err) => {
@@ -885,7 +889,8 @@ pub(in crate::agent) async fn parse_openai_sse(
         }
     }
 
-    if !buffer.trim().is_empty() {
+    let cancelled = cancel.load(std::sync::atomic::Ordering::SeqCst);
+    if !cancelled && !buffer.trim().is_empty() {
         handle_openai_sse_event_block(
             &request_id,
             buffer.trim(),
@@ -901,8 +906,15 @@ pub(in crate::agent) async fn parse_openai_sse(
     }
 
     // Drain remaining pending calls.
-    let dropped_pending_calls =
-        finalize_pending_tool_calls(pending_calls, &mut tool_calls, saw_stream_error);
+    if cancelled {
+        pending_calls.clear();
+        tool_calls.clear();
+    }
+    let dropped_pending_calls = finalize_pending_tool_calls(
+        pending_calls,
+        &mut tool_calls,
+        saw_stream_error || cancelled,
+    );
     if dropped_pending_calls > 0 {
         if let Some(logger) = crate::get_logger() {
             logger.log(

--- a/crates/ha-core/src/agent/streaming_loop.rs
+++ b/crates/ha-core/src/agent/streaming_loop.rs
@@ -413,6 +413,10 @@ impl AssistantAgent {
             last_round_thinking = outcome.thinking.clone();
             total_usage.accumulate_round(&outcome.usage);
 
+            if cancel.load(Ordering::SeqCst) {
+                break;
+            }
+
             if adapter.loop_should_exit(&outcome) {
                 natural_exit = true;
                 break;


### PR DESCRIPTION
## What changed
- Added a cancellation-aware provider helper for HTTP/SSE waits.
- Raced provider HTTP sends, error-body reads, SSE chunk waits, and Codex retry sleeps against the chat cancellation flag.
- Dropped pending/unexecuted tool calls when a stream is cancelled, so cancellation does not dirty tool-call history.

## Root cause
- The stop flag was set, but provider futures before the first token and during SSE waits did not observe it.
- Runtime cancellation counts covered async jobs/subagents/processes, not the active LLM HTTP request wait.

## Impact
- Stopping before the first token and during streaming should now return promptly while preserving any partial assistant text.

## Validation
- cargo fmt --all --check
- cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings
- cargo test -p ha-core -p ha-server --locked
- pnpm typecheck
- pnpm lint
- pnpm test
- git push pre-push hook reran the checks and passed
