### PR TITLE
release: v0.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ ha-core 主要领域：`agent/` `chat_engine/` `context_compact/` `memory/` `ski
 - **三 Crate 架构**：业务逻辑全进 `ha-core`（**零 Tauri 依赖**），`ha-server` 与 `src-tauri` 只做适配薄壳
 - **EventBus + CoreState**：核心层用 `ha-core::EventBus` 替代 Tauri `APP_HANDLE`；状态走 `CoreState`，Tauri 用 `State<AppState>`，server 用 axum `Extension`
 - **Transport 抽象**：前端走 [`src/lib/transport.ts`](src/lib/transport.ts)，**新 invoke 必须同时实现 Tauri + HTTP 两套适配**
-- **桌面 release 单一来源**：`package.json`，`pnpm version` 钩子（[`scripts/sync-version.mjs`](scripts/sync-version.mjs)）同步 `src-tauri/Cargo.toml` / `tauri.conf.json` / `crates/ha-server/Cargo.toml`（后者承载 Docker headless bin `hope-agent-server` 的 `CARGO_PKG_VERSION`，必须随桌面版本同步 —— `--version` 与 `app_update` `current_version` 都读它）；CI tag 构建前跑 `pnpm release:verify -- --tag vX.Y.Z` 校验全部上面四个来源 + `Cargo.lock` 一致。Updater 私钥严禁入仓
+- **桌面 release 单一来源**：`package.json`，`pnpm version` 钩子（[`scripts/sync-version.mjs`](scripts/sync-version.mjs)）同步 `src-tauri/Cargo.toml` / `tauri.conf.json` / `crates/ha-server/Cargo.toml` / `crates/ha-core/Cargo.toml`。`ha-server` 承载 Docker headless bin `hope-agent-server` 的 `CARGO_PKG_VERSION`，必须随桌面版本同步——`--version` 与 `app_update` `current_version` 都读它；`ha-core` 不发布也不是 user-facing binary，但作为 workspace 共享 crate 跟着 bump 让整个产品版本一致。CI tag 构建前跑 `pnpm release:verify -- --tag vX.Y.Z` 校验上面五个来源 + `Cargo.lock` 一致。Updater 私钥严禁入仓
 - **API Key 鉴权**：HTTP/WS 走 Bearer Token（[`ha-server/middleware.rs`](crates/ha-server/src/middleware.rs)），`/api/health` 免鉴权；浏览器 WS 用 `?token=` 兼容
 - **运行模式 getter**：`ha_core::runtime_role()` / `is_desktop()`，避免给共享函数加 mode 参数
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-05-19
 
 ### Removed
 
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **语音识别（STT）子系统**：新增独立的「语音识别」一级设置面板，覆盖云端 Provider（OpenAI Whisper / gpt-4o-transcribe、Groq、DashScope Qwen3-ASR、StepFun、SiliconFlow、Deepgram、AssemblyAI、Azure Speech、火山豆包 BigModel、讯飞 IAT）和 4 个本地 OpenAI 兼容后端（whisper.cpp / faster-whisper / FunASR / sherpa-onnx，一键探活 + 一键 upsert）。ChatInput 右下角麦克风按钮录音后自动转录塞入输入框；IM Channel 账号开 `autoTranscribeVoice` 后入站语音消息自动转录（12 语言本地化 `[语音转录]` 前缀，原音频附件保留）。macOS bundle 同 PR 加入 `NSMicrophoneUsageDescription` + `com.apple.security.device.audio-input`。`ha-settings` 技能登记 `stt_providers` / `active_stt_model` / `stt_fallback_models` 为只读 category（凭据 redact），`im_auto_transcribe` 为 medium 风险写入。详见 [`docs/architecture/stt.md`](docs/architecture/stt.md)。
+- **STT 全 provider 协议核验 + 录音 UX 打磨**：在 STT 子系统首版基础上把所有 streaming provider（OpenAI / Azure / Volcengine 豆包 BigModel / Xunfei 讯飞 IAT / Deepgram / AssemblyAI）按 vendor SDK 原文重新核验信令、握手与帧格式；新增 OpenAI 系 Chat Completions ASR 通用适配。ChatInput 录音 UX 整体重写：新增 RecordingBar / Waveform 实时波形 / PCM16 streamer，VoicePanel 配置表面整理 + provider preset 一键填，新增通用 SecretInput 组件；12 语言文案齐全。 (#227)
 - **Agent 编辑器：异步工具后台化策略三选**：`asyncToolPolicy` 字段（`model-decide` / `always-background` / `never-background`）此前只能手编 `agents/<id>/agent.json`，现在加到「能力」标签页的工具区，与 `maxToolRounds` / `sandbox` 同列。控制 async-capable 工具（`exec` / `web_search` / `image_generate`）何时 detach 到后台 —— 跟审批正交，不影响弹窗。12 语言齐全。
 - **IM 文本审批可用性增强（无按钮渠道：WeChat / Signal / iMessage / IRC / WhatsApp）**：审批回复 parsing 从「只接 `1`/`2`/`3`」扩到大小写无关 + 中英自然语言白名单（`yes` / `y` / `ok` / `allow` / `好` / `同意` / `允许` / `2` / `always` / `总是` / `永远` / `3` / `no` / `n` / `deny` / `拒绝` / `取消` 等）；审批 prompt 渲染 `#tag` 6 字符短前缀，多个 pending 时可用 `yes#abc123` 精准定位（不限于 LIFO 栈顶）；超时不再 IM 端静默 —— 走新的 `approval_timed_out` EventBus 事件给 chat 发一条「⏱ approval timed out」通知；pending 期间用户发非审批消息时 1 分钟节流提示一次「你有 N 个待审批，回 1/2/3 或 yes/no」，照常进入新 turn 不绑架用户。
 - **`hope-agent server` 新增 `--auto-approve-tools` flag / `HA_SERVER_AUTO_APPROVE_TOOLS=1` env**：headless 部署（CI / Docker / pipeline）下 HTTP 客户端通常不接审批 UI，所有工具调用会等满 5 分钟超时再被 deny。新开关让 HTTP 入口的 chat 全部按「自动批准工具」处理（permission engine 的 dangerous-commands / protected-paths / Plan Mode ask 仍执行），等同桌面 IM 渠道账号勾「auto-approve tools」。进程态、不持久化、启动 stderr 红字 banner 提醒。比 `--dangerously-skip-all-approvals` 更窄；常规 headless 推荐用这个。
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Agent 工具开关语义收敛**：`capabilities.tools.allow/deny` 现在只表示非 Core 内置工具的显式开 / 关覆盖；Core 工具始终可用，Standard / Configured 工具缺省走代码里的 tier 默认值，deferred 只决定已开启工具的 schema 加载方式。移除独立 `capabilityToggles` / `toolOverrides` 分支，OpenClaw 导入不再映射两边语义不同的工具权限；飞书业务工具仍默认关闭，需在 Agent 设置里显式开启，UI 列表补充中文语义化名称与说明。
 - **浏览器工具 27 → 8 action 收敛**：原来散乱的 `connect / launch / navigate / take_snapshot / click / fill / fill_form / hover / drag / press_key / upload_file / evaluate / wait_for / handle_dialog / resize / scroll / list_profiles / save_pdf` 等 27 个 action 全部下沉到 8 个高层 action（`status / profile / tabs / navigate / snapshot / act / observe / control`）。工具默认进 deferred 池（`tool_search` 按需暴露），常态不占 system prompt。配套新 [`ha-browser` bundled skill](skills/ha-browser/SKILL.md) 教模型标准 `status → tabs → snapshot → act` loop、stale-ref 自恢复、登录/2FA/captcha 阻塞情形清单。
