### PR TITLE
🦭[codex] Notify when background GUI chat completes

### DIFF
--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -3,7 +3,12 @@ import { getTransport } from "@/lib/transport-provider"
 import type { ChatAttachment } from "@/lib/transport"
 import { useTranslation } from "react-i18next"
 import { logger } from "@/lib/logger"
-import { loadNotificationConfig, isAgentNotifyEnabled, notify } from "@/lib/notifications"
+import {
+  loadNotificationConfig,
+  isAgentNotifyEnabled,
+  notify,
+  notifyIfBackground,
+} from "@/lib/notifications"
 import type {
   Message,
   ActiveModel,
@@ -520,6 +525,7 @@ export function useChatStream({
     })
 
     let targetSessionId = currentSessionId
+    let chatResolved = false
     let keepExistingStreamLoading = false
 
     try {
@@ -671,6 +677,7 @@ export function useChatStream({
         },
         onEvent,
       )
+      chatResolved = true
     } catch (e) {
       const sid = targetSessionId || "__pending__"
       if (isActiveStreamError(e) && sid !== "__pending__") {
@@ -792,16 +799,23 @@ export function useChatStream({
           setLoading(false)
         }
       }
-      // Notify on completion for non-current sessions
-      if (
-        !keepExistingStreamLoading &&
-        targetSessionId &&
-        currentSessionIdRef.current !== targetSessionId
-      ) {
+      // Notify on completion. Existing behavior: always notify for a
+      // different session. For the active session, only surface an OS
+      // notification when the app window is no longer foregrounded.
+      if (!keepExistingStreamLoading && chatResolved && targetSessionId) {
         const agent = agents.find((a) => a.id === currentAgentId)
         if (isAgentNotifyEnabled(agent?.notifyOnComplete)) {
+          const status = lastTurnStatusBySessionRef.current.get(targetSessionId)?.status
+          const completed =
+            status !== "failed" &&
+            status !== "interrupted" &&
+            status !== "cancelling"
           const sessionTitle = sessions.find((s) => s.id === targetSessionId)?.title || agentName
-          notify(t("notification.chatCompleted"), sessionTitle)
+          if (completed && currentSessionIdRef.current !== targetSessionId) {
+            void notify(t("notification.chatCompleted"), sessionTitle)
+          } else if (completed) {
+            void notifyIfBackground(t("notification.chatCompleted"), sessionTitle)
+          }
         }
       }
       // Mark current session as read so unread count stays 0 for active session

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -145,6 +145,23 @@ export async function initFocusTracking(): Promise<void> {
  * when the window is up front.
  */
 export async function notifyIfBackground(title: string, body: string): Promise<void> {
+  if (!focusTrackingStarted) {
+    try {
+      await initFocusTracking()
+    } catch {
+      // Fall back to the best synchronous signal below. Notification delivery
+      // should be best-effort, not blocked by a focus-listener setup failure.
+    }
+  }
+  if (typeof document !== "undefined" && document.visibilityState === "hidden") {
+    await notify(title, body)
+    return
+  }
+  if (!focusTrackingStarted && typeof document !== "undefined") {
+    if (document.hasFocus()) return
+    await notify(title, body)
+    return
+  }
   if (isWindowFocused) return
   await notify(title, body)
 }


### PR DESCRIPTION
## Summary

- Send a desktop notification when a GUI-started chat turn completes while the current window is not foregrounded.
- Preserve the existing notification behavior for completed turns in non-current sessions.
- Lazily initialize focus tracking for notification callers outside the main App mount, such as Quick Chat.

## Why

The GUI previously only notified for completed replies in sessions other than the currently selected session. If the user sent a message in the active session and then moved the window to the background, completion could finish silently.

## Impact

Users get a completion notification for GUI-originated replies when Hope Agent is in the background. IM inbound replies are not routed through this GUI send path, so they do not trigger this desktop completion notification.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `cargo test -p ha-core -p ha-server --locked`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- pre-push hook passed during `git push`