### PR TITLE
[codex] Fix AllowAlways permission scopes

### DIFF
--- a/crates/ha-core/src/channel/worker/approval.rs
+++ b/crates/ha-core/src/channel/worker/approval.rs
@@ -30,6 +30,7 @@ const APPROVAL_PREFIX: &str = "approval:";
 #[derive(Debug, Clone)]
 struct PendingTextApproval {
     request_id: String,
+    forbids_allow_always: bool,
 }
 
 /// Registry of pending text-reply approvals, keyed by (account_id, chat_id).
@@ -91,24 +92,40 @@ impl InlineButton {
 
 /// Build the standard 3-button row for approval prompts.
 /// The `callback_data` format is `approval:{request_id}:{action}`.
-pub(crate) fn build_approval_buttons(request_id: &str) -> Vec<Vec<InlineButton>> {
-    vec![vec![
-        InlineButton {
-            text: "✅ Allow Once".to_string(),
-            callback_data: Some(format!("{}{}:allow_once", APPROVAL_PREFIX, request_id)),
-            url: None,
-        },
-        InlineButton {
+pub(crate) fn build_approval_buttons(
+    request_id: &str,
+    reason: Option<&ApprovalReasonPayload>,
+) -> Vec<Vec<InlineButton>> {
+    let mut row = vec![InlineButton {
+        text: "✅ Allow Once".to_string(),
+        callback_data: Some(format!("{}{}:allow_once", APPROVAL_PREFIX, request_id)),
+        url: None,
+    }];
+    if !reason_forbids_allow_always(reason) {
+        row.push(InlineButton {
             text: "🔓 Always Allow".to_string(),
             callback_data: Some(format!("{}{}:allow_always", APPROVAL_PREFIX, request_id)),
             url: None,
-        },
-        InlineButton {
-            text: "❌ Deny".to_string(),
-            callback_data: Some(format!("{}{}:deny", APPROVAL_PREFIX, request_id)),
-            url: None,
-        },
-    ]]
+        });
+    }
+    row.push(InlineButton {
+        text: "❌ Deny".to_string(),
+        callback_data: Some(format!("{}{}:deny", APPROVAL_PREFIX, request_id)),
+        url: None,
+    });
+    vec![row]
+}
+
+fn reason_forbids_allow_always(reason: Option<&ApprovalReasonPayload>) -> bool {
+    matches!(
+        reason.map(|r| r.kind),
+        Some(
+            ApprovalReasonKind::DangerousCommand
+                | ApprovalReasonKind::ProtectedPath
+                | ApprovalReasonKind::MacControlDangerousAction
+                | ApprovalReasonKind::PlanModeAsk
+        )
+    )
 }
 
 /// Render the approval reason as a one-line suffix for IM prompts.
@@ -221,8 +238,19 @@ fn format_text_approval(
         String::new()
     };
     let reply_header = timeout_reply_header(timeout_secs);
+    let allow_always_forbidden = reason_forbids_allow_always(reason);
+    let always_line = if allow_always_forbidden {
+        ""
+    } else {
+        "\n  2 / always   — Always allow"
+    };
+    let zh_hint = if allow_always_forbidden {
+        "(中文也可: 同意 / 拒绝)"
+    } else {
+        "(中文也可: 同意 / 总是 / 拒绝)"
+    };
     format!(
-        "🔐 Tool approval required #{tag}:\n{preview}{smart}\n\n{reply_header}\n  1 / yes / ok — Allow once\n  2 / always   — Always allow\n  3 / no / deny — Deny\n(中文也可: 同意 / 总是 / 拒绝){stack_hint}",
+        "🔐 Tool approval required #{tag}:\n{preview}{smart}\n\n{reply_header}\n  1 / yes / ok — Allow once{always_line}\n  3 / no / deny — Deny\n{zh_hint}{stack_hint}",
         smart = reason_line(reason)
     )
 }
@@ -437,7 +465,7 @@ pub fn spawn_channel_approval_listener(channel_db: Arc<ChannelDB>, registry: Arc
                         &request.command,
                         request.reason.as_ref(),
                     )),
-                    buttons: build_approval_buttons(&request.request_id),
+                    buttons: build_approval_buttons(&request.request_id, request.reason.as_ref()),
                     thread_id: conversation.thread_id.clone(),
                     ..ReplyPayload::text("")
                 }
@@ -454,6 +482,7 @@ pub fn spawn_channel_approval_listener(channel_db: Arc<ChannelDB>, registry: Arc
                     let list = pending.entry(key).or_default();
                     list.push(PendingTextApproval {
                         request_id: request.request_id.clone(),
+                        forbids_allow_always: reason_forbids_allow_always(request.reason.as_ref()),
                     });
                     list.len()
                 };
@@ -603,7 +632,13 @@ pub async fn try_handle_approval_reply(msg: &crate::channel::types::MsgContext) 
     let key = (msg.account_id.clone(), msg.chat_id.clone());
     // Snapshot the available tags before popping so we can build a
     // helpful "did you mean" reply when the suffix doesn't match.
