### PR TITLE
🦭 UI 优化：Tooltip 防裁切、流式动画丝滑化、侧边栏 overscroll

### DIFF
--- a/src/components/chat/hooks/useStreamEventHandler.ts
+++ b/src/components/chat/hooks/useStreamEventHandler.ts
@@ -19,9 +19,16 @@ export interface StreamEventHandlerDeps {
 export interface StreamDeltaBuffers {
   pending: Map<string, { text: string; thinking: string }>
   rafs: Map<string, number>
+  lastFlushAt: Map<string, number>
 }
 
 const LEGACY_STREAM_ID = "__legacy__"
+
+// 流式 flush 节流：把每帧（≈60fps）flush 降到 ~30fps。每次 flush 都触发末块
+// markdown re-lex + Shiki 重高亮 + React reconcile，长内容下这是主成本之一。
+// char fadeIn 动画在视觉上补帧，掉到 30fps 几乎无感，CPU 直接减半。尾部因
+// stream_end 抢跑被丢的 delta 由 `mergeMessagesByDbId` 的 DB 终态重对账补回。
+const FLUSH_MIN_INTERVAL_MS = 33
 
 export function streamCursorKey(sessionId: string, streamId?: string | null): string {
   return `${sessionId}\u0000${streamId || LEGACY_STREAM_ID}`
@@ -41,6 +48,7 @@ export function createStreamDeltaBuffers(): StreamDeltaBuffers {
   return {
     pending: new Map(),
     rafs: new Map(),
+    lastFlushAt: new Map(),
   }
 }
 
@@ -55,6 +63,7 @@ export function discardPendingStreamDeltas(
   }
   state.rafs.delete(sid)
   state.pending.delete(sid)
+  state.lastFlushAt.delete(sid)
 }
 
 export function discardAllPendingStreamDeltas(
@@ -66,6 +75,7 @@ export function discardAllPendingStreamDeltas(
   }
   state.rafs.clear()
   state.pending.clear()
+  state.lastFlushAt.clear()
 }
 
 function pendingDeltasFor(
@@ -107,6 +117,7 @@ export function flushPendingStreamDeltas(
 ): void {
   const pending = takePendingStreamDeltas(sid, deps.deltaBuffersRef, cancelScheduled)
   if (!pending) return
+  deps.deltaBuffersRef.current.lastFlushAt.set(sid, Date.now())
 
   const textChunk = pending.text
   const thinkingChunk = pending.thinking
@@ -185,7 +196,16 @@ function schedulePendingStreamFlush(sid: string, deps: StreamEventHandlerDeps): 
   const state = deps.deltaBuffersRef.current
   if (state.rafs.has(sid)) return
   const raf = requestAnimationFrame(() => {
-    deps.deltaBuffersRef.current.rafs.delete(sid)
+    const s = deps.deltaBuffersRef.current
+    s.rafs.delete(sid)
+    // Throttle to ~30fps: if the previous flush was < FLUSH_MIN_INTERVAL_MS ago,
+    // wait one more frame instead of flushing now. Pending deltas keep
+    // accumulating in the buffer, so nothing is lost — just coalesced.
+    const last = s.lastFlushAt.get(sid) ?? 0
+    if (Date.now() - last < FLUSH_MIN_INTERVAL_MS) {
+      schedulePendingStreamFlush(sid, deps)
+      return
+    }
     flushPendingStreamDeltas(sid, deps, false)
   })
   state.rafs.set(sid, raf)

--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -458,7 +458,7 @@ export default function ChatSidebar({
             </div>
 
             <div
-              className="flex-1 overflow-y-auto overflow-x-hidden"
+              className="flex-1 overflow-y-auto overflow-x-hidden [overscroll-behavior-y:none]"
               onScroll={(e) => {
                 if (!hasMoreSessions || loadingMoreSessions || !onLoadMoreSessions) return
                 const el = e.currentTarget

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useState,
   useEffect,
   useMemo,
@@ -102,6 +103,12 @@ const streamingAnimation: AnimateOptions = {
   stagger: 16,
   easing: "cubic-bezier(0.22, 1, 0.36, 1)",
 }
+
+// char 级 animate 把每个字符 wrap 成一个 `<span>`，活跃块每帧重新 wrap 全部字符
+// （baseline 字符也是 duration=0 的 span）——O(n) span/帧，内容越长越爆。无空格的
+// 长中文尤其致命（一段 = 上千 span）。超过该阈值就关掉逐字动画：仍按流式渲染、
+// 保留 incomplete-markdown 处理，只是不再逐字渐显，长回复换来平滑出字。
+const ANIMATE_MAX_CHARS = 4000
 
 // Streamdown 默认 linkSafety 弹窗的 "Open link" 按钮调用 window.open，
 // Tauri webview 不支持该行为（点击无反应），改走 open_url 命令调起系统浏览器。
@@ -484,8 +491,6 @@ function StreamdownMarkdownRenderer({ content, isStreaming = false }: MarkdownRe
     if (count > 0) animatePlugin.setPrevContentLength(count)
   })
 
-  if (!content) return null
-
   // content 全量交给 Streamdown：它按 block 分块 memo，只重解析变化的末块；
   // 新增尾部由 animate plugin 按 stagger 逐字错峰渐显，无需外部 slice 打字机。
   const isActive = isStreaming
@@ -493,10 +498,22 @@ function StreamdownMarkdownRenderer({ content, isStreaming = false }: MarkdownRe
   // 流式期间把外部 animate plugin 注入 rehype 链尾；静态历史消息直接复用
   // streamdown 默认 rehype（raw/sanitize/harden 安全基线）。`animated={false}`
   // 关掉 streamdown 内部建实例的路径，避免与外部 plugin 重复跑。
-  const defaultRehypePluginList = Object.values(defaultRehypePlugins)
-  const rehypePlugins = isActive
-    ? [...defaultRehypePluginList, autolinkRehypePlugin, animatePlugin.rehypePlugin]
-    : [...defaultRehypePluginList, autolinkRehypePlugin]
+  //
+  // 超长内容关掉逐字动画（见 ANIMATE_MAX_CHARS）；仍是流式渲染，只是不挂 animate
+  // plugin。布尔值跨帧只在跨阈值时翻转一次，不破坏下面 useMemo 的稳定性。
+  const animateActive = isActive && content.length <= ANIMATE_MAX_CHARS
+
+  // **必须 memo**：Streamdown 的 Block memo 比较器要求 `rehypePlugins` 引用相等
+  // 才跳过重渲染（vendored chunk 里 `e.rehypePlugins!==t.rehypePlugins` 即判失效），
+  // 且它把该数组 `useMemo([a,...])` 原样转发给每个 block。若每帧新建数组，流式每帧
+  // 都会让**所有** block（含已定稿的长 prose / Shiki 代码块）全量重渲染——内容越长
+  // 越卡。稳定引用后，每帧只重渲染正在增长的末块。
+  const rehypePlugins = useMemo(() => {
+    const base = [...Object.values(defaultRehypePlugins), autolinkRehypePlugin]
+    return animateActive ? [...base, animatePlugin.rehypePlugin] : base
+  }, [animateActive, animatePlugin])
+
+  if (!content) return null
 
   return (
     <div className="markdown-content">
@@ -517,9 +534,15 @@ function StreamdownMarkdownRenderer({ content, isStreaming = false }: MarkdownRe
   )
 }
 
-export default function MarkdownRenderer({ content, isStreaming = false }: MarkdownRendererProps) {
+// memo：props 仅 `content`(string) + `isStreaming`(bool)，默认浅比较即可。
+// 流式 bubble 每帧重建所有 text block 的 MarkdownRenderer 元素，已定稿 block 的
+// 这两个 prop 都稳定——memo 让它们整体跳过 render，避免无谓的 Streamdown 全量
+// re-lex，只剩正在增长的末块真正重渲染。
+function MarkdownRenderer({ content, isStreaming = false }: MarkdownRendererProps) {
   if (shouldRenderAsBareJson(content)) {
     return <BareJsonRenderer content={content} isStreaming={isStreaming} />
   }
   return <StreamdownMarkdownRenderer content={content} isStreaming={isStreaming} />
 }
+
+export default memo(MarkdownRenderer)

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -1,7 +1,6 @@
 import {
   useState,
   useEffect,
-  useRef,
   useMemo,
   type AnchorHTMLAttributes,
 } from "react"
@@ -92,11 +91,15 @@ function useHeavyPlugins(content: string) {
   ])
 }
 
-/** Word-level blurIn: each completed word gets a blur-to-clear entrance */
+/** Char-level fadeIn: each newly-appended character fades in, staggered for a
+ *  smooth flowing reveal. The animate plugin animates only the new tail (chars
+ *  below the prev-render baseline get duration=0), so no external slice
+ *  typewriter is needed — content is handed to Streamdown in full. */
 const streamingAnimation: AnimateOptions = {
-  animation: "blurIn",
-  sep: "word",
-  duration: 500,
+  animation: "fadeIn",
+  sep: "char",
+  duration: 200,
+  stagger: 16,
   easing: "cubic-bezier(0.22, 1, 0.36, 1)",
 }
 
@@ -429,11 +432,6 @@ function autolinkRehypePlugin() {
   }
 }
 
-/** Start catching up when backlog exceeds this */
-const CATCHUP_THRESHOLD = 60
-/** Max chars per frame when catching up, prevents jarring jumps */
-const MAX_STEP = 8
-
 interface MarkdownRendererProps {
   content: string
   isStreaming?: boolean
@@ -460,7 +458,7 @@ function StreamdownMarkdownRenderer({ content, isStreaming = false }: MarkdownRe
   // `animated={AnimateOptions}` 简便用法把 plugin 实例藏在内部 useMemo，且
   // Block 组件每帧 render 会调 `setPrevContentLength(getLastRenderCharCount())`
   // —— 首次 render 时 lastRenderCharCount 还是 0，prevContentLength 被回写 0，
-  // 整段已渲染内容会被当成新内容跑 blurIn。组件 unmount + remount（切会话回到
+  // 整段已渲染内容会被当成新内容跑一遍入场动画。组件 unmount + remount（切会话回到
   // 流式输出中的会话 / 虚拟滚动剔出再返回视口）会重新走这条 0-baseline 路径，
   // 视觉上整段重放动画一次。
   //
@@ -478,18 +476,6 @@ function StreamdownMarkdownRenderer({ content, isStreaming = false }: MarkdownRe
     return plugin
   })
 
-  const [displayLen, setDisplayLen] = useState(() => content.length)
-
-  const cursorRef = useRef(content.length)
-  const targetRef = useRef(content.length)
-  const streamingRef = useRef(isStreaming)
-  const rafRef = useRef<number | null>(null)
-
-  // eslint-disable-next-line react-hooks/refs -- intentional "latest value" refs read only in rAF callback
-  targetRef.current = content.length
-  // eslint-disable-next-line react-hooks/refs
-  streamingRef.current = isStreaming
-
   // 每帧 commit 后把上一帧 rehype 跑出的字符数续写为下一帧的 baseline。
   // animate plugin 的 rehype 跑完会自动把 prevContentLength 清 0，因此必须
   // 每帧重新设。没有 deps：commit phase 都跑。
@@ -498,56 +484,11 @@ function StreamdownMarkdownRenderer({ content, isStreaming = false }: MarkdownRe
     if (count > 0) animatePlugin.setPrevContentLength(count)
   })
 
-  // Non-streaming (history): show full content immediately
-  useEffect(() => {
-    if (!isStreaming && rafRef.current === null) {
-      cursorRef.current = content.length
-      setDisplayLen(content.length)
-    }
-  }, [isStreaming, content.length])
-
-  // rAF loop: +1 char per frame, continues draining after stream ends (no jump)
-  useEffect(() => {
-    if (!isStreaming) return
-    if (rafRef.current !== null) return
-
-    const tick = () => {
-      const cursor = cursorRef.current
-      const target = targetRef.current
-
-      if (cursor >= target && !streamingRef.current) {
-        rafRef.current = null
-        return
-      }
-
-      if (cursor < target) {
-        const backlog = target - cursor
-        const step = backlog > CATCHUP_THRESHOLD ? Math.min(Math.ceil(backlog * 0.1), MAX_STEP) : 1
-        const next = Math.min(cursor + step, target)
-        cursorRef.current = next
-        setDisplayLen(next)
-      }
-
-      rafRef.current = requestAnimationFrame(tick)
-    }
-
-    rafRef.current = requestAnimationFrame(tick)
-  }, [isStreaming])
-
-  useEffect(() => {
-    return () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current)
-        rafRef.current = null
-      }
-    }
-  }, [])
-
   if (!content) return null
 
-  const revealing = displayLen < content.length
-  const displayContent = revealing ? content.slice(0, displayLen) : content
-  const isActive = isStreaming || revealing
+  // content 全量交给 Streamdown：它按 block 分块 memo，只重解析变化的末块；
+  // 新增尾部由 animate plugin 按 stagger 逐字错峰渐显，无需外部 slice 打字机。
+  const isActive = isStreaming
 
   // 流式期间把外部 animate plugin 注入 rehype 链尾；静态历史消息直接复用
   // streamdown 默认 rehype（raw/sanitize/harden 安全基线）。`animated={false}`
@@ -569,7 +510,7 @@ function StreamdownMarkdownRenderer({ content, isStreaming = false }: MarkdownRe
           linkSafety={linkSafetyDisabled}
           components={markdownComponents}
         >
-          {displayContent}
+          {content}
         </Streamdown>
       </div>
     </div>

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -20,15 +20,17 @@ const TooltipContent = React.forwardRef<
   React.ComponentRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 6, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 rounded-md bg-popover px-2.5 py-1 text-xs text-popover-foreground shadow-md border border-border/50 animate-in fade-in-0 zoom-in-95 pointer-events-none",
-      className,
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 rounded-md bg-popover px-2.5 py-1 text-xs text-popover-foreground shadow-md border border-border/50 animate-in fade-in-0 zoom-in-95 pointer-events-none",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 


### PR DESCRIPTION
今天的一批 UI 优化，base 是 `main`。

## 改动

### Tooltip 不再被裁切（补全 Radix Portal）
`TooltipContent` 之前直接渲染 Radix Content 未用 Portal，tooltip 落在 trigger 的 DOM 兄弟位置、被祖先 `overflow` 裁切（侧边栏「新建项目」等靠右按钮的 tooltip 右半截被截断）。补全 `TooltipPrimitive.Portal` 后渲染到 body，全项目所有被祖先 overflow 裁切的 tooltip 一并修好。

### 流式动画丝滑化（根治长回复掉帧）
删掉 `MarkdownRenderer` 里每帧把 `content.slice(0, displayLen)` 喂给 Streamdown 的自定义打字机循环——它逼着 Streamdown 每帧全量重解析整段 markdown，开销随消息长度线性增长，长回复后段必然掉帧。改为 content 全量交给 Streamdown（按 block memo，只重解析变化的末块），逐字揭示交给 animate plugin 的 stagger 错峰；动画从 `blurIn / word / 500ms` 换成 `fadeIn / char / 200ms`。

### 侧边栏会话列表禁用纵向 overscroll 橡皮筋
会话列表容器加 `[overscroll-behavior-y:none]`，与 MessageList 一致，防 macOS WebKit 橡皮筋滚动溢出。