### PR TITLE
[codex] Polish right panel and interaction animations

### DIFF
--- a/src/components/chat/AcpSpawnBlock.tsx
+++ b/src/components/chat/AcpSpawnBlock.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { getTransport } from "@/lib/transport-provider"
 import { Button } from "@/components/ui/button"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
 
 interface AcpSpawnBlockProps {
@@ -163,7 +164,7 @@ export default function AcpSpawnBlock({
       </button>
 
       {/* Expanded content */}
-      {expanded && (
+      <AnimatedCollapse open={expanded}>
         <div className="border-t px-3 py-2 space-y-2">
           {/* Tool calls */}
           {toolCalls.length > 0 && (
@@ -198,7 +199,7 @@ export default function AcpSpawnBlock({
             Run: {runId}
           </div>
         </div>
-      )}
+      </AnimatedCollapse>
     </div>
   )
 }

--- a/src/components/chat/BrowserPanel.tsx
+++ b/src/components/chat/BrowserPanel.tsx
@@ -25,6 +25,7 @@ interface BrowserPanelProps {
    *  for the sibling Plan / Diff / Canvas panels. */
   panelWidth?: number
   onPanelWidthChange?: (width: number) => void
+  collapsed?: boolean
   onClose: () => void
 }
 
@@ -40,6 +41,7 @@ const POLL_INTERVAL_MS = 1000
 export default function BrowserPanel({
   panelWidth = 480,
   onPanelWidthChange,
+  collapsed = false,
   onClose,
 }: BrowserPanelProps) {
   const { t } = useTranslation()
@@ -67,17 +69,28 @@ export default function BrowserPanel({
     }
   }, [t])
 
-  // Mount-only: initial frame + EventBus listener. Independent of paused so
-  // the interval can re-bind without tearing down the event subscription.
+  // Mount-only lifecycle flag. Keep it independent from collapsed/paused so
+  // in-flight capture responses from stale effects cannot update after unmount.
   useEffect(() => {
     mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
 
-    // setTimeout(0) defers the React-induced setState past the effect body so
-    // ESLint's react-hooks/set-state-in-effect rule stays happy.
+  // Initial frame when the visible panel opens. Skip while collapsed; the
+  // EventBus listener still tracks pushed frames, but active captures pause.
+  useEffect(() => {
+    if (collapsed) return
     const initialTimer = setTimeout(() => {
       if (mountedRef.current) void refresh()
     }, 0)
+    return () => clearTimeout(initialTimer)
+  }, [collapsed, refresh])
 
+  // Mount-only EventBus listener. Independent of paused/collapsed so pushed
+  // frames keep the local mirror fresh without active polling.
+  useEffect(() => {
     const unlisten = getTransport().listen(BROWSER_FRAME_EVENT, (raw) => {
       const payload = parsePayload<BrowserFramePayload>(raw)
       if (payload && mountedRef.current) {
@@ -87,24 +100,22 @@ export default function BrowserPanel({
     })
 
     return () => {
-      mountedRef.current = false
-      clearTimeout(initialTimer)
       try {
         unlisten?.()
       } catch {
         // ignore
       }
     }
-  }, [refresh])
+  }, [])
 
   // 1Hz fallback poll. Re-binds only when `paused` flips, not on every render.
   useEffect(() => {
-    if (paused) return
+    if (paused || collapsed) return
     const interval = setInterval(() => {
       void refresh()
     }, POLL_INTERVAL_MS)
     return () => clearInterval(interval)
-  }, [paused, refresh])
+  }, [collapsed, paused, refresh])
 
   // ── Render ─────────────────────────────────────────────────────────────
 
@@ -113,6 +124,8 @@ export default function BrowserPanel({
       width={panelWidth}
       onWidthChange={onPanelWidthChange}
       resizeLabel={t("chat.browserPanel.resizePanel", "Resize browser panel")}
+      collapsed={collapsed}
+      contentKey="browser"
     >
       {/* Header */}
       <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">

--- a/src/components/chat/CanvasPanel.tsx
+++ b/src/components/chat/CanvasPanel.tsx
@@ -49,6 +49,7 @@ interface CanvasPanelProps {
   currentSessionId?: string | null
   onOpenChange?: (open: boolean) => void
   visible?: boolean
+  collapsed?: boolean
 }
 
 export const CLOSE_CANVAS_PANEL_EVENT = "hope-agent:close-canvas"
@@ -59,6 +60,7 @@ export default function CanvasPanel({
   currentSessionId = null,
   onOpenChange,
   visible = true,
+  collapsed = false,
 }: CanvasPanelProps) {
   const { t } = useTranslation()
   const [canvas, setCanvas] = useState<CanvasInfo | null>(null)
@@ -403,6 +405,8 @@ export default function CanvasPanel({
         width={panelWidth}
         onWidthChange={onPanelWidthChange}
         resizeLabel={t("canvas.resizePanel", "Resize canvas panel")}
+        collapsed={collapsed}
+        contentKey="canvas-detached"
       >
         {/* Title Bar */}
         <div
@@ -442,6 +446,8 @@ export default function CanvasPanel({
       onWidthChange={onPanelWidthChange}
       resizeLabel={t("canvas.resizePanel", "Resize canvas panel")}
       maximized={maximized}
+      collapsed={collapsed}
+      contentKey="canvas"
     >
       {/* Title Bar */}
       <div

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -1482,7 +1482,7 @@ export default function ChatScreen({
     activeExclusiveRightPanel && rightPanelVisibility[activeExclusiveRightPanel]
       ? activeExclusiveRightPanel
       : (openExclusiveRightPanels[0] ?? null)
-  const shouldRenderRightPanelContent = !!renderedExclusiveRightPanel && !rightPanelCollapsed
+  const shouldRenderRightPanelContent = !!renderedExclusiveRightPanel
   const getRightPanelLabel = useCallback(
     (panel: ExclusiveRightPanel) => {
       switch (panel) {
@@ -2022,6 +2022,8 @@ export default function ChatScreen({
               onWidthChange={setRightPanelWidth}
               resizeLabel={t("diffPanel.resizePanel", "Resize diff panel")}
               maxWidth={860}
+              collapsed={rightPanelCollapsed}
+              contentKey="diff"
             >
               <DiffPanel
                 changes={diffPanel.activeChanges}
@@ -2040,6 +2042,8 @@ export default function ChatScreen({
               onWidthChange={setRightPanelWidth}
               resizeLabel={t("planMode.resizePanel", "Resize plan panel")}
               maxWidth={860}
+              collapsed={rightPanelCollapsed}
+              contentKey="plan"
             >
               <PlanPanel
                 planState={planMode.planState}
@@ -2066,6 +2070,7 @@ export default function ChatScreen({
             rootPath={effectiveWorkingDir}
             sessionId={session.currentSessionId}
             visible={shouldRenderRightPanelContent && renderedExclusiveRightPanel === "files"}
+            collapsed={rightPanelCollapsed}
             panelWidth={rightPanelWidth}
             onPanelWidthChange={setRightPanelWidth}
             onQuote={handleFileQuote}
@@ -2079,6 +2084,7 @@ export default function ChatScreen({
             onPanelWidthChange={setRightPanelWidth}
             currentSessionId={currentSessionId}
             onOpenChange={setCanvasPanelOpen}
+            collapsed={rightPanelCollapsed}
             visible={
               shouldRenderRightPanelContent && renderedExclusiveRightPanel === "canvas"
             }
@@ -2090,6 +2096,7 @@ export default function ChatScreen({
             <BrowserPanel
               panelWidth={rightPanelWidth}
               onPanelWidthChange={setRightPanelWidth}
+              collapsed={rightPanelCollapsed}
               onClose={() => {
                 browserPanelDismissedRef.current = true
                 setShowBrowserPanel(false)
@@ -2104,6 +2111,7 @@ export default function ChatScreen({
             <MacControlPanel
               panelWidth={rightPanelWidth}
               onPanelWidthChange={setRightPanelWidth}
+              collapsed={rightPanelCollapsed}
               onClose={() => {
                 macControlPanelDismissedRef.current = true
                 setShowMacControlPanel(false)
@@ -2119,6 +2127,7 @@ export default function ChatScreen({
                 teamId={activeTeamId}
                 panelWidth={rightPanelWidth}
                 onPanelWidthChange={setRightPanelWidth}
+                collapsed={rightPanelCollapsed}
                 onClose={() => setShowTeamPanel(false)}
                 onSwitchSession={session.handleSwitchSession}
               />
@@ -2131,6 +2140,8 @@ export default function ChatScreen({
               onWidthChange={setRightPanelWidth}
               resizeLabel={t("workspace.resizePanel", "Resize workspace panel")}
               maxWidth={860}
+              collapsed={rightPanelCollapsed}
+              contentKey="workspace"
             >
               <WorkspacePanel
                 taskSnapshot={taskProgressSnapshot}
@@ -2161,6 +2172,8 @@ export default function ChatScreen({
               onWidthChange={setRightPanelWidth}
               resizeLabel={t("filePreview.resizePanel", "Resize preview panel")}
               maxWidth={860}
+              collapsed={rightPanelCollapsed}
+              contentKey="preview"
             >
               <FilePreviewPanel
                 target={filePreview.target}

--- a/src/components/chat/FileBrowserPanel.tsx
+++ b/src/components/chat/FileBrowserPanel.tsx
@@ -43,6 +43,7 @@ interface FileBrowserPanelProps {
   /** Whether this panel is the active right-side panel. Hidden (but kept
    *  mounted) when false, so detached state survives panel switches. */
   visible: boolean
+  collapsed?: boolean
   panelWidth: number
   onPanelWidthChange: (w: number) => void
   onQuote?: (payload: QuotePayload) => void
@@ -64,6 +65,7 @@ export function FileBrowserPanel({
   rootPath,
   sessionId,
   visible,
+  collapsed = false,
   panelWidth,
   onPanelWidthChange,
   onQuote,
@@ -246,6 +248,8 @@ export function FileBrowserPanel({
       resizeLabel={t("fileBrowser.resizePanel", "Resize files panel")}
       maxWidth={1000}
       maximized={maximized}
+      collapsed={collapsed}
+      contentKey={detached ? "files-detached" : "files"}
     >
       {body}
     </RightPanelShell>

--- a/src/components/chat/MacControlPanel.tsx
+++ b/src/components/chat/MacControlPanel.tsx
@@ -46,6 +46,7 @@ interface MacControlFrameResponse {
 interface MacControlPanelProps {
   panelWidth?: number
   onPanelWidthChange?: (width: number) => void
+  collapsed?: boolean
   onClose: () => void
 }
 
@@ -55,6 +56,7 @@ const POLL_INTERVAL_MS = 1000
 export default function MacControlPanel({
   panelWidth = 480,
   onPanelWidthChange,
+  collapsed = false,
   onClose,
 }: MacControlPanelProps) {
   const { t } = useTranslation()
@@ -85,10 +87,20 @@ export default function MacControlPanel({
 
   useEffect(() => {
     mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (collapsed) return
     const initialTimer = setTimeout(() => {
       if (mountedRef.current) void refresh()
     }, 0)
+    return () => clearTimeout(initialTimer)
+  }, [collapsed, refresh])
 
+  useEffect(() => {
     const unlisten = getTransport().listen(MAC_CONTROL_FRAME_EVENT, (raw) => {
       const payload = parsePayload<MacControlFramePayload>(raw)
       if (payload && mountedRef.current) {
@@ -98,22 +110,21 @@ export default function MacControlPanel({
     })
 
     return () => {
-      mountedRef.current = false
-      clearTimeout(initialTimer)
       try {
         unlisten?.()
       } catch {
         // ignore
       }
     }
-  }, [refresh])
+  }, [])
 
   useEffect(() => {
+    if (collapsed) return
     const interval = setInterval(() => {
       void refresh()
     }, POLL_INTERVAL_MS)
     return () => clearInterval(interval)
-  }, [refresh])
+  }, [collapsed, refresh])
 
   const title = frame?.frontmostApp?.name || t("settings.macControl.title")
 
@@ -122,6 +133,8 @@ export default function MacControlPanel({
       width={panelWidth}
       onWidthChange={onPanelWidthChange}
       resizeLabel={t("chat.browserPanel.resizePanel", "Resize panel")}
+      collapsed={collapsed}
+      contentKey="mac-control"
     >
       <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2">
         <Monitor className="h-4 w-4 text-muted-foreground" />

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -5,6 +5,7 @@ import alphaLogoUrl from "@/assets/alpha-logo.png"
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
 import { applyInlineHighlight, clearInlineHighlight } from "@/lib/inlineHighlight"
+import { AnimatedCollapse, AnimatedPresenceBox } from "@/components/ui/animated-presence"
 import { isCenteredSystemMessage, isUserAlignedMessage } from "./chatUtils"
 import MessageBubble from "./MessageBubble"
 import MessageContextMenu from "./MessageContextMenu"
@@ -723,14 +724,15 @@ export default function MessageList({
     planCardData && planState && planState !== "off" && planState !== "planning",
   )
   const showEmpty = items.length === 0
-  const hasFooterContent =
-    pendingQuestionGroup || planCardVisible || planSubagentRunning || showEmpty
+  const hasFooterContent = Boolean(
+    pendingQuestionGroup || planCardVisible || planSubagentRunning || showEmpty,
+  )
   // Show whenever user is scrolled away from bottom — independent of loading
   // state. Lets the user always have a one-click way back to latest.
   // Also surface it whenever a search-jump has detached the view from the
   // live tail so the user has an obvious way to re-anchor regardless of
   // scroll position.
-  const showJumpToLatest = (!atBottom && items.length > 0) || hasMoreAfter
+  const showJumpToLatest = Boolean((!atBottom && items.length > 0) || hasMoreAfter)
 
   return (
     <div className="relative flex-1 min-h-0 min-w-0 overflow-hidden">
@@ -843,7 +845,7 @@ export default function MessageList({
           </div>
         )}
 
-        {hasFooterContent && (
+        <AnimatedCollapse open={hasFooterContent} durationMs={220}>
           <div className="flex flex-col gap-4 pt-2 pb-6">
             {pendingQuestionGroup && (
               <div className="w-full">
@@ -897,7 +899,7 @@ export default function MessageList({
               </div>
             )}
           </div>
-        )}
+        </AnimatedCollapse>
         </div>
       </div>
 
@@ -925,8 +927,12 @@ export default function MessageList({
         </div>
       )}
 
-      {showJumpToLatest && (
-        <div className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-4">
+      <AnimatedPresenceBox
+        open={showJumpToLatest}
+        className="pointer-events-none absolute inset-x-0 bottom-4 z-20 flex justify-center px-4"
+        enterClassName="translate-y-0 scale-100 opacity-100"
+        exitClassName="translate-y-2 scale-95 opacity-0 pointer-events-none"
+      >
           <button
             type="button"
             onClick={handleJumpToLatest}
@@ -935,8 +941,7 @@ export default function MessageList({
           >
             <ArrowDown className="h-4 w-4" />
           </button>
-        </div>
-      )}
+      </AnimatedPresenceBox>
 
       {contextMenu && (
         <MessageContextMenu

--- a/src/components/chat/ask-user/AskUserQuestionBlock.tsx
+++ b/src/components/chat/ask-user/AskUserQuestionBlock.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { IconTip } from "@/components/ui/tooltip"
+import { markdownComponents } from "@/components/common/MarkdownRenderer"
 import {
   HelpCircle,
   Check,
@@ -134,7 +135,9 @@ function OptionPreview({ option }: { option: AskUserQuestionOption }) {
   const body = kind === "mermaid" ? "```mermaid\n" + preview + "\n```" : preview
   return (
     <div className="mt-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs max-h-[28rem] overflow-auto">
-      <Streamdown plugins={staticPlugins}>{body}</Streamdown>
+      <Streamdown plugins={staticPlugins} components={markdownComponents}>
+        {body}
+      </Streamdown>
     </div>
   )
 }

--- a/src/components/chat/ask-user/AskUserQuestionBlock.tsx
+++ b/src/components/chat/ask-user/AskUserQuestionBlock.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useEffect, useMemo } from "react"
-import { Streamdown } from "streamdown"
 import { code } from "@streamdown/code"
 import { cjk } from "@streamdown/cjk"
 import "streamdown/styles.css"
@@ -10,7 +9,7 @@ import { cn } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { IconTip } from "@/components/ui/tooltip"
-import { markdownComponents } from "@/components/common/MarkdownRenderer"
+import { MarkdownStreamdown } from "@/components/common/MarkdownRenderer"
 import {
   HelpCircle,
   Check,
@@ -135,9 +134,9 @@ function OptionPreview({ option }: { option: AskUserQuestionOption }) {
   const body = kind === "mermaid" ? "```mermaid\n" + preview + "\n```" : preview
   return (
     <div className="mt-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs max-h-[28rem] overflow-auto">
-      <Streamdown plugins={staticPlugins} components={markdownComponents}>
+      <MarkdownStreamdown plugins={staticPlugins}>
         {body}
-      </Streamdown>
+      </MarkdownStreamdown>
     </div>
   )
 }

--- a/src/components/chat/input/AttachmentBar.tsx
+++ b/src/components/chat/input/AttachmentBar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useMemo, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import { IconTip } from "@/components/ui/tooltip"
 import { ImagePlus, Paperclip, X } from "lucide-react"
 import { useLightbox } from "@/components/common/ImageLightbox"
@@ -27,39 +28,39 @@ export function AttachmentPreview({ attachedFiles, onRemoveFile }: AttachmentPre
     [blobUrls],
   )
 
-  if (attachedFiles.length === 0) return null
-
   return (
-    <div className="flex gap-2 px-3 pt-3 pb-1 flex-wrap">
-      {attachedFiles.map((file, index) => (
-        <div
-          key={`${file.name}-${index}`}
-          className="group relative flex items-center gap-1.5 bg-secondary rounded-lg px-2 py-1 text-xs text-foreground/80 border border-border/50 animate-in fade-in-0 slide-in-from-bottom-1 duration-150"
-          style={{ animationDelay: `${index * 50}ms`, animationFillMode: "both" }}
-        >
-          {blobUrls[index] ? (
-            <img
-              src={blobUrls[index]}
-              alt={file.name}
-              className="h-8 w-8 rounded object-cover cursor-zoom-in"
-              onClick={(e) => {
-                e.stopPropagation()
-                openLightbox(blobUrls[index], file.name)
-              }}
-            />
-          ) : (
-            <Paperclip className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-          )}
-          <span className="max-w-[120px] truncate">{file.name}</span>
-          <button
-            className="ml-0.5 text-muted-foreground hover:text-foreground transition-colors"
-            onClick={() => onRemoveFile(index)}
+    <AnimatedCollapse open={attachedFiles.length > 0}>
+      <div className="flex gap-2 px-3 pt-3 pb-1 flex-wrap">
+        {attachedFiles.map((file, index) => (
+          <div
+            key={`${file.name}-${index}`}
+            className="group relative flex items-center gap-1.5 bg-secondary rounded-lg px-2 py-1 text-xs text-foreground/80 border border-border/50 animate-in fade-in-0 slide-in-from-bottom-1 duration-150"
+            style={{ animationDelay: `${index * 50}ms`, animationFillMode: "both" }}
           >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      ))}
-    </div>
+            {blobUrls[index] ? (
+              <img
+                src={blobUrls[index]}
+                alt={file.name}
+                className="h-8 w-8 rounded object-cover cursor-zoom-in"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  openLightbox(blobUrls[index], file.name)
+                }}
+              />
+            ) : (
+              <Paperclip className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            )}
+            <span className="max-w-[120px] truncate">{file.name}</span>
+            <button
+              className="ml-0.5 text-muted-foreground hover:text-foreground transition-colors"
+              onClick={() => onRemoveFile(index)}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        ))}
+      </div>
+    </AnimatedCollapse>
   )
 }
 

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useRef, useEffect, useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import { Textarea } from "@/components/ui/textarea"
 import { IconTip, Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn } from "@/lib/utils"
@@ -561,9 +562,9 @@ export default function ChatInput({
         <AttachmentPreview attachedFiles={attachedFiles} onRemoveFile={onRemoveFile} />
 
         {/* Staged "quote to chat" references */}
-        {pendingQuotes && pendingQuotes.length > 0 && (
+        <AnimatedCollapse open={!!pendingQuotes?.length}>
           <div className="flex flex-wrap gap-1.5 px-3 pt-2">
-            {pendingQuotes.map((q, index) => {
+            {pendingQuotes?.map((q, index) => {
               const lines =
                 q.startLine === q.endLine ? `${q.startLine}` : `${q.startLine}-${q.endLine}`
               return (
@@ -598,10 +599,10 @@ export default function ChatInput({
               )
             })}
           </div>
-        )}
+        </AnimatedCollapse>
 
         {/* Pending message card */}
-        {loading && pendingMessage && (
+        <AnimatedCollapse open={loading && !!pendingMessage}>
           <div className="px-3 pt-2.5 pb-0 animate-in fade-in-0 slide-in-from-top-1 duration-200">
             <div className="flex items-center gap-2 bg-amber-500/8 border border-amber-500/20 rounded-xl px-3 py-2">
               <BetweenHorizontalStart className="h-4 w-4 text-amber-500 shrink-0" />
@@ -645,10 +646,10 @@ export default function ChatInput({
               </DropdownMenu.Root>
             </div>
           </div>
-        )}
+        </AnimatedCollapse>
 
         {/* Plan Mode Banner */}
-        {planState === "planning" && (
+        <AnimatedCollapse open={planState === "planning"}>
           <div
             className={`flex items-center gap-2 px-3 py-1.5 bg-blue-500/10 border-b border-blue-500/20 text-blue-600 dark:text-blue-400 text-xs animate-in fade-in slide-in-from-top-1 duration-200${!hasVisibleTaskBar && attachedFiles.length === 0 && !(loading && pendingMessage) ? " rounded-t-2xl" : ""}`}
           >
@@ -661,7 +662,7 @@ export default function ChatInput({
               <X className="h-3.5 w-3.5" />
             </button>
           </div>
-        )}
+        </AnimatedCollapse>
 
         {/* Textarea + mention chip mirror — `@` mentions get a chip backdrop
             from the overlay; the textarea renders the actual characters on
@@ -702,7 +703,7 @@ export default function ChatInput({
         </div>
 
         {/* URL Previews */}
-        {urlPreviews.size > 0 && (
+        <AnimatedCollapse open={urlPreviews.size > 0}>
           <div className="px-3 pb-1 flex flex-col gap-1.5 max-h-[200px] overflow-y-auto">
             {Array.from(urlPreviews.entries())
               .filter(([url]) => !dismissedUrls.has(url))
@@ -715,12 +716,12 @@ export default function ChatInput({
                 />
               ))}
           </div>
-        )}
+        </AnimatedCollapse>
 
         {/* Toolbar — replaced by RecordingBar while voice capture / STT
             is in flight, since the normal toolbar buttons are
             unreachable during recording anyway. */}
-        {voice.state === "recording" || voice.state === "transcribing" ? (
+        <AnimatedCollapse open={voice.state === "recording" || voice.state === "transcribing"}>
           <RecordingBar
             transcribing={voice.state === "transcribing"}
             durationMs={voice.durationMs}
@@ -728,8 +729,9 @@ export default function ChatInput({
             onCancel={handleVoiceCancel}
             onStop={() => void handleVoiceStop()}
           />
-        ) : (
-        <div className="flex items-end justify-between gap-2 px-2 pb-2">
+        </AnimatedCollapse>
+        <AnimatedCollapse open={voice.state !== "recording" && voice.state !== "transcribing"}>
+        <div className="flex items-end justify-between gap-2 px-2 pb-2 animate-in fade-in-0 slide-in-from-bottom-1 duration-150">
           <div className="flex items-center gap-1 flex-wrap min-w-0">
             <div className={toolbarCompact ? "hidden" : CHAT_INPUT_INLINE_ADD_ACTIONS_CLASS}>
               {renderInlineAddControls()}
@@ -869,7 +871,7 @@ export default function ChatInput({
             </IconTip>
           </div>
         </div>
-        )}
+        </AnimatedCollapse>
       </div>
     </div>
   )

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -3,6 +3,7 @@ import { getTransport } from "@/lib/transport-provider"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { cn } from "@/lib/utils"
+import { AnimatedCollapse, AnimatedPresenceBox } from "@/components/ui/animated-presence"
 import { IconTip } from "@/components/ui/tooltip"
 import {
   Copy,
@@ -208,11 +209,11 @@ function CronTriggerBubble({ msg, t }: { msg: Message; t: (key: string) => strin
           <polyline points="6 9 12 15 18 9" />
         </svg>
       </button>
-      {expanded && (
+      <AnimatedCollapse open={expanded}>
         <div className="w-full px-3 py-2 rounded-lg bg-amber-500/5 border border-amber-500/15 text-xs text-foreground/80 whitespace-pre-wrap break-words animate-in fade-in-0 slide-in-from-top-1 duration-150">
           {msg.content}
         </div>
-      )}
+      </AnimatedCollapse>
     </div>
   )
 }
@@ -304,93 +305,96 @@ function MessageBubbleInner({
           <Info className="h-3.5 w-3.5" />
         </button>
       </IconTip>
-      {detailsIndex === index && (
-        <div className="absolute bottom-full left-0 z-50 mb-1 w-64 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover p-2.5 shadow-lg">
-          <div className="space-y-1.5 text-xs">
-            {msg.model && (
-              <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                  {t("chat.statusModel")}
+      <AnimatedPresenceBox
+        open={detailsIndex === index}
+        className="absolute bottom-full left-0 z-50 mb-1 w-64 max-w-[calc(100vw-2rem)] origin-bottom-left rounded-lg border border-border bg-popover p-2.5 shadow-lg"
+        enterClassName="translate-y-0 scale-100 opacity-100"
+        exitClassName="translate-y-1 scale-[0.98] opacity-0 pointer-events-none"
+      >
+        <div className="space-y-1.5 text-xs">
+          {msg.model && (
+            <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+              <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                {t("chat.statusModel")}
+              </span>
+              <IconTip label={msg.model}>
+                <span className="block truncate text-right font-medium text-foreground">
+                  {msg.model}
                 </span>
-                <IconTip label={msg.model}>
-                  <span className="block truncate text-right font-medium text-foreground">
-                    {msg.model}
-                  </span>
-                </IconTip>
-              </div>
-            )}
-            {msg.model && msg.usage?.inputTokens != null && (
-              <div className="border-t border-border" />
-            )}
-            {(() => {
-              const inputTokens = msg.usage?.inputTokens
-              const lastInputTokens = msg.usage?.lastInputTokens
-              const showLastInput =
-                inputTokens != null &&
-                lastInputTokens != null &&
-                lastInputTokens !== inputTokens
-              if (inputTokens == null) return null
-              return (
-                <>
-                  <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                    <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                      {showLastInput
-                        ? t("chat.inputTokensCumulative")
-                        : t("chat.inputTokens")}
-                    </span>
-                    <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                      {formatTokens(inputTokens)}
-                    </span>
-                  </div>
-                  {showLastInput && lastInputTokens != null && (
-                    <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                      <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                        {t("chat.lastRoundInputTokens")}
-                      </span>
-                      <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                        {formatTokens(lastInputTokens)}
-                      </span>
-                    </div>
-                  )}
-                </>
-              )
-            })()}
-            {msg.usage?.outputTokens != null && (
-              <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
-                <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                  {t("chat.outputTokens")}
-                </span>
-                <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                  {formatTokens(msg.usage.outputTokens)}
-                </span>
-              </div>
-            )}
-            {msg.usage?.inputTokens != null && msg.usage?.outputTokens != null && (
+              </IconTip>
+            </div>
+          )}
+          {msg.model && msg.usage?.inputTokens != null && (
+            <div className="border-t border-border" />
+          )}
+          {(() => {
+            const inputTokens = msg.usage?.inputTokens
+            const lastInputTokens = msg.usage?.lastInputTokens
+            const showLastInput =
+              inputTokens != null &&
+              lastInputTokens != null &&
+              lastInputTokens !== inputTokens
+            if (inputTokens == null) return null
+            return (
               <>
-                <div className="border-t border-border" />
                 <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                   <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                    {t("chat.totalTokens")}
+                    {showLastInput
+                      ? t("chat.inputTokensCumulative")
+                      : t("chat.inputTokens")}
                   </span>
                   <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                    {formatTokens(msg.usage.inputTokens + msg.usage.outputTokens)}
+                    {formatTokens(inputTokens)}
                   </span>
                 </div>
+                {showLastInput && lastInputTokens != null && (
+                  <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+                    <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                      {t("chat.lastRoundInputTokens")}
+                    </span>
+                    <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                      {formatTokens(lastInputTokens)}
+                    </span>
+                  </div>
+                )}
               </>
-            )}
-            {msg.usage?.durationMs != null && (
+            )
+          })()}
+          {msg.usage?.outputTokens != null && (
+            <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+              <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                {t("chat.outputTokens")}
+              </span>
+              <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                {formatTokens(msg.usage.outputTokens)}
+              </span>
+            </div>
+          )}
+          {msg.usage?.inputTokens != null && msg.usage?.outputTokens != null && (
+            <>
+              <div className="border-t border-border" />
               <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
                 <span className="text-muted-foreground whitespace-nowrap shrink-0">
-                  {t("chat.duration")}
+                  {t("chat.totalTokens")}
                 </span>
                 <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
-                  {formatDuration(msg.usage.durationMs)}
+                  {formatTokens(msg.usage.inputTokens + msg.usage.outputTokens)}
                 </span>
               </div>
-            )}
-          </div>
+            </>
+          )}
+          {msg.usage?.durationMs != null && (
+            <div className="grid grid-cols-[auto_minmax(0,1fr)] items-center gap-3">
+              <span className="text-muted-foreground whitespace-nowrap shrink-0">
+                {t("chat.duration")}
+              </span>
+              <span className="justify-self-end whitespace-nowrap text-right font-medium text-foreground tabular-nums">
+                {formatDuration(msg.usage.durationMs)}
+              </span>
+            </div>
+          )}
         </div>
-      )}
+      </AnimatedPresenceBox>
     </div>
   ) : null
 
@@ -501,17 +505,19 @@ function MessageBubbleInner({
             />
           )}
         </button>
-        {hasDetail && resultExpanded && (
-          <div
-            className={cn(
-              "w-full max-h-[360px] overflow-auto px-3 py-2 rounded-lg border text-xs text-foreground/85 whitespace-pre-wrap break-words animate-in fade-in-0 slide-in-from-top-1 duration-150",
-              resultDisplay.isToolJob
-                ? cn(resultTone.detail, "font-mono text-[11px]")
-                : "bg-purple-500/5 border-purple-500/15",
-            )}
-          >
-            {resultDisplay.detail}
-          </div>
+        {hasDetail && (
+          <AnimatedCollapse open={resultExpanded}>
+            <div
+              className={cn(
+                "w-full max-h-[360px] overflow-auto px-3 py-2 rounded-lg border text-xs text-foreground/85 whitespace-pre-wrap break-words animate-in fade-in-0 slide-in-from-top-1 duration-150",
+                resultDisplay.isToolJob
+                  ? cn(resultTone.detail, "font-mono text-[11px]")
+                  : "bg-purple-500/5 border-purple-500/15",
+              )}
+            >
+              {resultDisplay.detail}
+            </div>
+          </AnimatedCollapse>
         )}
       </div>
     )

--- a/src/components/chat/message/PlanResultBlocks.tsx
+++ b/src/components/chat/message/PlanResultBlocks.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { getTransport } from "@/lib/transport-provider"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import { IconTip } from "@/components/ui/tooltip"
 import {
   Check,
@@ -66,7 +67,7 @@ export function AskUserQuestionResult({
         <Check className="h-4 w-4" />
         <span className="font-medium">{t("planMode.question.answered")}</span>
       </button>
-      {expanded && (
+      <AnimatedCollapse open={expanded}>
         <div className="px-4 pb-3 space-y-2 border-t border-green-500/10 pt-2">
           {items.map((item, i) => (
             <div key={i} className="text-xs text-muted-foreground">
@@ -80,7 +81,7 @@ export function AskUserQuestionResult({
             </div>
           ))}
         </div>
-      )}
+      </AnimatedCollapse>
     </div>
   )
 }

--- a/src/components/chat/message/ProcessedBlockGroup.tsx
+++ b/src/components/chat/message/ProcessedBlockGroup.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { AlertCircle, CheckCircle2, ChevronRight } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 
 interface ProcessedBlockGroupProps {
   children: ReactNode
@@ -42,11 +43,11 @@ export default function ProcessedBlockGroup({
           </span>
         )}
       </button>
-      {expanded && (
+      <AnimatedCollapse open={expanded}>
         <div className="ml-3 border-l border-border/40 pl-2 animate-in fade-in-0 slide-in-from-top-1 duration-150">
           {children}
         </div>
-      )}
+      </AnimatedCollapse>
     </div>
   )
 }

--- a/src/components/chat/message/TaskBlock.tsx
+++ b/src/components/chat/message/TaskBlock.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react"
 import { AlertCircle, ChevronRight, CirclePause, ListChecks } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import type { ChatTurnStatus, ToolCall } from "@/types/chat"
 import {
   createCurrentTaskProgressSnapshot,
@@ -97,7 +98,7 @@ export default function TaskBlock({ tool, executionState }: TaskBlockProps) {
         <span className="font-medium text-foreground">{summaryText}</span>
       </button>
 
-      {expanded && (
+      <AnimatedCollapse open={expanded}>
         <ul className="space-y-0.5 px-2 pb-2">
           {tasks.map((tk) => {
             const baseIcon = TASK_STATUS_ICON[tk.status] ?? TASK_STATUS_ICON.pending
@@ -137,7 +138,7 @@ export default function TaskBlock({ tool, executionState }: TaskBlockProps) {
             )
           })}
         </ul>
-      )}
+      </AnimatedCollapse>
     </div>
   )
 }

--- a/src/components/chat/project/file-browser/FileBrowserTree.tsx
+++ b/src/components/chat/project/file-browser/FileBrowserTree.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner"
 import { cn } from "@/lib/utils"
 import { iconForEntry } from "@/lib/fileKind"
 import { FileTypeIcon } from "@/components/icons/FileTypeIcon"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import { Input } from "@/components/ui/input"
 import {
   ContextMenu,
@@ -383,7 +384,7 @@ function TreeNode({
         </ContextMenuContent>
       </ContextMenu>
 
-      {expanded ? (
+      <AnimatedCollapse open={expanded} durationMs={160}>
         <div>
           {childState?.loading && childEntries.length === 0 ? (
             <div
@@ -398,7 +399,7 @@ function TreeNode({
             <TreeNode key={child.relPath} entry={child} depth={depth + 1} ctx={ctx} />
           ))}
         </div>
-      ) : null}
+      </AnimatedCollapse>
     </div>
   )
 }

--- a/src/components/chat/right-panel/RightPanelShell.tsx
+++ b/src/components/chat/right-panel/RightPanelShell.tsx
@@ -10,6 +10,8 @@ interface RightPanelShellProps {
   maxWidth?: number
   maxViewportRatio?: number
   maximized?: boolean
+  collapsed?: boolean
+  contentKey?: string | number | null
   surfaceClassName?: string
   bodyClassName?: string
 }
@@ -23,12 +25,14 @@ export function RightPanelShell({
   maxWidth = 960,
   maxViewportRatio = 0.55,
   maximized = false,
+  collapsed = false,
+  contentKey,
   surfaceClassName,
   bodyClassName,
 }: RightPanelShellProps) {
   const handleDragStart = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      if (!onWidthChange) return
+      if (!onWidthChange || collapsed) return
       e.preventDefault()
       const startX = e.clientX
       const startWidth = width
@@ -57,10 +61,10 @@ export function RightPanelShell({
       document.body.style.cursor = "col-resize"
       document.body.style.userSelect = "none"
     },
-    [maxViewportRatio, maxWidth, minWidth, onWidthChange, width],
+    [collapsed, maxViewportRatio, maxWidth, minWidth, onWidthChange, width],
   )
 
-  if (maximized) {
+  if (maximized && !collapsed) {
     return (
       <div
         className={cn(
@@ -75,13 +79,21 @@ export function RightPanelShell({
 
   return (
     <div
-      className="relative flex h-full min-h-0 shrink-0 min-w-[360px] max-w-[55%] p-3 pl-2"
-      style={{ width }}
+      className={cn(
+        "relative flex h-full min-h-0 shrink-0 overflow-hidden transition-[width,min-width,max-width,padding,opacity,transform] duration-200 ease-out motion-reduce:transition-none",
+        collapsed
+          ? "min-w-0 max-w-0 translate-x-2 p-0 opacity-0 pointer-events-none"
+          : "min-w-[360px] max-w-[55%] translate-x-0 p-3 pl-2 opacity-100",
+      )}
+      style={{ width: collapsed ? 0 : width }}
+      aria-hidden={collapsed ? true : undefined}
+      inert={collapsed ? true : undefined}
     >
       <div
         className={cn(
           "group absolute left-0 top-3 bottom-3 z-10 flex w-3 items-center justify-center",
-          onWidthChange && "cursor-col-resize",
+          onWidthChange && !collapsed && "cursor-col-resize",
+          collapsed && "hidden",
         )}
         onMouseDown={handleDragStart}
         role="separator"
@@ -96,7 +108,12 @@ export function RightPanelShell({
           bodyClassName,
         )}
       >
-        {children}
+        <div
+          key={contentKey ?? "right-panel-content"}
+          className="flex h-full min-h-0 w-full flex-col animate-in fade-in-0 slide-in-from-right-1 duration-150 motion-reduce:animate-none"
+        >
+          {children}
+        </div>
       </div>
     </div>
   )

--- a/src/components/chat/sidebar/SessionList.tsx
+++ b/src/components/chat/sidebar/SessionList.tsx
@@ -286,7 +286,13 @@ export default function SessionList({
 
       {/* Search results or session list */}
       {isSearching ? (
-        <div className={cn("p-2", displayMode === "compact" ? "space-y-1" : "space-y-0.5")}>
+        <div
+          key={`search-${sessionFilter}-${displayMode}`}
+          className={cn(
+            "p-2 animate-in fade-in-0 slide-in-from-bottom-1 duration-150",
+            displayMode === "compact" ? "space-y-1" : "space-y-0.5",
+          )}
+        >
           {searching && visibleResults.length === 0 ? (
             <div className="flex justify-center py-6">
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
@@ -327,7 +333,13 @@ export default function SessionList({
           )}
         </div>
       ) : (
-        <div className={cn("p-2", displayMode === "compact" ? "space-y-1" : "space-y-0.5")}>
+        <div
+          key={`sessions-${sessionFilter}-${selectedAgentId ?? "all"}-${displayMode}`}
+          className={cn(
+            "p-2 animate-in fade-in-0 slide-in-from-bottom-1 duration-150",
+            displayMode === "compact" ? "space-y-1" : "space-y-0.5",
+          )}
+        >
           {filteredSessions.length === 0 ? (
             <div className="text-center py-8">
               <MessageSquare className="h-8 w-8 text-muted-foreground/20 mx-auto mb-2" />

--- a/src/components/chat/tasks/TaskProgressPanel.tsx
+++ b/src/components/chat/tasks/TaskProgressPanel.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, ChevronRight, CirclePause, ListChecks, Trash2 } from "luci
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { getTransport } from "@/lib/transport-provider"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import { IconTip } from "@/components/ui/tooltip"
 import type { Task, TaskStatus } from "@/types/chat"
 import {
@@ -120,7 +121,7 @@ export default function TaskProgressPanel({
         />
       </button>
 
-      {expanded && (
+      <AnimatedCollapse open={expanded}>
         <div className="border-t border-border/60 px-3 py-2">
           <ol className="max-h-[30vh] space-y-1 overflow-y-auto pr-1">
             {snapshot.tasks.map((task, index) => {
@@ -148,7 +149,7 @@ export default function TaskProgressPanel({
                 <li
                   key={task.id}
                   className={cn(
-                    "group/task flex min-h-7 items-start gap-2 rounded-md px-2 py-1 text-sm",
+                    "group/task flex min-h-7 items-start gap-2 rounded-md px-2 py-1 text-sm transition-[background-color,opacity] duration-150",
                     task.status === "in_progress" && "bg-blue-500/10",
                     task.status === "completed" && "opacity-75",
                   )}
@@ -195,7 +196,7 @@ export default function TaskProgressPanel({
             })}
           </ol>
         </div>
-      )}
+      </AnimatedCollapse>
     </div>
   )
 }

--- a/src/components/chat/workspace/WorkspacePanel.tsx
+++ b/src/components/chat/workspace/WorkspacePanel.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import { IconTip } from "@/components/ui/tooltip"
 import { basename } from "@/lib/path"
 import { openExternalUrl } from "@/lib/openExternalUrl"
@@ -93,7 +94,9 @@ function WorkspaceSection({
           )}
         />
       </button>
-      {expanded && <div className="border-t border-border/60 px-2 py-2">{children}</div>}
+      <AnimatedCollapse open={expanded}>
+        <div className="border-t border-border/60 px-2 py-2">{children}</div>
+      </AnimatedCollapse>
     </div>
   )
 }

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   useMemo,
   type AnchorHTMLAttributes,
+  type ImgHTMLAttributes,
 } from "react"
 import {
   Streamdown,
@@ -323,6 +324,26 @@ function linkIconForHref(href: string | undefined, local: boolean): LinkIconInfo
 }
 
 type MarkdownAnchorProps = AnchorHTMLAttributes<HTMLAnchorElement> & { node?: unknown }
+type MarkdownImageProps = ImgHTMLAttributes<HTMLImageElement> & { node?: unknown }
+
+function MarkdownImage({
+  alt,
+  className,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  node: _node,
+  ...rest
+}: MarkdownImageProps) {
+  return (
+    <span className="markdown-image-wrapper" data-streamdown="image-wrapper">
+      <img
+        {...rest}
+        alt={alt ?? ""}
+        className={cn("markdown-image", className)}
+        data-streamdown="image"
+      />
+    </span>
+  )
+}
 
 export function MarkdownLink({
   href,
@@ -410,7 +431,7 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   )
 })
 
-const markdownComponents = { a: MarkdownLink }
+export const markdownComponents = { a: MarkdownLink, img: MarkdownImage }
 
 interface HastNode {
   type?: string

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   useMemo,
   type AnchorHTMLAttributes,
+  type ComponentProps,
   type ImgHTMLAttributes,
 } from "react"
 import {
@@ -431,7 +432,18 @@ const MarkdownFileLink = memo(function MarkdownFileLink({
   )
 })
 
-export const markdownComponents = { a: MarkdownLink, img: MarkdownImage }
+const markdownComponents = { a: MarkdownLink, img: MarkdownImage }
+
+export function MarkdownStreamdown({
+  children,
+  ...props
+}: Omit<ComponentProps<typeof Streamdown>, "components">) {
+  return (
+    <Streamdown {...props} components={markdownComponents}>
+      {children}
+    </Streamdown>
+  )
+}
 
 interface HastNode {
   type?: string

--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -342,7 +342,7 @@ export default function SettingsView({
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
           <div
             key={activeSection}
-            className="flex-1 flex flex-col min-h-0 overflow-hidden animate-in fade-in-0 duration-150"
+            className="flex-1 flex flex-col min-h-0 overflow-hidden animate-in fade-in-0 slide-in-from-right-1 duration-150"
           >
             {activeSection === "general" && <GeneralPanel />}
             {activeSection === "modelConfig" &&

--- a/src/components/tasks/TaskCenterView.tsx
+++ b/src/components/tasks/TaskCenterView.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import { Progress } from "@/components/ui/progress"
 import { getTransport } from "@/lib/transport-provider"
 import { parsePayload } from "@/lib/transport"
@@ -327,7 +328,7 @@ export default function TaskCenterView({ onBack }: { onBack: () => void }) {
                       </div>
                     </div>
                   </div>
-                  {expanded && (
+                  <AnimatedCollapse open={expanded}>
                     <div className="border-t border-border bg-muted/30 p-3">
                       {jobLogs.length === 0 ? (
                         <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -344,7 +345,7 @@ export default function TaskCenterView({ onBack }: { onBack: () => void }) {
                         </div>
                       )}
                     </div>
-                  )}
+                  </AnimatedCollapse>
                 </div>
               )
             })}

--- a/src/components/team/TeamPanel.tsx
+++ b/src/components/team/TeamPanel.tsx
@@ -15,6 +15,7 @@ interface TeamPanelProps {
   teamId: string
   panelWidth?: number
   onPanelWidthChange?: (w: number) => void
+  collapsed?: boolean
   onClose: () => void
   onSwitchSession?: (sessionId: string) => void
 }
@@ -27,6 +28,7 @@ export function TeamPanel({
   teamId,
   panelWidth,
   onPanelWidthChange,
+  collapsed = false,
   onClose,
   onSwitchSession,
 }: TeamPanelProps) {
@@ -58,6 +60,8 @@ export function TeamPanel({
         resizeLabel={t("team.resizePanel", "Resize team panel")}
         minWidth={MIN_WIDTH}
         maxWidth={MAX_WIDTH}
+        collapsed={collapsed}
+        contentKey="team-loading"
       >
         <div className="flex h-full min-h-0 w-full items-center justify-center text-sm text-muted-foreground">
           {t("team.loading", "Loading...")}
@@ -73,6 +77,8 @@ export function TeamPanel({
       resizeLabel={t("team.resizePanel", "Resize team panel")}
       minWidth={MIN_WIDTH}
       maxWidth={MAX_WIDTH}
+      collapsed={collapsed}
+      contentKey="team"
     >
       <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden">
         {/* Close button */}

--- a/src/components/ui/animated-presence.tsx
+++ b/src/components/ui/animated-presence.tsx
@@ -21,13 +21,27 @@ export function AnimatedCollapse({
 }: AnimatedCollapseProps) {
   const [present, setPresent] = useState(open || !unmountOnExit)
   const [visible, setVisible] = useState(open)
+  const [renderedChildren, setRenderedChildren] = useState(children)
   const timerRef = useRef<number | null>(null)
   const frameRef = useRef<number | null>(null)
-  const lastChildrenRef = useRef<ReactNode>(children)
+  const childrenTimerRef = useRef<number | null>(null)
 
-  if (open) {
-    lastChildrenRef.current = children
-  }
+  useEffect(() => {
+    if (!open) return
+    if (childrenTimerRef.current !== null) {
+      window.clearTimeout(childrenTimerRef.current)
+    }
+    childrenTimerRef.current = window.setTimeout(() => {
+      setRenderedChildren(children)
+      childrenTimerRef.current = null
+    }, 0)
+    return () => {
+      if (childrenTimerRef.current !== null) {
+        window.clearTimeout(childrenTimerRef.current)
+        childrenTimerRef.current = null
+      }
+    }
+  }, [children, open])
 
   useEffect(() => {
     if (timerRef.current !== null) {
@@ -40,10 +54,12 @@ export function AnimatedCollapse({
     }
 
     if (open) {
-      setPresent(true)
       frameRef.current = window.requestAnimationFrame(() => {
-        setVisible(true)
-        frameRef.current = null
+        setPresent(true)
+        frameRef.current = window.requestAnimationFrame(() => {
+          setVisible(true)
+          frameRef.current = null
+        })
       })
       return () => {
         if (frameRef.current !== null) {
@@ -53,14 +69,28 @@ export function AnimatedCollapse({
       }
     }
 
-    setVisible(false)
-    if (!unmountOnExit) return
+    frameRef.current = window.requestAnimationFrame(() => {
+      setVisible(false)
+      frameRef.current = null
+    })
+    if (!unmountOnExit) {
+      return () => {
+        if (frameRef.current !== null) {
+          window.cancelAnimationFrame(frameRef.current)
+          frameRef.current = null
+        }
+      }
+    }
     timerRef.current = window.setTimeout(() => {
       setPresent(false)
       timerRef.current = null
     }, durationMs)
 
     return () => {
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current)
+        frameRef.current = null
+      }
       if (timerRef.current !== null) {
         window.clearTimeout(timerRef.current)
         timerRef.current = null
@@ -83,7 +113,7 @@ export function AnimatedCollapse({
       aria-hidden={open ? undefined : true}
     >
       <div className={cn("min-h-0 overflow-hidden", innerClassName)}>
-        {open ? children : lastChildrenRef.current}
+        {open ? children : renderedChildren}
       </div>
     </div>
   )
@@ -110,13 +140,27 @@ export function AnimatedPresenceBox({
 }: AnimatedPresenceBoxProps) {
   const [present, setPresent] = useState(open || !unmountOnExit)
   const [visible, setVisible] = useState(open)
+  const [renderedChildren, setRenderedChildren] = useState(children)
   const timerRef = useRef<number | null>(null)
   const frameRef = useRef<number | null>(null)
-  const lastChildrenRef = useRef<ReactNode>(children)
+  const childrenTimerRef = useRef<number | null>(null)
 
-  if (open) {
-    lastChildrenRef.current = children
-  }
+  useEffect(() => {
+    if (!open) return
+    if (childrenTimerRef.current !== null) {
+      window.clearTimeout(childrenTimerRef.current)
+    }
+    childrenTimerRef.current = window.setTimeout(() => {
+      setRenderedChildren(children)
+      childrenTimerRef.current = null
+    }, 0)
+    return () => {
+      if (childrenTimerRef.current !== null) {
+        window.clearTimeout(childrenTimerRef.current)
+        childrenTimerRef.current = null
+      }
+    }
+  }, [children, open])
 
   useEffect(() => {
     if (timerRef.current !== null) {
@@ -129,10 +173,12 @@ export function AnimatedPresenceBox({
     }
 
     if (open) {
-      setPresent(true)
       frameRef.current = window.requestAnimationFrame(() => {
-        setVisible(true)
-        frameRef.current = null
+        setPresent(true)
+        frameRef.current = window.requestAnimationFrame(() => {
+          setVisible(true)
+          frameRef.current = null
+        })
       })
       return () => {
         if (frameRef.current !== null) {
@@ -142,14 +188,28 @@ export function AnimatedPresenceBox({
       }
     }
 
-    setVisible(false)
-    if (!unmountOnExit) return
+    frameRef.current = window.requestAnimationFrame(() => {
+      setVisible(false)
+      frameRef.current = null
+    })
+    if (!unmountOnExit) {
+      return () => {
+        if (frameRef.current !== null) {
+          window.cancelAnimationFrame(frameRef.current)
+          frameRef.current = null
+        }
+      }
+    }
     timerRef.current = window.setTimeout(() => {
       setPresent(false)
       timerRef.current = null
     }, durationMs)
 
     return () => {
+      if (frameRef.current !== null) {
+        window.cancelAnimationFrame(frameRef.current)
+        frameRef.current = null
+      }
       if (timerRef.current !== null) {
         window.clearTimeout(timerRef.current)
         timerRef.current = null
@@ -169,7 +229,7 @@ export function AnimatedPresenceBox({
       style={{ transitionDuration: `${durationMs}ms` }}
       aria-hidden={open ? undefined : true}
     >
-      {open ? children : lastChildrenRef.current}
+      {open ? children : renderedChildren}
     </div>
   )
 }

--- a/src/components/ui/animated-presence.tsx
+++ b/src/components/ui/animated-presence.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useRef, useState, type ReactNode } from "react"
+
+import { cn } from "@/lib/utils"
+
+interface AnimatedCollapseProps {
+  open: boolean
+  children: ReactNode
+  className?: string
+  innerClassName?: string
+  durationMs?: number
+  unmountOnExit?: boolean
+}
+
+export function AnimatedCollapse({
+  open,
+  children,
+  className,
+  innerClassName,
+  durationMs = 200,
+  unmountOnExit = true,
+}: AnimatedCollapseProps) {
+  const [present, setPresent] = useState(open || !unmountOnExit)
+  const [visible, setVisible] = useState(open)
+  const timerRef = useRef<number | null>(null)
+  const frameRef = useRef<number | null>(null)
+  const lastChildrenRef = useRef<ReactNode>(children)
+
+  if (open) {
+    lastChildrenRef.current = children
+  }
+
+  useEffect(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    if (frameRef.current !== null) {
+      window.cancelAnimationFrame(frameRef.current)
+      frameRef.current = null
+    }
+
+    if (open) {
+      setPresent(true)
+      frameRef.current = window.requestAnimationFrame(() => {
+        setVisible(true)
+        frameRef.current = null
+      })
+      return () => {
+        if (frameRef.current !== null) {
+          window.cancelAnimationFrame(frameRef.current)
+          frameRef.current = null
+        }
+      }
+    }
+
+    setVisible(false)
+    if (!unmountOnExit) return
+    timerRef.current = window.setTimeout(() => {
+      setPresent(false)
+      timerRef.current = null
+    }, durationMs)
+
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [durationMs, open, unmountOnExit])
+
+  if (!present && !open && unmountOnExit) return null
+
+  return (
+    <div
+      className={cn(
+        "grid overflow-hidden transition-[grid-template-rows,opacity] ease-out motion-reduce:transition-none",
+        visible
+          ? "grid-rows-[1fr] opacity-100"
+          : "grid-rows-[0fr] opacity-0 pointer-events-none",
+        className,
+      )}
+      style={{ transitionDuration: `${durationMs}ms` }}
+      aria-hidden={open ? undefined : true}
+    >
+      <div className={cn("min-h-0 overflow-hidden", innerClassName)}>
+        {open ? children : lastChildrenRef.current}
+      </div>
+    </div>
+  )
+}
+
+interface AnimatedPresenceBoxProps {
+  open: boolean
+  children: ReactNode
+  className?: string
+  enterClassName?: string
+  exitClassName?: string
+  durationMs?: number
+  unmountOnExit?: boolean
+}
+
+export function AnimatedPresenceBox({
+  open,
+  children,
+  className,
+  enterClassName = "translate-y-0 scale-100 opacity-100",
+  exitClassName = "translate-y-1 scale-[0.98] opacity-0 pointer-events-none",
+  durationMs = 180,
+  unmountOnExit = true,
+}: AnimatedPresenceBoxProps) {
+  const [present, setPresent] = useState(open || !unmountOnExit)
+  const [visible, setVisible] = useState(open)
+  const timerRef = useRef<number | null>(null)
+  const frameRef = useRef<number | null>(null)
+  const lastChildrenRef = useRef<ReactNode>(children)
+
+  if (open) {
+    lastChildrenRef.current = children
+  }
+
+  useEffect(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    if (frameRef.current !== null) {
+      window.cancelAnimationFrame(frameRef.current)
+      frameRef.current = null
+    }
+
+    if (open) {
+      setPresent(true)
+      frameRef.current = window.requestAnimationFrame(() => {
+        setVisible(true)
+        frameRef.current = null
+      })
+      return () => {
+        if (frameRef.current !== null) {
+          window.cancelAnimationFrame(frameRef.current)
+          frameRef.current = null
+        }
+      }
+    }
+
+    setVisible(false)
+    if (!unmountOnExit) return
+    timerRef.current = window.setTimeout(() => {
+      setPresent(false)
+      timerRef.current = null
+    }, durationMs)
+
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [durationMs, open, unmountOnExit])
+
+  if (!present && !open && unmountOnExit) return null
+
+  return (
+    <div
+      className={cn(
+        "transition-[opacity,transform] ease-out motion-reduce:transition-none",
+        visible ? enterClassName : exitClassName,
+        className,
+      )}
+      style={{ transitionDuration: `${durationMs}ms` }}
+      aria-hidden={open ? undefined : true}
+    >
+      {open ? children : lastChildrenRef.current}
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -317,6 +317,20 @@
   cursor: zoom-in;
 }
 
+.markdown-content .markdown-image-wrapper {
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: middle;
+}
+
+.markdown-content .markdown-image {
+  display: block;
+  max-width: 100%;
+  max-height: min(70vh, 640px);
+  border-radius: 0.5rem;
+  object-fit: contain;
+}
+
 .markdown-content [data-streamdown="link"] {
   color: hsl(210 100% 32%);
   border-radius: 0.25rem;


### PR DESCRIPTION
## Summary

- Add reusable animation primitives for collapsible content and transient presence states.
- Smooth right-side panel collapse/expand, panel content switches, chat input height changes, workspace sections, task panels, file tree expansion, message details, sidebar/search transitions, settings navigation, and task-center logs.
- Keep collapsed right panels out of keyboard navigation with `inert`, and pause active Browser/Mac Control screenshot polling while collapsed.
- Fix markdown image rendering so images are wrapped safely without invalid nesting, and expose a component wrapper for shared markdown preview rendering.

## Validation

Pre-push hook passed:

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `pnpm typecheck`
- `pnpm lint` (one existing `ChatScreen.tsx` exhaustive-deps warning remains)
- updater public key verification
- `pnpm test`
- `cargo test -p ha-core -p ha-server --locked`
