### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,35 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-05-22
 
 ### Added
 
-- **macOS Control 截图能力 v2**：`mac_control.snapshot(includeScreenshot=true)` 支持 `screenshotTarget=display|window`，可按 `displayId` 采集指定显示器，或按 `windowId`/当前前台窗口采集窗口截图；截图与右侧镜像 frame 现在返回目标类型、display/window id、窗口标题、bounds 与 scale，便于模型区分多屏、Retina 和窗口级视觉上下文。
-- **macOS Control 菜单范围**：`mac_control.menu.list/click` 新增 `scope=app|system`，默认继续操作前台 App 菜单；`system` 用于读取和点击 macOS 菜单栏 extras/status items，并在菜单项摘要中补充 `description`、`value` 与可执行 actions，减少状态栏入口无标题时的误判。
-- **macOS Control 跨 App 窗口发现**：`mac_control.windows.list` 新增 `windowScope=frontmost|all`，默认保持前台 App 行为；显式 `all` 时可列出所有运行中 App 的窗口，并返回可复用的 `win_<pid>_<index>` id，便于模型先发现后台窗口再聚焦、移动、缩放、最小化或关闭。
-- **macOS Control 剪贴板文本**：`mac_control.clipboard` 新增 `get/set/clear` 三个文本操作；`get` 支持 `maxChars` 截断，`set` 不在结果中回显写入内容，三者均作为隐私/副作用动作走审批，避免模型静默读取或改写用户剪贴板。
-- **macOS Control 粘贴输入**：`mac_control.act` 新增 `op=paste`，用于长文本或 `AXValue` 不稳定的输入场景；执行时临时写入 pasteboard、触发系统粘贴，并备份/恢复原 pasteboard items，结果只报告恢复状态、不回显旧剪贴板或待粘贴文本。
-- **macOS Control 目标消歧**：`mac_control.act` 在 AX 元素候选最高分并列时不再默认操作第一个匹配项，而是返回带候选提示的歧义错误，要求模型用 `elementId`、窗口标题、role 或更具体文本重试，降低点错相似按钮/输入框的风险。
-- **macOS Control 元素检索**：`mac_control.elements.find` 新增只读 AX 元素检索，按 target 过滤并返回排序候选、score、reasons 和所在窗口，方便模型在点击/输入前先确认 `elementId`。
-- **macOS Control 动作预解析**：`mac_control.act.dry_run` 新增只读目标解析，可在点击、设置值或拖拽前验证将命中的 AX 元素和歧义状态，不产生 UI 副作用。
-- **macOS Control 结果收敛**：`mac_control.act`、`wait`、`dialog` 默认不再返回完整 AX snapshot，只返回目标、命中或对话框摘要；调试或确需完整树时可显式传 `includeSnapshot=true`。
+- **macOS Control 截图能力 v2**：`mac_control.snapshot(includeScreenshot=true)` 支持 `screenshotTarget=display|window`，可按 `displayId` 采集指定显示器，或按 `windowId`/当前前台窗口采集窗口截图；截图与右侧镜像 frame 现在返回目标类型、display/window id、窗口标题、bounds 与 scale，便于模型区分多屏、Retina 和窗口级视觉上下文。 (#231)
+- **macOS Control 菜单范围**：`mac_control.menu.list/click` 新增 `scope=app|system`，默认继续操作前台 App 菜单；`system` 用于读取和点击 macOS 菜单栏 extras/status items，并在菜单项摘要中补充 `description`、`value` 与可执行 actions，减少状态栏入口无标题时的误判。 (#231)
+- **macOS Control 跨 App 窗口发现**：`mac_control.windows.list` 新增 `windowScope=frontmost|all`，默认保持前台 App 行为；显式 `all` 时可列出所有运行中 App 的窗口，并返回可复用的 `win_<pid>_<index>` id，便于模型先发现后台窗口再聚焦、移动、缩放、最小化或关闭。 (#231)
+- **macOS Control 剪贴板文本**：`mac_control.clipboard` 新增 `get/set/clear` 三个文本操作；`get` 支持 `maxChars` 截断，`set` 不在结果中回显写入内容，三者均作为隐私/副作用动作走审批，避免模型静默读取或改写用户剪贴板。 (#231)
+- **macOS Control 粘贴输入**：`mac_control.act` 新增 `op=paste`，用于长文本或 `AXValue` 不稳定的输入场景；执行时临时写入 pasteboard、触发系统粘贴，并备份/恢复原 pasteboard items，结果只报告恢复状态、不回显旧剪贴板或待粘贴文本。 (#231)
+- **macOS Control 目标消歧**：`mac_control.act` 在 AX 元素候选最高分并列时不再默认操作第一个匹配项，而是返回带候选提示的歧义错误，要求模型用 `elementId`、窗口标题、role 或更具体文本重试，降低点错相似按钮/输入框的风险。 (#231)
+- **macOS Control 元素检索**：`mac_control.elements.find` 新增只读 AX 元素检索，按 target 过滤并返回排序候选、score、reasons 和所在窗口，方便模型在点击/输入前先确认 `elementId`。 (#231)
+- **macOS Control 动作预解析**：`mac_control.act.dry_run` 新增只读目标解析，可在点击、设置值或拖拽前验证将命中的 AX 元素和歧义状态，不产生 UI 副作用。 (#231)
+- **macOS Control 结果收敛**：`mac_control.act`、`wait`、`dialog` 默认不再返回完整 AX snapshot，只返回目标、命中或对话框摘要；调试或确需完整树时可显式传 `includeSnapshot=true`。 (#231)
+- **IM 渠道媒体附件发送**：Signal / Slack / iMessage / WhatsApp 渠道新增媒体附件发送，并支持把公共媒体链接直接路由给渠道。 (#232)
+- **聊天斜杠命令动作卡片**：斜杠命令动作结果以卡片形式渲染，新增 Recap 进度卡片与 Skill Fork 状态卡片。 (#232)
+- **后台聊天完成系统通知**：GUI 聊天在窗口失焦或切到其它会话时于后台完成后，发送系统通知提醒。 (#229)
+- **主窗口尺寸与位置持久化**：关闭重开应用后记住上次主窗口的大小与位置。 (#228)
+- **询问对话框 12 语言本地化**：`ask_user_question` 弹窗文案补齐全部 12 种语言。 (#232)
+
+### Changed
+
+- **聊天右侧面板交互统一**：Browser / Plan / Diff / Canvas / Team / Mac Control 面板强制互斥、可在已打开面板间一键切换并共享同一宽度。 (#232)
+- **IM 渠道稳定性整体加固**：Discord gateway 状态、Slack socket 断线重连、QQ Bot gateway 元数据、Signal daemon 就绪轮询、IRCv3 能力协商、iMessage RPC、LINE push 幂等重试、WhatsApp 轮询退避、Telegram 请求节流、飞书 token singleflight 与卡片动作 toast、IM callback origin 校验等多渠道修复。 (#232)
+
+### Fixed
+
+- **聊天「停止」状态稳定保留**：重做 chat engine 活动 turn / 持久化 / 流序号管线，按下停止后会话状态正确保留，不再丢失或错乱（覆盖 failover 与 subagent 路径）。 (#230)
+- **流式 JSON 渲染修复**：流式输出过程中的 JSON 代码块渲染正确，不再中途错乱。 (#233)
+- **review followup 杂项修复**：IM 审批原因渲染、斜杠命令选择器去重、权限模式事件同步、NSIS 中文安装语言恢复、Release webview 右键菜单抑制等。 (#232)
 
 ## [0.3.0] - 2026-05-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3223,7 +3223,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.3.0"
+version = "0.4.0"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.3.0"
+version = "0.4.0"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.4.0.en.md
+++ b/docs/release-notes/v0.4.0.en.md
@@ -1,0 +1,34 @@
+# Hope Agent 0.4.0 — macOS Desktop Control v2 · IM Channel Enhancements · UX Polish
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.4.0/docs/release-notes/v0.4.0.md) · **English**
+
+> Release date: 2026-05-22
+
+> Full list in [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.4.0/CHANGELOG.md#040---2026-05-22).
+
+v0.4 is a deepening-and-polish release. macOS desktop control builds on the first cut with screenshots, menus, cross-app windows, clipboard, disambiguation, element lookup, and dry-run — moving from "can click and type" to "sees accurately, clicks reliably, previews first." IM channels gain media attachment sending across multiple platforms plus a systematic hardening of per-channel connection stability, and the chat side fixes stop-state preservation, streaming JSON rendering, and background-completion notifications one by one.
+
+## macOS desktop control v2
+
+After the first `mac_control` cut landed, v0.4 polishes it to everyday-reliable precision:
+
+- **Screenshots v2**: `snapshot(includeScreenshot=true)` supports `screenshotTarget=display|window` — capture a specific display by `displayId`, or a window by `windowId` / the current frontmost window. Screenshots and the right-side mirror frame now return target type, display/window id, window title, bounds, and scale, so the model can tell multi-monitor, Retina, and window-level context apart
+- **Target disambiguation + element lookup + dry-run**: when AX candidates tie on top score, it no longer defaults to the first match — it returns a disambiguation error asking you to retry with `elementId` / window title / role. New read-only `elements.find` confirms an `elementId` before acting, and `act.dry_run` previews the element that would be hit (and the ambiguity state) before a click / set-value / drag, with zero UI side effects
+- **Cross-app window discovery**: `windows.list` adds `windowScope=frontmost|all`; with an explicit `all` it lists windows across every running app and returns reusable `win_<pid>_<index>` ids, so you can discover a background window first, then focus / move / resize / minimize / close it
+- **Menu scope + clipboard + paste input**: `menu.list/click` adds `scope=app|system` to read and click macOS menu-bar extras/status items; `clipboard` adds `get/set/clear` text operations (privacy / side-effect actions go through approval and never echo content); `act` adds `op=paste` for long text or unstable-`AXValue` cases, temporarily writing to the pasteboard and backing up / restoring the original
+- **Result narrowing**: `act` / `wait` / `dialog` no longer return the full AX snapshot by default — only the target, hit, or dialog summary — pass `includeSnapshot=true` explicitly when you need the full tree for debugging
+
+## IM channel enhancements
+
+- **Media attachment sending across platforms**: Signal / Slack / iMessage / WhatsApp channels gain media attachment sending, plus routing of public media links straight to the channel
+- **Systematic connection-stability hardening**: Discord gateway state, Slack socket reconnect-on-disconnect, QQ Bot gateway metadata, Signal daemon readiness polling, IRCv3 capability negotiation, iMessage RPC, LINE push idempotent retry, WhatsApp polling backoff, Telegram request throttling, Feishu token singleflight and card-action toasts, IM callback origin validation, and more multi-channel fixes
+- **Ask-user dialogs localized in 12 languages**: `ask_user_question` modal copy is now complete across all 12 languages
+
+## Chat UX polish
+
+- **Stable "stop" state preservation**: the chat engine's active-turn / persistence / stream-sequence pipelines were reworked so that pressing stop preserves session state correctly without loss or corruption (covering the failover and subagent paths)
+- **Streaming JSON rendering fix**: JSON code blocks render correctly mid-stream and no longer garble partway through
+- **Background chat-completion system notification**: when a GUI chat finishes in the background — window unfocused or switched to another session — a system notification is posted
+- **Slash-command action cards**: slash-command action results render as cards, with new Recap progress and Skill Fork status cards
+- **Unified right-panel interaction**: the Browser / Plan / Diff / Canvas / Team / Mac Control panels are mutually exclusive, switch between open panels with one click, and share a single width
+- **Main window size & position persistence**: the app remembers the last main-window size and position across restarts

--- a/docs/release-notes/v0.4.0.md
+++ b/docs/release-notes/v0.4.0.md
@@ -1,0 +1,34 @@
+# Hope Agent 0.4.0 — macOS 桌面控制 v2 · IM 渠道增强 · 体验打磨
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.4.0/docs/release-notes/v0.4.0.en.md)
+
+> 发布日期：2026-05-22
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.4.0/CHANGELOG.md#040---2026-05-22)。
+
+v0.4 是一个深化与打磨的版本。macOS 桌面控制在首版基础上补齐截图、菜单、跨 App 窗口、剪贴板、消歧、检索、dry-run 等能力，从「能点能输入」走向「看得准、点得稳、可预演」；IM 渠道新增多平台媒体附件发送并对各渠道连接稳定性做了系统加固；聊天侧把停止状态保留、流式 JSON 渲染、后台完成通知等体验问题逐一修掉。
+
+## macOS 桌面控制 v2
+
+首版 `mac_control` 落地后，v0.4 把它打磨到可日常依赖的精度：
+
+- **截图能力 v2**：`snapshot(includeScreenshot=true)` 支持 `screenshotTarget=display|window`，可按 `displayId` 采集指定显示器、按 `windowId` / 当前前台窗口采集窗口截图；截图与右侧镜像 frame 现在返回目标类型、display/window id、窗口标题、bounds 与 scale，模型能区分多屏、Retina 与窗口级视觉上下文
+- **目标消歧 + 元素检索 + 动作预解析**：AX 候选最高分并列时不再默认操作第一个匹配项，而是返回带候选提示的歧义错误，要求用 `elementId` / 窗口标题 / role 重试；新增只读 `elements.find` 在操作前确认 `elementId`、`act.dry_run` 在点击 / 设值 / 拖拽前预演将命中的元素与歧义状态，零 UI 副作用
+- **跨 App 窗口发现**：`windows.list` 新增 `windowScope=frontmost|all`，显式 `all` 时可列出所有运行中 App 的窗口并返回可复用的 `win_<pid>_<index>` id，先发现后台窗口再聚焦 / 移动 / 缩放 / 最小化 / 关闭
+- **菜单范围 + 剪贴板 + 粘贴输入**：`menu.list/click` 新增 `scope=app|system` 支持读取与点击 macOS 菜单栏 extras/status items；`clipboard` 新增 `get/set/clear` 文本操作（隐私 / 副作用动作走审批，不回显内容）；`act` 新增 `op=paste` 用于长文本或 `AXValue` 不稳定场景，临时写入 pasteboard 并备份 / 恢复原内容
+- **结果收敛**：`act` / `wait` / `dialog` 默认不再返回完整 AX snapshot，只返回目标、命中或对话框摘要，调试或确需完整树时显式传 `includeSnapshot=true`
+
+## IM 渠道增强
+
+- **多平台媒体附件发送**：Signal / Slack / iMessage / WhatsApp 渠道新增媒体附件发送，并支持把公共媒体链接直接路由给渠道
+- **连接稳定性系统加固**：Discord gateway 状态、Slack socket 断线重连、QQ Bot gateway 元数据、Signal daemon 就绪轮询、IRCv3 能力协商、iMessage RPC、LINE push 幂等重试、WhatsApp 轮询退避、Telegram 请求节流、飞书 token singleflight 与卡片动作 toast、IM callback origin 校验等多渠道修复
+- **询问对话框 12 语言本地化**：`ask_user_question` 弹窗文案补齐全部 12 种语言
+
+## 聊天体验打磨
+
+- **「停止」状态稳定保留**：重做 chat engine 的活动 turn / 持久化 / 流序号管线，按下停止后会话状态正确保留，不再丢失或错乱（覆盖 failover 与 subagent 路径）
+- **流式 JSON 渲染修复**：流式输出过程中的 JSON 代码块渲染正确，不再中途错乱
+- **后台聊天完成系统通知**：GUI 聊天在窗口失焦或切到其它会话时于后台完成后，发送系统通知提醒
+- **斜杠命令动作卡片**：斜杠命令动作结果以卡片形式渲染，新增 Recap 进度卡片与 Skill Fork 状态卡片
+- **右侧面板交互统一**：Browser / Plan / Diff / Canvas / Team / Mac Control 面板强制互斥、可在已打开面板间一键切换并共享同一宽度
+- **主窗口尺寸与位置持久化**：关闭重开应用后记住上次主窗口的大小与位置

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.3.0"
+version = "0.4.0"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## 0.4.0 发版 PR（新 minor，base `main`）

按 [`docs/release-process.md`](docs/release-process.md) §2 准备发版三件事：

- [x] **CHANGELOG**：新增 `## [0.4.0] - 2026-05-22` 段，并补全此前漏登记的 #228 / #229 / #230 / #232 / #233（原 `[Unreleased]` 仅含 #231 macOS Control v2）
- [x] **双语 release notes**：`docs/release-notes/v0.4.0.md` + `v0.4.0.en.md`（跨文件链接全用 v0.4.0 tag-pin 绝对 URL）
- [x] **版本号 0.4.0**：`package.json` / `src-tauri/Cargo.toml` / `tauri.conf.json` / `ha-server` / `ha-core` / `Cargo.lock` 六处同步；`pnpm release:verify -- --tag v0.4.0` 通过

### 主要变更
- **macOS 桌面控制 v2**（#231）：截图 v2 / 目标消歧 / 元素检索 / dry-run / 跨 App 窗口发现 / 菜单 scope / 剪贴板 / 粘贴输入 / 结果收敛
- **IM 渠道增强**（#232）：Signal·Slack·iMessage·WhatsApp 媒体附件发送 + 多渠道连接稳定性系统加固 + `ask_user_question` 12 语言本地化
- **聊天体验打磨**：停止状态稳定保留（#230）、流式 JSON 渲染修复（#233）、后台完成系统通知（#229）、斜杠命令动作卡片（#232）、右侧面板交互统一（#232）、主窗口尺寸与位置持久化（#228）

### 合并后剩余步骤（人工，按 §2.2 / §2.3）
1. 在 `main` HEAD 打 tag `v0.4.0` 并 push → 触发 `release.yml` 构建多平台产物 + draft Release
2. 审阅 draft Release（产物齐全 + notes 渲染正确）→ **publish**
3. 切长期维护分支：`git branch release/v0.4 v0.4.0 && git push -u origin release/v0.4`

---
_Generated by [Claude Code](https://claude.ai/code/session_01YQmgv8U5tpMbZJMiAaxWZs)_