-    let (popped, available_tags) = {
+    enum TextReplySelection {
+        Popped(PendingTextApproval),
+        Missing { available_tags: Vec<String> },
+        AlwaysUnavailable { tag: String },
+    }
+
+    let selection = {
         let mut pending = get_text_pending().lock().await;
         let Some(list) = pending.get_mut(&key) else {
             return false;
@@ -616,34 +651,58 @@ pub async fn try_handle_approval_reply(msg: &crate::channel::types::MsgContext) 
         // (`id_tag` prefix match). Without suffix, fall back to LIFO so the
         // most-recently-prompted approval is the default — matches what's
         // visually on screen.
-        let popped = match parsed.id_suffix {
+        let maybe_idx = match parsed.id_suffix {
             Some(target) => list
                 .iter()
                 .position(|entry| id_tag(&entry.request_id) == target)
-                .map(|idx| list.remove(idx)),
-            None => list.pop(),
+                .map(Some)
+                .unwrap_or(None),
+            None => Some(list.len() - 1),
         };
-        let tags: Vec<String> = list
-            .iter()
-            .map(|entry| id_tag(&entry.request_id).to_string())
-            .collect();
-        if list.is_empty() {
-            pending.remove(&key);
+        match maybe_idx {
+            Some(idx)
+                if parsed.response == ApprovalResponse::AllowAlways
+                    && list[idx].forbids_allow_always =>
+            {
+                TextReplySelection::AlwaysUnavailable {
+                    tag: id_tag(&list[idx].request_id).to_string(),
+                }
+            }
+            Some(idx) => {
+                let popped = list.remove(idx);
+                if list.is_empty() {
+                    pending.remove(&key);
+                }
+                TextReplySelection::Popped(popped)
+            }
+            None => {
+                let available_tags: Vec<String> = list
+                    .iter()
+                    .map(|entry| id_tag(&entry.request_id).to_string())
+                    .collect();
+                TextReplySelection::Missing { available_tags }
+            }
         }
-        (popped, tags)
     };
 
-    let Some(entry) = popped else {
-        // Suffix typo: the user clearly tried to reply to an approval
-        // (verb parsed, `#<tag>` provided) but the tag doesn't match any
-        // pending entry. Consume the message and tell them which tags are
-        // valid — falling through to a fresh chat turn would silently
-        // route the typo to the LLM and leave the approval pending.
-        if let Some(target) = parsed.id_suffix {
-            send_suffix_mismatch_notice(msg, target, &available_tags).await;
+    let entry = match selection {
+        TextReplySelection::Popped(entry) => entry,
+        TextReplySelection::AlwaysUnavailable { tag } => {
+            send_allow_always_unavailable_notice(msg, &tag).await;
             return true;
         }
-        return false;
+        TextReplySelection::Missing { available_tags } => {
+            // Suffix typo: the user clearly tried to reply to an approval
+            // (verb parsed, `#<tag>` provided) but the tag doesn't match any
+            // pending entry. Consume the message and tell them which tags are
+            // valid — falling through to a fresh chat turn would silently
+            // route the typo to the LLM and leave the approval pending.
+            if let Some(target) = parsed.id_suffix {
+                send_suffix_mismatch_notice(msg, target, &available_tags).await;
+                return true;
+            }
+            return false;
+        }
     };
     let request_id = entry.request_id;
 
@@ -705,6 +764,37 @@ async fn send_suffix_mismatch_notice(
             "channel",
             "approval",
             "Failed to send suffix-mismatch notice: {}",
+            e
+        );
+    }
+}
+
+/// Tell text-reply users that this strict approval cannot be persisted.
+/// Leave the approval pending so they can still reply `1` / `yes` or deny it.
+async fn send_allow_always_unavailable_notice(msg: &crate::channel::types::MsgContext, tag: &str) {
+    let store = crate::config::cached_config();
+    let Some(account_config) = store.channels.find_account(&msg.account_id).cloned() else {
+        return;
+    };
+    let registry = match crate::globals::get_channel_registry() {
+        Some(r) => r,
+        None => return,
+    };
+    let payload = ReplyPayload {
+        text: Some(format!(
+            "ℹ️ Approval `#{tag}` requires per-call confirmation. Reply `1` / `yes` to allow once, or `3` / `no` to deny."
+        )),
+        thread_id: msg.thread_id.clone(),
+        ..ReplyPayload::text("")
+    };
+    if let Err(e) = registry
+        .send_reply(&account_config, &msg.chat_id, &payload)
+        .await
+    {
+        app_warn!(
+            "channel",
+            "approval",
+            "Failed to send AllowAlways-unavailable notice: {}",
             e
         );
     }
@@ -951,6 +1041,24 @@ mod tests {
     }
 
     #[test]
+    fn format_text_approval_hides_always_for_strict_reason() {
+        let txt = format_text_approval(
+            "exec rm -rf /",
+            Some(&ApprovalReasonPayload {
+                kind: ApprovalReasonKind::DangerousCommand,
+                detail: Some("rm -rf".to_string()),
+            }),
+            "abc123def456",
+            1,
+            300,
+        );
+        assert!(txt.contains("1 / yes / ok"));
+        assert!(!txt.contains("2 / always"));
+        assert!(!txt.contains("总是"));
+        assert!(txt.contains("3 / no / deny"));
+    }
+
+    #[test]
     fn format_text_approval_renders_stack_hint_when_multiple_pending() {
         let single = format_text_approval("exec ls", None, "abcdef123456", 1, 300);
         assert!(!single.contains("pending"));
@@ -1074,12 +1182,14 @@ mod tests {
                 .or_default()
                 .push(PendingTextApproval {
                     request_id: "older-id-aaa".to_string(),
+                    forbids_allow_always: false,
                 });
             pending
                 .entry(key.clone())
                 .or_default()
                 .push(PendingTextApproval {
                     request_id: "newer-id-bbb".to_string(),
+                    forbids_allow_always: false,
                 });
         }
         // Bare "yes" parses with no suffix → dispatcher uses `list.pop()`.
@@ -1111,12 +1221,14 @@ mod tests {
                 .or_default()
                 .push(PendingTextApproval {
                     request_id: "aaaaaa-older".to_string(),
+                    forbids_allow_always: false,
                 });
             pending
                 .entry(key.clone())
                 .or_default()
                 .push(PendingTextApproval {
                     request_id: "bbbbbb-newer".to_string(),
+                    forbids_allow_always: false,
                 });
         }
 
@@ -1160,18 +1272,21 @@ mod tests {
                 .or_default()
                 .push(PendingTextApproval {
                     request_id: "shared-id-xyz".to_string(),
+                    forbids_allow_always: false,
                 });
             pending
                 .entry(key_b.clone())
                 .or_default()
                 .push(PendingTextApproval {
                     request_id: "shared-id-xyz".to_string(),
+                    forbids_allow_always: false,
                 });
             pending
                 .entry(key_b.clone())
                 .or_default()
                 .push(PendingTextApproval {
                     request_id: "unrelated-id-pdq".to_string(),
+                    forbids_allow_always: false,
                 });
         }
 

--- a/crates/ha-core/src/permission/allowlist.rs
+++ b/crates/ha-core/src/permission/allowlist.rs
@@ -6,14 +6,26 @@
 //! - **Project** — `~/.hope-agent/projects/{project_id}/allowlist.json`
 //! - **Session** — in-memory only, dies with the session
 //! - **Agent home** — `~/.hope-agent/agents/{agent_id}/allowlist.json`
-//!   (only used when the rule's path/command is rooted in agent home)
+//!   (agent-scoped fallback when no project is active)
 //! - **Global** — `~/.hope-agent/permission/global-allowlist.json`
-//!   (default for `web_fetch` domain rules and cross-project commands)
+//!   (default for URL domain rules and commands when no project is active)
 //!
-//! The dialog UX picks a context-appropriate default scope but lets the user
-//! override.
+//! The backend currently picks a context-appropriate default scope. The dialog
+//! can grow an explicit scope picker later without changing the rule format.
 
+use std::collections::HashMap;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{OnceLock, RwLock};
+
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::rules::{
+    normalize_lexical, path_starts_with, resolve_path_with_default, ArgMatcher, PermissionRules,
+    RuleSpec,
+};
 
 /// Scope of an AllowAlways grant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -40,14 +52,474 @@ impl AllowScope {
     }
 }
 
-// Persistence helpers (load / add_rule / remove_rule per scope) land here
-// once the GUI / approval-dialog wiring needs them. In-memory session
-// scope: `Lazy<RwLock<HashMap<SessionId, PermissionRules>>>`. File-backed
-// scopes use `platform::write_secure_file` for atomic 0600 writes.
+/// Minimal context needed to choose the AllowAlways scope and build
+/// context-aware path matchers.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GrantContext<'a> {
+    pub session_id: Option<&'a str>,
+    pub project_id: Option<&'a str>,
+    pub agent_id: Option<&'a str>,
+    pub default_path: Option<&'a str>,
+    pub home_dir: Option<&'a str>,
+}
+
+/// The concrete grant that was persisted after an AllowAlways response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredGrant {
+    pub scope: AllowScope,
+    pub rule: RuleSpec,
+}
+
+static SESSION_RULES: OnceLock<RwLock<HashMap<String, PermissionRules>>> = OnceLock::new();
+static PROJECT_RULES: OnceLock<RwLock<HashMap<String, PermissionRules>>> = OnceLock::new();
+static AGENT_RULES: OnceLock<RwLock<HashMap<String, PermissionRules>>> = OnceLock::new();
+static GLOBAL_RULES: OnceLock<RwLock<Option<PermissionRules>>> = OnceLock::new();
+
+fn session_rules() -> &'static RwLock<HashMap<String, PermissionRules>> {
+    SESSION_RULES.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn project_rules() -> &'static RwLock<HashMap<String, PermissionRules>> {
+    PROJECT_RULES.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn agent_rules() -> &'static RwLock<HashMap<String, PermissionRules>> {
+    AGENT_RULES.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn global_rules() -> &'static RwLock<Option<PermissionRules>> {
+    GLOBAL_RULES.get_or_init(|| RwLock::new(None))
+}
+
+/// Return `true` if any active AllowAlways scope permits this tool call.
+pub fn allows_tool_call(
+    tool_name: &str,
+    args: &Value,
+    session_id: Option<&str>,
+    project_id: Option<&str>,
+    agent_id: Option<&str>,
+    default_path: Option<&str>,
+) -> bool {
+    let default_path = default_path.map(Path::new);
+    let matches = |rules: PermissionRules| {
+        rules
+            .allow
+            .iter()
+            .any(|rule| rule.matches_with_default_path(tool_name, args, default_path))
+    };
+
+    if let Some(session_id) = non_empty(session_id) {
+        if let Some(rules) = session_rules()
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(session_id)
+            .cloned()
+        {
+            if matches(rules) {
+                return true;
+            }
+        }
+    }
+
+    if let Some(project_id) = non_empty(project_id) {
+        if matches(load_project_rules(project_id)) {
+            return true;
+        }
+    }
+
+    if let Some(agent_id) = non_empty(agent_id) {
+        if matches(load_agent_rules(agent_id)) {
+            return true;
+        }
+    }
+
+    matches(load_global_rules())
+}
+
+/// Build and persist an AllowAlways rule for the approved tool call.
+pub fn add_allow_always_for_call(
+    tool_name: &str,
+    args: &Value,
+    ctx: GrantContext<'_>,
+) -> Result<StoredGrant> {
+    let rule = rule_for_call(tool_name, args, &ctx);
+    let scope = choose_scope(&rule, &ctx);
+    add_rule(scope, scope_key(scope, &ctx), rule.clone())?;
+    Ok(StoredGrant { scope, rule })
+}
+
+fn add_rule(scope: AllowScope, key: Option<String>, rule: RuleSpec) -> Result<()> {
+    match scope {
+        AllowScope::Session => {
+            let key = key.context("session AllowAlways scope requires a session id")?;
+            let mut guard = session_rules().write().unwrap_or_else(|e| e.into_inner());
+            let rules = guard.entry(key).or_default();
+            push_unique(&mut rules.allow, rule);
+            Ok(())
+        }
+        AllowScope::Project => {
+            let project_id = key.context("project AllowAlways scope requires a project id")?;
+            let mut rules = load_project_rules(&project_id);
+            push_unique(&mut rules.allow, rule);
+            write_rules(&project_path(&project_id)?, &rules)?;
+            project_rules()
+                .write()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(project_id, rules);
+            Ok(())
+        }
+        AllowScope::AgentHome => {
+            let agent_id = key.context("agent AllowAlways scope requires an agent id")?;
+            let mut rules = load_agent_rules(&agent_id);
+            push_unique(&mut rules.allow, rule);
+            write_rules(&agent_path(&agent_id)?, &rules)?;
+            agent_rules()
+                .write()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(agent_id, rules);
+            Ok(())
+        }
+        AllowScope::Global => {
+            let mut rules = load_global_rules();
+            push_unique(&mut rules.allow, rule);
+            write_rules(&global_path()?, &rules)?;
+            *global_rules().write().unwrap_or_else(|e| e.into_inner()) = Some(rules);
+            Ok(())
+        }
+    }
+}
+
+fn push_unique(rules: &mut Vec<RuleSpec>, rule: RuleSpec) {
+    if !rules.contains(&rule) {
+        rules.push(rule);
+    }
+}
+
+fn choose_scope(rule: &RuleSpec, ctx: &GrantContext<'_>) -> AllowScope {
+    if non_empty(ctx.project_id).is_some() {
+        return AllowScope::Project;
+    }
+    if rule_prefers_global_scope(rule) {
+        return AllowScope::Global;
+    }
+    if non_empty(ctx.agent_id).is_some() {
+        return AllowScope::AgentHome;
+    }
+    if non_empty(ctx.session_id).is_some() && is_broad_tool_rule(rule) {
+        return AllowScope::Session;
+    }
+    AllowScope::Global
+}
+
+fn is_broad_tool_rule(rule: &RuleSpec) -> bool {
+    matches!(rule, RuleSpec::Tool { .. })
+}
+
+fn rule_prefers_global_scope(rule: &RuleSpec) -> bool {
+    match rule {
+        RuleSpec::Tool { .. } => false,
+        RuleSpec::ToolPattern { matcher, .. } => matcher_prefers_global_scope(matcher),
+    }
+}
+
+fn matcher_prefers_global_scope(matcher: &ArgMatcher) -> bool {
+    match matcher {
+        ArgMatcher::CommandPrefix { .. } | ArgMatcher::DomainGlob { .. } => true,
+        ArgMatcher::All { matchers } => matchers.iter().any(matcher_prefers_global_scope),
+        _ => false,
+    }
+}
+
+fn scope_key(scope: AllowScope, ctx: &GrantContext<'_>) -> Option<String> {
+    match scope {
+        AllowScope::Project => non_empty(ctx.project_id).map(str::to_string),
+        AllowScope::Session => non_empty(ctx.session_id).map(str::to_string),
+        AllowScope::AgentHome => non_empty(ctx.agent_id).map(str::to_string),
+        AllowScope::Global => None,
+    }
+}
+
+fn rule_for_call(tool_name: &str, args: &Value, ctx: &GrantContext<'_>) -> RuleSpec {
+    if let Some(matcher) = command_matcher(tool_name, args) {
+        return RuleSpec::ToolPattern {
+            name: tool_name.to_string(),
+            matcher,
+        };
+    }
+    if let Some(matcher) = path_matcher(tool_name, args, ctx) {
+        return RuleSpec::ToolPattern {
+            name: tool_name.to_string(),
+            matcher,
+        };
+    }
+    if let Some(matcher) = url_and_action_matcher(args) {
+        return RuleSpec::ToolPattern {
+            name: tool_name.to_string(),
+            matcher,
+        };
+    }
+    if let Some(matcher) = stable_field_matcher(args) {
+        return RuleSpec::ToolPattern {
+            name: tool_name.to_string(),
+            matcher,
+        };
+    }
+    RuleSpec::Tool {
+        name: tool_name.to_string(),
+    }
+}
+
+fn command_matcher(tool_name: &str, args: &Value) -> Option<ArgMatcher> {
+    if tool_name != crate::tools::TOOL_EXEC {
+        return None;
+    }
+    let command = args.get("command").and_then(|v| v.as_str())?;
+    let prefix = command_prefix(command)?;
+    Some(ArgMatcher::CommandPrefix { prefix })
+}
+
+fn command_prefix(command: &str) -> Option<String> {
+    let trimmed = command.trim();
+    let prefix = trimmed.split_whitespace().next().unwrap_or(trimmed).trim();
+    (!prefix.is_empty()).then(|| prefix.to_string())
+}
+
+fn path_matcher(tool_name: &str, args: &Value, ctx: &GrantContext<'_>) -> Option<ArgMatcher> {
+    let default_path = ctx.default_path.map(Path::new);
+    if tool_name == crate::tools::TOOL_APPLY_PATCH {
+        let patch = args.get("input").and_then(|v| v.as_str())?;
+        let paths = super::rules::paths_in_patch_directives(patch);
+        let prefix = path_prefix_for_paths(&paths, default_path)?;
+        return Some(ArgMatcher::PathPrefix { prefix });
+    }
+    let prefix = super::rules::extract_path_arg(tool_name, args)
+        .map(|path| path_prefix_for_call(&path, default_path))?;
+    Some(ArgMatcher::PathPrefix { prefix })
+}
+
+fn path_prefix_for_paths(paths: &[PathBuf], default_path: Option<&Path>) -> Option<PathBuf> {
+    if paths.is_empty() {
+        return None;
+    }
+    let prefixes: Vec<PathBuf> = paths
+        .iter()
+        .map(|path| path_prefix_for_call(path, default_path))
+        .collect();
+    let common = common_path_prefix(&prefixes).unwrap_or_else(|| prefixes[0].clone());
+    if common.parent().is_none() && prefixes[0].parent().is_some() {
+        Some(prefixes[0].clone())
+    } else {
+        Some(common)
+    }
+}
+
+fn path_prefix_for_call(path: &Path, default_path: Option<&Path>) -> PathBuf {
+    let resolved = resolve_path_with_default(path, default_path);
+    if let Some(default_path) = default_path {
+        let default_path = normalize_lexical(&super::rules::expand_tilde(
+            default_path.to_string_lossy().as_ref(),
+        ));
+        if path_starts_with(&resolved, &default_path) {
+            return default_path;
+        }
+    }
+    if let Some(parent) = resolved.parent() {
+        if parent.parent().is_some() {
+            return parent.to_path_buf();
+        }
+        resolved
+    } else {
+        resolved
+    }
+}
+
+fn common_path_prefix(paths: &[PathBuf]) -> Option<PathBuf> {
+    let first = paths.first()?;
+    let mut common: Vec<_> = first.components().collect();
+    for path in &paths[1..] {
+        let components: Vec<_> = path.components().collect();
+        let shared_len = common
+            .iter()
+            .zip(components.iter())
+            .take_while(|(a, b)| a == b)
+            .count();
+        common.truncate(shared_len);
+        if common.is_empty() {
+            return None;
+        }
+    }
+    let mut out = PathBuf::new();
+    for component in common {
+        out.push(component.as_os_str());
+    }
+    (!out.as_os_str().is_empty()).then_some(normalize_lexical(&out))
+}
+
+fn url_and_action_matcher(args: &Value) -> Option<ArgMatcher> {
+    let host = args
+        .get("url")
+        .and_then(|v| v.as_str())
+        .and_then(url_host)?;
+    let mut matchers = stable_field_matchers(args);
+    matchers.push(ArgMatcher::DomainGlob { glob: host });
+    Some(one_or_all(matchers))
+}
+
+fn url_host(raw: &str) -> Option<String> {
+    let parsed = url::Url::parse(raw).ok()?;
+    parsed.host_str().map(|h| h.to_ascii_lowercase())
+}
+
+fn stable_field_matcher(args: &Value) -> Option<ArgMatcher> {
+    let matchers = stable_field_matchers(args);
+    (!matchers.is_empty()).then(|| one_or_all(matchers))
+}
+
+fn stable_field_matchers(args: &Value) -> Vec<ArgMatcher> {
+    ["action", "op", "kind", "scope"]
+        .iter()
+        .filter_map(|field| {
+            args.get(*field)
+                .and_then(|v| v.as_str())
+                .filter(|v| !v.is_empty())
+                .map(|value| ArgMatcher::FieldEquals {
+                    field: (*field).to_string(),
+                    value: value.to_string(),
+                })
+        })
+        .collect()
+}
+
+fn one_or_all(mut matchers: Vec<ArgMatcher>) -> ArgMatcher {
+    if matchers.len() == 1 {
+        matchers.remove(0)
+    } else {
+        ArgMatcher::All { matchers }
+    }
+}
+
+fn load_project_rules(project_id: &str) -> PermissionRules {
+    if let Some(rules) = project_rules()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(project_id)
+        .cloned()
+    {
+        return rules;
+    }
+    let loaded = read_rules(project_path(project_id).ok());
+    project_rules()
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(project_id.to_string(), loaded.clone());
+    loaded
+}
+
+fn load_agent_rules(agent_id: &str) -> PermissionRules {
+    if let Some(rules) = agent_rules()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(agent_id)
+        .cloned()
+    {
+        return rules;
+    }
+    let loaded = read_rules(agent_path(agent_id).ok());
+    agent_rules()
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(agent_id.to_string(), loaded.clone());
+    loaded
+}
+
+fn load_global_rules() -> PermissionRules {
+    if let Some(rules) = global_rules()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+    {
+        return rules;
+    }
+    let loaded = read_rules(global_path().ok());
+    *global_rules().write().unwrap_or_else(|e| e.into_inner()) = Some(loaded.clone());
+    loaded
+}
+
+fn read_rules(path: Option<PathBuf>) -> PermissionRules {
+    let Some(path) = path else {
+        return PermissionRules::default();
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => serde_json::from_str(&raw).unwrap_or_else(|e| {
+            app_warn!(
+                "permission",
+                "allowlist",
+                "Failed to parse AllowAlways rules at {}: {}",
+                path.display(),
+                e
+            );
+            PermissionRules::default()
+        }),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => PermissionRules::default(),
+        Err(e) => {
+            app_warn!(
+                "permission",
+                "allowlist",
+                "Failed to read AllowAlways rules at {}: {}",
+                path.display(),
+                e
+            );
+            PermissionRules::default()
+        }
+    }
+}
+
+fn write_rules(path: &Path, rules: &PermissionRules) -> Result<()> {
+    let json = serde_json::to_vec_pretty(rules)?;
+    crate::platform::write_secure_file(path, &json)
+        .with_context(|| format!("write AllowAlways rules to {}", path.display()))?;
+    Ok(())
+}
+
+fn project_path(project_id: &str) -> Result<PathBuf> {
+    Ok(crate::paths::project_dir(project_id)?.join("allowlist.json"))
+}
+
+fn agent_path(agent_id: &str) -> Result<PathBuf> {
+    Ok(crate::paths::agent_dir(agent_id)?.join("allowlist.json"))
+}
+
+fn global_path() -> Result<PathBuf> {
+    Ok(crate::paths::permission_dir()?.join("global-allowlist.json"))
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.and_then(|v| {
+        let trimmed = v.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn clear_caches_for_tests() {
+    if let Some(cache) = SESSION_RULES.get() {
+        cache.write().unwrap_or_else(|e| e.into_inner()).clear();
+    }
+    if let Some(cache) = PROJECT_RULES.get() {
+        cache.write().unwrap_or_else(|e| e.into_inner()).clear();
+    }
+    if let Some(cache) = AGENT_RULES.get() {
+        cache.write().unwrap_or_else(|e| e.into_inner()).clear();
+    }
+    if let Some(cache) = GLOBAL_RULES.get() {
+        *cache.write().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn allow_scope_as_str() {
@@ -72,5 +544,67 @@ mod tests {
                 .to_string();
             assert_eq!(scope.as_str(), via_serde);
         }
+    }
+
+    #[test]
+    fn builds_workspace_path_rule_for_relative_write() {
+        let ctx = GrantContext {
+            project_id: Some("proj"),
+            default_path: Some("/tmp/work"),
+            ..Default::default()
+        };
+        let rule = rule_for_call("write", &json!({"path": "src/lib.rs"}), &ctx);
+        assert!(rule.matches_with_default_path(
+            "write",
+            &json!({"path": "src/main.rs"}),
+            Some(Path::new("/tmp/work"))
+        ));
+        assert!(!rule.matches_with_default_path(
+            "write",
+            &json!({"path": "/tmp/other/main.rs"}),
+            Some(Path::new("/tmp/work"))
+        ));
+    }
+
+    #[test]
+    fn apply_patch_path_rule_checks_patch_directives() {
+        let ctx = GrantContext {
+            project_id: Some("proj"),
+            default_path: Some("/tmp/work"),
+            ..Default::default()
+        };
+        let rule = rule_for_call(
+            crate::tools::TOOL_APPLY_PATCH,
+            &json!({"input": "*** Begin Patch\n*** Update File: src/lib.rs\n@@\n*** End Patch\n"}),
+            &ctx,
+        );
+        assert!(rule.matches_with_default_path(
+            crate::tools::TOOL_APPLY_PATCH,
+            &json!({"input": "*** Begin Patch\n*** Update File: src/main.rs\n@@\n*** End Patch\n"}),
+            Some(Path::new("/tmp/work"))
+        ));
+        assert!(!rule.matches_with_default_path(
+            crate::tools::TOOL_APPLY_PATCH,
+            &json!({"input": "*** Begin Patch\n*** Update File: /tmp/other/main.rs\n@@\n*** End Patch\n"}),
+            Some(Path::new("/tmp/work"))
+        ));
+    }
+
+    #[test]
+    fn builds_action_op_rule_for_mac_control() {
+        let ctx = GrantContext::default();
+        let rule = rule_for_call(
+            crate::tools::TOOL_MAC_CONTROL,
+            &json!({"action": "act", "op": "click", "x": 10, "y": 20}),
+            &ctx,
+        );
+        assert!(rule.matches(
+            crate::tools::TOOL_MAC_CONTROL,
+            &json!({"action": "act", "op": "click", "x": 99, "y": 100})
+        ));
+        assert!(!rule.matches(
+            crate::tools::TOOL_MAC_CONTROL,
+            &json!({"action": "act", "op": "type", "text": "hello"})
+        ));
     }
 }

--- a/crates/ha-core/src/permission/engine.rs
+++ b/crates/ha-core/src/permission/engine.rs
@@ -50,6 +50,8 @@ pub struct ResolveContext<'a> {
     pub project_id: Option<&'a str>,
     /// Optional agent ID used for agent_home-scoped allowlist lookup.
     pub agent_id: Option<&'a str>,
+    /// Default path used to resolve relative AllowAlways path matchers.
+    pub default_path: Option<&'a str>,
     /// `true` if the tool is internal (per `ToolDefinition.internal`); these
     /// always bypass approval regardless of mode.
     pub is_internal_tool: bool,
@@ -158,12 +160,23 @@ pub fn resolve(ctx: &ResolveContext<'_>) -> Decision {
     if let Some(reason) = check_dangerous_command(ctx) {
         return Decision::Ask { reason };
     }
-    if let Some(reason) = check_mac_control_action(ctx) {
+    if let Some(reason) = check_mac_control_action(ctx).filter(AskReason::forbids_allow_always) {
         return Decision::Ask { reason };
     }
 
-    // AllowAlways file-backed scopes (project / session / agent_home / global)
-    // will be queried here once the GUI editor lands.
+    if super::allowlist::allows_tool_call(
+        ctx.tool_name,
+        ctx.args,
+        ctx.session_id,
+        ctx.project_id,
+        ctx.agent_id,
+        ctx.default_path,
+    ) {
+        return Decision::Allow;
+    }
+    if let Some(reason) = check_mac_control_action(ctx) {
+        return Decision::Ask { reason };
+    }
 
     match ctx.session_mode {
         SessionMode::Default => resolve_default_mode(ctx),
@@ -308,8 +321,9 @@ pub async fn resolve_async(ctx: &ResolveContext<'_>) -> Decision {
 }
 
 fn check_protected_path(ctx: &ResolveContext<'_>) -> Option<AskReason> {
-    use super::rules::normalize_lexical;
+    use super::rules::resolve_path_with_default;
     let patterns = super::protected_paths::current_patterns();
+    let default_path = ctx.default_path.map(std::path::Path::new);
 
     // Standard arg-level path (read/write/edit/ls/grep/find — and the cwd of
     // exec/process/apply_patch). Lex-normalize after expand_tilde so a
@@ -317,7 +331,7 @@ fn check_protected_path(ctx: &ResolveContext<'_>) -> Option<AskReason> {
     // `~/.ssh/id_rsa` before the prefix matcher runs — otherwise the prefix
     // mismatch ("…/Documents/../…" vs "…/.ssh") silently slips past.
     if let Some(path) = extract_path_arg(ctx.tool_name, ctx.args) {
-        let normalized = normalize_lexical(&path);
+        let normalized = resolve_path_with_default(&path, default_path);
         if let Some(matched) = super::protected_paths::matches(&normalized, &patterns) {
             return Some(AskReason::ProtectedPath {
                 matched_path: matched,
@@ -332,7 +346,8 @@ fn check_protected_path(ctx: &ResolveContext<'_>) -> Option<AskReason> {
     if ctx.tool_name == "exec" {
         if let Some(cmd) = ctx.args.get("command").and_then(|v| v.as_str()) {
             for token in path_like_tokens_in_command(cmd) {
-                if let Some(matched) = super::protected_paths::matches(&token, &patterns) {
+                let normalized = resolve_path_with_default(&token, default_path);
+                if let Some(matched) = super::protected_paths::matches(&normalized, &patterns) {
                     return Some(AskReason::ProtectedPath {
                         matched_path: matched,
                     });
@@ -346,8 +361,9 @@ fn check_protected_path(ctx: &ResolveContext<'_>) -> Option<AskReason> {
     // pull each declared path and check it against the protected list.
     if ctx.tool_name == "apply_patch" {
         if let Some(patch) = ctx.args.get("input").and_then(|v| v.as_str()) {
-            for path in paths_in_patch_directives(patch) {
-                if let Some(matched) = super::protected_paths::matches(&path, &patterns) {
+            for path in super::rules::paths_in_patch_directives(patch) {
+                let normalized = resolve_path_with_default(&path, default_path);
+                if let Some(matched) = super::protected_paths::matches(&normalized, &patterns) {
                     return Some(AskReason::ProtectedPath {
                         matched_path: matched,
                     });
@@ -395,30 +411,6 @@ fn path_like_tokens_in_command(command: &str) -> Vec<std::path::PathBuf> {
         })
         .map(|tok| normalize_lexical(&expand_tilde(tok)))
         .collect()
-}
-
-/// Pull each `*** Add File: ` / `*** Delete File: ` / `*** Update File: ` /
-/// `*** Move to: ` directive target out of an `apply_patch` body. Note the
-/// asymmetric naming — the parser in `tools::apply_patch` uses `*** Move to: `
-/// (not `Move File:`); the patch protected-path scan must match the same
-/// strings or rename targets slip through unchecked.
-fn paths_in_patch_directives(patch: &str) -> Vec<std::path::PathBuf> {
-    use crate::permission::rules::{expand_tilde, normalize_lexical};
-    let mut out = Vec::new();
-    for line in patch.lines() {
-        let trimmed = line.trim_start();
-        for prefix in [
-            "*** Add File: ",
-            "*** Delete File: ",
-            "*** Update File: ",
-            "*** Move to: ",
-        ] {
-            if let Some(path) = trimmed.strip_prefix(prefix) {
-                out.push(normalize_lexical(&expand_tilde(path.trim())));
-            }
-        }
-    }
-    out
 }
 
 fn check_dangerous_command(ctx: &ResolveContext<'_>) -> Option<AskReason> {
@@ -587,6 +579,7 @@ mod tests {
             session_id: None,
             project_id: None,
             agent_id: None,
+            default_path: Some("/tmp/project"),
             is_internal_tool: false,
             smart_config: None,
         }
@@ -1031,6 +1024,37 @@ mod tests {
     }
 
     #[test]
+    fn relative_path_resolves_before_protected_path_check() {
+        let args = json!({"path": "hosts"});
+        let plan: Vec<String> = vec![];
+        let custom: Vec<String> = vec![];
+        let mut c = ctx("write", &args, SessionMode::Default, &plan, &custom);
+        c.default_path = Some("/etc");
+        match resolve(&c) {
+            Decision::Ask {
+                reason: AskReason::ProtectedPath { .. },
+            } => {}
+            other => panic!("expected ProtectedPath ask, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn apply_patch_relative_directive_resolves_before_protected_path_check() {
+        let patch = "*** Begin Patch\n*** Update File: hosts\n@@ ...\n*** End Patch\n";
+        let args = json!({"input": patch});
+        let plan: Vec<String> = vec![];
+        let custom: Vec<String> = vec![];
+        let mut c = ctx("apply_patch", &args, SessionMode::Default, &plan, &custom);
+        c.default_path = Some("/etc");
+        match resolve(&c) {
+            Decision::Ask {
+                reason: AskReason::ProtectedPath { .. },
+            } => {}
+            other => panic!("expected ProtectedPath ask, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn internal_tools_skip_all_gates() {
         let args = json!({"path": "/tmp/foo"});
         let plan: Vec<String> = vec![];
@@ -1070,6 +1094,71 @@ mod tests {
         let custom: Vec<String> = vec![];
         let c = ctx("read", &args, SessionMode::Yolo, &plan, &custom);
         assert_eq!(resolve(&c), Decision::Allow);
+    }
+
+    #[test]
+    fn allowalways_preempts_default_edit_layer() {
+        let args = json!({"path": "src/lib.rs"});
+        let plan: Vec<String> = vec![];
+        let custom: Vec<String> = vec![];
+        let mut c = ctx("write", &args, SessionMode::Default, &plan, &custom);
+        c.project_id = Some("project-allow");
+        c.default_path = Some("/tmp/project-allow");
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        crate::test_support::with_env_vars(&[("HA_DATA_DIR", tmp.path())], || {
+            super::super::allowlist::clear_caches_for_tests();
+            super::super::allowlist::add_allow_always_for_call(
+                "write",
+                &args,
+                super::super::allowlist::GrantContext {
+                    session_id: c.session_id,
+                    project_id: c.project_id,
+                    agent_id: c.agent_id,
+                    default_path: c.default_path,
+                    home_dir: None,
+                },
+            )
+            .expect("persist allow grant");
+
+            assert_eq!(resolve(&c), Decision::Allow);
+            super::super::allowlist::clear_caches_for_tests();
+        });
+    }
+
+    #[test]
+    fn allowalways_preempts_non_dangerous_mac_control_action() {
+        let args = json!({"action": "act", "op": "click", "x": 1, "y": 2});
+        let plan: Vec<String> = vec![];
+        let custom: Vec<String> = vec![];
+        let mut c = ctx(
+            crate::tools::TOOL_MAC_CONTROL,
+            &args,
+            SessionMode::Default,
+            &plan,
+            &custom,
+        );
+        c.agent_id = Some("agent-allow");
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        crate::test_support::with_env_vars(&[("HA_DATA_DIR", tmp.path())], || {
+            super::super::allowlist::clear_caches_for_tests();
+            super::super::allowlist::add_allow_always_for_call(
+                crate::tools::TOOL_MAC_CONTROL,
+                &args,
+                super::super::allowlist::GrantContext {
+                    session_id: c.session_id,
+                    project_id: c.project_id,
+                    agent_id: c.agent_id,
+                    default_path: c.default_path,
+                    home_dir: None,
+                },
+            )
+            .expect("persist allow grant");
+
+            assert_eq!(resolve(&c), Decision::Allow);
+            super::super::allowlist::clear_caches_for_tests();
+        });
     }
 
     #[test]

--- a/crates/ha-core/src/permission/engine.rs
+++ b/crates/ha-core/src/permission/engine.rs
@@ -1025,11 +1025,11 @@ mod tests {
 
     #[test]
     fn relative_path_resolves_before_protected_path_check() {
-        let args = json!({"path": "hosts"});
+        let args = json!({"path": "id_rsa"});
         let plan: Vec<String> = vec![];
         let custom: Vec<String> = vec![];
         let mut c = ctx("write", &args, SessionMode::Default, &plan, &custom);
-        c.default_path = Some("/etc");
+        c.default_path = Some("~/.ssh");
         match resolve(&c) {
             Decision::Ask {
                 reason: AskReason::ProtectedPath { .. },
@@ -1040,12 +1040,12 @@ mod tests {
 
     #[test]
     fn apply_patch_relative_directive_resolves_before_protected_path_check() {
-        let patch = "*** Begin Patch\n*** Update File: hosts\n@@ ...\n*** End Patch\n";
+        let patch = "*** Begin Patch\n*** Update File: id_rsa\n@@ ...\n*** End Patch\n";
         let args = json!({"input": patch});
         let plan: Vec<String> = vec![];
         let custom: Vec<String> = vec![];
         let mut c = ctx("apply_patch", &args, SessionMode::Default, &plan, &custom);
-        c.default_path = Some("/etc");
+        c.default_path = Some("~/.ssh");
         match resolve(&c) {
             Decision::Ask {
                 reason: AskReason::ProtectedPath { .. },

--- a/crates/ha-core/src/permission/mod.rs
+++ b/crates/ha-core/src/permission/mod.rs
@@ -81,6 +81,7 @@ impl AskReason {
             AskReason::ProtectedPath { .. }
                 | AskReason::DangerousCommand { .. }
                 | AskReason::MacControlDangerousAction { .. }
+                | AskReason::PlanModeAsk
         )
     }
 }

--- a/crates/ha-core/src/permission/rules.rs
+++ b/crates/ha-core/src/permission/rules.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 /// A bag of rules at one scope (e.g. a project's allowlist file, or the
 /// global allowlist). The engine collects multiple bags from different
 /// scopes and merges them by priority.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PermissionRules {
     /// Allow without prompting.
@@ -37,7 +37,7 @@ impl PermissionRules {
 
 /// A single rule. Either matches by tool name alone, or by tool name plus
 /// a parameter-level matcher (path prefix, command prefix, domain glob…).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum RuleSpec {
     /// Match the tool by name regardless of args.
@@ -58,18 +58,33 @@ impl RuleSpec {
     /// Does this rule match the given tool call? `args` is the tool_call args
     /// JSON, used to extract path / command / domain when applicable.
     pub fn matches(&self, name: &str, args: &serde_json::Value) -> bool {
+        self.matches_with_default_path(name, args, None)
+    }
+
+    /// Context-aware variant of [`Self::matches`]. Path-aware matchers use
+    /// `default_path` to resolve relative tool paths the same way execution
+    /// does, so an AllowAlways grant for a workspace also covers future
+    /// relative paths inside that workspace.
+    pub fn matches_with_default_path(
+        &self,
+        name: &str,
+        args: &serde_json::Value,
+        default_path: Option<&Path>,
+    ) -> bool {
         if self.tool_name() != name {
             return false;
         }
         match self {
             Self::Tool { .. } => true,
-            Self::ToolPattern { matcher, .. } => matcher.matches(name, args),
+            Self::ToolPattern { matcher, .. } => {
+                matcher.matches_with_default_path(name, args, default_path)
+            }
         }
     }
 }
 
 /// Parameter-level matcher. Each variant knows where in `args` to look.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum ArgMatcher {
     /// `args.path` (or `cwd` for `exec`) starts with this prefix.
@@ -84,14 +99,40 @@ pub enum ArgMatcher {
     /// Generic substring match against the JSON-stringified args. Use sparingly
     /// — prefer one of the structured variants when possible.
     Substring { needle: String },
+    /// Top-level JSON string field equals this value.
+    FieldEquals { field: String, value: String },
+    /// All child matchers must match. Used for action/op pairs.
+    All { matchers: Vec<ArgMatcher> },
 }
 
 impl ArgMatcher {
     pub fn matches(&self, tool: &str, args: &serde_json::Value) -> bool {
+        self.matches_with_default_path(tool, args, None)
+    }
+
+    pub fn matches_with_default_path(
+        &self,
+        tool: &str,
+        args: &serde_json::Value,
+        default_path: Option<&Path>,
+    ) -> bool {
         match self {
             Self::PathPrefix { prefix } => {
+                let resolved_prefix = normalize_lexical(prefix);
+                if tool == crate::tools::TOOL_APPLY_PATCH {
+                    let Some(patch) = args.get("input").and_then(|v| v.as_str()) else {
+                        return false;
+                    };
+                    let paths = paths_in_patch_directives(patch);
+                    return !paths.is_empty()
+                        && paths.iter().all(|path| {
+                            let resolved_path = resolve_path_with_default(path, default_path);
+                            path_starts_with(&resolved_path, &resolved_prefix)
+                        });
+                }
                 if let Some(path) = extract_path_arg(tool, args) {
-                    path_starts_with(&path, prefix)
+                    let resolved_path = resolve_path_with_default(&path, default_path);
+                    path_starts_with(&resolved_path, &resolved_prefix)
                 } else {
                     false
                 }
@@ -111,6 +152,14 @@ impl ArgMatcher {
                 }
             }
             Self::Substring { needle } => args.to_string().contains(needle),
+            Self::FieldEquals { field, value } => args
+                .get(field)
+                .and_then(|v| v.as_str())
+                .map(|s| s == value)
+                .unwrap_or(false),
+            Self::All { matchers } => matchers
+                .iter()
+                .all(|m| m.matches_with_default_path(tool, args, default_path)),
         }
     }
 }
@@ -120,10 +169,9 @@ impl ArgMatcher {
 /// + the protected-paths gate.
 pub fn extract_path_arg(tool: &str, args: &serde_json::Value) -> Option<PathBuf> {
     // The tool registry uses `path` for read/write/edit/ls/grep/find and
-    // `cwd` for exec / process. `apply_patch` operates on multiple paths
-    // embedded in the patch body — we don't currently inspect those at the
-    // permission layer (the patch body is opaque text), so apply_patch
-    // matches on optional `cwd` only.
+    // `cwd` for exec / process. `apply_patch` also has directive paths inside
+    // its patch body; those are handled by `paths_in_patch_directives`, while
+    // this helper still returns optional `cwd` for generic path checks.
     let candidate = match tool {
         "read" | "write" | "edit" | "ls" | "grep" | "find" => args
             .get("path")
@@ -163,6 +211,43 @@ pub fn extract_domain_arg(args: &serde_json::Value) -> Option<String> {
 /// returns `String` for tool-arg parsing.
 pub fn expand_tilde(s: &str) -> PathBuf {
     PathBuf::from(crate::tools::expand_tilde(s))
+}
+
+/// Resolve a possibly-relative path against the current tool default path,
+/// then lexically normalize the result. This mirrors
+/// `ToolExecContext::resolve_path` closely enough for permission matching
+/// without making the rules module depend on the tools execution context.
+pub fn resolve_path_with_default(path: &Path, default_path: Option<&Path>) -> PathBuf {
+    let normalized = normalize_lexical(path);
+    if normalized.is_absolute() {
+        return normalized;
+    }
+    match default_path {
+        Some(base) => {
+            normalize_lexical(&expand_tilde(base.to_string_lossy().as_ref()).join(normalized))
+        }
+        None => normalized,
+    }
+}
+
+/// Pull each `*** Add File: ` / `*** Delete File: ` / `*** Update File: ` /
+/// `*** Move to: ` directive target out of an `apply_patch` body.
+pub fn paths_in_patch_directives(patch: &str) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    for line in patch.lines() {
+        let trimmed = line.trim_start();
+        for prefix in [
+            "*** Add File: ",
+            "*** Delete File: ",
+            "*** Update File: ",
+            "*** Move to: ",
+        ] {
+            if let Some(path) = trimmed.strip_prefix(prefix) {
+                out.push(normalize_lexical(&expand_tilde(path.trim())));
+            }
+        }
+    }
+    out
 }
 
 /// Lexically resolve `..` and `.` segments without touching the filesystem.

--- a/crates/ha-core/src/tools/approval.rs
+++ b/crates/ha-core/src/tools/approval.rs
@@ -220,38 +220,12 @@ fn load_allowlist() -> Result<Vec<String>> {
     }
 }
 
-async fn save_allowlist(list: &[String]) -> Result<()> {
-    let data = serde_json::to_string_pretty(list)?;
-    tokio::fs::write(allowlist_path(), data).await?;
-    Ok(())
-}
-
 /// Check if command is in the allowlist
 pub(crate) async fn is_command_allowed(command: &str) -> bool {
     let list = get_allowlist().lock().await;
     let cmd_trimmed = command.trim();
     list.iter()
         .any(|pattern| cmd_trimmed.starts_with(pattern) || cmd_trimmed == *pattern)
-}
-
-/// Add command prefix to allowlist
-pub(crate) async fn add_to_allowlist(command: &str) {
-    let mut list = get_allowlist().lock().await;
-    let prefix = extract_command_prefix(command);
-    if !list.contains(&prefix) {
-        list.push(prefix);
-        let _ = save_allowlist(&list).await;
-    }
-}
-
-/// Extract a meaningful command prefix for the allowlist
-fn extract_command_prefix(command: &str) -> String {
-    let trimmed = command.trim();
-    trimmed
-        .split_whitespace()
-        .next()
-        .unwrap_or(trimmed)
-        .to_string()
 }
 
 pub(crate) fn approval_timeout_secs() -> u64 {

--- a/crates/ha-core/src/tools/exec.rs
+++ b/crates/ha-core/src/tools/exec.rs
@@ -10,8 +10,8 @@ use crate::process_registry::{
 };
 
 use super::approval::{
-    add_to_allowlist, approval_timeout_action, check_and_request_approval, is_command_allowed,
-    ApprovalCheckError, ApprovalResponse,
+    approval_timeout_action, check_and_request_approval, is_command_allowed, ApprovalCheckError,
+    ApprovalResponse,
 };
 use super::TOOL_EXEC;
 
@@ -469,7 +469,20 @@ pub(crate) async fn tool_exec(args: &Value, ctx: &super::ToolExecContext) -> Res
                         Ok(ApprovalResponse::AllowAlways) => {
                             if allow_always_ok {
                                 app_info!("tool", "exec", "Command approved (always): {}", command);
-                                add_to_allowlist(command).await;
+                                if let Err(e) =
+                                    crate::permission::allowlist::add_allow_always_for_call(
+                                        TOOL_EXEC,
+                                        args,
+                                        ctx.allowlist_grant_context(),
+                                    )
+                                {
+                                    app_warn!(
+                                        "tool",
+                                        "exec",
+                                        "Command AllowAlways persistence failed: {}",
+                                        e
+                                    );
+                                }
                             } else {
                                 app_info!(
                                     "tool",

--- a/crates/ha-core/src/tools/execution.rs
+++ b/crates/ha-core/src/tools/execution.rs
@@ -94,6 +94,7 @@ pub(super) async fn resolve_tool_permission(
         session_id: ctx.session_id.as_deref(),
         project_id: ctx.project_id.as_deref(),
         agent_id: ctx.agent_id.as_deref(),
+        default_path: Some(ctx.default_path()),
         is_internal_tool,
         smart_config: app_cfg.as_deref().map(|c| &c.permission.smart),
     };
@@ -285,6 +286,16 @@ impl ToolExecContext {
             .as_deref()
             .or(self.home_dir.as_deref())
             .unwrap_or(".")
+    }
+
+    pub fn allowlist_grant_context(&self) -> crate::permission::allowlist::GrantContext<'_> {
+        crate::permission::allowlist::GrantContext {
+            session_id: self.session_id.as_deref(),
+            project_id: self.project_id.as_deref(),
+            agent_id: self.agent_id.as_deref(),
+            default_path: Some(self.default_path()),
+            home_dir: self.home_dir.as_deref(),
+        }
     }
 
     /// Returns the default cwd for process tools: session working dir, then
@@ -625,12 +636,27 @@ pub async fn execute_tool_with_context(
                                 reason
                             );
                         } else {
-                            // Multi-scope (project / session / agent_home /
-                            // global) AllowAlways persistence is wired in by
-                            // the approval dialog upgrade. For now `exec`
-                            // still uses the legacy command-prefix store
-                            // inside `tool_exec`.
-                            app_info!("tool", "approval", "Tool '{}' approved (always)", name);
+                            match crate::permission::allowlist::add_allow_always_for_call(
+                                name,
+                                args,
+                                ctx.allowlist_grant_context(),
+                            ) {
+                                Ok(grant) => app_info!(
+                                    "tool",
+                                    "approval",
+                                    "Tool '{}' approved (always, scope={}, rule={:?})",
+                                    name,
+                                    grant.scope.as_str(),
+                                    grant.rule
+                                ),
+                                Err(e) => app_warn!(
+                                    "tool",
+                                    "approval",
+                                    "Tool '{}' AllowAlways persistence failed; approved for this call only: {}",
+                                    name,
+                                    e
+                                ),
+                            }
                         }
                     }
                     Ok(approval::ApprovalResponse::Deny) => {

--- a/src/components/chat/ApprovalDialog.tsx
+++ b/src/components/chat/ApprovalDialog.tsx
@@ -99,7 +99,8 @@ export default function ApprovalDialog({ requests, onRespond }: ApprovalDialogPr
   const isStrict =
     reason?.kind === "protected_path" ||
     reason?.kind === "dangerous_command" ||
-    reason?.kind === "mac_control_dangerous_action"
+    reason?.kind === "mac_control_dangerous_action" ||
+    reason?.kind === "plan_mode_ask"
 
   return (
     <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -33,7 +33,7 @@
   },
   "approval": {
     "allowAlways": "Always Allow",
-    "allowAlwaysDisabled": "Cannot Always-Allow — protected path or dangerous command requires per-call confirmation",
+    "allowAlwaysDisabled": "Cannot Always-Allow — this approval reason requires per-call confirmation",
     "allowOnce": "Allow Once",
     "command": "Command",
     "countdownAction": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -33,7 +33,7 @@
   },
   "approval": {
     "allowAlways": "始终允许",
-    "allowAlwaysDisabled": "命中保护路径或危险命令时无法选择「始终允许」",
+    "allowAlwaysDisabled": "该审批原因要求每次确认，无法选择「始终允许」",
     "allowOnce": "允许一次",
     "command": "命令",
     "countdownAction": {


### PR DESCRIPTION
## Summary

- Add scoped AllowAlways persistence and lookup across project, session, agent home, and global permission scopes.
- Keep protected paths, dangerous commands, dangerous macOS control actions, and Plan Mode ask-before-each-call as strict per-call approvals.
- Align desktop approval dialog and IM approval buttons/text fallback so strict approvals no longer expose a misleading Always Allow option.
- Resolve relative paths against the tool default path before protected-path checks, including apply_patch directive paths.

## Why

The previous approval flow could imply that Always Allow applied to strict approval reasons, and exec approvals still wrote a legacy global command allowlist. This made approval scope too broad and confusing, especially for protected operations and IM text fallback approvals.

## Validation

- cargo fmt --all --check
- cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings
- cargo test -p ha-core -p ha-server --locked
- pnpm typecheck
- pnpm lint (passes with existing ChatScreen hook warning)
- pnpm test
- pre-push hook reran and passed the configured checks, including verify-updater-pubkey
