### PR TITLE
[codex] Fix subagent and parent stream usage bugs

### DIFF
--- a/crates/ha-core/src/app_init.rs
+++ b/crates/ha-core/src/app_init.rs
@@ -1119,86 +1119,89 @@ mod tests {
     use super::*;
     use crate::session::{ChatTurnInterruptReason, ChatTurnStatus, NewMessage};
 
-    fn temp_db() -> Arc<SessionDB> {
+    fn with_temp_data_dir<T>(f: impl FnOnce(Arc<SessionDB>) -> T) -> T {
         let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("sessions.db");
-        // Leak tempdir for test lifetime so SQLite can keep the file open.
-        std::mem::forget(dir);
-        Arc::new(SessionDB::open(&path).expect("open session db"))
+        crate::test_support::with_env_vars(&[("HA_DATA_DIR", dir.path())], || {
+            let path = dir.path().join("sessions.db");
+            let db = Arc::new(SessionDB::open(&path).expect("open session db"));
+            f(db)
+        })
     }
 
     #[test]
     fn secondary_startup_recovery_does_not_mutate_shared_session_state() {
-        let db = temp_db();
-        let session = db
-            .create_session_with_project(crate::agent_loader::DEFAULT_AGENT_ID, None, None)
-            .expect("create session");
-        let turn = db
-            .create_chat_turn(&session.id, "desktop", Some("stream-1"), None)
-            .expect("create turn");
-        let mut streaming = NewMessage::text_block("partial");
-        streaming.stream_status = Some("streaming".to_string());
-        db.append_message(&session.id, &streaming)
-            .expect("append streaming message");
+        with_temp_data_dir(|db| {
+            let session = db
+                .create_session_with_project(crate::agent_loader::DEFAULT_AGENT_ID, None, None)
+                .expect("create session");
+            let turn = db
+                .create_chat_turn(&session.id, "desktop", Some("stream-1"), None)
+                .expect("create turn");
+            let mut streaming = NewMessage::text_block("partial");
+            streaming.stream_status = Some("streaming".to_string());
+            db.append_message(&session.id, &streaming)
+                .expect("append streaming message");
 
-        recover_startup_session_state(&db, crate::runtime_lock::Tier::Secondary);
+            recover_startup_session_state(&db, crate::runtime_lock::Tier::Secondary);
 
-        let persisted_turn = db
-            .get_chat_turn(&turn.id)
-            .expect("load turn")
-            .expect("turn exists");
-        assert_eq!(persisted_turn.status, ChatTurnStatus::Running);
-        assert!(persisted_turn.interrupt_reason.is_none());
+            let persisted_turn = db
+                .get_chat_turn(&turn.id)
+                .expect("load turn")
+                .expect("turn exists");
+            assert_eq!(persisted_turn.status, ChatTurnStatus::Running);
+            assert!(persisted_turn.interrupt_reason.is_none());
 
-        let messages = db
-            .load_session_messages(&session.id)
-            .expect("load messages");
-        assert_eq!(messages[0].stream_status.as_deref(), Some("streaming"));
+            let messages = db
+                .load_session_messages(&session.id)
+                .expect("load messages");
+            assert_eq!(messages[0].stream_status.as_deref(), Some("streaming"));
+        });
     }
 
     #[test]
     fn primary_startup_recovery_marks_stale_state_and_clears_active_turns() {
-        let _lock = crate::chat_engine::active_turn::test_lock();
-        let db = temp_db();
-        let session = db
-            .create_session_with_project(crate::agent_loader::DEFAULT_AGENT_ID, None, None)
-            .expect("create session");
-        let turn = db
-            .create_chat_turn(&session.id, "desktop", Some("stream-1"), None)
-            .expect("create turn");
-        let mut streaming = NewMessage::text_block("partial");
-        streaming.stream_status = Some("streaming".to_string());
-        db.append_message(&session.id, &streaming)
-            .expect("append streaming message");
+        with_temp_data_dir(|db| {
+            let _lock = crate::chat_engine::active_turn::test_lock();
+            let session = db
+                .create_session_with_project(crate::agent_loader::DEFAULT_AGENT_ID, None, None)
+                .expect("create session");
+            let turn = db
+                .create_chat_turn(&session.id, "desktop", Some("stream-1"), None)
+                .expect("create turn");
+            let mut streaming = NewMessage::text_block("partial");
+            streaming.stream_status = Some("streaming".to_string());
+            db.append_message(&session.id, &streaming)
+                .expect("append streaming message");
 
-        let _guard = crate::chat_engine::active_turn::try_acquire(
-            &session.id,
-            crate::chat_engine::stream_seq::ChatSource::Desktop,
-            turn.id.clone(),
-            Arc::new(AtomicBool::new(false)),
-        )
-        .expect("acquire active turn");
+            let _guard = crate::chat_engine::active_turn::try_acquire(
+                &session.id,
+                crate::chat_engine::stream_seq::ChatSource::Desktop,
+                turn.id.clone(),
+                Arc::new(AtomicBool::new(false)),
+            )
+            .expect("acquire active turn");
 
-        recover_startup_session_state(&db, crate::runtime_lock::Tier::Primary);
+            recover_startup_session_state(&db, crate::runtime_lock::Tier::Primary);
 
-        let persisted_turn = db
-            .get_chat_turn(&turn.id)
-            .expect("load turn")
-            .expect("turn exists");
-        assert_eq!(persisted_turn.status, ChatTurnStatus::Interrupted);
-        assert_eq!(
-            persisted_turn.interrupt_reason,
-            Some(ChatTurnInterruptReason::CrashRecovery)
-        );
+            let persisted_turn = db
+                .get_chat_turn(&turn.id)
+                .expect("load turn")
+                .expect("turn exists");
+            assert_eq!(persisted_turn.status, ChatTurnStatus::Interrupted);
+            assert_eq!(
+                persisted_turn.interrupt_reason,
+                Some(ChatTurnInterruptReason::CrashRecovery)
+            );
 
-        let messages = db
-            .load_session_messages(&session.id)
-            .expect("load messages");
-        assert_eq!(messages[0].stream_status.as_deref(), Some("orphaned"));
-        assert!(crate::chat_engine::active_turn::current(&session.id).is_none());
+            let messages = db
+                .load_session_messages(&session.id)
+                .expect("load messages");
+            assert_eq!(messages[0].stream_status.as_deref(), Some("orphaned"));
+            assert!(crate::chat_engine::active_turn::current(&session.id).is_none());
 
-        // Ensure the dropped guard cannot resurrect a cleared entry.
-        drop(_guard);
-        assert!(crate::chat_engine::active_turn::current(&session.id).is_none());
+            // Ensure the dropped guard cannot resurrect a cleared entry.
+            drop(_guard);
+            assert!(crate::chat_engine::active_turn::current(&session.id).is_none());
+        });
     }
 }

--- a/crates/ha-core/src/chat_engine/finalize/sentinel.rs
+++ b/crates/ha-core/src/chat_engine/finalize/sentinel.rs
@@ -90,37 +90,25 @@ pub fn read_and_clear() -> StartupCause {
 
 #[cfg(test)]
 mod tests {
-    //! All tests in this module share the `HA_DATA_DIR` env var (read
-    //! by `paths::root_dir`), so they're packed into a single test
-    //! function to avoid the cross-test race that `cargo test`'s
-    //! default thread-pool would create.
     use super::*;
 
     #[test]
     fn sentinel_lifecycle() {
         let tmp = tempfile::tempdir().unwrap();
-        let prev = std::env::var_os("HA_DATA_DIR");
-        // SAFETY: single-threaded scope inside this test.
-        std::env::set_var("HA_DATA_DIR", tmp.path());
+        crate::test_support::with_env_vars(&[("HA_DATA_DIR", tmp.path())], || {
+            // 1. Missing sentinel reads as Crash.
+            assert_eq!(read_and_clear(), StartupCause::Crash);
 
-        // 1. Missing sentinel reads as Crash.
-        assert_eq!(read_and_clear(), StartupCause::Crash);
+            // 2. write_clean_marker creates the file.
+            write_clean_marker();
+            assert!(sentinel_path().unwrap().exists());
 
-        // 2. write_clean_marker creates the file.
-        write_clean_marker();
-        assert!(sentinel_path().unwrap().exists());
+            // 3. read_and_clear reports Clean and removes the file.
+            assert_eq!(read_and_clear(), StartupCause::Clean);
+            assert!(!sentinel_path().unwrap().exists(), "must be removed");
 
-        // 3. read_and_clear reports Clean and removes the file.
-        assert_eq!(read_and_clear(), StartupCause::Clean);
-        assert!(!sentinel_path().unwrap().exists(), "must be removed");
-
-        // 4. Re-read after consume → Crash again.
-        assert_eq!(read_and_clear(), StartupCause::Crash);
-
-        if let Some(v) = prev {
-            std::env::set_var("HA_DATA_DIR", v);
-        } else {
-            std::env::remove_var("HA_DATA_DIR");
-        }
+            // 4. Re-read after consume -> Crash again.
+            assert_eq!(read_and_clear(), StartupCause::Crash);
+        });
     }
 }

--- a/crates/ha-core/src/subagent/injection.rs
+++ b/crates/ha-core/src/subagent/injection.rs
@@ -103,11 +103,52 @@ pub(crate) fn build_subagent_push_message(
     error: Option<&str>,
 ) -> String {
     let duration = format!("{:.1}s", duration_ms as f64 / 1000.0);
-    let content = result.or(error).unwrap_or("(no output)");
+    let result_block = result
+        .filter(|text| !text.trim().is_empty())
+        .map(|text| format!("<result>\n{}\n</result>\n", escape_xml_text(text.trim())))
+        .unwrap_or_default();
+    let error_block = error
+        .filter(|text| !text.trim().is_empty())
+        .map(|text| format!("<error>\n{}\n</error>\n", escape_xml_text(text.trim())))
+        .unwrap_or_default();
+    let output_block = if result_block.is_empty() && error_block.is_empty() {
+        "<result>(no output)</result>\n".to_string()
+    } else {
+        format!("{}{}", result_block, error_block)
+    };
+    let summary = format!(
+        "Sub-agent \"{}\" finished with status \"{}\" in {}.",
+        agent_id,
+        status.as_str(),
+        duration
+    );
     format!(
-        "[Sub-Agent Completion — auto-delivered]\nRun ID: {}\nAgent: {}\nTask: {}\nStatus: {}\nDuration: {}\n<<<BEGIN_SUBAGENT_RESULT>>>\n{}\n<<<END_SUBAGENT_RESULT>>>",
-        run_id, agent_id, truncate_str(task, 50), status.as_str(), duration, content
+        "<subagent-result>\n\
+         <run-id>{}</run-id>\n\
+         <agent>{}</agent>\n\
+         <status>{}</status>\n\
+         <duration-ms>{}</duration-ms>\n\
+         <duration>{}</duration>\n\
+         <task>{}</task>\n\
+         {}\
+         <summary>{}</summary>\n\
+         </subagent-result>",
+        escape_xml_text(run_id),
+        escape_xml_text(agent_id),
+        escape_xml_text(status.as_str()),
+        duration_ms,
+        escape_xml_text(&duration),
+        escape_xml_text(&truncate_str(task, 50)),
+        output_block,
+        escape_xml_text(&summary)
     )
+}
+
+fn escape_xml_text(input: &str) -> String {
+    input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
 }
 
 /// Backend-driven result injection: wait for idle, then run the parent agent with the push message.
@@ -464,5 +505,30 @@ pub(crate) async fn inject_and_run_parent(
             delta: None,
             error: Some(format!("All models failed: {}", last_error)),
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subagent_push_message_uses_xmlish_payload_and_escapes_text() {
+        let msg = build_subagent_push_message(
+            "run<&",
+            "agent>&",
+            "read <file> & report",
+            &SubagentStatus::Completed,
+            1234,
+            Some("ok <done> & safe"),
+            None,
+        );
+
+        assert!(msg.starts_with("<subagent-result>"));
+        assert!(msg.contains("<run-id>run&lt;&amp;</run-id>"));
+        assert!(msg.contains("<agent>agent&gt;&amp;</agent>"));
+        assert!(msg.contains("<task>read &lt;file&gt; &amp; report</task>"));
+        assert!(msg.contains("<result>\nok &lt;done&gt; &amp; safe\n</result>"));
+        assert!(!msg.contains("BEGIN_SUBAGENT_RESULT"));
     }
 }

--- a/crates/ha-core/src/system_prompt/constants.rs
+++ b/crates/ha-core/src/system_prompt/constants.rs
@@ -182,7 +182,7 @@ const TOOL_DESC_SEND_NOTIFICATION: &str = "\
 const TOOL_DESC_SUBAGENT: &str = "\
 - subagent: Spawn and manage sub-agents to delegate tasks.\n\
   - Actions: spawn, check, list, result, kill, kill_all, steer, batch_spawn, wait_all, spawn_and_wait\n\
-  - Sub-agents run asynchronously — results are auto-pushed when complete\n\
+  - Sub-agents run asynchronously — results are auto-pushed as `<subagent-result>` user messages when complete\n\
   - spawn_and_wait: spawn + wait up to foreground_timeout (default 30s, max 120s). If completes in time, returns result inline. Otherwise auto-backgrounds — result injected later\n\
   - Use steer to redirect a running sub-agent without killing it";
 

--- a/crates/ha-core/src/system_prompt/sections.rs
+++ b/crates/ha-core/src/system_prompt/sections.rs
@@ -343,7 +343,7 @@ pub(super) fn build_subagent_section(
         "2. The sub-agent runs **asynchronously** — you can continue working on other things"
             .to_string(),
     );
-    lines.push("3. When the sub-agent completes, its result is **automatically pushed** to you as a new message".to_string());
+    lines.push("3. When the sub-agent completes, its result is **automatically pushed** to you as a `<subagent-result>` user message".to_string());
     lines.push("4. If you need to actively wait: `subagent(action=\"check\", run_id=\"...\", wait=true)` blocks until done (fallback)".to_string());
     lines.push(String::new());
     lines.push("## Steer a running sub-agent".to_string());

--- a/src/components/chat/SubagentBlock.tsx
+++ b/src/components/chat/SubagentBlock.tsx
@@ -7,6 +7,7 @@ import type { AgentSummaryForSidebar, SubagentEvent, SubagentRun } from "@/types
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
 import { IconTip } from "@/components/ui/tooltip"
 import { loadAgents, statusConfig, TERMINAL_STATUSES } from "./subagentShared"
+import SubagentRunDetails from "./SubagentRunDetails"
 
 interface SubagentBlockProps {
   runId: string
@@ -68,9 +69,9 @@ export default function SubagentBlock({
         if (run.durationMs) setDurationMs(run.durationMs)
         if (run.label) setLabel(run.label)
         if (run.modelUsed) setModelUsed(run.modelUsed)
-        if (run.inputTokens) setInputTokens(run.inputTokens)
-        if (run.outputTokens) setOutputTokens(run.outputTokens)
-        if (run.attachmentCount) setAttachmentCount(run.attachmentCount)
+        if (run.inputTokens != null) setInputTokens(run.inputTokens)
+        if (run.outputTokens != null) setOutputTokens(run.outputTokens)
+        if (run.attachmentCount != null) setAttachmentCount(run.attachmentCount)
         if (run.childSessionId) setChildSessionId(run.childSessionId)
       })
       .catch(() => {})
@@ -87,8 +88,9 @@ export default function SubagentBlock({
       if (payload.error) setError(payload.error)
       if (payload.durationMs) setDurationMs(payload.durationMs)
       if (payload.label) setLabel(payload.label)
-      if (payload.inputTokens) setInputTokens(payload.inputTokens)
-      if (payload.outputTokens) setOutputTokens(payload.outputTokens)
+      if (payload.inputTokens != null) setInputTokens(payload.inputTokens)
+      if (payload.outputTokens != null) setOutputTokens(payload.outputTokens)
+      if (payload.childSessionId) setChildSessionId(payload.childSessionId)
     })
   }, [runId])
 
@@ -100,8 +102,6 @@ export default function SubagentBlock({
   const nameTooltip = agentMissing ? t("subagent.deletedAgentTooltip") : undefined
 
   const canViewSession = !!(onSwitchSession && childSessionId)
-  const rowInteractive = isTerminal || canViewSession
-
   async function handleCancel() {
     if (isTerminal || cancelling) return
     setCancelling(true)
@@ -121,28 +121,21 @@ export default function SubagentBlock({
       <div
         className={cn(
           "flex items-center rounded-lg transition-colors",
-          // Only show row-hover tint when *something* in the row is actually
-          // interactable — otherwise disabled rows visually fake affordance.
-          rowInteractive && "hover:bg-secondary/80",
+          "hover:bg-secondary/80",
         )}
       >
         <button
           type="button"
           className="flex items-center gap-1.5 flex-1 min-w-0 px-2.5 py-1.5 text-left disabled:cursor-default"
-          onClick={() => isTerminal && setExpanded(!expanded)}
-          disabled={!isTerminal}
-          aria-expanded={isTerminal ? expanded : undefined}
+          onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
         >
-          {!isTerminal ? (
-            <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0" />
-          ) : (
-            <ChevronRight
-              className={cn(
-                "h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-200",
-                expanded && "rotate-90",
-              )}
-            />
-          )}
+          <ChevronRight
+            className={cn(
+              "h-3 w-3 shrink-0 text-muted-foreground transition-transform duration-200",
+              expanded && "rotate-90",
+            )}
+          />
           {emoji ? (
             <span className="shrink-0 leading-none" aria-hidden>
               {emoji}
@@ -158,6 +151,11 @@ export default function SubagentBlock({
           <span className="text-[10px] text-muted-foreground shrink-0 hidden sm:inline">
             {toolLabel}
           </span>
+          <IconTip label={runId}>
+            <span className="text-[10px] text-muted-foreground/70 font-mono shrink-0 hidden md:inline">
+              {runId.slice(0, 8)}
+            </span>
+          </IconTip>
           {attachmentCount > 0 && (
             <span className="flex items-center gap-0.5 text-muted-foreground shrink-0">
               <Paperclip className="h-2.5 w-2.5" />
@@ -223,10 +221,20 @@ export default function SubagentBlock({
       <div
         className={cn(
           "overflow-hidden transition-all duration-200 ease-out",
-          expanded && (resultFull || error) ? "max-h-[600px] opacity-100" : "max-h-0 opacity-0",
+          expanded ? "max-h-[760px] opacity-100" : "max-h-0 opacity-0",
         )}
       >
-        <div className="px-2.5 pb-2 pt-0.5 max-h-[600px] overflow-y-auto">
+        <div className="space-y-2 px-2.5 pb-2 pt-0.5 max-h-[760px] overflow-y-auto">
+          <SubagentRunDetails
+            runId={runId}
+            agentId={agentId}
+            childSessionId={childSessionId}
+            task={task}
+            modelUsed={modelUsed}
+            durationMs={durationMs}
+            inputTokens={inputTokens}
+            outputTokens={outputTokens}
+          />
           {error && (
             <pre className="whitespace-pre-wrap text-red-400 bg-background rounded p-2 text-[11px] leading-relaxed">
               {error}

--- a/src/components/chat/SubagentGroup.tsx
+++ b/src/components/chat/SubagentGroup.tsx
@@ -14,6 +14,7 @@ import { getTransport } from "@/lib/transport-provider"
 import type { AgentSummaryForSidebar, SubagentEvent, SubagentRun } from "@/types/chat"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
 import { IconTip } from "@/components/ui/tooltip"
+import SubagentRunDetails from "./SubagentRunDetails"
 import {
   loadAgents,
   statusConfig,
@@ -130,6 +131,7 @@ export default function SubagentGroup({ runs, onSwitchSession }: SubagentGroupPr
           label: payload.label ?? cur.label,
           inputTokens: payload.inputTokens ?? cur.inputTokens,
           outputTokens: payload.outputTokens ?? cur.outputTokens,
+          childSessionId: payload.childSessionId ?? cur.childSessionId,
         })
         return next
       })
@@ -278,11 +280,8 @@ function SubagentRow({
   // Only mark as missing after the metadata load has resolved
   const agentMissing = agentMetasLoaded && !agentMeta
   const nameTooltip = agentMissing ? t("subagent.deletedAgentTooltip") : undefined
-  const hasContent = !!(state?.resultFull || state?.error)
-  const canExpand = isTerminal && hasContent
   const childSessionId = state?.childSessionId
   const canViewSession = !!(onSwitchSession && childSessionId)
-  const rowInteractive = canExpand || canViewSession
 
   async function handleCancel() {
     if (isTerminal || cancelling) return
@@ -302,28 +301,21 @@ function SubagentRow({
       <div
         className={cn(
           "flex items-center transition-colors",
-          rowInteractive && "hover:bg-secondary/60",
+          "hover:bg-secondary/60",
         )}
       >
         <button
           type="button"
           className="flex items-center gap-1.5 flex-1 min-w-0 px-2.5 py-1 text-left disabled:cursor-default"
-          onClick={() => canExpand && setExpanded(!expanded)}
-          disabled={!canExpand}
-          aria-expanded={canExpand ? expanded : undefined}
+          onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
         >
-          {!isTerminal ? (
-            <span className="animate-spin h-3 w-3 border border-current border-t-transparent rounded-full shrink-0 text-muted-foreground/60" />
-          ) : hasContent ? (
-            <ChevronRight
-              className={cn(
-                "h-3 w-3 shrink-0 text-muted-foreground/40 transition-transform duration-150",
-                expanded && "rotate-90",
-              )}
-            />
-          ) : (
-            <span className="h-3 w-3 shrink-0" />
-          )}
+          <ChevronRight
+            className={cn(
+              "h-3 w-3 shrink-0 text-muted-foreground/40 transition-transform duration-150",
+              expanded && "rotate-90",
+            )}
+          />
           {emoji ? (
             <span className="shrink-0 leading-none" aria-hidden>
               {emoji}
@@ -334,6 +326,11 @@ function SubagentRow({
           <IconTip label={nameTooltip || friendlyName}>
             <span className="font-medium text-foreground truncate max-w-[40%]">
               {friendlyName}
+            </span>
+          </IconTip>
+          <IconTip label={run.runId}>
+            <span className="text-muted-foreground/60 font-mono text-[10px] shrink-0 hidden md:inline">
+              {run.runId.slice(0, 8)}
             </span>
           </IconTip>
           {state?.attachmentCount !== undefined && state.attachmentCount > 0 && (
@@ -393,10 +390,20 @@ function SubagentRow({
       <div
         className={cn(
           "overflow-hidden transition-all duration-200 ease-out",
-          expanded && hasContent ? "max-h-[600px] opacity-100" : "max-h-0 opacity-0",
+          expanded ? "max-h-[760px] opacity-100" : "max-h-0 opacity-0",
         )}
       >
-        <div className="px-2.5 pb-2 pt-0.5 max-h-[600px] overflow-y-auto">
+        <div className="space-y-2 px-2.5 pb-2 pt-0.5 max-h-[760px] overflow-y-auto">
+          <SubagentRunDetails
+            runId={run.runId}
+            agentId={run.agentId}
+            childSessionId={childSessionId}
+            task={run.task}
+            modelUsed={state?.modelUsed}
+            durationMs={state?.durationMs}
+            inputTokens={state?.inputTokens}
+            outputTokens={state?.outputTokens}
+          />
           {state?.error && (
             <pre className="whitespace-pre-wrap text-red-400 bg-background rounded p-2 text-[11px] leading-relaxed">
               {state.error}

--- a/src/components/chat/SubagentRunDetails.tsx
+++ b/src/components/chat/SubagentRunDetails.tsx
@@ -1,0 +1,127 @@
+import { useState } from "react"
+import { Check, Copy } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { IconTip } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+interface DetailRow {
+  key: string
+  label: string
+  value: string | number | undefined
+  monospace?: boolean
+}
+
+interface SubagentRunDetailsProps {
+  runId: string
+  agentId: string
+  childSessionId?: string
+  task: string
+  modelUsed?: string
+  durationMs?: number
+  inputTokens?: number
+  outputTokens?: number
+}
+
+export default function SubagentRunDetails({
+  runId,
+  agentId,
+  childSessionId,
+  task,
+  modelUsed,
+  durationMs,
+  inputTokens,
+  outputTokens,
+}: SubagentRunDetailsProps) {
+  const { t } = useTranslation()
+  const [copiedKey, setCopiedKey] = useState<string | null>(null)
+  const tokenSummary =
+    inputTokens != null && outputTokens != null
+      ? `${inputTokens.toLocaleString()} in / ${outputTokens.toLocaleString()} out`
+      : undefined
+  const rows: DetailRow[] = [
+    {
+      key: "runId",
+      label: t("subagent.runId", { defaultValue: "Run ID" }),
+      value: runId,
+      monospace: true,
+    },
+    {
+      key: "agentId",
+      label: t("subagent.agentId", { defaultValue: "Agent ID" }),
+      value: agentId,
+      monospace: true,
+    },
+    {
+      key: "childSessionId",
+      label: t("subagent.childSessionId", { defaultValue: "Child session" }),
+      value: childSessionId,
+      monospace: true,
+    },
+    {
+      key: "task",
+      label: t("subagent.task", { defaultValue: "Task" }),
+      value: task,
+    },
+    {
+      key: "model",
+      label: t("subagent.model", { defaultValue: "Model" }),
+      value: modelUsed,
+      monospace: true,
+    },
+    {
+      key: "duration",
+      label: t("subagent.duration", { defaultValue: "Duration" }),
+      value: durationMs != null ? `${(durationMs / 1000).toFixed(1)}s` : undefined,
+    },
+    {
+      key: "tokens",
+      label: t("subagent.tokens", { defaultValue: "Tokens" }),
+      value: tokenSummary,
+    },
+  ].filter((row) => row.value !== undefined && row.value !== "")
+
+  async function copyValue(key: string, value: string) {
+    try {
+      await navigator.clipboard?.writeText(value)
+      setCopiedKey(key)
+      window.setTimeout(() => setCopiedKey((cur) => (cur === key ? null : cur)), 1200)
+    } catch {
+      /* Clipboard is best-effort; details remain selectable. */
+    }
+  }
+
+  return (
+    <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1.5 rounded bg-background/70 px-2.5 py-2 text-[11px] leading-relaxed">
+      {rows.map((row) => {
+        const value = String(row.value)
+        const copied = copiedKey === row.key
+        return (
+          <div key={row.key} className="contents">
+            <dt className="text-muted-foreground whitespace-nowrap">{row.label}</dt>
+            <dd className="min-w-0 flex items-center gap-1.5 text-foreground/85">
+              <span
+                className={cn(
+                  "min-w-0 truncate select-text",
+                  row.monospace && "font-mono text-[10px]",
+                )}
+                title={value}
+              >
+                {value}
+              </span>
+              <IconTip label={copied ? t("chat.copied") : t("chat.copy")}>
+                <button
+                  type="button"
+                  className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-secondary hover:text-foreground transition-colors"
+                  onClick={() => copyValue(row.key, value)}
+                  aria-label={copied ? t("chat.copied") : t("chat.copy")}
+                >
+                  {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                </button>
+              </IconTip>
+            </dd>
+          </div>
+        )
+      })}
+    </dl>
+  )
+}

--- a/src/components/chat/hooks/useNotificationListeners.test.tsx
+++ b/src/components/chat/hooks/useNotificationListeners.test.tsx
@@ -17,6 +17,7 @@ const transportMock = vi.hoisted(() => {
         listeners.delete(eventName)
       }
     }),
+    call: vi.fn(() => Promise.reject(new Error("not mocked"))),
   }
 })
 
@@ -136,5 +137,52 @@ describe("useNotificationListeners", () => {
       type: "text",
       content: " after tool",
     })
+  })
+
+  test("flushes buffered parent stream text before handling done", async () => {
+    const rafCallbacks = new Map<number, FrameRequestCallback>()
+    let nextRaf = 1
+    const requestFrame = (cb: FrameRequestCallback) => {
+      const id = nextRaf++
+      rafCallbacks.set(id, cb)
+      return id
+    }
+    const cancelFrame = (id: number) => {
+      rafCallbacks.delete(id)
+    }
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(requestFrame)
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(cancelFrame)
+    vi.stubGlobal("requestAnimationFrame", window.requestAnimationFrame)
+    vi.stubGlobal("cancelAnimationFrame", window.cancelAnimationFrame)
+
+    let latest: Message[] = []
+    render(<Harness onMessages={(messages) => { latest = messages }} />)
+
+    const emit = transportMock.listeners.get("parent_agent_stream")
+    expect(emit).toBeTruthy()
+
+    await act(async () => {
+      emit?.({ eventType: "started", parentSessionId: "parent-session" })
+    })
+
+    await act(async () => {
+      emit?.({
+        eventType: "delta",
+        parentSessionId: "parent-session",
+        delta: JSON.stringify({ type: "text_delta", content: "final chunk" }),
+      })
+    })
+
+    expect(latest[0]?.content).toBe("")
+
+    await act(async () => {
+      emit?.({ eventType: "done", parentSessionId: "parent-session" })
+    })
+
+    expect(latest[0]?.content).toBe("final chunk")
+    expect(latest[0]?.contentBlocks).toEqual([
+      { type: "text", content: "final chunk" },
+    ])
+    expect(rafCallbacks.size).toBe(0)
   })
 })

--- a/src/components/chat/hooks/useNotificationListeners.test.tsx
+++ b/src/components/chat/hooks/useNotificationListeners.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+
+import { useEffect, useRef, useState } from "react"
+import { act, cleanup, render } from "@testing-library/react"
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import type { Message } from "@/types/chat"
+import { useNotificationListeners } from "./useNotificationListeners"
+
+const transportMock = vi.hoisted(() => {
+  const listeners = new Map<string, (payload: unknown) => void>()
+  return {
+    listeners,
+    listen: vi.fn((eventName: string, handler: (payload: unknown) => void) => {
+      listeners.set(eventName, handler)
+      return () => {
+        listeners.delete(eventName)
+      }
+    }),
+  }
+})
+
+vi.mock("@/lib/transport-provider", () => ({
+  getTransport: () => transportMock,
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}))
+
+vi.mock("@/lib/notifications", () => ({
+  notify: vi.fn(),
+}))
+
+afterEach(() => {
+  cleanup()
+  transportMock.listeners.clear()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
+
+function Harness({ onMessages }: { onMessages: (messages: Message[]) => void }) {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [loading, setLoading] = useState(false)
+  const [, setLoadingSessionIds] = useState<Set<string>>(new Set())
+  const currentSessionIdRef = useRef<string | null>("parent-session")
+  const loadingSessionsRef = useRef<Set<string>>(new Set())
+  const sessionCacheRef = useRef<Map<string, Message[]>>(new Map())
+
+  useNotificationListeners({
+    currentSessionIdRef,
+    setMessages,
+    setLoading,
+    loadingSessionsRef,
+    setLoadingSessionIds,
+    sessionCacheRef,
+    reloadSessions: async () => {},
+  })
+
+  useEffect(() => {
+    onMessages(messages)
+  }, [messages, onMessages])
+
+  return <div data-loading={loading ? "true" : "false"} />
+}
+
+describe("useNotificationListeners", () => {
+  test("renders parent-agent stream deltas through the shared chat stream handler", async () => {
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0)
+      return 1
+    })
+    vi.stubGlobal("cancelAnimationFrame", () => {})
+
+    let latest: Message[] = []
+    render(<Harness onMessages={(messages) => { latest = messages }} />)
+
+    const emit = transportMock.listeners.get("parent_agent_stream")
+    expect(emit).toBeTruthy()
+
+    await act(async () => {
+      emit?.({ eventType: "started", parentSessionId: "parent-session" })
+    })
+
+    await act(async () => {
+      emit?.({
+        eventType: "delta",
+        parentSessionId: "parent-session",
+        delta: JSON.stringify({ type: "text_delta", content: "before tool" }),
+      })
+    })
+
+    expect(latest[0]?.content).toBe("before tool")
+    expect(latest[0]?.contentBlocks).toEqual([
+      { type: "text", content: "before tool" },
+    ])
+
+    await act(async () => {
+      emit?.({
+        eventType: "delta",
+        parentSessionId: "parent-session",
+        delta: JSON.stringify({
+          type: "tool_call",
+          call_id: "call-1",
+          name: "read",
+          arguments: "{\"path\":\"README.md\"}",
+        }),
+      })
+      emit?.({
+        eventType: "delta",
+        parentSessionId: "parent-session",
+        delta: JSON.stringify({
+          type: "tool_result",
+          call_id: "call-1",
+          result: "ok",
+          duration_ms: 5,
+        }),
+      })
+      emit?.({
+        eventType: "delta",
+        parentSessionId: "parent-session",
+        delta: JSON.stringify({ type: "text_delta", content: " after tool" }),
+      })
+    })
+
+    expect(latest[0]?.content).toBe("before tool after tool")
+    expect(latest[0]?.contentBlocks?.map((block) => block.type)).toEqual([
+      "text",
+      "tool_call",
+      "text",
+    ])
+    expect(latest[0]?.contentBlocks?.[2]).toEqual({
+      type: "text",
+      content: " after tool",
+    })
+  })
+})

--- a/src/components/chat/hooks/useNotificationListeners.ts
+++ b/src/components/chat/hooks/useNotificationListeners.ts
@@ -8,6 +8,7 @@ import {
   createStreamDeltaBuffers,
   discardAllPendingStreamDeltas,
   discardPendingStreamDeltas,
+  flushPendingStreamDeltas,
   handleStreamEvent,
 } from "./useStreamEventHandler"
 import type {
@@ -36,6 +37,17 @@ export function useNotificationListeners(deps: UseNotificationListenersDeps) {
     reloadSessions,
   } = deps
   const parentDeltaBuffersRef = useRef(createStreamDeltaBuffers())
+
+  const parentStreamHandlerDeps = {
+    deltaBuffersRef: parentDeltaBuffersRef,
+    updateSessionMessages: (sessionId: string, updater: (prev: Message[]) => Message[]) => {
+      setMessages((prev) => {
+        const next = updater(prev)
+        sessionCacheRef.current.set(sessionId, next)
+        return next
+      })
+    },
+  }
 
   // Listen for agent-initiated notification events
   useEffect(() => {
@@ -86,21 +98,16 @@ export function useNotificationListeners(deps: UseNotificationListenersDeps) {
           const event = JSON.parse(delta) as Record<string, unknown>
           const sid = parentSessionId
           if (!event?.type) return
-          handleStreamEvent(event, sid, {
-            deltaBuffersRef: parentDeltaBuffersRef,
-            updateSessionMessages: (sessionId, updater) => {
-              setMessages((prev) => {
-                const next = updater(prev)
-                sessionCacheRef.current.set(sessionId, next)
-                return next
-              })
-            },
-          })
+          handleStreamEvent(event, sid, parentStreamHandlerDeps)
         } catch {
           /* ignore parse errors */
         }
       } else if (eventType === "done" || eventType === "error") {
-        discardPendingStreamDeltas(parentSessionId, parentDeltaBuffersRef)
+        if (isCurrentSession) {
+          flushPendingStreamDeltas(parentSessionId, parentStreamHandlerDeps, true)
+        } else {
+          discardPendingStreamDeltas(parentSessionId, parentDeltaBuffersRef)
+        }
         if (eventType === "error") {
           logger.error("subagent", "inject", "Backend parent agent injection failed", payload.error)
         }

--- a/src/components/chat/hooks/useNotificationListeners.ts
+++ b/src/components/chat/hooks/useNotificationListeners.ts
@@ -1,15 +1,18 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import { notify } from "@/lib/notifications"
 import { reloadAndMergeSessionMessages } from "../chatUtils"
-import { hasToolError } from "../message/executionStatus"
 import { PAGE_SIZE } from "../useChatSession"
+import {
+  createStreamDeltaBuffers,
+  discardAllPendingStreamDeltas,
+  discardPendingStreamDeltas,
+  handleStreamEvent,
+} from "./useStreamEventHandler"
 import type {
   Message,
-  MediaItem,
   ParentAgentStreamEvent,
-  ToolMetadata,
 } from "@/types/chat"
 
 export interface UseNotificationListenersDeps {
@@ -32,6 +35,7 @@ export function useNotificationListeners(deps: UseNotificationListenersDeps) {
     sessionCacheRef,
     reloadSessions,
   } = deps
+  const parentDeltaBuffersRef = useRef(createStreamDeltaBuffers())
 
   // Listen for agent-initiated notification events
   useEffect(() => {
@@ -79,125 +83,24 @@ export function useNotificationListeners(deps: UseNotificationListenersDeps) {
         setLoadingSessionIds(new Set(loadingSessionsRef.current))
       } else if (eventType === "delta" && delta && isCurrentSession) {
         try {
-          const ev = JSON.parse(delta)
+          const event = JSON.parse(delta) as Record<string, unknown>
           const sid = parentSessionId
-          if (ev.type === "text_delta" && ev.text) {
-            setMessages((prev) => {
-              const updated = [...prev]
-              const last = updated[updated.length - 1]
-              if (last?.role === "assistant") {
-                updated[updated.length - 1] = {
-                  ...last,
-                  content: last.content + ev.text,
-                }
-                sessionCacheRef.current.set(sid, updated)
-              }
-              return updated
-            })
-          } else if (ev.type === "tool_call") {
-            setMessages((prev) => {
-              const updated = [...prev]
-              const last = updated[updated.length - 1]
-              if (last?.role === "assistant") {
-                const toolCalls = [
-                  ...(last.toolCalls || []),
-                  {
-                    callId: ev.call_id,
-                    name: ev.name,
-                    arguments: ev.arguments || "",
-                    startedAtMs: Date.now(),
-                  },
-                ]
-                const blocks = [...(last.contentBlocks || [])]
-                if (last.content) blocks.push({ type: "text" as const, content: last.content })
-                blocks.push({
-                  type: "tool_call" as const,
-                  tool: toolCalls[toolCalls.length - 1],
-                })
-                updated[updated.length - 1] = {
-                  ...last,
-                  toolCalls,
-                  contentBlocks: blocks,
-                }
-                sessionCacheRef.current.set(sid, updated)
-              }
-              return updated
-            })
-          } else if (ev.type === "tool_result") {
-            setMessages((prev) => {
-              const updated = [...prev]
-              const last = updated[updated.length - 1]
-              if (last?.role === "assistant" && last.toolCalls) {
-                const mediaItems: MediaItem[] | undefined =
-                  Array.isArray(ev.media_items) && (ev.media_items as MediaItem[]).length
-                    ? (ev.media_items as MediaItem[])
-                    : undefined
-                const toolMetadata: ToolMetadata | undefined =
-                  ev.tool_metadata && typeof ev.tool_metadata === "object"
-                    ? (ev.tool_metadata as ToolMetadata)
-                    : undefined
-                const current = last.toolCalls.find((tc) => tc.callId === ev.call_id)
-                const resolvedDurationMs = ev.duration_ms ?? (
-                  current?.startedAtMs ? Date.now() - current.startedAtMs : undefined
-                )
-                const isError = typeof ev.is_error === "boolean"
-                  ? ev.is_error
-                  : hasToolError({ result: ev.result })
-                const toolCalls = last.toolCalls.map((tc) =>
-                  tc.callId === ev.call_id
-                    ? {
-                        ...tc,
-                        result: ev.result,
-                        isError,
-                        ...(mediaItems && { mediaItems }),
-                        ...(resolvedDurationMs != null ? { durationMs: resolvedDurationMs } : {}),
-                        ...(toolMetadata ? { metadata: toolMetadata } : {}),
-                      }
-                    : tc,
-                )
-                const blocks = (last.contentBlocks || []).map((b) =>
-                  b.type === "tool_call" && b.tool?.callId === ev.call_id
-                    ? {
-                        ...b,
-                        tool: {
-                          ...b.tool!,
-                          result: ev.result,
-                          isError,
-                          ...(mediaItems && { mediaItems }),
-                          ...(resolvedDurationMs != null ? { durationMs: resolvedDurationMs } : {}),
-                          ...(toolMetadata ? { metadata: toolMetadata } : {}),
-                        },
-                      }
-                    : b,
-                )
-                updated[updated.length - 1] = {
-                  ...last,
-                  toolCalls,
-                  contentBlocks: blocks,
-                }
-                sessionCacheRef.current.set(sid, updated)
-              }
-              return updated
-            })
-          } else if (ev.type === "usage") {
-            setMessages((prev) => {
-              const updated = [...prev]
-              const last = updated[updated.length - 1]
-              if (last?.role === "assistant") {
-                updated[updated.length - 1] = {
-                  ...last,
-                  usage: ev,
-                  model: ev.model,
-                }
-                sessionCacheRef.current.set(sid, updated)
-              }
-              return updated
-            })
-          }
+          if (!event?.type) return
+          handleStreamEvent(event, sid, {
+            deltaBuffersRef: parentDeltaBuffersRef,
+            updateSessionMessages: (sessionId, updater) => {
+              setMessages((prev) => {
+                const next = updater(prev)
+                sessionCacheRef.current.set(sessionId, next)
+                return next
+              })
+            },
+          })
         } catch {
           /* ignore parse errors */
         }
       } else if (eventType === "done" || eventType === "error") {
+        discardPendingStreamDeltas(parentSessionId, parentDeltaBuffersRef)
         if (eventType === "error") {
           logger.error("subagent", "inject", "Backend parent agent injection failed", payload.error)
         }
@@ -219,7 +122,10 @@ export function useNotificationListeners(deps: UseNotificationListenersDeps) {
         }
       }
     })
-    return unlisten
+    return () => {
+      unlisten()
+      discardAllPendingStreamDeltas(parentDeltaBuffersRef)
+    }
     // reloadSessions is useCallback([setSessions]) — setSessions is a stable
     // useState setter, so this effect subscribes once per mount in practice.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/chat/hooks/useStreamEventHandler.ts
+++ b/src/components/chat/hooks/useStreamEventHandler.ts
@@ -100,7 +100,7 @@ function takePendingStreamDeltas(
   return pending
 }
 
-function flushPendingStreamDeltas(
+export function flushPendingStreamDeltas(
   sid: string,
   deps: StreamEventHandlerDeps,
   cancelScheduled: boolean,

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -110,23 +110,50 @@ function getXmlishElement(content: string, name: string): string | undefined {
   return match?.[1]?.trim()
 }
 
+function decodeXmlishText(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+}
+
 function parseToolJobPayload(
   content: string,
 ): { toolName?: string; status?: string; detail?: string } | null {
   const match = content.match(/<tool-job-result\b([^>]*)>/)
-  if (!match) return null
-  const attrs = match[1] || ""
+  if (match) {
+    const attrs = match[1] || ""
+    return {
+      toolName: decodeXmlishText(getXmlishAttribute(attrs, "tool")),
+      status: decodeXmlishText(getXmlishAttribute(attrs, "status")),
+      detail:
+        decodeXmlishText(getXmlishElement(content, "output")) ||
+        decodeXmlishText(getXmlishElement(content, "error")) ||
+        decodeXmlishText(getXmlishElement(content, "note")),
+    }
+  }
+
+  if (!content.includes("<task-notification>")) {
+    return null
+  }
   return {
-    toolName: getXmlishAttribute(attrs, "tool"),
-    status: getXmlishAttribute(attrs, "status"),
+    toolName: decodeXmlishText(getXmlishElement(content, "tool")),
+    status: decodeXmlishText(getXmlishElement(content, "status")),
     detail:
-      getXmlishElement(content, "output") ||
-      getXmlishElement(content, "error") ||
-      getXmlishElement(content, "note"),
+      decodeXmlishText(getXmlishElement(content, "output-preview")) ||
+      decodeXmlishText(getXmlishElement(content, "error")) ||
+      decodeXmlishText(getXmlishElement(content, "summary")) ||
+      decodeXmlishText(getXmlishElement(content, "output-file")),
   }
 }
 
 function parseSubagentResultDetail(content: string): string | undefined {
+  const xmlDetail =
+    decodeXmlishText(getXmlishElement(content, "result")) ||
+    decodeXmlishText(getXmlishElement(content, "error"))
+  if (xmlDetail) return xmlDetail
+
   const match = content.match(
     /<<<BEGIN_SUBAGENT_RESULT>>>\n?([\s\S]*?)\n?<<<END_SUBAGENT_RESULT>>>/,
   )
@@ -134,11 +161,14 @@ function parseSubagentResultDetail(content: string): string | undefined {
 }
 
 function parseSubagentResultStatus(content: string): string {
-  const status = content.match(/^Status:\s*(\S+)/m)?.[1]
+  const status =
+    decodeXmlishText(getXmlishElement(content, "status")) ||
+    content.match(/^Status:\s*(\S+)/m)?.[1]
   switch (status) {
     case "completed":
       return "completed"
     case "timeout":
+    case "timed_out":
       return "timed_out"
     case "killed":
       return "cancelled"

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -48,6 +48,13 @@ import ModelPickerCard from "@/components/chat/ModelPickerCard"
 import ContextBreakdownCard from "@/components/chat/context-view/ContextBreakdownCard"
 import RecapProgressCard from "@/components/chat/RecapProgressCard"
 import SkillForkStatusCard from "@/components/chat/SkillForkStatusCard"
+import {
+  parseSubagentResultDetail,
+  parseSubagentResultStatus,
+  parseToolJobPayload,
+  TOOL_JOB_AGENT_PREFIX,
+  TOOL_JOB_STATUSES,
+} from "./asyncResultPayload"
 
 export interface MessageBubbleProps {
   msg: Message
@@ -84,102 +91,10 @@ export interface MessageBubbleProps {
   displayMode?: ChatDisplayMode
 }
 
-const TOOL_JOB_AGENT_PREFIX = "tool_job:"
-const TOOL_JOB_STATUSES = new Set([
-  "completed",
-  "failed",
-  "timed_out",
-  "cancelled",
-  "interrupted",
-  "running",
-])
-
 function hasRenderableTextContent(msg: Message): boolean {
   return (
     !!msg.content || !!msg.contentBlocks?.some((block) => block.type === "text" && !!block.content)
   )
-}
-
-function getXmlishAttribute(attrs: string, name: string): string | undefined {
-  const match = attrs.match(new RegExp(`\\b${name}="([^"]*)"`))
-  return match?.[1]
-}
-
-function getXmlishElement(content: string, name: string): string | undefined {
-  const match = content.match(new RegExp(`<${name}>([\\s\\S]*?)</${name}>`))
-  return match?.[1]?.trim()
-}
-
-function decodeXmlishText(value: string | undefined): string | undefined {
-  if (!value) return undefined
-  return value
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&")
-}
-
-function parseToolJobPayload(
-  content: string,
-): { toolName?: string; status?: string; detail?: string } | null {
-  const match = content.match(/<tool-job-result\b([^>]*)>/)
-  if (match) {
-    const attrs = match[1] || ""
-    return {
-      toolName: decodeXmlishText(getXmlishAttribute(attrs, "tool")),
-      status: decodeXmlishText(getXmlishAttribute(attrs, "status")),
-      detail:
-        decodeXmlishText(getXmlishElement(content, "output")) ||
-        decodeXmlishText(getXmlishElement(content, "error")) ||
-        decodeXmlishText(getXmlishElement(content, "note")),
-    }
-  }
-
-  if (!content.includes("<task-notification>")) {
-    return null
-  }
-  return {
-    toolName: decodeXmlishText(getXmlishElement(content, "tool")),
-    status: decodeXmlishText(getXmlishElement(content, "status")),
-    detail:
-      decodeXmlishText(getXmlishElement(content, "output-preview")) ||
-      decodeXmlishText(getXmlishElement(content, "error")) ||
-      decodeXmlishText(getXmlishElement(content, "summary")) ||
-      decodeXmlishText(getXmlishElement(content, "output-file")),
-  }
-}
-
-function parseSubagentResultDetail(content: string): string | undefined {
-  const xmlDetail =
-    decodeXmlishText(getXmlishElement(content, "result")) ||
-    decodeXmlishText(getXmlishElement(content, "error"))
-  if (xmlDetail) return xmlDetail
-
-  const match = content.match(
-    /<<<BEGIN_SUBAGENT_RESULT>>>\n?([\s\S]*?)\n?<<<END_SUBAGENT_RESULT>>>/,
-  )
-  return match?.[1]?.trim()
-}
-
-function parseSubagentResultStatus(content: string): string {
-  const status =
-    decodeXmlishText(getXmlishElement(content, "status")) ||
-    content.match(/^Status:\s*(\S+)/m)?.[1]
-  switch (status) {
-    case "completed":
-      return "completed"
-    case "timeout":
-    case "timed_out":
-      return "timed_out"
-    case "killed":
-      return "cancelled"
-    case "running":
-    case "spawning":
-      return "running"
-    case "error":
-      return "failed"
-    default:
-      return "completed"
-  }
 }
 
 function getSubagentResultDisplay(

--- a/src/components/chat/message/asyncResultPayload.test.ts
+++ b/src/components/chat/message/asyncResultPayload.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest"
+import { parseSubagentResultDetail, parseSubagentResultStatus } from "./asyncResultPayload"
+
+describe("subagent async result parsing", () => {
+  test("does not parse XML tags inside legacy subagent output as metadata", () => {
+    const content = [
+      "[Sub-Agent Completion - auto-delivered]",
+      "Run ID: run-1",
+      "Agent: child",
+      "Task: inspect output",
+      "Status: completed",
+      "Duration: 1.2s",
+      "<<<BEGIN_SUBAGENT_RESULT>>>",
+      "<result>this is literal child output</result>",
+      "<status>error</status>",
+      "<<<END_SUBAGENT_RESULT>>>",
+    ].join("\n")
+
+    expect(parseSubagentResultStatus(content)).toBe("completed")
+    expect(parseSubagentResultDetail(content)).toBe(
+      "<result>this is literal child output</result>\n<status>error</status>",
+    )
+  })
+
+  test("parses the new subagent-result envelope", () => {
+    const content = [
+      "<subagent-result>",
+      "<status>error</status>",
+      "<result>ok &lt;done&gt; &amp; safe</result>",
+      "</subagent-result>",
+    ].join("\n")
+
+    expect(parseSubagentResultStatus(content)).toBe("failed")
+    expect(parseSubagentResultDetail(content)).toBe("ok <done> & safe")
+  })
+})

--- a/src/components/chat/message/asyncResultPayload.ts
+++ b/src/components/chat/message/asyncResultPayload.ts
@@ -1,0 +1,98 @@
+export const TOOL_JOB_AGENT_PREFIX = "tool_job:"
+export const TOOL_JOB_STATUSES = new Set([
+  "completed",
+  "failed",
+  "timed_out",
+  "cancelled",
+  "interrupted",
+  "running",
+])
+
+function getXmlishAttribute(attrs: string, name: string): string | undefined {
+  const match = attrs.match(new RegExp(`\\b${name}="([^"]*)"`))
+  return match?.[1]
+}
+
+function getXmlishElement(content: string, name: string): string | undefined {
+  const match = content.match(new RegExp(`<${name}>([\\s\\S]*?)</${name}>`))
+  return match?.[1]?.trim()
+}
+
+function decodeXmlishText(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+}
+
+function hasSubagentResultEnvelope(content: string): boolean {
+  const trimmed = content.trimStart()
+  return /^<subagent-result(?:\s|>)/.test(trimmed) && trimmed.includes("</subagent-result>")
+}
+
+export function parseToolJobPayload(
+  content: string,
+): { toolName?: string; status?: string; detail?: string } | null {
+  const match = content.match(/<tool-job-result\b([^>]*)>/)
+  if (match) {
+    const attrs = match[1] || ""
+    return {
+      toolName: decodeXmlishText(getXmlishAttribute(attrs, "tool")),
+      status: decodeXmlishText(getXmlishAttribute(attrs, "status")),
+      detail:
+        decodeXmlishText(getXmlishElement(content, "output")) ||
+        decodeXmlishText(getXmlishElement(content, "error")) ||
+        decodeXmlishText(getXmlishElement(content, "note")),
+    }
+  }
+
+  if (!content.includes("<task-notification>")) {
+    return null
+  }
+  return {
+    toolName: decodeXmlishText(getXmlishElement(content, "tool")),
+    status: decodeXmlishText(getXmlishElement(content, "status")),
+    detail:
+      decodeXmlishText(getXmlishElement(content, "output-preview")) ||
+      decodeXmlishText(getXmlishElement(content, "error")) ||
+      decodeXmlishText(getXmlishElement(content, "summary")) ||
+      decodeXmlishText(getXmlishElement(content, "output-file")),
+  }
+}
+
+export function parseSubagentResultDetail(content: string): string | undefined {
+  if (hasSubagentResultEnvelope(content)) {
+    return (
+      decodeXmlishText(getXmlishElement(content, "result")) ||
+      decodeXmlishText(getXmlishElement(content, "error"))
+    )
+  }
+
+  const match = content.match(
+    /<<<BEGIN_SUBAGENT_RESULT>>>\n?([\s\S]*?)\n?<<<END_SUBAGENT_RESULT>>>/,
+  )
+  return match?.[1]?.trim()
+}
+
+export function parseSubagentResultStatus(content: string): string {
+  const status = hasSubagentResultEnvelope(content)
+    ? decodeXmlishText(getXmlishElement(content, "status"))
+    : content.match(/^Status:\s*(\S+)/m)?.[1]
+  switch (status) {
+    case "completed":
+      return "completed"
+    case "timeout":
+    case "timed_out":
+      return "timed_out"
+    case "killed":
+      return "cancelled"
+    case "running":
+    case "spawning":
+      return "running"
+    case "error":
+      return "failed"
+    default:
+      return "completed"
+  }
+}


### PR DESCRIPTION
## What changed

- Route `parent_agent_stream` delta events through the shared chat stream handler so parent-agent injection renders live text, tool calls, tool results, and post-tool text consistently.
- Flush buffered parent-agent stream deltas before terminal `done` / `error` events so the final chunk is not lost before reload.
- Switch sub-agent completion injection to structured `<subagent-result>` user messages and document that contract in the system prompt.
- Expose sub-agent run details in the chat UI, including run ID, agent ID, child session ID, task, model, duration, and token counts.
- Preserve legacy sub-agent result rendering by only parsing XML metadata when a top-level `<subagent-result>` envelope is present.
- Isolate startup recovery and shutdown sentinel tests with temporary `HA_DATA_DIR` scopes.

## Why

The parent-agent injection listener still read legacy stream shapes in a few places, which could hide live text during sub-agent result injection, especially after tool calls or when the last text chunk was still buffered.

Sub-agent result messages also needed a clearer machine-readable format and better UI visibility for real debugging details like run IDs and child sessions. The compatibility guard prevents old `BEGIN_SUBAGENT_RESULT` payloads from being misparsed when the child output itself contains tags like `<result>` or `<status>`.

## Validation

Pre-push hook passed:

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `pnpm typecheck`
- `pnpm lint` (existing warning in `src/components/chat/ChatScreen.tsx:952`)
- `pnpm test`
- `cargo test -p ha-core -p ha-server --locked`