### PR TITLE
[codex] Fix streaming JSON rendering

### DIFF
--- a/src/components/common/MarkdownRenderer.test.ts
+++ b/src/components/common/MarkdownRenderer.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest"
+import { shouldRenderAsBareJson } from "./markdownJson"
+
+describe("shouldRenderAsBareJson", () => {
+  test("detects complete and streaming bare JSON objects", () => {
+    expect(shouldRenderAsBareJson('{"status":{"supported":true}}')).toBe(true)
+    expect(shouldRenderAsBareJson('{\n  "status": {\n    "supported": true')).toBe(true)
+  })
+
+  test("detects bare JSON arrays without treating Markdown links as JSON", () => {
+    expect(shouldRenderAsBareJson('[{"id":"el_1"}]')).toBe(true)
+    expect(shouldRenderAsBareJson("[link](https://example.com)")).toBe(false)
+  })
+
+  test("leaves fenced code and prose on the Markdown path", () => {
+    expect(shouldRenderAsBareJson('```json\n{"ok":true}\n```')).toBe(false)
+    expect(shouldRenderAsBareJson('Result:\n{\n  "ok": true\n}')).toBe(false)
+  })
+})

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -1,7 +1,6 @@
 import {
   useState,
   useEffect,
-  useLayoutEffect,
   useRef,
   useMemo,
   type AnchorHTMLAttributes,
@@ -40,6 +39,7 @@ import { getTransport } from "@/lib/transport-provider"
 import { openExternalUrl } from "@/lib/openExternalUrl"
 import { cn } from "@/lib/utils"
 import { findAutoLinkMatches } from "@/lib/autoLink"
+import { shouldRenderAsBareJson } from "./markdownJson"
 
 // Math and mermaid plugins are lazy-loaded on first use to reduce initial bundle size.
 // KaTeX (~300KB) and Mermaid (~200KB) are only loaded when content requires them.
@@ -432,18 +432,27 @@ function autolinkRehypePlugin() {
 const CATCHUP_THRESHOLD = 60
 /** Max chars per frame when catching up, prevents jarring jumps */
 const MAX_STEP = 8
-const STREAMING_HEIGHT_GUARD_PX = 2
-
-function getStreamingContentHeight(el: HTMLElement): number {
-  return Math.ceil(el.getBoundingClientRect().height + STREAMING_HEIGHT_GUARD_PX)
-}
 
 interface MarkdownRendererProps {
   content: string
   isStreaming?: boolean
 }
 
-export default function MarkdownRenderer({ content, isStreaming = false }: MarkdownRendererProps) {
+function BareJsonRenderer({ content, isStreaming }: MarkdownRendererProps) {
+  return (
+    <div className="markdown-content markdown-json-content">
+      <pre
+        data-hope-bare-json
+        data-streaming={isStreaming || undefined}
+        className="hope-bare-json-block"
+      >
+        <code>{content}</code>
+      </pre>
+    </div>
+  )
+}
+
+function StreamdownMarkdownRenderer({ content, isStreaming = false }: MarkdownRendererProps) {
   const plugins = useHeavyPlugins(content)
 
   // 外部接管 Streamdown 的 animate plugin 生命周期。Streamdown 自带的
@@ -474,10 +483,6 @@ export default function MarkdownRenderer({ content, isStreaming = false }: Markd
   const targetRef = useRef(content.length)
   const streamingRef = useRef(isStreaming)
   const rafRef = useRef<number | null>(null)
-
-  // Height animation refs
-  const containerRef = useRef<HTMLDivElement>(null)
-  const contentRef = useRef<HTMLDivElement>(null)
 
   // eslint-disable-next-line react-hooks/refs -- intentional "latest value" refs read only in rAF callback
   targetRef.current = content.length
@@ -528,32 +533,6 @@ export default function MarkdownRenderer({ content, isStreaming = false }: Markd
     rafRef.current = requestAnimationFrame(tick)
   }, [isStreaming])
 
-  // Smooth height transition: mount ResizeObserver once when streaming starts,
-  // let it detect height changes on its own to avoid breaking CSS transitions
-  useLayoutEffect(() => {
-    const container = containerRef.current
-    const contentEl = contentRef.current
-    if (!container || !contentEl || !isStreaming) {
-      if (containerRef.current) containerRef.current.style.height = ""
-      return
-    }
-
-    container.style.height = `${getStreamingContentHeight(contentEl)}px`
-
-    const observer = new ResizeObserver(() => {
-      const h = getStreamingContentHeight(contentEl)
-      if (container.style.height !== `${h}px`) {
-        container.style.height = `${h}px`
-      }
-    })
-    observer.observe(contentEl)
-
-    return () => {
-      observer.disconnect()
-      container.style.height = ""
-    }
-  }, [isStreaming])
-
   useEffect(() => {
     return () => {
       if (rafRef.current !== null) {
@@ -578,11 +557,8 @@ export default function MarkdownRenderer({ content, isStreaming = false }: Markd
     : [...defaultRehypePluginList, autolinkRehypePlugin]
 
   return (
-    <div
-      ref={containerRef}
-      className={isActive ? "streaming-height markdown-content" : "markdown-content"}
-    >
-      <div ref={contentRef}>
+    <div className="markdown-content">
+      <div>
         <Streamdown
           animated={false}
           plugins={plugins}
@@ -597,4 +573,11 @@ export default function MarkdownRenderer({ content, isStreaming = false }: Markd
       </div>
     </div>
   )
+}
+
+export default function MarkdownRenderer({ content, isStreaming = false }: MarkdownRendererProps) {
+  if (shouldRenderAsBareJson(content)) {
+    return <BareJsonRenderer content={content} isStreaming={isStreaming} />
+  }
+  return <StreamdownMarkdownRenderer content={content} isStreaming={isStreaming} />
 }

--- a/src/components/common/markdownJson.ts
+++ b/src/components/common/markdownJson.ts
@@ -1,0 +1,26 @@
+export function shouldRenderAsBareJson(content: string): boolean {
+  const trimmed = content.trimStart()
+  if (!trimmed) return false
+  if (trimmed.startsWith("```")) return false
+
+  const first = trimmed[0]
+  if (first !== "{" && first !== "[") return false
+
+  // Avoid JSON.parse here: during streaming the payload is incomplete for most
+  // frames, and repeatedly parsing a growing tool-result-sized JSON blob is
+  // exactly the kind of work that makes the text appear to repaint.
+  const sample = trimmed.slice(0, 512)
+  if (first === "{") {
+    return (
+      sample === "{" ||
+      sample === "{}" ||
+      sample.includes("\n") ||
+      /"[^"\n]+"\s*:/.test(sample)
+    )
+  }
+  return (
+    sample === "[" ||
+    sample === "[]" ||
+    /^\[\s*(?:\{|\[|"|-?\d|true\b|false\b|null\b)/.test(sample)
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -153,7 +153,7 @@
   }
 }
 
-/* Smooth streaming bubble growth — height + padding transitions.
+/* Streaming bubble floor.
  * `min-width` / `min-height` lock the bubble to a one-line-of-text floor
  * so the dots → first-token transition doesn't shrink the box during the
  * brief frames where Streamdown's `blurIn` keyframe holds the first char
@@ -168,12 +168,6 @@
   transition: padding 0.15s ease-out;
   min-width: 4rem;
   min-height: 4.0625rem;
-}
-
-/* Streaming content height transition — new lines slide in smoothly */
-.streaming-height {
-  overflow: hidden;
-  transition: height 0.35s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 /* Anti-flicker: Streamdown sets --sd-duration:0ms on already-visible chars,
@@ -581,6 +575,32 @@
 .plain-text-content {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+}
+
+.markdown-json-content {
+  width: 100%;
+}
+
+.hope-bare-json-block {
+  box-sizing: border-box;
+  max-width: 100%;
+  overflow-x: auto;
+  margin: 0;
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+  border-radius: 0.5rem;
+  background: color-mix(in srgb, var(--color-muted) 42%, transparent);
+  padding: 0.625rem 0.75rem;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  tab-size: 2;
+  white-space: pre;
+}
+
+.hope-bare-json-block code {
+  white-space: inherit;
 }
 
 .message-markdown-content .markdown-content > div > div > :first-child,


### PR DESCRIPTION
## Summary

- Render bare JSON responses through a stable preformatted path instead of Streamdown Markdown.
- Preserve JSON newlines and allow horizontal scrolling for long lines while letting the message bubble grow naturally.
- Remove the streaming content height wrapper that could lag behind text layout and make bubble height drift.
- Add focused tests for bare JSON detection boundaries.

## Root Cause

Large tool-result JSON was streamed through the general Markdown path, so incomplete JSON was repeatedly sliced and reparsed while Markdown collapsed raw newlines. The extra streaming-height wrapper also fixed and transitioned container height, which could leave the bubble out of sync with the text.

## Validation

- cargo fmt --all --check
- cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings
- cargo test -p ha-core -p ha-server --locked
- pnpm typecheck
- pnpm lint (passes with existing ChatScreen exhaustive-deps warning)
- pnpm test
- pre-push hook passed on push
