### PR TITLE
ci: allow checkout to read repository 🦭

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, "release/**"]
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     name: Frontend lint + typecheck

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, "release/**"]
 
+permissions:
+  contents: read
+
 concurrency:
   group: rust-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add explicit `contents: read` permissions to the Lint and Rust workflows so `actions/checkout@v6` can fetch the repository when default token permissions are restricted.

## Verification
- Pre-push hook passed locally: cargo fmt, clippy, pnpm typecheck, eslint, Vitest, updater pubkey check, cargo test.