### PR TITLE
[codex] Adjust chat panel controls

### DIFF
--- a/src/FileBrowserDetachedWindow.tsx
+++ b/src/FileBrowserDetachedWindow.tsx
@@ -11,7 +11,7 @@
 import { useCallback, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { getCurrentWindow } from "@tauri-apps/api/window"
-import { FolderTree, X } from "lucide-react"
+import { FolderOpen, X } from "lucide-react"
 
 import { initLanguageFromConfig } from "@/i18n/i18n"
 import { TooltipProvider, IconTip } from "@/components/ui/tooltip"
@@ -42,7 +42,7 @@ export default function FileBrowserDetachedWindow() {
           className="flex shrink-0 items-center gap-2 border-b border-border bg-secondary/30 px-3 py-2 pt-8"
           data-tauri-drag-region
         >
-          <FolderTree className="h-4 w-4 text-muted-foreground" />
+          <FolderOpen className="h-4 w-4 text-muted-foreground" />
           <span className="flex-1 truncate text-sm font-medium">
             {t("fileBrowser.panelTitle", "Files")}
           </span>

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -8,8 +8,6 @@ import { logger } from "@/lib/logger"
 import { cn } from "@/lib/utils"
 import {
   Brain,
-  ChevronLeft,
-  ChevronRight,
   ClipboardList,
   FolderTree,
   GitCompare,
@@ -23,7 +21,6 @@ import {
 import type {
   ActiveModel,
   AvailableModel,
-  ChatDisplayMode,
   Message,
   SessionMode,
 } from "@/types/chat"
@@ -47,7 +44,6 @@ import { TeamPanel } from "@/components/team/TeamPanel"
 import TeamMiniIndicator from "@/components/team/TeamMiniIndicator"
 import { useActiveTeam } from "@/components/team/useTeam"
 import SessionSearchBar from "@/components/chat/SessionSearchBar"
-import { IconTip } from "@/components/ui/tooltip"
 import {
   AlertDialog,
   AlertDialogContent,
@@ -228,13 +224,7 @@ export default function ChatScreen({
     window.localStorage.setItem("hope.chatSidebarCollapsed", String(sidebarCollapsed))
   }, [sidebarCollapsed])
 
-  const [defaultDisplayMode, setDefaultDisplayMode] = useState<ChatDisplayMode>(() =>
-    readChatDisplayModePreference(),
-  )
-  const [sessionDisplayModeOverrides, setSessionDisplayModeOverrides] = useState<
-    Record<string, ChatDisplayMode>
-  >({})
-
+  const [defaultDisplayMode, setDefaultDisplayMode] = useState(() => readChatDisplayModePreference())
   useEffect(() => {
     let cancelled = false
     getTransport()
@@ -395,35 +385,10 @@ export default function ChatScreen({
   const handleNewChat = session.handleNewChat
   const handleNewChatInProject = session.handleNewChatInProject
   const currentSessionId = session.currentSessionId
-  const displayModeSessionKey = currentSessionId ?? "draft"
-  const displayMode = sessionDisplayModeOverrides[displayModeSessionKey] ?? defaultDisplayMode
-  const previousDisplayModeSessionKeyRef = useRef(displayModeSessionKey)
+  const displayMode = defaultDisplayMode
   const setAgentName = session.setAgentName
   const updateSessionMeta = session.updateSessionMeta
   const handleSwitchSession = session.handleSwitchSession
-
-  useEffect(() => {
-    const previousKey = previousDisplayModeSessionKeyRef.current
-    if (previousKey === "draft" && currentSessionId) {
-      setSessionDisplayModeOverrides((prev) => {
-        const draftMode = prev.draft
-        if (!draftMode || prev[currentSessionId]) return prev
-        const next = { ...prev, [currentSessionId]: draftMode }
-        delete next.draft
-        return next
-      })
-    }
-    previousDisplayModeSessionKeyRef.current = displayModeSessionKey
-  }, [currentSessionId, displayModeSessionKey])
-
-  const handleDisplayModeChange = useCallback(
-    (mode: ChatDisplayMode) => {
-      setSessionDisplayModeOverrides((prev) =>
-        prev[displayModeSessionKey] === mode ? prev : { ...prev, [displayModeSessionKey]: mode },
-      )
-    },
-    [displayModeSessionKey],
-  )
 
   const handleSessionEffortChange = useCallback(
     async (effort: string) => {
@@ -1488,11 +1453,7 @@ export default function ChatScreen({
     activeExclusiveRightPanel && rightPanelVisibility[activeExclusiveRightPanel]
       ? activeExclusiveRightPanel
       : (openExclusiveRightPanels[0] ?? null)
-  const shouldRenderRightPanelContent =
-    !!renderedExclusiveRightPanel && !rightPanelCollapsed
-  const rightPanelToggleLabel = rightPanelCollapsed
-    ? t("chat.rightPanel.expand", "Expand right panel")
-    : t("chat.rightPanel.collapse", "Collapse right panel")
+  const shouldRenderRightPanelContent = !!renderedExclusiveRightPanel && !rightPanelCollapsed
   const getRightPanelLabel = useCallback(
     (panel: ExclusiveRightPanel) => {
       switch (panel) {
@@ -1516,6 +1477,20 @@ export default function ChatScreen({
     },
     [t],
   )
+  const titleBarRightPanels = useMemo(
+    () =>
+      openExclusiveRightPanels.map((panel) => ({
+        id: panel,
+        label: getRightPanelLabel(panel),
+        icon: EXCLUSIVE_RIGHT_PANEL_ICONS[panel],
+      })),
+    [getRightPanelLabel, openExclusiveRightPanels],
+  )
+  const handleSelectRightPanel = useCallback((panelId: string) => {
+    if (!EXCLUSIVE_RIGHT_PANEL_ORDER.includes(panelId as ExclusiveRightPanel)) return
+    setActiveExclusiveRightPanel(panelId as ExclusiveRightPanel)
+    setRightPanelCollapsed(false)
+  }, [])
 
   // Stage a "quote to chat" reference as a removable chip above the composer.
   // On send it becomes a quote attachment: the model sees a <file_reference>
@@ -1817,8 +1792,6 @@ export default function ChatScreen({
           onChangeAgent={handleChangeAgent}
           sidebarCollapsed={sidebarCollapsed}
           onExpandSidebar={() => setSidebarCollapsed(false)}
-          displayMode={displayMode}
-          onDisplayModeChange={handleDisplayModeChange}
           incognitoEnabled={incognitoEnabled}
           incognitoDisabledReason={incognitoDisabledReason}
           onIncognitoChange={handleIncognitoChange}
@@ -1826,6 +1799,15 @@ export default function ChatScreen({
             effectiveWorkingDir ? () => setShowFilesPanel((p) => !p) : undefined
           }
           filesPanelOpen={showFilesPanel}
+          rightPanels={titleBarRightPanels}
+          activeRightPanelId={renderedExclusiveRightPanel}
+          rightPanelCollapsed={rightPanelCollapsed}
+          onSelectRightPanel={handleSelectRightPanel}
+          onToggleRightPanelCollapsed={
+            hasOpenExclusiveRightPanel
+              ? () => setRightPanelCollapsed((collapsed) => !collapsed)
+              : undefined
+          }
         />
 
         <div className="flex-1 flex min-h-0 overflow-hidden">
@@ -1987,60 +1969,7 @@ export default function ChatScreen({
             )}
           </div>
 
-          {hasOpenExclusiveRightPanel && (
-            <div className="flex h-full shrink-0 items-start py-3 pl-1">
-              <div className="flex flex-col gap-1 rounded-lg border border-border-soft bg-surface-panel/95 p-1 shadow-panel">
-                {openExclusiveRightPanels.length > 1 &&
-                  openExclusiveRightPanels.map((panel) => {
-                    const PanelIcon = EXCLUSIVE_RIGHT_PANEL_ICONS[panel]
-                    const label = getRightPanelLabel(panel)
-                    const isActive = renderedExclusiveRightPanel === panel
-
-                    return (
-                      <IconTip key={panel} label={label} side="left">
-                        <button
-                          type="button"
-                          aria-label={label}
-                          aria-pressed={isActive}
-                          onClick={() => {
-                            setActiveExclusiveRightPanel(panel)
-                            setRightPanelCollapsed(false)
-                          }}
-                          className={cn(
-                            "flex h-8 w-8 items-center justify-center rounded-md transition-colors",
-                            isActive
-                              ? "bg-secondary text-foreground shadow-sm"
-                              : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
-                          )}
-                        >
-                          <PanelIcon className="h-4 w-4" />
-                        </button>
-                      </IconTip>
-                    )
-                  })}
-                {openExclusiveRightPanels.length > 1 && (
-                  <div className="mx-1 my-0.5 h-px bg-border-soft" />
-                )}
-                <IconTip label={rightPanelToggleLabel} side="left">
-                  <button
-                    type="button"
-                    aria-label={rightPanelToggleLabel}
-                    aria-expanded={!rightPanelCollapsed}
-                    onClick={() => setRightPanelCollapsed((collapsed) => !collapsed)}
-                    className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground"
-                  >
-                    {rightPanelCollapsed ? (
-                      <ChevronLeft className="h-4 w-4" />
-                    ) : (
-                      <ChevronRight className="h-4 w-4" />
-                    )}
-                  </button>
-                </IconTip>
-              </div>
-            </div>
-          )}
-
-          {/* Diff panel (right side, selected from the shared panel rail) */}
+          {/* Diff panel (right side, selected from the title-bar panel switcher) */}
           {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "diff" && (
             <RightPanelShell
               width={rightPanelWidth}
@@ -2110,7 +2039,7 @@ export default function ChatScreen({
           />
 
           {/* Browser live-mirror panel — open on first `browser:frame` push,
-              close-only by user, then switchable from the shared panel rail. */}
+              close-only by user, then switchable from the title bar. */}
           {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "browser" && (
             <BrowserPanel
               panelWidth={rightPanelWidth}

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils"
 import {
   Brain,
   ClipboardList,
-  FolderTree,
+  FolderOpen,
   GitCompare,
   Globe,
   LayoutDashboard,
@@ -131,7 +131,7 @@ const EXCLUSIVE_RIGHT_PANEL_ICONS: Record<ExclusiveRightPanel, LucideIcon> = {
   workspace: LayoutDashboard,
   diff: GitCompare,
   plan: ClipboardList,
-  files: FolderTree,
+  files: FolderOpen,
   browser: Globe,
   "mac-control": MousePointer2,
   canvas: Monitor,

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -259,6 +259,9 @@ export default function ChatTitleBar({
   const rightPanelToggleLabel = rightPanelCollapsed
     ? t("chat.rightPanel.expand", "展开右侧面板")
     : t("chat.rightPanel.collapse", "收起右侧面板")
+  const hasRightPanelControls =
+    !!onToggleFilesPanel ||
+    (rightPanels.length > 0 && (rightPanels.length > 1 || !!onToggleRightPanelCollapsed))
   const workingDirChip = effectiveWorkingDir ? (
     <IconTip
       label={
@@ -281,8 +284,24 @@ export default function ChatTitleBar({
     </IconTip>
   ) : null
   const rightPanelControls =
-    rightPanels.length > 0 && (rightPanels.length > 1 || onToggleRightPanelCollapsed) ? (
+    hasRightPanelControls ? (
       <div className="ml-1 flex items-center gap-0.5 border-l border-border-soft pl-1">
+        {onToggleFilesPanel && (
+          <IconTip label={t("fileBrowser.open", "Show files")}>
+            <button
+              type="button"
+              className={cn(
+                "flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground",
+                filesPanelOpen && "text-foreground",
+              )}
+              aria-label={t("fileBrowser.open", "Show files")}
+              aria-pressed={filesPanelOpen}
+              onClick={onToggleFilesPanel}
+            >
+              <FolderTree className="h-4 w-4" />
+            </button>
+          </IconTip>
+        )}
         {rightPanels.length > 1 && activeRightPanel && ActiveRightPanelIcon && (
           <div className="relative" ref={rightPanelMenuRef}>
             <IconTip label={t("chat.rightPanel.switch", "切换右侧面板")}>
@@ -467,21 +486,6 @@ export default function ChatTitleBar({
             showLabel={false}
             onChange={onIncognitoChange}
           />
-        )}
-        {/* Show Files Button — opens the right-side file browser panel. */}
-        {onToggleFilesPanel && (
-          <IconTip label={t("fileBrowser.open", "Show files")}>
-            <button
-              className={cn(
-                "pb-1.5 text-muted-foreground hover:text-foreground transition-colors",
-                filesPanelOpen && "text-foreground",
-              )}
-              aria-pressed={filesPanelOpen}
-              onClick={onToggleFilesPanel}
-            >
-              <FolderTree className="h-4 w-4" />
-            </button>
-          </IconTip>
         )}
         {/* In-session Search Button */}
         {currentSessionId && onOpenSearch && (

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -163,9 +163,7 @@ export default function ChatTitleBar({
   const { t } = useTranslation()
   const appVersion = useAppVersion()
   const [showStatus, setShowStatus] = useState(false)
-  const [showRightPanelMenu, setShowRightPanelMenu] = useState(false)
   const statusRef = useRef<HTMLDivElement>(null)
-  const rightPanelMenuRef = useRef<HTMLDivElement>(null)
 
   // Compact result toast
   const [compactToast, setCompactToast] = useState<{ success: boolean; message: string } | null>(
@@ -219,17 +217,6 @@ export default function ChatTitleBar({
   }, [showStatus])
 
   useEffect(() => {
-    if (!showRightPanelMenu) return
-    const handler = (e: MouseEvent) => {
-      if (rightPanelMenuRef.current && !rightPanelMenuRef.current.contains(e.target as Node)) {
-        setShowRightPanelMenu(false)
-      }
-    }
-    document.addEventListener("mousedown", handler)
-    return () => document.removeEventListener("mousedown", handler)
-  }, [showRightPanelMenu])
-
-  useEffect(() => {
     return () => {
       if (sessionIdCopiedTimer.current) clearTimeout(sessionIdCopiedTimer.current)
     }
@@ -255,7 +242,6 @@ export default function ChatTitleBar({
     : null
   const activeRightPanel =
     rightPanels.find((panel) => panel.id === activeRightPanelId) ?? rightPanels[0] ?? null
-  const ActiveRightPanelIcon = activeRightPanel?.icon
   const rightPanelToggleLabel = rightPanelCollapsed
     ? t("chat.rightPanel.expand", "展开右侧面板")
     : t("chat.rightPanel.collapse", "收起右侧面板")
@@ -302,61 +288,33 @@ export default function ChatTitleBar({
             </button>
           </IconTip>
         )}
-        {rightPanels.length > 1 && activeRightPanel && ActiveRightPanelIcon && (
-          <div className="relative" ref={rightPanelMenuRef}>
-            <IconTip label={t("chat.rightPanel.switch", "切换右侧面板")}>
-              <button
-                type="button"
-                className={cn(
-                  "flex h-7 min-w-7 items-center justify-center gap-1 rounded-md px-1.5 text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground",
-                  showRightPanelMenu && "bg-secondary text-foreground",
-                )}
-                aria-label={t("chat.rightPanel.switch", "切换右侧面板")}
-                aria-haspopup="menu"
-                aria-expanded={showRightPanelMenu}
-                onClick={() => setShowRightPanelMenu((v) => !v)}
-              >
-                <ActiveRightPanelIcon className="h-4 w-4" />
-                <span className="max-w-[72px] truncate text-[11px] font-medium">
-                  {activeRightPanel.label}
-                </span>
-              </button>
-            </IconTip>
-            <div
-              className={cn(
-                "absolute right-0 top-full z-50 mt-1.5 min-w-[164px] rounded-lg border border-border bg-popover p-1 shadow-xl transition-all duration-150 origin-top-right",
-                showRightPanelMenu
-                  ? "scale-100 opacity-100 pointer-events-auto"
-                  : "scale-95 opacity-0 pointer-events-none",
-              )}
-              role="menu"
-            >
-              {rightPanels.map((panel) => {
-                const PanelIcon = panel.icon
-                const active = panel.id === activeRightPanel.id
-                return (
+        {rightPanels.length > 1 && activeRightPanel && (
+          <div
+            className="flex h-7 max-w-[184px] items-center gap-0.5 overflow-x-auto rounded-lg bg-secondary/40 p-0.5"
+            role="tablist"
+            aria-label={t("chat.rightPanel.switch", "切换右侧面板")}
+          >
+            {rightPanels.map((panel) => {
+              const PanelIcon = panel.icon
+              const active = panel.id === activeRightPanel.id
+              return (
+                <IconTip key={panel.id} label={panel.label}>
                   <button
-                    key={panel.id}
                     type="button"
-                    role="menuitemradio"
-                    aria-checked={active}
+                    role="tab"
+                    aria-selected={active}
+                    aria-label={panel.label}
                     className={cn(
-                      "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors",
-                      active
-                        ? "bg-secondary text-foreground"
-                        : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
+                      "flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-all hover:bg-background/80 hover:text-foreground",
+                      active && "bg-background text-foreground shadow-sm ring-1 ring-border/60",
                     )}
-                    onClick={() => {
-                      onSelectRightPanel?.(panel.id)
-                      setShowRightPanelMenu(false)
-                    }}
+                    onClick={() => onSelectRightPanel?.(panel.id)}
                   >
-                    <PanelIcon className="h-3.5 w-3.5 shrink-0" />
-                    <span className="min-w-0 flex-1 truncate">{panel.label}</span>
+                    <PanelIcon className="h-3.5 w-3.5" />
                   </button>
-                )
-              })}
-            </div>
+                </IconTip>
+              )
+            })}
           </div>
         )}
         {onToggleRightPanelCollapsed && (

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -14,7 +14,7 @@ import {
   X,
   FileText,
   FolderCheck,
-  FolderTree,
+  FolderOpen,
   Loader2,
   Search,
   Send,
@@ -298,7 +298,7 @@ export default function ChatTitleBar({
               aria-pressed={filesPanelOpen}
               onClick={onToggleFilesPanel}
             >
-              <FolderTree className="h-4 w-4" />
+              <FolderOpen className="h-4 w-4" />
             </button>
           </IconTip>
         )}

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -15,14 +15,15 @@ import {
   FileText,
   FolderCheck,
   FolderTree,
-  ListChecks,
   Loader2,
-  MessageCircle,
   Search,
   Send,
   Ghost,
   Share2,
-  PanelLeft,
+  PanelLeftDashed,
+  PanelRight,
+  PanelRightDashed,
+  type LucideIcon,
 } from "lucide-react"
 import { ExportSessionDialog } from "@/components/chat/export/ExportSessionDialog"
 import ChannelIcon from "@/components/common/ChannelIcon"
@@ -39,9 +40,14 @@ import type {
   ActiveModel,
   SessionMeta,
   AgentSummaryForSidebar,
-  ChatDisplayMode,
 } from "@/types/chat"
 import type { ProjectMeta } from "@/types/project"
+
+interface RightPanelTitleBarItem {
+  id: string
+  label: string
+  icon: LucideIcon
+}
 
 interface ChatTitleBarProps {
   agentName: string
@@ -94,10 +100,6 @@ interface ChatTitleBarProps {
   sidebarCollapsed?: boolean
   /** Expands the session sidebar from the title bar. */
   onExpandSidebar?: () => void
-  /** Message presentation mode in the main conversation. */
-  displayMode?: ChatDisplayMode
-  /** Switches between bubble and task timeline presentation. */
-  onDisplayModeChange?: (mode: ChatDisplayMode) => void
   /** Draft/new-session incognito toggle, surfaced in the title bar. */
   incognitoEnabled?: boolean
   incognitoSaving?: boolean
@@ -107,6 +109,16 @@ interface ChatTitleBarProps {
   onToggleFilesPanel?: () => void
   /** Whether the file browser panel is currently open (controls active styling). */
   filesPanelOpen?: boolean
+  /** Open right-side panels available for switching/collapsing. */
+  rightPanels?: RightPanelTitleBarItem[]
+  /** Active right-side panel id. */
+  activeRightPanelId?: string | null
+  /** Whether the active right-side panel is collapsed. */
+  rightPanelCollapsed?: boolean
+  /** Switch to an already-open right-side panel. */
+  onSelectRightPanel?: (panelId: string) => void
+  /** Collapse/expand the active right-side panel. */
+  onToggleRightPanelCollapsed?: () => void
 }
 
 export default function ChatTitleBar({
@@ -136,19 +148,24 @@ export default function ChatTitleBar({
   onChangeAgent,
   sidebarCollapsed,
   onExpandSidebar,
-  displayMode = "bubble",
-  onDisplayModeChange,
   incognitoEnabled = false,
   incognitoSaving = false,
   incognitoDisabledReason,
   onIncognitoChange,
   onToggleFilesPanel,
   filesPanelOpen = false,
+  rightPanels = [],
+  activeRightPanelId,
+  rightPanelCollapsed = false,
+  onSelectRightPanel,
+  onToggleRightPanelCollapsed,
 }: ChatTitleBarProps) {
   const { t } = useTranslation()
   const appVersion = useAppVersion()
   const [showStatus, setShowStatus] = useState(false)
+  const [showRightPanelMenu, setShowRightPanelMenu] = useState(false)
   const statusRef = useRef<HTMLDivElement>(null)
+  const rightPanelMenuRef = useRef<HTMLDivElement>(null)
 
   // Compact result toast
   const [compactToast, setCompactToast] = useState<{ success: boolean; message: string } | null>(
@@ -202,6 +219,17 @@ export default function ChatTitleBar({
   }, [showStatus])
 
   useEffect(() => {
+    if (!showRightPanelMenu) return
+    const handler = (e: MouseEvent) => {
+      if (rightPanelMenuRef.current && !rightPanelMenuRef.current.contains(e.target as Node)) {
+        setShowRightPanelMenu(false)
+      }
+    }
+    document.addEventListener("mousedown", handler)
+    return () => document.removeEventListener("mousedown", handler)
+  }, [showRightPanelMenu])
+
+  useEffect(() => {
     return () => {
       if (sessionIdCopiedTimer.current) clearTimeout(sessionIdCopiedTimer.current)
     }
@@ -225,6 +253,12 @@ export default function ChatTitleBar({
         (x) => x.providerId === activeModel.providerId && x.modelId === activeModel.modelId,
       )
     : null
+  const activeRightPanel =
+    rightPanels.find((panel) => panel.id === activeRightPanelId) ?? rightPanels[0] ?? null
+  const ActiveRightPanelIcon = activeRightPanel?.icon
+  const rightPanelToggleLabel = rightPanelCollapsed
+    ? t("chat.rightPanel.expand", "展开右侧面板")
+    : t("chat.rightPanel.collapse", "收起右侧面板")
   const workingDirChip = effectiveWorkingDir ? (
     <IconTip
       label={
@@ -246,6 +280,88 @@ export default function ChatTitleBar({
       </span>
     </IconTip>
   ) : null
+  const rightPanelControls =
+    rightPanels.length > 0 && (rightPanels.length > 1 || onToggleRightPanelCollapsed) ? (
+      <div className="ml-1 flex items-center gap-0.5 border-l border-border-soft pl-1">
+        {rightPanels.length > 1 && activeRightPanel && ActiveRightPanelIcon && (
+          <div className="relative" ref={rightPanelMenuRef}>
+            <IconTip label={t("chat.rightPanel.switch", "切换右侧面板")}>
+              <button
+                type="button"
+                className={cn(
+                  "flex h-7 min-w-7 items-center justify-center gap-1 rounded-md px-1.5 text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground",
+                  showRightPanelMenu && "bg-secondary text-foreground",
+                )}
+                aria-label={t("chat.rightPanel.switch", "切换右侧面板")}
+                aria-haspopup="menu"
+                aria-expanded={showRightPanelMenu}
+                onClick={() => setShowRightPanelMenu((v) => !v)}
+              >
+                <ActiveRightPanelIcon className="h-4 w-4" />
+                <span className="max-w-[72px] truncate text-[11px] font-medium">
+                  {activeRightPanel.label}
+                </span>
+              </button>
+            </IconTip>
+            <div
+              className={cn(
+                "absolute right-0 top-full z-50 mt-1.5 min-w-[164px] rounded-lg border border-border bg-popover p-1 shadow-xl transition-all duration-150 origin-top-right",
+                showRightPanelMenu
+                  ? "scale-100 opacity-100 pointer-events-auto"
+                  : "scale-95 opacity-0 pointer-events-none",
+              )}
+              role="menu"
+            >
+              {rightPanels.map((panel) => {
+                const PanelIcon = panel.icon
+                const active = panel.id === activeRightPanel.id
+                return (
+                  <button
+                    key={panel.id}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={active}
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors",
+                      active
+                        ? "bg-secondary text-foreground"
+                        : "text-muted-foreground hover:bg-secondary/70 hover:text-foreground",
+                    )}
+                    onClick={() => {
+                      onSelectRightPanel?.(panel.id)
+                      setShowRightPanelMenu(false)
+                    }}
+                  >
+                    <PanelIcon className="h-3.5 w-3.5 shrink-0" />
+                    <span className="min-w-0 flex-1 truncate">{panel.label}</span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+        {onToggleRightPanelCollapsed && (
+          <IconTip label={rightPanelToggleLabel}>
+            <button
+              type="button"
+              className={cn(
+                "flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-secondary/70 hover:text-foreground",
+                rightPanelCollapsed ? "text-muted-foreground" : "text-foreground",
+              )}
+              aria-label={rightPanelToggleLabel}
+              aria-expanded={!rightPanelCollapsed}
+              onClick={onToggleRightPanelCollapsed}
+            >
+              {rightPanelCollapsed ? (
+                <PanelRightDashed className="h-4 w-4" />
+              ) : (
+                <PanelRight className="h-4 w-4" />
+              )}
+            </button>
+          </IconTip>
+        )}
+      </div>
+    ) : null
 
   return (
     <div
@@ -260,7 +376,7 @@ export default function ChatTitleBar({
               aria-label={t("chat.expandSidebar")}
               onClick={onExpandSidebar}
             >
-              <PanelLeft className="h-4 w-4" />
+              <PanelLeftDashed className="h-4 w-4" />
             </button>
           </IconTip>
         )}
@@ -351,36 +467,6 @@ export default function ChatTitleBar({
             showLabel={false}
             onChange={onIncognitoChange}
           />
-        )}
-        {onDisplayModeChange && (
-          <IconTip
-            label={
-              displayMode === "timeline"
-                ? t("chat.viewModeBubble")
-                : t("chat.viewModeTimeline")
-            }
-          >
-            <button
-              className={cn(
-                "pb-1.5 text-muted-foreground hover:text-foreground transition-colors",
-              )}
-              aria-pressed={displayMode === "timeline"}
-              aria-label={
-                displayMode === "timeline"
-                  ? t("chat.viewModeBubble")
-                  : t("chat.viewModeTimeline")
-              }
-              onClick={() =>
-                onDisplayModeChange(displayMode === "timeline" ? "bubble" : "timeline")
-              }
-            >
-              {displayMode === "timeline" ? (
-                <MessageCircle className="h-4 w-4" />
-              ) : (
-                <ListChecks className="h-4 w-4" />
-              )}
-            </button>
-          </IconTip>
         )}
         {/* Show Files Button — opens the right-side file browser panel. */}
         {onToggleFilesPanel && (
@@ -800,6 +886,7 @@ export default function ChatTitleBar({
             </button>
           </IconTip>
         )}
+        {rightPanelControls}
       </div>
       {currentSessionId && exportOpen && (
         <ExportSessionDialog

--- a/src/components/chat/FileBrowserPanel.tsx
+++ b/src/components/chat/FileBrowserPanel.tsx
@@ -21,7 +21,7 @@ import { WebviewWindow } from "@tauri-apps/api/webviewWindow"
 import {
   ChevronRight,
   ExternalLink,
-  FolderTree,
+  FolderOpen,
   Maximize2,
   Minimize2,
   PanelLeftClose,
@@ -160,7 +160,7 @@ export function FileBrowserPanel({
     // When maximized the panel covers the whole window (fixed inset-0), so pad
     // the top to clear the macOS overlay traffic lights — mirrors CanvasPanel.
     <div className={cn("flex items-center gap-1 border-b px-2 py-1", maximized && "pt-7")}>
-      <FolderTree className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <FolderOpen className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
       <span className="text-xs font-medium text-muted-foreground">
         {t("fileBrowser.panelTitle", "Files")}
       </span>

--- a/src/components/chat/project/file-browser/FileBrowserView.tsx
+++ b/src/components/chat/project/file-browser/FileBrowserView.tsx
@@ -16,7 +16,7 @@ import {
   ChevronsDownUp,
   FilePlus,
   FolderPlus,
-  FolderTree,
+  FolderOpen,
   GitBranch,
   RefreshCw,
   RotateCcw,
@@ -217,7 +217,7 @@ export function FileBrowserView({
   const toolbar = useMemo(
     () => (
       <div className="flex items-center gap-0.5 border-b px-2 py-1">
-        <FolderTree className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
+        <FolderOpen className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
         <span className="mr-auto text-xs font-medium text-muted-foreground">
           {t("fileBrowser.panelTitle", "Files")}
         </span>

--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/alert-dialog"
 import { IconTip } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
-import { Bot, MessageSquarePlus, PanelLeftDashed, Rows2, Rows3 } from "lucide-react"
+import { Bot, MessageSquarePlus, PanelLeft } from "lucide-react"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import type { SessionSearchResult } from "@/types/chat"
@@ -322,24 +322,6 @@ export default function ChatSidebar({
     setDeleteConfirmSessionId(null)
   }
 
-  async function toggleSidebarDisplayMode() {
-    const next = sidebarDisplayMode === "compact" ? "detailed" : "compact"
-    const previous = sidebarDisplayMode
-    setSidebarDisplayMode(next)
-    window.dispatchEvent(new CustomEvent("sidebar-display-mode-changed", { detail: { mode: next } }))
-    try {
-      await getTransport().call("set_sidebar_display_mode", { mode: next })
-    } catch (err) {
-      setSidebarDisplayMode(previous)
-      window.dispatchEvent(
-        new CustomEvent("sidebar-display-mode-changed", { detail: { mode: previous } }),
-      )
-      logger.error("chat", "ChatSidebar::toggleDisplayMode", "failed to save sidebar mode", err)
-    }
-  }
-
-  const SidebarDisplayModeIcon = sidebarDisplayMode === "compact" ? Rows2 : Rows3
-
   return (
     <>
       <div
@@ -367,42 +349,16 @@ export default function ChatSidebar({
                 {t("chat.conversations")}
               </h2>
               <div className="ml-auto flex items-center gap-1 pb-2">
-                <IconTip
-                  label={
-                    sidebarDisplayMode === "compact"
-                      ? t("chat.sidebarDetailedMode", "切换到详细模式")
-                      : t("chat.sidebarCompactMode", "切换到简约模式")
-                  }
-                >
-                  <button
-                    className={cn(
-                      "flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface-subtle hover:text-foreground",
-                      sidebarDisplayMode === "compact" && "bg-secondary/70 text-foreground",
-                    )}
-                    aria-label={
-                      sidebarDisplayMode === "compact"
-                        ? t("chat.sidebarDetailedMode", "切换到详细模式")
-                        : t("chat.sidebarCompactMode", "切换到简约模式")
-                    }
-                    aria-pressed={sidebarDisplayMode === "compact"}
-                    onClick={(e) => {
-                      e.currentTarget.blur()
-                      void toggleSidebarDisplayMode()
-                    }}
-                  >
-                    <SidebarDisplayModeIcon className="h-4 w-4" />
-                  </button>
-                </IconTip>
                 <IconTip label={t("chat.collapseSidebar")}>
                   <button
-                    className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-surface-subtle hover:text-foreground"
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-foreground transition-colors hover:bg-surface-subtle"
                     aria-label={t("chat.collapseSidebar")}
                     onClick={(e) => {
                       e.currentTarget.blur()
                       onSidebarCollapsedChange(true)
                     }}
                   >
-                    <PanelLeftDashed className="h-4 w-4" />
+                    <PanelLeft className="h-4 w-4" />
                   </button>
                 </IconTip>
                 {/* New Chat button */}

--- a/src/components/settings/ChatSettingsPanel.tsx
+++ b/src/components/settings/ChatSettingsPanel.tsx
@@ -15,19 +15,12 @@ import {
 import ContextCompactPanel from "@/components/settings/ContextCompactPanel"
 import AwarenessPanel from "@/components/settings/AwarenessPanel"
 import { invalidateThinkingExpandCache } from "@/components/chat/thinkingCache"
-import {
-  normalizeChatDisplayMode,
-  readChatDisplayModePreference,
-  writeChatDisplayModePreference,
-} from "@/components/chat/chatDisplayModePreference"
-import { Check, ListChecks, Loader2, MessagesSquare } from "lucide-react"
+import { Check, Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
-import type { ChatDisplayMode } from "@/types/chat"
 
 interface ChatConfig {
   autoSendPending: boolean
   autoExpandThinking: boolean
-  chatDisplayMode: ChatDisplayMode
 }
 
 interface SessionTitleConfig {
@@ -48,7 +41,6 @@ export default function ChatSettingsPanel() {
   const [config, setConfig] = useState<ChatConfig>({
     autoSendPending: true,
     autoExpandThinking: true,
-    chatDisplayMode: readChatDisplayModePreference(),
   })
   const [narrationEnabled, setNarrationEnabled] = useState(false)
   const [sessionTitleConfig, setSessionTitleConfig] = useState<SessionTitleConfig>({
@@ -67,21 +59,16 @@ export default function ChatSettingsPanel() {
       getTransport().call<{
         autoSendPending?: boolean
         autoExpandThinking?: boolean
-        chatDisplayMode?: unknown
       }>("get_user_config"),
       getTransport().call<boolean>("get_tool_call_narration_enabled"),
       getTransport().call<SessionTitleConfig>("get_session_title_config"),
       getTransport().call<ProviderOption[]>("get_providers"),
     ])
       .then(([cfg, narration, sessionTitle, providerList]) => {
-        const displayMode =
-          normalizeChatDisplayMode(cfg.chatDisplayMode) ?? readChatDisplayModePreference()
         setConfig({
           autoSendPending: cfg.autoSendPending !== false,
           autoExpandThinking: cfg.autoExpandThinking !== false,
-          chatDisplayMode: displayMode,
         })
-        writeChatDisplayModePreference(displayMode)
         setNarrationEnabled(narration === true)
         setSessionTitleConfig({
           enabled: sessionTitle.enabled === true,
@@ -110,26 +97,6 @@ export default function ChatSettingsPanel() {
       }
     } catch (e) {
       logger.error("settings", "ChatSettingsPanel::save", "Failed to save chat config", e)
-    }
-  }
-
-  async function updateChatDisplayMode(mode: ChatDisplayMode) {
-    if (mode === config.chatDisplayMode) return
-    const updated = { ...config, chatDisplayMode: mode }
-    setConfig(updated)
-    writeChatDisplayModePreference(mode)
-    try {
-      const full = await getTransport().call<Record<string, unknown>>("get_user_config")
-      await getTransport().call("save_user_config", {
-        config: { ...full, chatDisplayMode: mode },
-      })
-    } catch (e) {
-      logger.error(
-        "settings",
-        "ChatSettingsPanel::saveDisplayMode",
-        "Failed to save chat display mode",
-        e,
-      )
     }
   }
 
@@ -216,39 +183,6 @@ export default function ChatSettingsPanel() {
                 checked={config.autoExpandThinking}
                 onCheckedChange={() => toggle("autoExpandThinking")}
               />
-            </div>
-
-            <div className="flex items-center justify-between gap-3 px-3 py-3 rounded-lg">
-              <div className="space-y-0.5 min-w-0">
-                <div className="text-sm font-medium">{t("settings.chatDisplayMode")}</div>
-                <div className="text-xs text-muted-foreground">{t("settings.chatDisplayModeDesc")}</div>
-              </div>
-              <div className="grid shrink-0 grid-cols-2 rounded-lg border border-border/60 bg-background p-0.5">
-                <button
-                  type="button"
-                  onClick={() => void updateChatDisplayMode("bubble")}
-                  className={cn(
-                    "inline-flex h-8 items-center justify-center gap-1.5 rounded-md px-2.5 text-xs text-muted-foreground transition-colors",
-                    config.chatDisplayMode === "bubble" &&
-                      "bg-secondary text-foreground shadow-sm",
-                  )}
-                >
-                  <MessagesSquare className="h-3.5 w-3.5" />
-                  {t("settings.chatDisplayModeBubble")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void updateChatDisplayMode("timeline")}
-                  className={cn(
-                    "inline-flex h-8 items-center justify-center gap-1.5 rounded-md px-2.5 text-xs text-muted-foreground transition-colors",
-                    config.chatDisplayMode === "timeline" &&
-                      "bg-secondary text-foreground shadow-sm",
-                  )}
-                >
-                  <ListChecks className="h-3.5 w-3.5" />
-                  {t("settings.chatDisplayModeTimeline")}
-                </button>
-              </div>
             </div>
 
             <div

--- a/src/components/settings/general-panel/SystemSection.tsx
+++ b/src/components/settings/general-panel/SystemSection.tsx
@@ -2,12 +2,25 @@ import { useState, useEffect } from "react"
 import { getTransport } from "@/lib/transport-provider"
 import { useTranslation } from "react-i18next"
 import { Switch } from "@/components/ui/switch"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 import { logger } from "@/lib/logger"
 import {
   DEFAULT_SIDEBAR_DISPLAY_MODE,
   normalizeSidebarDisplayMode,
   type SidebarDisplayMode,
 } from "@/components/chat/sidebar/types"
+import {
+  normalizeChatDisplayMode,
+  readChatDisplayModePreference,
+  writeChatDisplayModePreference,
+} from "@/components/chat/chatDisplayModePreference"
+import type { ChatDisplayMode } from "@/types/chat"
 
 /**
  * AutostartToggle -- rendered in the System tab
@@ -190,6 +203,78 @@ export function SidebarDisplayModeSelector() {
 }
 
 /**
+ * ChatDisplayModeSelector -- rendered in the Appearance tab
+ */
+export function ChatDisplayModeSelector() {
+  const { t } = useTranslation()
+
+  const [mode, setMode] = useState<ChatDisplayMode>(readChatDisplayModePreference())
+  const [loaded, setLoaded] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    getTransport()
+      .call<{ chatDisplayMode?: unknown }>("get_user_config")
+      .then((cfg) => {
+        if (cancelled) return
+        const next = normalizeChatDisplayMode(cfg.chatDisplayMode) ?? readChatDisplayModePreference()
+        setMode(next)
+        writeChatDisplayModePreference(next, { emit: false })
+        setLoaded(true)
+      })
+      .catch((e) => {
+        logger.error("settings", "ChatDisplayModeSelector::load", "Failed to load chat display mode", e)
+        setLoaded(true)
+      })
+    return () => { cancelled = true }
+  }, [])
+
+  async function updateMode(next: ChatDisplayMode) {
+    if (next === mode) return
+    const previous = mode
+    setMode(next)
+    writeChatDisplayModePreference(next)
+    try {
+      const full = await getTransport().call<Record<string, unknown>>("get_user_config")
+      await getTransport().call("save_user_config", {
+        config: { ...full, chatDisplayMode: next },
+      })
+    } catch (e) {
+      setMode(previous)
+      writeChatDisplayModePreference(previous)
+      logger.error(
+        "settings",
+        "ChatDisplayModeSelector::update",
+        "Failed to save chat display mode",
+        e,
+      )
+    }
+  }
+
+  return (
+    <div>
+      {loaded && (
+        <div className="flex items-center justify-between gap-3 px-3 py-3 rounded-lg transition-colors hover:bg-secondary/40">
+          <div className="space-y-0.5 min-w-0">
+            <div className="text-sm font-medium">{t("settings.chatDisplayMode")}</div>
+            <div className="text-xs text-muted-foreground">{t("settings.chatDisplayModeDesc")}</div>
+          </div>
+          <Select value={mode} onValueChange={(value) => void updateMode(value as ChatDisplayMode)}>
+            <SelectTrigger className="h-8 w-[128px] shrink-0 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="bubble">{t("settings.chatDisplayModeBubble")}</SelectItem>
+              <SelectItem value="timeline">{t("settings.chatDisplayModeTimeline")}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
  * Default export combines both toggles (for use when rendering together)
  */
 export default function SystemSection() {
@@ -197,6 +282,7 @@ export default function SystemSection() {
     <>
       <AutostartToggle />
       <SidebarDisplayModeSelector />
+      <ChatDisplayModeSelector />
       <UiEffectsToggle />
     </>
   )

--- a/src/components/settings/general-panel/index.tsx
+++ b/src/components/settings/general-panel/index.tsx
@@ -2,7 +2,12 @@ import { useTranslation } from "react-i18next"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import ThemeSection from "./ThemeSection"
 import LanguageSection from "./LanguageSection"
-import { AutostartToggle, SidebarDisplayModeSelector, UiEffectsToggle } from "./SystemSection"
+import {
+  AutostartToggle,
+  ChatDisplayModeSelector,
+  SidebarDisplayModeSelector,
+  UiEffectsToggle,
+} from "./SystemSection"
 import ShortcutSection from "./ShortcutSection"
 import ProxySection from "./ProxySection"
 import OnboardingResetSection from "./OnboardingResetSection"
@@ -26,7 +31,10 @@ export default function GeneralPanel() {
           <div className="w-full space-y-8 pt-4">
             <ThemeSection />
             <LanguageSection />
-            <SidebarDisplayModeSelector />
+            <div>
+              <SidebarDisplayModeSelector />
+              <ChatDisplayModeSelector />
+            </div>
             <UiEffectsToggle />
           </div>
         </TabsContent>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2585,7 +2585,7 @@
     "chatAutoSendDesc": "Automatically send queued messages after reply finishes. When off, message is filled back to input.",
     "chatDisplayMode": "Default message view",
     "chatDisplayModeBubble": "Bubble",
-    "chatDisplayModeDesc": "Choose the default layout for new conversations and sessions without an override. The title bar toggle only affects the current session.",
+    "chatDisplayModeDesc": "Choose the default layout for chat messages.",
     "chatDisplayModeTimeline": "Task",
     "configBackupsDesc": "Every settings change is snapshotted automatically. Roll back to any previous version (last 50 kept).",
     "configBackupsEmpty": "No history yet",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2585,7 +2585,7 @@
     "chatAutoSendDesc": "回复结束后自动发送排队中的消息，关闭则回填到输入框",
     "chatDisplayMode": "默认消息视图",
     "chatDisplayModeBubble": "气泡",
-    "chatDisplayModeDesc": "选择新对话和未单独切换会话的默认布局。标题栏切换只影响当前会话。",
+    "chatDisplayModeDesc": "选择聊天消息的默认布局。",
     "chatDisplayModeTimeline": "任务",
     "configBackupsDesc": "每次修改配置自动快照，可一键回滚到任意历史版本（最近 50 份）",
     "configBackupsEmpty": "暂无历史记录",


### PR DESCRIPTION
## Summary
- move right-panel expand/collapse and panel switching into the chat title bar controls
- move the file browser title-bar icon into the right-side control group after the divider
- remove title-bar/chat-list display toggles and keep those preferences in Settings > General > Appearance & Language
- switch the default message view setting to a select control and align hover styling with adjacent rows

## Validation
- `git diff --check`
- `pnpm typecheck`
- pre-push hook ran: `cargo fmt --all --check`, `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`, `cargo test -p ha-core -p ha-server --locked`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `verify-updater-pubkey`

Note: ESLint still reports the existing non-blocking warning in `src/components/chat/ChatScreen.tsx:947` about a missing `useEffect` dependency (`stream`).