+- **异步工具后台化语义硬化**：`run_in_background` / 新增的 `async_job_timeout_secs` 等 async-job 控制参数在进入工具实现前由外层框架统一 strip，工具自己不再看见；后台完成后注入的提示词从 `<tool-job-result>` 重命名为 `<task-notification>`（与磁盘溢出的 `output-file` 配对），并在文案里明确「`job_status` 只用于拿快照，不要再用来 block」。背景任务接入新的 cancel token + 5s cleanup grace，stop / 会话切换时能干净地停掉孤儿进程；`exec` 等长跑工具内部新增 `suppress_global_tool_timeout` / `suppress_result_disk_persistence` 旁路，避免外层超时与后台任务自身的 deadline 互相打架。 (#215)
 
 ### Added
 
@@ -45,8 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **浏览器 act.upload 路径安全闸门**：上传文件前 `canonicalize` 路径并按 `permission::protected_paths` 检查（默认覆盖 `~/.ssh/`、`~/.aws/`、`*.pem`、`*.key`、`*secret*` 等），拒绝 prompt injection 把本机敏感文件塞进网页 file input 的攻击面。
 - **浏览器 control.evaluate 走 ask_user_question 审批**：任意 JS 执行是浏览器工具最危险的出站口，每次调用前都弹模态确认（脚本预览 280 字），用户取消 = 工具失败；YOLO / `permission.global_yolo` 模式按用户已知风险跳过；非交互上下文（缺 session_id）默认 deny。SSRF 字面量 regex 仍保留为 best-effort 第一道闸门。
 - **官方 Docker 镜像 + docker-compose 部署**：新增多架构容器镜像 `ghcr.io/shiwenwen/hope-agent`（覆盖 `linux/amd64` / `linux/arm64`），随每次 Release Tag 自动构建发布；浏览器访问容器暴露端口即得完整 Web GUI 与桌面端等价。默认 loopback + 浏览器 token 输入对话框 + `?token=` URL 一次性 bootstrap；`app_update` 工具在容器内检测后引导 `docker pull` 升级而非 binary swap。 (#171)
+- **侧边栏 section 折叠状态持久化**：左侧栏「项目」/「Agent」/「会话」等分组的展开/折叠状态现在按 section 独立写入 `localStorage`，刷新或重启 App 后保留上次布局；通用 `SidebarSectionHeader` 抽出一份，复用同一交互与样式。 (#216)
 
 ### Fixed
+
+- **按下「停止」时真正取消 provider 等待**：以前 stop 按钮只在 streaming 帧之间起作用，如果正在等 Anthropic / OpenAI Chat / OpenAI Responses / Codex 的首个 byte（连接 + headers + 第一帧），stop 要等 provider 自然返回才生效，用户体验是「按了没反应」。本期 4 个 adapter 统一接入新的 `cancel` helper：`tokio::select!` 同时监听 `cancel_token` 与 reqwest 流，stop 命中立即 abort HTTP 连接、丢已缓冲字节，回到引擎走统一 turn 终止管线。 (#224)
+- **桌面端 markdown 路径链接稳健性 + 聊天流末尾不再被截**：(1) MarkdownRenderer 对绝对路径链接的判定收紧到 OS 真实根（macOS / Linux `/`，Windows 盘符），不再误把以 `/` 开头的相对 URL 当本地路径；点击走 `open_directory` 前在 Rust 侧用 `canonicalize` + 用户家目录范围校验，拒绝越界路径。(2) 修复流式输出底部 follow 的边界：MessageList 在用户已经滚到底时 delta 到达自动跟随到最后一行，途中用户主动上拉则不再被强行拽回底部，回到底再继续 auto-follow。 (#214)
 
 - **#218 / #219 / #220 post-merge `/simplify` + `/codex:review` 反馈整体修复**：(1) IM 审批 `TEXT_PENDING` 在 cancel-path / timeout-path 都通过新的 `drop_pending_by_request_id` helper 清理，修复长跑 IM 部署的 stale entry 泄漏；(2) 节流 map 换用 `TtlCache` 限容；(3) `id_tag` 改走 `truncate_utf8` 对齐红线；(4) `approval_timed_out` event payload 走 derived struct；(5) `parse_approval_reply` 用 `to_ascii_lowercase` + alias 表抽 const arrays（便于加日 / 韩 / 西等语言）；(6) `permission.imApprovalHintThrottleSecs` 暴露为 config（默认 60s）；(7) `#tag` 后缀拼错时不再 fall-through 走新 turn，而是消费消息 + 明确列出可用 tags（消除「你有 N 个 pending」+「当作新对话」的语义冲突）；(8) `hope-agent server` 启用 auto-approve 时在 `init_runtime` 后写一条 `app_warn!` 入 `logs.db`；banner 解析挪到 `server` 子命令分支内，`hope-agent --version` 不再因 env 启用而附带 banner；CLI helper rename `cli_flag_active` → `is_active`。(9) Agent 编辑器 `asyncToolPolicy` 三选 i18n 重构为嵌套对象结构（与 `permissionMode` / `asyncToolJobNames` 对齐），`AsyncToolPolicy` type 显式 export，多个 const 合并为单一数组。(10) `--auto-approve-tools` 的文档 / banner / help / `app_warn!` 全面修正：原本误称「engine gates（dangerous-commands / protected-paths）仍执行」，实际上 `ChatEngineParams.auto_approve_tools=true` 是「全自动放行」语义，与 IM 账户级 `auto_approve_tools=true` 等价 —— 危险命令也直接执行。现已明确标注「不要用于不可信租户」。(11) IM 文本审批超时通知按 `permission.approval_timeout_action` 渲染：`deny` 仍显示「tool call has been denied」，`proceed` 改为「tool call continued anyway — any side effects have already happened」，避免在 tool 实际执行后误告用户「已拒绝」。(12) IM 文本审批 prompt 不再写死「Reply within 5 min」，按 `permission.approval_timeout_secs` 渲染实际时限（300→「5 min」/ 120→「2 min」/ 90→「90s」/ 0→「no time limit」），跟用户的实际等待时间一致。
 - **修复异步后台化路径下 `exec` 工具静默跳过审批的安全 bug**：原先任何会进 auto-background 或 `run_in_background:true` 路径的 shell 命令都会完全绕过审批（含 `git push --force` / `rm -rf` 这类 dangerous-commands），本版起按权限模式正常审计。**操作影响**：之前依赖 IM 账号未勾「自动批准工具」也不弹审批的部署，从这版起每条 `exec` 都会按规则弹审批；想保持静默执行请显式勾选账号「自动批准工具」。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3223,7 +3223,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.1.0"
+version = "0.3.0"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.2.0"
+version = "0.3.0"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.3.0.en.md
+++ b/docs/release-notes/v0.3.0.en.md
@@ -1,0 +1,52 @@
+# Hope Agent 0.3.0 — Voice Input · Desktop Control · Browser Automation
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.3.0/docs/release-notes/v0.3.0.md) · **English**
+
+> Release date: 2026-05-19
+
+> Full list in [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.3.0/CHANGELOG.md#030---2026-05-19).
+
+v0.3 moves Hope Agent from "chat + tool calls" to a form that can hear the user, operate the desktop, and see the screen. A new STT subsystem ships voice input and inbound IM voice auto-transcribe, the first cut of native macOS desktop control lands, browser automation got a full surface + runtime rewrite, and a stack of usability issues in IM text approvals are fixed end-to-end.
+
+## STT subsystem
+
+- **Desktop**: a mic button at the bottom-right of ChatInput records, transcribes, and drops the text straight into the input box
+- **IM**: turn on `autoTranscribeVoice` for an account and inbound voice messages are auto-transcribed with a localized `[Voice transcript]` prefix in 12 languages (original audio attachment is preserved)
+- **10 cloud providers + 4 local backends**: OpenAI Whisper / gpt-4o-transcribe, Groq, DashScope Qwen3-ASR, StepFun, SiliconFlow, Deepgram, AssemblyAI, Azure Speech, Volcengine BigModel, iFlytek IAT; local one-click probe + upsert for whisper.cpp / faster-whisper / FunASR / sherpa-onnx
+- **Every streaming protocol verified against the vendor SDK**, paired with a full ChatInput recording UX rewrite (RecordingBar + live waveform + PCM16 streamer), a tidied VoicePanel configuration surface, and one-click provider presets
+- macOS bundle adds `NSMicrophoneUsageDescription` + audio-input entitlement in the same PR
+
+## Native macOS desktop control
+
+New built-in `mac_control` tool and `ha-mac-control` skill cover permission readiness, app/window discovery and activation, AX snapshot / wait, click / type, menus, dialogs, and window move/resize/close. The tool goes through the unified approval engine, the right-side Mac Control panel renders live desktop state, and HTTP / server modes return the unsupported shape. Paired with the new macOS system permissions page v2, which covers the full permissions catalog (accessibility, screen recording, input monitoring, media / personal data / file access / automation / notifications). Permissions that can be probed or requested natively use the macOS API; the rest are tagged "manual confirmation" with a deep link into System Settings.
+
+## Browser automation rewrite
+
+- **27 → 8 action consolidation**: scattered `connect / launch / click / fill / press_key / evaluate / ...` actions collapsed into 8 high-level actions (`status / profile / tabs / navigate / snapshot / act / observe / control`). Tools default to the deferred pool so they don't sit in the system prompt; new [`ha-browser` skill](https://github.com/shiwenwen/hope-agent/blob/v0.3.0/skills/ha-browser/SKILL.md) teaches the standard loop and stale-ref auto-recovery
+- **Live BrowserPanel (chat right-side mirror)**: while the agent drives the browser, a live mirror panel opens on the right and pushes a frame after every `act` / `navigate` / `tabs`, with a 1-second poll fallback to catch manual interactions; a "Take over" button pauses auto-refresh so the user can drive Chrome directly
+- **Chromium runtime auto-install**: if Chrome / Edge / Brave / Chromium is missing, one click downloads a pinned Chromium snapshot (~150 MB) and extracts it to `~/.hope-agent/browser/runtime/`; subsequent `launch` calls use it automatically. The official Docker image now bundles chromium + fonts so headless works out of the box in containers
+- **Three outbound safety gates**: `navigate` / `tabs.new` / `profile.connect` / `control.evaluate` all flow through SSRF checks to block prompt injections that point the browser at intranets or cloud metadata; `act.upload` paths run through `protected_paths` to refuse uploads of `~/.ssh/`-class files into web file inputs; `control.evaluate` (arbitrary JS) requires an `ask_user_question` modal confirmation (YOLO skips)
+- **Settings → Browser UX rewrite**: top-level "Independent / Take over user Chrome" mode radio plus an inline doctor banner. If port 9222 is detected, it shows "Found Chrome at … [Attach]"; if not, a single button launches a separate user-data-dir Chrome (leaving the user's everyday profile alone)
+- **`chrome-devtools-mcp` backend removed**: browser automation now runs only on direct CDP — no Node.js / npx dependency. Old `"backend": "auto" | "mcp"` in `config.json` is silently ignored
+
+## IM approval usability
+
+- **Async-path `exec` silent approval-bypass security fix**: any shell command going through auto-background or `run_in_background:true` (including dangerous-commands like `git push --force` / `rm -rf`) used to skip approval entirely. As of this version it is properly audited per permission mode. **Operational impact**: deployments that previously enjoyed silent exec on IM accounts without "auto-approve tools" enabled will now see an approval prompt on every shell call — toggle the account's "auto-approve tools" explicitly to restore silent execution
+- **Buttonless-channel (WeChat / Signal / iMessage / IRC / WhatsApp) text reply parsing expanded**: from "only `1`/`2`/`3`" to case-insensitive English + Chinese natural-language whitelist (`yes` / `好` / `同意` / `always` / `总是` / `no` / `拒绝`, etc.); the prompt renders a 6-char `#tag` short prefix and the parser supports `yes#abc123` for precise targeting when multiple approvals are pending. Timeouts are no longer silent — a new `approval_timed_out` event posts a "⏱ approval timed out" notice into the chat
+- **`hope-agent server --auto-approve-tools` flag / `HA_SERVER_AUTO_APPROVE_TOOLS=1` env**: in headless deployments (CI / Docker / pipeline) the HTTP client usually has no approval UI, so every tool call used to wait out the 5-minute timeout and get denied. The new switch routes HTTP chats with "auto-approve tools" semantics (**caution**: equivalent to an IM account's `auto_approve_tools=true` — dangerous commands also run; **do not use on untrusted multi-tenant deployments**)
+
+## Chat workbench visuals & layout
+
+- The main UI is split into a global rail + session pane two-level navigation; right-side Browser / Plan / Diff / Canvas / Team / Mac Control panels share a unified shell; on empty sessions the input is centered and widened with the brand logo, dropping back to the bottom once messages exist; default window size enlarged to 1360×860
+- **Chat messages — Markdown / plain-text toggle**: user messages now default to Markdown rendering like model messages; a hover action toggles between modes. Both modes auto-linkify bare URLs (`https://...` / `www.example.com` / emails)
+- **Per-session model switching no longer pollutes the global default**: ChatPanel's ModelPicker, the desktop `/model` card, and the IM `/model` command all pin the model to the current session only and stop writing `config.active_model`. The resolution order on next send becomes **session > agent.primary > config.active_model**. The global default is now only changed from Settings → Models
+- **Sidebar section collapse state persisted** + **macOS permissions page v2** + **narrow-column polish** (working-directory entry as icon-only; incognito moved to the top title bar; right panels auto-collapse the left session list when opened)
+
+## Misc
+
+- **Dashboard "Local models" panel**: Ollama runtime state, loaded model & VRAM, local-model call count / tokens / avg TTFT / error rate in the selected window, plus in-flight install / pull / warmup background jobs at a glance
+- **Skill auto-review "five-gate waterfall" tightened**: pure-chat conversations no longer trigger skill creation; model self-score hard threshold + user-deleted-topic blacklist + step-count / naming / command-specificity lint catch the rest. Settings → Skills → Evolution panel tunes each field, plus a "recent rejections" timeline and a draft-merge scan
+- **MCP tool toggle hot-reload consistency**: changing server `allowedTools` / `deniedTools` no longer wipes Ready MCP tools and force-Reconnects; server `autoApprove` only actually skips general-tool approvals when `trustLevel=Trusted`
+- **Agent tool-toggle semantics narrowed**: `capabilities.tools.allow/deny` is now only an explicit override for non-Core built-in tools; Core tools are always available; the separate `capabilityToggles` / `toolOverrides` branches are removed
+- **Async tool backgrounding semantics hardened**: `run_in_background` and the new `async_job_timeout_secs` control parameters are stripped by the outer framework before reaching the tool; background-completion notice renamed to `<task-notification>`; cancel token + 5s cleanup grace let stop / session-switch cleanly terminate orphan processes
+- **Stop button truly cancels provider waits**: all 4 provider adapters wire into a new cancel helper, so pressing stop aborts the HTTP connection immediately instead of waiting for the provider to return on its own

--- a/docs/release-notes/v0.3.0.md
+++ b/docs/release-notes/v0.3.0.md
@@ -1,0 +1,52 @@
+# Hope Agent 0.3.0 — 语音输入 · 桌面控制 · 浏览器自动化
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.3.0/docs/release-notes/v0.3.0.en.md)
+
+> 发布日期：2026-05-19
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.3.0/CHANGELOG.md#030---2026-05-19)。
+
+v0.3 把 Hope Agent 从「聊天 + 工具调用」推进到「能听见用户、能操控桌面、能看见屏幕」的形态。新增独立的语音 STT 子系统覆盖桌面输入与 IM 入站自动转写，macOS 原生桌面控制落地第一个版本，浏览器自动化重做了工具表面与运行时，并把 IM 文本审批的可用性问题成片修掉。
+
+## 语音 STT 子系统
+
+- **桌面端**：ChatInput 右下角麦克风按钮录音后自动转录塞入输入框
+- **IM 端**：账号开 `autoTranscribeVoice` 后，入站语音消息自动转录为 12 语言本地化 `[语音转录]` 前缀（原音频附件保留）
+- **10 个云端 provider + 4 个本地 backend**：OpenAI Whisper / gpt-4o-transcribe、Groq、DashScope Qwen3-ASR、StepFun、SiliconFlow、Deepgram、AssemblyAI、Azure Speech、火山豆包 BigModel、讯飞 IAT；本地一键探活 + 一键 upsert whisper.cpp / faster-whisper / FunASR / sherpa-onnx
+- **所有 streaming provider 协议按 vendor SDK 原文核验**，配 ChatInput 录音 UX 整体重写（RecordingBar + 实时波形 + PCM16 streamer），VoicePanel 配置表面整理 + provider preset 一键填
+- macOS bundle 同 PR 加入 `NSMicrophoneUsageDescription` + audio-input entitlement
+
+## macOS 原生桌面控制
+
+新增内置 `mac_control` 工具与 `ha-mac-control` skill，覆盖权限 readiness、应用与窗口发现激活、AX snapshot / wait、点击 / 输入、菜单、对话框、窗口移动缩放关闭。工具接入统一审批引擎，右侧 Mac Control 面板实时展示桌面状态，HTTP / server 模式保持 unsupported 形状返回。配套 macOS 系统权限页 v2，覆盖辅助功能、屏幕录制、输入监控、媒体 / 个人数据 / 文件访问 / 自动化 / 通知等全量权限，可原生检测或请求的走 macOS API，无法可靠检测的标记为「手动确认」并跳转系统设置。
+
+## 浏览器自动化重做
+
+- **27 → 8 action 收敛**：散乱的 `connect / launch / click / fill / press_key / evaluate / ...` 等 27 个 action 全部下沉到 8 个高层 action（`status / profile / tabs / navigate / snapshot / act / observe / control`）。工具默认进 deferred 池，常态不占 system prompt；配套新 [`ha-browser` skill](https://github.com/shiwenwen/hope-agent/blob/v0.3.0/skills/ha-browser/SKILL.md) 教模型标准 loop 与 stale-ref 自恢复
+- **实时 BrowserPanel（chat 右侧镜像）**：agent 操作浏览器时右侧自动弹出实时镜像面板，每次 `act` / `navigate` / `tabs` 后立即推一帧 + 1 秒兜底轮询捕捉用户手动操作；面板支持「我来操作」按钮暂停自动刷新让用户接管 Chrome
+- **Chromium 运行时自动安装兜底**：系统没装 Chrome / Edge / Brave / Chromium 时一键下载 pinned Chromium snapshot（~150 MB）解压到 `~/.hope-agent/browser/runtime/`，下载完后 `launch` 自动使用；Docker 镜像同步内置 chromium + 字体让 headless 在容器内开箱即用
+- **三道出站安全闸门**：`navigate` / `tabs.new` / `profile.connect` / `control.evaluate` 全部经 SSRF 检查防 prompt injection 让浏览器访问内网与 cloud metadata；`act.upload` 路径走 `protected_paths` 检查拒绝把 `~/.ssh/` 等敏感文件塞进网页 file input；`control.evaluate` 任意 JS 执行强制走 `ask_user_question` 模态确认（YOLO 跳过）
+- **设置 → 浏览器 UX 重写**：顶部「独立浏览器 / 接管用户态 Chrome」Mode Radio + 内嵌 doctor banner，探到 9222 显示「Found Chrome at … [Attach]」，未探到一键启动独立 user-data-dir 的 Chrome（不动用户日常 profile）
+- **删除 `chrome-devtools-mcp` backend**：浏览器自动化只剩 CDP 直连一条路径，不再需要 Node.js / npx；老 `config.json` 里的 `"backend": "auto" | "mcp"` 字段被静默忽略
+
+## IM 审批可用性大改进
+
+- **异步路径 `exec` 静默绕审批的安全 bug 修复**：原先任何走 auto-background 或 `run_in_background:true` 的 shell 命令都会完全绕过审批（含 `git push --force` / `rm -rf` 这类 dangerous-commands），本版起按权限模式正常审计。**操作影响**：之前依赖 IM 账号未勾「自动批准工具」也不弹审批的部署，从这版起每条 `exec` 都会弹审批；想保持静默执行请显式勾选账号「自动批准工具」
+- **无按钮渠道（WeChat / Signal / iMessage / IRC / WhatsApp）审批文本回复增强**：从「只接 `1`/`2`/`3`」扩到大小写无关 + 中英自然语言白名单（`yes` / `好` / `同意` / `always` / `总是` / `no` / `拒绝` 等）；审批 prompt 渲染 `#tag` 6 字符短前缀，多个 pending 时 `yes#abc123` 精准定位；超时不再 IM 端静默——走新的 `approval_timed_out` 事件给 chat 发一条「⏱ approval timed out」通知
+- **`hope-agent server --auto-approve-tools` flag / `HA_SERVER_AUTO_APPROVE_TOOLS=1` env**：headless 部署（CI / Docker / pipeline）下 HTTP 客户端通常不接审批 UI，原来所有工具调用会等满 5 分钟超时被 deny。新开关把 HTTP 入口的 chat 全部按「自动批准工具」处理（**注意**：与 IM 账户级 `auto_approve_tools=true` 同语义，危险命令也直接执行，**不要用于不可信租户**）
+
+## 聊天工作台视觉与布局改造
+
+- 主界面切成全局 rail + 会话 pane 两层导航，右侧 Browser / Plan / Diff / Canvas / Team / Mac Control 面板统一为共享 shell；空会话时输入框居中加宽并显示品牌 Logo，有消息后回到底部；默认窗口尺寸放大到 1360×860
+- **聊天消息 Markdown / 纯文本渲染可切换**：用户消息现在与模型消息一样默认 Markdown 渲染，气泡 hover 操作区新增切换按钮；两种模式都会自动识别裸链接（`https://...` / `www.example.com` / 邮箱）渲染为可点击超链
+- **会话级模型切换不再污染全局默认**：聊天界面 ModelPicker、桌面 `/model` 卡片、IM `/model` 命令现在都只把模型固定到当前会话，不再改 `config.active_model`；下次发消息时解析顺序变为 **session > agent.primary > config.active_model**。全局默认模型仅由「设置 → 模型」面板修改
+- **侧边栏 section 折叠状态持久化** + **macOS 系统权限页 v2** + **窄栏自适应整理**（输入框工作目录入口纯图标 + 无痕模式入口移至顶部标题栏 + 右侧面板打开时自动收起左侧 session 列表）
+
+## 其它
+
+- **Dashboard 新增「本地模型」面板**：Ollama 运行态、当前加载模型与 VRAM 占用、本地模型在所选时间窗内的调用次数 / Token / 平均 TTFT / 错误率，以及在跑的安装 / 拉取 / 预热后台任务一览
+- **技能自动审核「五道瀑布」收紧**：纯聊天对话不再触发自动建技能 + 模型自评分硬阈值 + 用户已删主题黑名单 + 步骤数 / 命名 / 命令具体度 lint；设置 → 技能 → 演化面板可逐字段微调 + 「最近被拒原因」时间线 + 草稿合并扫描
+- **MCP 工具开关热更新一致性**：修改 server `allowedTools` / `deniedTools` 不再把已 Ready 的 MCP 工具清空到必须手动 Reconnect；server `autoApprove` 现在只在 `trustLevel=Trusted` 时真正跳过审批
+- **Agent 工具开关语义收敛**：`capabilities.tools.allow/deny` 现在只表示非 Core 内置工具的显式覆盖；Core 工具始终可用；移除独立 `capabilityToggles` / `toolOverrides` 分支
+- **异步工具后台化语义硬化**：`run_in_background` / 新增的 `async_job_timeout_secs` 控制参数由外层框架统一 strip，后台完成提示词重命名为 `<task-notification>`；新增 cancel token + 5s cleanup grace，stop / 会话切换时能干净停掉孤儿进程
+- **按下「停止」时真正取消 provider 等待**：4 个 provider adapter 统一接入新的 cancel helper，stop 命中立即 abort HTTP 连接，不再要等 provider 自然返回

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -12,6 +12,10 @@ const tauriConfigPath = path.join(rootDir, "src-tauri", "tauri.conf.json")
 // the version must move in lockstep with the desktop binary or
 // `--version` / `app_update` will report the wrong number in containers.
 const haServerCargoTomlPath = path.join(rootDir, "crates", "ha-server", "Cargo.toml")
+// ha-core is the shared business-logic crate. Not published to crates.io
+// and not a user-facing binary, but kept in lockstep so all crates in
+// the workspace report one coherent product version.
+const haCoreCargoTomlPath = path.join(rootDir, "crates", "ha-core", "Cargo.toml")
 
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
 const version = packageJson.version
@@ -37,19 +41,21 @@ function bumpCargoTomlVersion(filePath, label) {
 
 bumpCargoTomlVersion(tauriCargoTomlPath, "src-tauri/Cargo.toml")
 bumpCargoTomlVersion(haServerCargoTomlPath, "crates/ha-server/Cargo.toml")
+bumpCargoTomlVersion(haCoreCargoTomlPath, "crates/ha-core/Cargo.toml")
 
-// hope-agent / ha-server are workspace packages; cargo update only bumps
-// the Cargo.lock entries to match the new manifest version. `--offline`
-// keeps the script working with no network. Skipping any of these would
-// make CI's `cargo clippy --locked` reject the version-bump commit.
+// hope-agent / ha-server / ha-core are workspace packages; cargo update
+// only bumps the Cargo.lock entries to match the new manifest version.
+// `--offline` keeps the script working with no network. Skipping any of
+// these would make CI's `cargo clippy --locked` reject the version-bump
+// commit.
 try {
-  execSync("cargo update -p hope-agent -p ha-server --offline --quiet", {
+  execSync("cargo update -p hope-agent -p ha-server -p ha-core --offline --quiet", {
     cwd: rootDir,
     stdio: "inherit",
   })
 } catch {
   console.error(
-    "[sync-version] failed to sync Cargo.lock; ensure Rust toolchain is installed, or run `cargo update -p hope-agent -p ha-server` manually",
+    "[sync-version] failed to sync Cargo.lock; ensure Rust toolchain is installed, or run `cargo update -p hope-agent -p ha-server -p ha-core` manually",
   )
   process.exit(1)
 }
@@ -61,7 +67,7 @@ if (process.env.npm_lifecycle_event === "version") {
       stdio: "ignore",
     })
     execSync(
-      "git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json crates/ha-server/Cargo.toml Cargo.lock",
+      "git add package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json crates/ha-server/Cargo.toml crates/ha-core/Cargo.toml Cargo.lock",
       {
         cwd: rootDir,
         stdio: "ignore",
@@ -74,5 +80,5 @@ if (process.env.npm_lifecycle_event === "version") {
 
 console.log(`[sync-version] synced desktop version to ${version}`)
 console.log(
-  "[sync-version] updated: src-tauri/Cargo.toml, src-tauri/tauri.conf.json, crates/ha-server/Cargo.toml, Cargo.lock",
+  "[sync-version] updated: src-tauri/Cargo.toml, src-tauri/tauri.conf.json, crates/ha-server/Cargo.toml, crates/ha-core/Cargo.toml, Cargo.lock",
 )

--- a/scripts/verify-release-version.mjs
+++ b/scripts/verify-release-version.mjs
@@ -11,6 +11,9 @@ const cargoLockPath = path.join(rootDir, "Cargo.lock")
 // CARGO_PKG_VERSION must move with the desktop version (see
 // scripts/sync-version.mjs).
 const haServerCargoTomlPath = path.join(rootDir, "crates", "ha-server", "Cargo.toml")
+// ha-core is the shared business-logic crate. Not user-facing, but kept
+// in lockstep so the whole workspace reports one coherent version.
+const haCoreCargoTomlPath = path.join(rootDir, "crates", "ha-core", "Cargo.toml")
 
 const args = process.argv.slice(2)
 let expectedTag = null
@@ -39,9 +42,17 @@ if (!haServerVersionMatch) {
   process.exit(1)
 }
 
+const haCoreCargoToml = readFileSync(haCoreCargoTomlPath, "utf8")
+const haCoreVersionMatch = haCoreCargoToml.match(/^version = "(.*)"$/m)
+if (!haCoreVersionMatch) {
+  console.error("[release:verify] could not read crates/ha-core/Cargo.toml version")
+  process.exit(1)
+}
+
 const cargoLock = readFileSync(cargoLockPath, "utf8")
 const cargoLockHopeAgentMatch = cargoLock.match(/name = "hope-agent"\r?\nversion = "(.*)"/)
 const cargoLockHaServerMatch = cargoLock.match(/name = "ha-server"\r?\nversion = "(.*)"/)
+const cargoLockHaCoreMatch = cargoLock.match(/name = "ha-core"\r?\nversion = "(.*)"/)
 
 if (!cargoLockHopeAgentMatch) {
   console.error("[release:verify] could not find hope-agent version in Cargo.lock")
@@ -51,6 +62,10 @@ if (!cargoLockHaServerMatch) {
   console.error("[release:verify] could not find ha-server version in Cargo.lock")
   process.exit(1)
 }
+if (!cargoLockHaCoreMatch) {
+  console.error("[release:verify] could not find ha-core version in Cargo.lock")
+  process.exit(1)
+}
 
 const packageVersion = packageJson.version
 const tauriVersion = tauriConfig.version
@@ -58,6 +73,8 @@ const cargoVersion = cargoVersionMatch[1]
 const cargoLockVersion = cargoLockHopeAgentMatch[1]
 const haServerVersion = haServerVersionMatch[1]
 const haServerLockVersion = cargoLockHaServerMatch[1]
+const haCoreVersion = haCoreVersionMatch[1]
+const haCoreLockVersion = cargoLockHaCoreMatch[1]
 
 const mismatches = [
   ["package.json", packageVersion],
@@ -66,6 +83,8 @@ const mismatches = [
   ["Cargo.lock (hope-agent)", cargoLockVersion],
   ["crates/ha-server/Cargo.toml", haServerVersion],
   ["Cargo.lock (ha-server)", haServerLockVersion],
+  ["crates/ha-core/Cargo.toml", haCoreVersion],
+  ["Cargo.lock (ha-core)", haCoreLockVersion],
 ].filter(([, value], _, all) => value !== all[0][1])
 
 if (mismatches.length > 0) {
@@ -76,6 +95,8 @@ if (mismatches.length > 0) {
   console.error(`  Cargo.lock (hope-agent): ${cargoLockVersion}`)
   console.error(`  crates/ha-server/Cargo.toml: ${haServerVersion}`)
   console.error(`  Cargo.lock (ha-server): ${haServerLockVersion}`)
+  console.error(`  crates/ha-core/Cargo.toml: ${haCoreVersion}`)
+  console.error(`  Cargo.lock (ha-core): ${haCoreLockVersion}`)
   process.exit(1)
 }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.2.0"
+version = "0.3.0"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

v0.3.0 minor release。release notes: [`docs/release-notes/v0.3.0.md`](docs/release-notes/v0.3.0.md) / [`v0.3.0.en.md`](docs/release-notes/v0.3.0.en.md)。CHANGELOG `[Unreleased]` 段已封档为 `## [0.3.0] - 2026-05-18`，并补全此前漏登记的 #214 / #215 / #216 / #224。

主线（详见 release notes）：

1. **语音 STT 子系统**（10 cloud + 4 local backend，桌面麦克风 + IM 入站自动转写）
2. **macOS 原生桌面控制**（`mac_control` + `ha-mac-control` skill + 权限页 v2）
3. **浏览器自动化重做**（27 → 8 action / 实时 BrowserPanel / Chromium 自动安装 + Docker 内置 / 三道出站安全闸门 / Settings UX 重写 / 删 `chrome-devtools-mcp` backend）
4. **IM 审批可用性大改进**（异步 `exec` 静默绕审批安全 fix #217 / 无按钮渠道自然语言回复 + `#tag` 消歧 + 超时通知 / `--auto-approve-tools` flag）
5. **聊天工作台视觉与布局改造**（双层导航 / Markdown 切换 / 会话级模型不污染全局 / sidebar 折叠状态持久化）
6. **其它**（Dashboard 本地模型面板 / 五道瀑布 / MCP 热更新 / Agent 工具开关语义收敛 / async tool timeout 硬化 / stop 真正取消 provider 等待）

## 版本号同步顺手收掉的债

`crates/ha-core/Cargo.toml` 一直停在 `0.1.0`，没接入 [`scripts/sync-version.mjs`](scripts/sync-version.mjs) 的同步列表。本 PR：

- `ha-core` 0.1.0 → 0.3.0
- `sync-version.mjs` / `verify-release-version.mjs` / `AGENTS.md` 单一来源段把 `crates/ha-core/Cargo.toml` 加进去
- `cargo update -p ha-core` 同步 `Cargo.lock`

至此 5 处版本来源（`package.json` / `src-tauri/Cargo.toml` / `tauri.conf.json` / `crates/ha-server/Cargo.toml` / `crates/ha-core/Cargo.toml`）+ `Cargo.lock` 全部对齐 v0.3.0；`pnpm release:verify -- --tag v0.3.0` 通过。

## Test plan

- [x] `pnpm release:verify -- --tag v0.3.0` 全 5 处版本号 + Cargo.lock 一致
- [ ] CI 8 项 status check 全绿（rust fmt / clippy / test + lint typecheck eslint vitest + scripts/check-release-paths / verify-updater-pubkey）
- [ ] 合并后在 main HEAD 打 tag `v0.3.0` 触发 release.yml
- [ ] 审 draft Release：5 平台产物齐全（macOS arm64+x64 DMG / Windows NSIS / Linux amd64+arm64 .deb/.AppImage/.rpm）+ latest.json + bare-binary tar.gz/zip + Release body 是 v0.3.0 notes 内容
- [ ] Publish Release → 触发 Homebrew tap / AUR / Scoop / Linux apt+dnf 自动同步
- [ ] 切 `release/v0.3` 维护分支