### PR TITLE
[codex] Keep sidebar open when panels open 🦭

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -1477,16 +1477,6 @@ export default function ChatScreen({
     },
     [t],
   )
-  const rightPanelKey = renderedExclusiveRightPanel
-  const lastRightPanelKeyRef = useRef<string | null>(rightPanelKey)
-
-  useEffect(() => {
-    if (rightPanelKey && rightPanelKey !== lastRightPanelKeyRef.current) {
-      setSidebarCollapsed(true)
-    }
-    lastRightPanelKeyRef.current = rightPanelKey
-  }, [rightPanelKey])
-
   useEffect(() => {
     if (!hasOpenExclusiveRightPanel && rightPanelCollapsed) {
       setRightPanelCollapsed(false)


### PR DESCRIPTION
## What changed

- Removed the right-panel side effect that automatically collapsed the conversation sidebar whenever a new exclusive right panel became active.
- Kept the manual sidebar collapse/expand controls unchanged.

## Why

Opening Plan, Diff, Browser, Canvas, Mac Control, or Team panels should not unexpectedly hide the session list. The sidebar now only collapses when the user explicitly collapses it.

## Validation

- Attempted `pnpm typecheck`, but this checkout is missing frontend dependencies: `tsc: command not found` and `node_modules` is absent.
