### PR TITLE
[codex] optimize chat defaults and search diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ docker compose --profile with-ollama up -d    # + Ollama 本地 LLM sidecar
 
 ## 提交前检查（强制）
 
-`git push` 前**必须**本地跑以下六条；`pnpm install` 后 [`.husky/pre-push`](.husky/pre-push) 钩子按这个顺序自动跑：
+以下六条是 `git push` 的强制门禁（对应 CI 8 项 status check）；`pnpm install` 后 [`.husky/pre-push`](.husky/pre-push) 钩子会在 push 时按此顺序自动跑——**无需在 push 前手动重复执行**：
 
 ```bash
 cargo fmt --all --check                                                    # CI: rust.yml fmt
@@ -55,7 +55,7 @@ pnpm test                                                                    # C
 - **改代码过程中**：默认只做单点验证——Rust 用 `cargo check -p <crate>`，TS/TSX 用 `pnpm typecheck`；不要主动跑 clippy / cargo test / pnpm test / pnpm lint
 - **想跑全套必须先问**：判断需要跑这四项之一时，先问用户「是否要跑 X？」并说明原因，等回复再跑
 - **长任务收尾例外**：跨多文件多模块 / 完整 plan / 跨 crate 重构这类阶段性收尾时，可主动跑必要项，跑前说一句"改动较大，跑一下 X 收尾"
-- **commit / push 前 / 用户明确要求**：直接按指示跑
+- **push 由钩子兜底**：`git push` 时钩子自动跑全套，**Agent 不要在 push 前手动重复跑一遍**；只有用户明确要求跑某项时才手动跑
 
 ## 分支与发布
 

--- a/crates/ha-core/src/agent_config.rs
+++ b/crates/ha-core/src/agent_config.rs
@@ -169,6 +169,11 @@ pub struct AgentModelConfig {
     /// When set, overrides the global temperature. Can be further overridden at session level.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f64>,
+
+    /// Default Think / reasoning effort for this agent.
+    /// Session-level overrides still take priority.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
 }
 
 // ── Filter Config ────────────────────────────────────────────────

--- a/crates/ha-core/src/agent_loader.rs
+++ b/crates/ha-core/src/agent_loader.rs
@@ -455,6 +455,20 @@ pub fn save_agent_config(id: &str, config: &AgentConfig) -> Result<()> {
     Ok(())
 }
 
+/// Persist this agent's default Think / reasoning effort.
+pub fn update_agent_reasoning_effort(id: &str, effort: &str) -> Result<()> {
+    if !crate::agent::is_valid_reasoning_effort(effort) {
+        anyhow::bail!(
+            "Invalid reasoning effort: {}. Valid: {:?}",
+            effort,
+            crate::agent::VALID_REASONING_EFFORTS
+        );
+    }
+    let mut def = load_agent(id)?;
+    def.config.model.reasoning_effort = Some(effort.to_string());
+    save_agent_config(id, &def.config)
+}
+
 // ── Save Agent Markdown ──────────────────────────────────────────
 
 /// Save a markdown file for the given agent.

--- a/crates/ha-core/src/channel/worker/dispatcher.rs
+++ b/crates/ha-core/src/channel/worker/dispatcher.rs
@@ -654,7 +654,15 @@ async fn handle_inbound_message(
         .ok()
         .flatten()
         .and_then(|meta| meta.reasoning_effort)
+        .or_else(|| {
+            agent_def
+                .as_ref()
+                .and_then(|def| def.config.model.reasoning_effort.clone())
+        })
         .or(crate::agent::live_reasoning_effort(None).await);
+    if let Some(effort) = reasoning_effort.as_ref() {
+        let _ = session_db.update_session_reasoning_effort(&session_id, Some(effort));
+    }
     if let (Some(cell), Some(effort)) = (
         crate::get_reasoning_effort_cell(),
         reasoning_effort.as_ref(),

--- a/crates/ha-core/src/channel/worker/slash.rs
+++ b/crates/ha-core/src/channel/worker/slash.rs
@@ -211,6 +211,25 @@ pub(super) async fn dispatch_slash_for_channel(
             } else {
                 if let Some(db) = crate::get_session_db() {
                     let _ = db.update_session_reasoning_effort(session_id, Some(&effort));
+                    if let Ok(Some(meta)) = db.get_session(session_id) {
+                        if let Err(e) = crate::agent_loader::update_agent_reasoning_effort(
+                            &meta.agent_id,
+                            &effort,
+                        ) {
+                            app_warn!(
+                                "channel",
+                                "worker",
+                                "Failed to persist reasoning effort for agent {}: {}",
+                                meta.agent_id,
+                                e
+                            );
+                        } else if let Some(bus) = crate::get_event_bus() {
+                            bus.emit(
+                                "agents:changed",
+                                serde_json::json!({ "id": meta.agent_id, "kind": "saved" }),
+                            );
+                        }
+                    }
                 }
                 if let Some(bus) = crate::get_event_bus() {
                     bus.emit(

--- a/crates/ha-core/src/cron/executor.rs
+++ b/crates/ha-core/src/cron/executor.rs
@@ -306,7 +306,10 @@ pub async fn build_and_run_agent_with_context(
                 )
                 .to_string(),
         ),
-        reasoning_effort: crate::agent::live_reasoning_effort(None).await,
+        reasoning_effort: agent_def
+            .as_ref()
+            .and_then(|def| def.config.model.reasoning_effort.clone())
+            .or(crate::agent::live_reasoning_effort(None).await),
         cancel: cancel.unwrap_or_else(|| Arc::new(AtomicBool::new(false))),
         plan_context_override: None,
         skill_allowed_tools: Vec::new(),
@@ -314,7 +317,7 @@ pub async fn build_and_run_agent_with_context(
         subagent_depth: 0,
         steer_run_id: None,
         auto_approve_tools: false,
-        follow_global_reasoning_effort: true,
+        follow_global_reasoning_effort: false,
         post_turn_effects: true,
         abort_on_cancel: false,
         persist_final_error_event: true,

--- a/crates/ha-core/src/subagent/injection.rs
+++ b/crates/ha-core/src/subagent/injection.rs
@@ -347,7 +347,10 @@ pub(crate) async fn inject_and_run_parent(
                 .or(store.temperature),
             compact_config: store.compact.clone(),
             extra_system_context: None,
-            reasoning_effort: crate::agent::live_reasoning_effort(None).await,
+            reasoning_effort: parent_agent_def
+                .as_ref()
+                .and_then(|def| def.config.model.reasoning_effort.clone())
+                .or(crate::agent::live_reasoning_effort(None).await),
             cancel: cancel.clone(),
             plan_context_override: None,
             skill_allowed_tools: Vec::new(),

--- a/crates/ha-core/src/subagent/spawn.rs
+++ b/crates/ha-core/src/subagent/spawn.rs
@@ -373,6 +373,8 @@ fn execute_subagent(
 
         // Load agent config for model resolution
         let agent_def = crate::agent_loader::load_agent(&agent_id)?;
+        let effective_reasoning_effort =
+            reasoning_effort.or_else(|| agent_def.config.model.reasoning_effort.clone());
         let agent_model_config = if let Some(ref override_str) = model_override {
             let mut cfg = agent_def.config.model.clone();
             cfg.primary = Some(override_str.clone());
@@ -498,7 +500,7 @@ fn execute_subagent(
             resolved_temperature: agent_def.config.model.temperature.or(store.temperature),
             compact_config: store.compact.clone(),
             extra_system_context,
-            reasoning_effort,
+            reasoning_effort: effective_reasoning_effort,
             cancel,
             plan_context_override,
             skill_allowed_tools,

--- a/crates/ha-core/src/tools/web_search/duckduckgo.rs
+++ b/crates/ha-core/src/tools/web_search/duckduckgo.rs
@@ -45,7 +45,7 @@ pub(super) async fn search_duckduckgo(
             "web_search",
             "DDG rate-limit cooldown active, skipping"
         );
-        return Ok(Vec::new());
+        return Err(anyhow::anyhow!("DuckDuckGo rate-limit cooldown active"));
     }
 
     let client = build_ddg_client()?;
@@ -74,7 +74,7 @@ pub(super) async fn search_duckduckgo(
                     "DDG blocked ({}), skipping Lite fallback",
                     err_msg
                 );
-                Vec::new()
+                return Err(anyhow::anyhow!("DuckDuckGo unavailable: {}", err_msg));
             } else {
                 app_warn!(
                     "tool",

--- a/crates/ha-core/src/tools/web_search/mod.rs
+++ b/crates/ha-core/src/tools/web_search/mod.rs
@@ -428,11 +428,12 @@ pub(crate) async fn tool_web_search(args: &Value) -> Result<String> {
             result.snippet
         ));
     }
+    let cache_output = output.clone();
     append_provider_diagnostics(&mut output, &no_result_providers, &provider_errors);
 
     // Write to cache
     let ck = search_cache_key(&used_provider, query, count, &params);
-    write_search_cache(ck, output.clone(), config.cache_ttl_minutes);
+    write_search_cache(ck, cache_output, config.cache_ttl_minutes);
 
     Ok(output)
 }

--- a/crates/ha-core/src/tools/web_search/mod.rs
+++ b/crates/ha-core/src/tools/web_search/mod.rs
@@ -289,6 +289,8 @@ pub(crate) async fn tool_web_search(args: &Value) -> Result<String> {
     let mut results = Vec::new();
     let mut used_provider = String::new();
     let mut last_error: Option<anyhow::Error> = None;
+    let mut no_result_providers: Vec<String> = Vec::new();
+    let mut provider_errors: Vec<(String, String)> = Vec::new();
 
     for entry in &providers {
         let provider_id = &entry.id;
@@ -380,16 +382,19 @@ pub(crate) async fn tool_web_search(args: &Value) -> Result<String> {
                     provider_id,
                     query
                 );
+                no_result_providers.push(provider_id.to_string());
             }
             Err(e) => {
+                let error_message = e.to_string();
                 app_warn!(
                     "tool",
                     "web_search",
                     "Provider [{}] error for '{}': {}, trying next provider",
                     provider_id,
                     query,
-                    e
+                    error_message
                 );
+                provider_errors.push((provider_id.to_string(), error_message));
                 last_error = Some(e);
             }
         }
@@ -405,7 +410,11 @@ pub(crate) async fn tool_web_search(args: &Value) -> Result<String> {
                 e
             );
         }
-        return Ok(format!("No results found for: {}", query));
+        return Ok(format_empty_search_result(
+            query,
+            &no_result_providers,
+            &provider_errors,
+        ));
     }
 
     let mut output = format!("Search results for: {} (via {})\n\n", query, used_provider);
@@ -419,12 +428,66 @@ pub(crate) async fn tool_web_search(args: &Value) -> Result<String> {
             result.snippet
         ));
     }
+    append_provider_diagnostics(&mut output, &no_result_providers, &provider_errors);
 
     // Write to cache
     let ck = search_cache_key(&used_provider, query, count, &params);
     write_search_cache(ck, output.clone(), config.cache_ttl_minutes);
 
     Ok(output)
+}
+
+fn format_empty_search_result(
+    query: &str,
+    no_result_providers: &[String],
+    provider_errors: &[(String, String)],
+) -> String {
+    let mut output = if provider_errors.is_empty() {
+        format!("No results found for: {}\n", query)
+    } else if no_result_providers.is_empty() {
+        format!(
+            "Search failed for: {}\n\nNo configured search provider returned results.\n",
+            query
+        )
+    } else {
+        format!("No results found by available providers for: {}\n", query)
+    };
+
+    append_provider_diagnostics(&mut output, no_result_providers, provider_errors);
+
+    if !provider_errors.is_empty() {
+        output.push_str(
+            "\nProvider failures or rate limits are not the same as the web having no results.\n",
+        );
+    }
+
+    output
+}
+
+fn append_provider_diagnostics(
+    output: &mut String,
+    no_result_providers: &[String],
+    provider_errors: &[(String, String)],
+) {
+    if no_result_providers.is_empty() && provider_errors.is_empty() {
+        return;
+    }
+
+    output.push('\n');
+
+    if !no_result_providers.is_empty() {
+        output.push_str("Providers with no results:\n");
+        for provider in no_result_providers {
+            output.push_str(&format!("- {}\n", provider));
+        }
+    }
+
+    if !provider_errors.is_empty() {
+        output.push_str("Providers unavailable or failed:\n");
+        for (provider, error) in provider_errors {
+            output.push_str(&format!("- {}: {}\n", provider, error));
+        }
+    }
 }
 
 struct SearchResult {

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -185,6 +185,13 @@ pub async fn chat(
             .map_err(|e| AppError::bad_request(e.to_string()))?;
     }
 
+    // Load app/agent config before resolving per-turn settings.
+    let store = ha_core::config::cached_config();
+    let agent_def = ha_core::agent_loader::load_agent(&agent_id).ok();
+    let agent_default_effort = agent_def
+        .as_ref()
+        .and_then(|def| def.config.model.reasoning_effort.clone());
+
     let requested_effort = body
         .reasoning_effort
         .as_deref()
@@ -192,9 +199,15 @@ pub async fn chat(
         .filter(|effort| !effort.is_empty())
         .map(str::to_string);
     let session_effort = db.get_session(&sid)?.and_then(|meta| meta.reasoning_effort);
+    let global_effort = if let Some(cell) = ha_core::get_reasoning_effort_cell() {
+        cell.lock().await.clone()
+    } else {
+        "medium".to_string()
+    };
     let effort = requested_effort
         .or(session_effort)
-        .unwrap_or_else(|| "medium".to_string());
+        .or(agent_default_effort)
+        .unwrap_or(global_effort);
     if !ha_core::agent::is_valid_reasoning_effort(&effort) {
         return Err(AppError::bad_request(format!(
             "Invalid reasoning effort: {}. Valid: {:?}",
@@ -245,11 +258,7 @@ pub async fn chat(
     // Auto-generate fallback title from first user message (prefer display text so titles read naturally).
     let _ = session::ensure_first_message_title(&db, &sid, persisted_content);
 
-    // Load app config (cached after first call)
-    let store = ha_core::config::cached_config();
-
     // Resolve model chain
-    let agent_def = ha_core::agent_loader::load_agent(&agent_id).ok();
     let agent_model_config = agent_def
         .as_ref()
         .map(|def| def.config.model.clone())

--- a/crates/ha-server/src/routes/models.rs
+++ b/crates/ha-server/src/routes/models.rs
@@ -108,8 +108,8 @@ pub async fn set_fallback_models(
 
 /// `POST /api/models/reasoning-effort` — validate and persist the current
 /// Think / reasoning effort. When `sessionId` is supplied, it is stored as a
-/// session-scoped override; when `agentId` can be resolved, it is also stored
-/// as that agent's default for future conversations.
+/// session-scoped override; when `agentId` is supplied, it is also stored as
+/// that agent's default for future conversations.
 pub async fn set_reasoning_effort(
     State(ctx): State<Arc<AppContext>>,
     Json(body): Json<SetReasoningEffortBody>,
@@ -130,13 +130,8 @@ pub async fn set_reasoning_effort(
         .agent_id
         .as_deref()
         .map(str::trim)
-        .filter(|id| !id.trim().is_empty())
-        .map(str::to_string)
-        .or_else(|| {
-            session_id
-                .and_then(|sid| ctx.session_db.get_session(sid).ok().flatten())
-                .map(|meta| meta.agent_id)
-        });
+        .filter(|id| !id.is_empty())
+        .map(str::to_string);
 
     if session_id.is_some() || agent_id.is_none() {
         if let Some(cell) = ha_core::get_reasoning_effort_cell() {

--- a/crates/ha-server/src/routes/models.rs
+++ b/crates/ha-server/src/routes/models.rs
@@ -45,6 +45,8 @@ pub struct SetReasoningEffortBody {
     pub effort: String,
     #[serde(default)]
     pub session_id: Option<String>,
+    #[serde(default)]
+    pub agent_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -105,8 +107,9 @@ pub async fn set_fallback_models(
 }
 
 /// `POST /api/models/reasoning-effort` — validate and persist the current
-/// Think / reasoning effort. When `sessionId` is supplied, it is also stored
-/// as a session-scoped override so switching conversations restores it.
+/// Think / reasoning effort. When `sessionId` is supplied, it is stored as a
+/// session-scoped override; when `agentId` can be resolved, it is also stored
+/// as that agent's default for future conversations.
 pub async fn set_reasoning_effort(
     State(ctx): State<Arc<AppContext>>,
     Json(body): Json<SetReasoningEffortBody>,
@@ -118,16 +121,37 @@ pub async fn set_reasoning_effort(
             ha_core::agent::VALID_REASONING_EFFORTS
         )));
     }
-    if let Some(cell) = ha_core::get_reasoning_effort_cell() {
-        *cell.lock().await = body.effort.clone();
-    }
-    if let Some(session_id) = body
+    let session_id = body
         .session_id
         .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty());
+    let agent_id = body
+        .agent_id
+        .as_deref()
+        .map(str::trim)
         .filter(|id| !id.trim().is_empty())
-    {
+        .map(str::to_string)
+        .or_else(|| {
+            session_id
+                .and_then(|sid| ctx.session_db.get_session(sid).ok().flatten())
+                .map(|meta| meta.agent_id)
+        });
+
+    if session_id.is_some() || agent_id.is_none() {
+        if let Some(cell) = ha_core::get_reasoning_effort_cell() {
+            *cell.lock().await = body.effort.clone();
+        }
+    }
+    if let Some(session_id) = session_id {
         ctx.session_db
             .update_session_reasoning_effort(session_id, Some(&body.effort))?;
+    }
+    if let Some(agent_id) = agent_id {
+        ha_core::agent_loader::update_agent_reasoning_effort(&agent_id, &body.effort)?;
+        if let Some(bus) = ha_core::get_event_bus() {
+            bus.emit("agents:changed", json!({ "id": agent_id, "kind": "saved" }));
+        }
     }
     Ok(Json(json!({ "ok": true })))
 }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -307,12 +307,7 @@ pub async fn set_reasoning_effort(
         .as_deref()
         .map(str::trim)
         .filter(|id| !id.is_empty())
-        .map(str::to_string)
-        .or_else(|| {
-            session_id
-                .and_then(|sid| state.session_db.get_session(sid).ok().flatten())
-                .map(|meta| meta.agent_id)
-        });
+        .map(str::to_string);
 
     if session_id.is_some() || agent_id.is_none() {
         set_reasoning_effort_core(&effort, &state).await?;

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -296,13 +296,47 @@ pub(crate) async fn set_reasoning_effort_core(
 pub async fn set_reasoning_effort(
     effort: String,
     session_id: Option<String>,
+    agent_id: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), CmdError> {
-    set_reasoning_effort_core(&effort, &state).await?;
-    if let Some(session_id) = session_id.as_deref().filter(|id| !id.trim().is_empty()) {
+    let session_id = session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty());
+    let agent_id = agent_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            session_id
+                .and_then(|sid| state.session_db.get_session(sid).ok().flatten())
+                .map(|meta| meta.agent_id)
+        });
+
+    if session_id.is_some() || agent_id.is_none() {
+        set_reasoning_effort_core(&effort, &state).await?;
+    } else if !ha_core::agent::is_valid_reasoning_effort(&effort) {
+        return Err(CmdError::msg(format!(
+            "Invalid reasoning effort: {}. Valid: {:?}",
+            effort,
+            ha_core::agent::VALID_REASONING_EFFORTS
+        )));
+    }
+
+    if let Some(session_id) = session_id {
         state
             .session_db
             .update_session_reasoning_effort(session_id, Some(&effort))?;
+    }
+    if let Some(agent_id) = agent_id {
+        ha_core::agent_loader::update_agent_reasoning_effort(&agent_id, &effort)?;
+        if let Some(bus) = ha_core::get_event_bus() {
+            bus.emit(
+                "agents:changed",
+                serde_json::json!({ "id": agent_id, "kind": "saved" }),
+            );
+        }
     }
     Ok(())
 }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -187,6 +187,10 @@ pub async fn chat(
             meta.id
         }
     };
+    let agent_def = agent_loader::load_agent(&current_agent_id).ok();
+    let agent_default_effort = agent_def
+        .as_ref()
+        .and_then(|def| def.config.model.reasoning_effort.clone());
 
     let requested_effort = reasoning_effort
         .as_deref()
@@ -195,7 +199,10 @@ pub async fn chat(
         .map(str::to_string);
     let session_effort = db.get_session(&sid)?.and_then(|meta| meta.reasoning_effort);
     let global_effort = state.reasoning_effort.lock().await.clone();
-    let effort = requested_effort.or(session_effort).unwrap_or(global_effort);
+    let effort = requested_effort
+        .or(session_effort)
+        .or(agent_default_effort)
+        .unwrap_or(global_effort);
     if !ha_core::agent::is_valid_reasoning_effort(&effort) {
         return Err(CmdError::msg(format!(
             "Invalid reasoning effort: {}. Valid: {:?}",
@@ -394,7 +401,6 @@ pub async fn chat(
     // (`AssistantAgent::agent_caps`), where it folds into
     // `capability_toggles.send_notification` so the dispatcher gates the
     // tool consistently — no need to thread it through here.
-    let agent_def = agent_loader::load_agent(&current_agent_id).ok();
     let agent_model_config = agent_def
         .as_ref()
         .map(|def| def.config.model.clone())

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -24,6 +24,7 @@ import type {
 } from "@/types/chat"
 import { normalizeEffortForModel } from "@/types/chat"
 import type { CommandResult } from "./slash-commands/types"
+import type { AgentConfig } from "@/components/settings/types"
 import ApprovalDialog from "@/components/chat/ApprovalDialog"
 import ChatSidebar from "@/components/chat/ChatSidebar"
 import ChatInput from "@/components/chat/ChatInput"
@@ -394,9 +395,9 @@ export default function ChatScreen({
           prev.reasoningEffort === effort ? prev : { ...prev, reasoningEffort: effort },
         )
       }
-      await handleEffortChange(effort, sid)
+      await handleEffortChange(effort, sid, session.currentAgentId)
     },
-    [handleEffortChange, session.currentSessionId, updateSessionMeta],
+    [handleEffortChange, session.currentAgentId, session.currentSessionId, updateSessionMeta],
   )
 
   const handleStartNewChat = useCallback(
@@ -471,12 +472,7 @@ export default function ChatScreen({
         getTransport().call<ActiveModel | null>("get_active_model"),
         getTransport().call<{ model: string; reasoning_effort: string }>("get_current_settings"),
         getTransport()
-          .call<{
-            name: string
-            model?: { primary?: string | null }
-            emoji?: string | null
-            avatar?: string | null
-          }>("get_agent_config", { id: currentAgentId })
+          .call<AgentConfig>("get_agent_config", { id: currentAgentId })
           .catch(() => null),
       ])
 
@@ -523,7 +519,10 @@ export default function ChatScreen({
             (m) => m.providerId === displayModel.providerId && m.modelId === displayModel.modelId,
           )
         : undefined
-      const effort = currentSessionMeta?.reasoningEffort ?? settings.reasoning_effort
+      const effort =
+        currentSessionMeta?.reasoningEffort ??
+        agentConfig?.model?.reasoningEffort ??
+        settings.reasoning_effort
       setReasoningEffort(normalizeEffortForModel(displayModelInfo, effort, t))
 
       if (agentConfig?.name) {
@@ -550,9 +549,9 @@ export default function ChatScreen({
       const [providerId, modelId] = key.split("::")
       if (!providerId || !modelId) return
       manualModelOverrideRef.current = { providerId, modelId }
-      await handleModelChange(key, currentSessionId)
+      await handleModelChange(key, currentSessionId, session.currentAgentId)
     },
-    [handleModelChange, currentSessionId],
+    [handleModelChange, currentSessionId, session.currentAgentId],
   )
 
   // Auto-show team panel when a team is created

--- a/src/components/chat/hooks/useModelState.ts
+++ b/src/components/chat/hooks/useModelState.ts
@@ -16,8 +16,16 @@ export interface UseModelStateReturn {
   setSessionTemperature: React.Dispatch<React.SetStateAction<number | null>>
   globalActiveModelRef: React.MutableRefObject<ActiveModel | null>
   applyModelForDisplay: (key: string) => void
-  handleModelChange: (key: string, sessionId?: string | null) => Promise<void>
-  handleEffortChange: (effort: string, sessionId?: string | null) => Promise<void>
+  handleModelChange: (
+    key: string,
+    sessionId?: string | null,
+    agentId?: string | null,
+  ) => Promise<void>
+  handleEffortChange: (
+    effort: string,
+    sessionId?: string | null,
+    agentId?: string | null,
+  ) => Promise<void>
 }
 
 export function useModelState(): UseModelStateReturn {
@@ -45,12 +53,17 @@ export function useModelState(): UseModelStateReturn {
     [availableModels, t],
   )
 
-  const handleEffortChange = useCallback(async (effort: string, sessionId?: string | null) => {
+  const handleEffortChange = useCallback(async (
+    effort: string,
+    sessionId?: string | null,
+    agentId?: string | null,
+  ) => {
     setReasoningEffort(effort)
     try {
       await getTransport().call("set_reasoning_effort", {
         effort,
         ...(sessionId ? { sessionId } : {}),
+        ...(agentId ? { agentId } : {}),
       })
     } catch (e) {
       logger.error("ui", "ChatScreen::effortChange", "Failed to set reasoning effort", e)
@@ -64,7 +77,7 @@ export function useModelState(): UseModelStateReturn {
   //   会自动把它落到 sessions 行
   // 全局默认模型现在只能由 Settings 里的 GlobalModelPanel 修改。
   const handleModelChange = useCallback(
-    async (key: string, sessionId?: string | null) => {
+    async (key: string, sessionId?: string | null, agentId?: string | null) => {
       const [providerId, modelId] = key.split("::")
       if (!providerId || !modelId) return
       setActiveModel({ providerId, modelId })
@@ -86,11 +99,13 @@ export function useModelState(): UseModelStateReturn {
         const normalized = normalizeEffortForModel(newModel, reasoningEffort, t)
         if (normalized !== reasoningEffort) {
           if (sessionId) {
-            handleEffortChange(normalized, sessionId)
+            handleEffortChange(normalized, sessionId, agentId)
+          } else if (agentId) {
+            handleEffortChange(normalized, null, agentId)
           } else {
             // 草稿模式（会话还没创建）：只更新本地 reasoningEffort，
-            // 不调 handleEffortChange——后者会把 effort 写到后端的全局 in-memory
-            // state，导致一次草稿切模型把 Think 默认泄漏到其它会话。
+            // 且没有 agentId 时不调 handleEffortChange，避免把 Think 默认泄漏
+            // 到其它会话。
             // 首次发消息时 chat_engine 会把 modelOverride + reasoningEffort 一起带
             // 上去，落到新创建的 sessions 行。
             setReasoningEffort(normalized)

--- a/src/components/chat/project/ProjectSection.tsx
+++ b/src/components/chat/project/ProjectSection.tsx
@@ -328,13 +328,7 @@ function ProjectGroup({
               <ProjectIcon project={project} size="sm" withColorChip />
               {projectUnreadCount > 0 && (
                 <span
-                  className="absolute -top-1 -right-1.5 z-10 min-w-[16px] h-[16px] px-0.5 rounded-full text-white text-[9px] font-bold flex items-center justify-center border border-background pointer-events-none leading-none"
-                  style={{
-                    background:
-                      "linear-gradient(135deg, #ff6b6b 0%, #ee3333 50%, #cc1111 100%)",
-                    boxShadow:
-                      "0 2px 6px rgba(220, 38, 38, 0.45), inset 0 1px 1px rgba(255, 255, 255, 0.25)",
-                  }}
+                  className="absolute -top-1 -right-1.5 z-10 flex h-[16px] min-w-[16px] items-center justify-center rounded-full border border-background bg-destructive px-0.5 text-[9px] font-semibold leading-none text-destructive-foreground tabular-nums pointer-events-none"
                 >
                   {projectUnreadCount > 99 ? "99+" : projectUnreadCount}
                 </span>

--- a/src/components/chat/sidebar/SessionItem.tsx
+++ b/src/components/chat/sidebar/SessionItem.tsx
@@ -147,13 +147,7 @@ export default function SessionItem({
             </div>
             {!isActive && displayUnreadCount > 0 && (
               <span
-                className="absolute -top-1 -right-1.5 z-10 min-w-[16px] h-[16px] px-0.5 rounded-full text-white text-[9px] font-bold flex items-center justify-center border border-background pointer-events-none leading-none"
-                style={{
-                  background:
-                    "linear-gradient(135deg, #ff6b6b 0%, #ee3333 50%, #cc1111 100%)",
-                  boxShadow:
-                    "0 2px 6px rgba(220, 38, 38, 0.45), inset 0 1px 1px rgba(255, 255, 255, 0.25)",
-                }}
+                className="absolute -top-1 -right-1.5 z-10 flex h-[16px] min-w-[16px] items-center justify-center rounded-full border border-background bg-destructive px-0.5 text-[9px] font-semibold leading-none text-destructive-foreground tabular-nums pointer-events-none"
               >
                 {displayUnreadCount > 99 ? "99+" : displayUnreadCount}
               </span>

--- a/src/components/chat/useQuickChatSession.ts
+++ b/src/components/chat/useQuickChatSession.ts
@@ -17,6 +17,12 @@ import type { AgentConfig } from "@/components/settings/types"
 const STORAGE_PREFIX = "quickchat:lastSession:"
 const QUICK_CHAT_PAGE_SIZE = 20
 
+type QuickModelSnapshot = {
+  models: AvailableModel[]
+  displayModel: ActiveModel | null
+  defaultEffort: string
+}
+
 function getLastSessionId(agentId: string): string | null {
   try {
     return localStorage.getItem(STORAGE_PREFIX + agentId)
@@ -130,14 +136,14 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
   }, [])
 
   // Load models and settings
-  const loadModels = useCallback(async () => {
+  const loadModels = useCallback(async (agentId = currentAgentId): Promise<QuickModelSnapshot | null> => {
     try {
       const [models, active, settings, agentConfig] = await Promise.all([
         getTransport().call<AvailableModel[]>("get_available_models"),
         getTransport().call<ActiveModel | null>("get_active_model"),
         getTransport().call<{ reasoning_effort: string }>("get_current_settings"),
         getTransport()
-          .call<AgentConfig>("get_agent_config", { id: currentAgentId })
+          .call<AgentConfig>("get_agent_config", { id: agentId })
           .catch(() => null),
       ])
       setAvailableModels(models)
@@ -167,9 +173,12 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
             (m) => m.providerId === displayModel.providerId && m.modelId === displayModel.modelId,
           )
         : undefined
-      setReasoningEffort(normalizeEffortForModel(currentModel, settings.reasoning_effort, (key) => key))
+      const effort = agentConfig?.model?.reasoningEffort ?? settings.reasoning_effort
+      setReasoningEffort(normalizeEffortForModel(currentModel, effort, (key) => key))
+      return { models, displayModel, defaultEffort: effort }
     } catch (e) {
       logger.error("ui", "QuickChat::loadModels", "Failed to load models", e)
+      return null
     }
   }, [currentAgentId])
 
@@ -199,17 +208,46 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
     [resetPagination],
   )
 
-  // Reload sessions list (for useChatStream compatibility)
-  const reloadSessions = useCallback(async () => {
+  const loadSessionsForAgent = useCallback(async (agentId: string): Promise<SessionMeta[]> => {
     try {
       const [list] = await getTransport().call<[SessionMeta[], number]>("list_sessions_cmd", {
-        agentId: currentAgentId === DEFAULT_AGENT_ID ? null : currentAgentId,
+        agentId: agentId === DEFAULT_AGENT_ID ? null : agentId,
       })
       setSessions(list)
+      return list
     } catch {
-      // ignore
+      return []
     }
-  }, [currentAgentId])
+  }, [])
+
+  // Reload sessions list (for useChatStream compatibility)
+  const reloadSessions = useCallback(async () => {
+    await loadSessionsForAgent(currentAgentId)
+  }, [currentAgentId, loadSessionsForAgent])
+
+  const applySessionRuntimeState = useCallback(
+    (session: SessionMeta, snapshot: QuickModelSnapshot | null) => {
+      if (!snapshot) return
+      let displayModel = snapshot.displayModel
+      if (session.providerId && session.modelId) {
+        const sessionModel = snapshot.models.find(
+          (m) => m.providerId === session.providerId && m.modelId === session.modelId,
+        )
+        if (sessionModel) {
+          displayModel = { providerId: session.providerId, modelId: session.modelId }
+          setActiveModel(displayModel)
+        }
+      }
+      const modelInfo = displayModel
+        ? snapshot.models.find(
+            (m) => m.providerId === displayModel.providerId && m.modelId === displayModel.modelId,
+          )
+        : undefined
+      const effort = session.reasoningEffort ?? snapshot.defaultEffort
+      setReasoningEffort(normalizeEffortForModel(modelInfo, effort, (key) => key))
+    },
+    [],
+  )
 
   // Update session messages helper (for useChatStream compatibility)
   const updateSessionMessages = useCallback(
@@ -228,7 +266,7 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
   // Initialize/restore session for current agent
   const initSession = useCallback(async () => {
     const agentList = await loadAgents()
-    await loadModels()
+    const modelSnapshot = await loadModels()
 
     // Try to find the agent name
     const agent = agentList.find((a) => a.id === currentAgentId)
@@ -236,6 +274,11 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
 
     const lastSid = getLastSessionId(currentAgentId)
     if (lastSid && (await loadSessionMessages(lastSid))) {
+      const sessionList = await loadSessionsForAgent(currentAgentId)
+      const restoredSession = sessionList.find((s) => s.id === lastSid)
+      if (restoredSession) {
+        applySessionRuntimeState(restoredSession, modelSnapshot)
+      }
       setCurrentSessionId(lastSid)
       return
     }
@@ -244,7 +287,15 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
     setCurrentSessionId(null)
     setMessages([])
     resetPagination()
-  }, [currentAgentId, loadAgents, loadModels, loadSessionMessages, resetPagination])
+  }, [
+    applySessionRuntimeState,
+    currentAgentId,
+    loadAgents,
+    loadModels,
+    loadSessionMessages,
+    loadSessionsForAgent,
+    resetPagination,
+  ])
 
   // Re-init when dialog opens
   useEffect(() => {
@@ -299,28 +350,19 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
       const agent = agents.find((a) => a.id === agentId)
       if (agent) setAgentName(agent.name)
 
-      // Try to load the agent's specific model config
-      try {
-        const agentConfig = await getTransport().call<AgentConfig>("get_agent_config", { id: agentId })
-        if (agentConfig.model.primary) {
-          const [pId, mId] = agentConfig.model.primary.split("::")
-          if (pId && mId) {
-            setActiveModel({ providerId: pId, modelId: mId })
-          }
-        }
-      } catch {
-        // Fall back to global active model
-      }
+      const modelSnapshot = await loadModels(agentId)
 
       // Try to restore last session for new agent
       const lastSid = getLastSessionId(agentId)
       if (lastSid) {
-        try {
-          await loadSessionMessages(lastSid)
+        if (await loadSessionMessages(lastSid)) {
+          const sessionList = await loadSessionsForAgent(agentId)
+          const restoredSession = sessionList.find((s) => s.id === lastSid)
+          if (restoredSession) {
+            applySessionRuntimeState(restoredSession, modelSnapshot)
+          }
           setCurrentSessionId(lastSid)
           return
-        } catch {
-          // Session deleted, create new
         }
       }
 
@@ -330,7 +372,15 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
       resetPagination()
       setDraftIncognito(false)
     },
-    [currentAgentId, agents, loadSessionMessages, resetPagination],
+    [
+      applySessionRuntimeState,
+      currentAgentId,
+      agents,
+      loadModels,
+      loadSessionMessages,
+      loadSessionsForAgent,
+      resetPagination,
+    ],
   )
 
   // Pin model to the current Quick Chat session — same semantics as the main
@@ -348,7 +398,27 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
         (m) => m.providerId === providerId && m.modelId === modelId,
       )
       if (newModel) {
-        setReasoningEffort((prev) => normalizeEffortForModel(newModel, prev, (k) => k))
+        const normalized = normalizeEffortForModel(newModel, reasoningEffort, (k) => k)
+        if (normalized !== reasoningEffort) {
+          setReasoningEffort(normalized)
+          const sessionId = currentSessionIdRef.current
+          if (sessionId) {
+            setSessions((prev) =>
+              prev.map((s) =>
+                s.id === sessionId ? { ...s, reasoningEffort: normalized } : s,
+              ),
+            )
+          }
+          getTransport()
+            .call("set_reasoning_effort", {
+              effort: normalized,
+              ...(sessionId ? { sessionId } : {}),
+              agentId: currentAgentId,
+            })
+            .catch((e) =>
+              logger.error("ui", "QuickChat::modelChange", "Failed to normalize effort", e),
+            )
+        }
       }
       const sessionId = currentSessionIdRef.current
       if (sessionId) {
@@ -363,7 +433,7 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
         }
       }
     },
-    [availableModels],
+    [availableModels, currentAgentId, reasoningEffort],
   )
 
   // Effort change
@@ -379,11 +449,12 @@ export function useQuickChatSession(open: boolean): UseQuickChatSessionReturn {
       await getTransport().call("set_reasoning_effort", {
         effort,
         ...(sessionId ? { sessionId } : {}),
+        agentId: currentAgentId,
       })
     } catch (e) {
       logger.error("ui", "QuickChat::effortChange", "Failed to set effort", e)
     }
-  }, [])
+  }, [currentAgentId])
 
   const handleLoadMore = useCallback(async () => {
     const curSid = currentSessionIdRef.current

--- a/src/components/settings/ImageGeneratePanel.tsx
+++ b/src/components/settings/ImageGeneratePanel.tsx
@@ -119,18 +119,21 @@ function PresetModelSelect({
     )
   }
 
+  const selectedValue = value || options[0].value
+  const selectedOption = options.find((opt) => opt.value === selectedValue) ?? options[0]
+
   return (
     <div className="flex gap-1.5">
       <Select
-        value={value || options[0].value}
+        value={selectedValue}
         onValueChange={(v) => onChange(v)}
       >
         <SelectTrigger className="flex-1">
-          <SelectValue />
+          <SelectValue>{selectedOption.label}</SelectValue>
         </SelectTrigger>
         <SelectContent>
           {options.map((opt) => (
-            <SelectItem key={opt.value} value={opt.value}>
+            <SelectItem key={opt.value} value={opt.value} textValue={opt.label}>
               <span className="text-xs">{opt.label}</span>
               <span className="text-[10px] text-muted-foreground ml-1.5">{opt.value}</span>
             </SelectItem>

--- a/src/components/settings/agent-panel/tabs/CapabilitiesTab.tsx
+++ b/src/components/settings/agent-panel/tabs/CapabilitiesTab.tsx
@@ -33,6 +33,9 @@ const ASYNC_TOOL_POLICIES: ReadonlyArray<{ value: AsyncToolPolicy; i18nKey: stri
   { value: "never-background", i18nKey: "neverBackground" },
 ]
 const ASYNC_TOOL_POLICY_DEFAULT = ASYNC_TOOL_POLICIES[0].value
+const asyncToolPolicyI18nKey = (value: AsyncToolPolicy) =>
+  ASYNC_TOOL_POLICIES.find((policy) => policy.value === value)?.i18nKey ??
+  ASYNC_TOOL_POLICIES[0].i18nKey
 
 /** Collapsible section wrapper used by every tier block in this tab. */
 function CollapsibleSection({
@@ -134,6 +137,8 @@ export default function CapabilitiesTab({
   const [standardOpen, setStandardOpen] = useState(false)
   const [mcpOpen, setMcpOpen] = useState(false)
   const [skillsOpen, setSkillsOpen] = useState(false)
+  const asyncToolPolicyValue =
+    config.capabilities.asyncToolPolicy ?? ASYNC_TOOL_POLICY_DEFAULT
 
   const toolDisplayName = (tool: BuiltinTool) => {
     const name = tool.name
@@ -240,13 +245,19 @@ export default function CapabilitiesTab({
             {t("settings.agentAsyncToolPolicy.title")}
           </div>
           <Select
-            value={config.capabilities.asyncToolPolicy ?? ASYNC_TOOL_POLICY_DEFAULT}
+            value={asyncToolPolicyValue}
             onValueChange={(v) =>
               updateCapabilities({ asyncToolPolicy: v as AsyncToolPolicy })
             }
           >
             <SelectTrigger className="h-8 w-full text-sm">
-              <SelectValue />
+              <SelectValue>
+                {t(
+                  `settings.agentAsyncToolPolicy.${asyncToolPolicyI18nKey(
+                    asyncToolPolicyValue,
+                  )}.label`,
+                )}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               {ASYNC_TOOL_POLICIES.map(({ value, i18nKey }) => (

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -244,7 +244,13 @@ export interface AgentConfig {
   description?: string | null
   emoji?: string | null
   avatar?: string | null
-  model: { primary?: string | null; fallbacks: string[]; planModel?: string | null; temperature?: number | null }
+  model: {
+    primary?: string | null
+    fallbacks: string[]
+    planModel?: string | null
+    temperature?: number | null
+    reasoningEffort?: string | null
+  }
   personality: PersonalityConfig
   capabilities: {
     maxToolRounds: number


### PR DESCRIPTION
## Summary

- Persist and resolve agent-level Think / reasoning effort defaults across desktop, HTTP, IM, cron, and subagent paths while preserving session-level overrides.
- Refresh quick chat and main chat runtime model/effort state from session and agent config so restored conversations use the expected model settings.
- Improve web search fallback diagnostics and avoid caching transient provider failure details.
- Polish a few settings/sidebar UI display details.

## Why

This keeps per-agent defaults from leaking through the global in-memory Think state, makes restored chat sessions more predictable, and makes web search failures clearer without turning temporary provider outages into cached output.

## Validation

- `cargo check -p ha-core -p ha-server`
- `cargo check -p hope-agent`
- Pre-push hook passed:
  - `cargo fmt --all --check`
  - `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
  - `pnpm typecheck`
  - `pnpm lint` (1 existing warning in `src/components/chat/ChatScreen.tsx`)
  - updater pubkey verification
  - `pnpm test`
  - `cargo test -p ha-core -p ha-server --locked`