### PR TITLE
release: 🦭 v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,41 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-02
+
 ### Added
 
-- **文件操作统一 + 内置预览面板**：Markdown 链接、消息下挂文件、工作台产物文件现在操作完全一致——可预览类型（文本 / 代码 / Markdown、PDF / Office、音视频、图片）点击在右侧面板内预览，其余类型在本机点击「打开」、远端点击「下载」；右键或「⋯」菜单按场景提供预览 / 打开 / 在文件夹中打开（本机）或预览 / 下载（远端）。HTTP / Web 模式下指向工作目录内或会话引用过的本地文件不再被禁用。
-- **工作台面板**：聊天右侧新增「工作台」面板，聚合本会话的任务进度、碰到的文件（读取 + 改动，点击查看 diff 或在文件浏览器中定位）与引用来源（web 搜索命中与正文链接）；文件与来源覆盖**整个会话历史**（不限于当前已加载的消息），仍能实时反映正在进行的这一轮，数量多时每段独立滚动、向下滚动按需加载。任务进度从输入框上方移到面板内，输入框仅保留一条可点击展开的「运行中 N/M」状态条。面板在本会话首次产生内容时自动出现，关闭后不再自动弹出。
 - **Hooks 系统（字段级兼容 Claude Code 协议）**：可在会话、工具调用、上下文压缩、权限决策等 28 个生命周期事件上挂接自定义处理器，支持 `command` / `http` / `mcp_tool` / `prompt` / `agent` 五种处理器；配置分 user / managed / project / local 四层作用域并叠加合并，项目级 hooks 可随仓库共享给团队（出于供应链安全默认关闭，需在设置 → Hooks 中显式开启）；提供可视化设置面板（设置 → Hooks），配置改动即时热重载。每个处理器还可配置条件执行（`if`，按工具 + 参数模式匹配）、每会话仅运行一次（`once`）、运行时桌面提示（`statusMessage`），以及 async 命令钩子在退出码 2 时把结果作为提醒回注下一轮对话（`asyncRewake`）。 (#254)
-- **项目文件浏览器**：项目设置「文件」标签与主聊天区（标题栏入口、右侧面板，可弹出独立窗口或最大化）提供 VSCode 风格文件浏览器，文件树与预览左右分栏、分隔线可拖拽调宽；支持目录树浏览、新建 / 重命名 / 删除 / 移动 / 拖拽上传，以及代码（Shiki 语法高亮）、Markdown（渲染 / 源码切换）、图片、PDF 原样与 Office（docx/xlsx/pptx）提取内容的只读预览，预览顶部显示文件相对路径；工作目录为 git 仓库时展示当前分支与 worktree 列表，可只读跳转浏览其它 worktree；在预览中选中文本可右键复制或引用到对话，点击输入框的引用卡片会跳回文件浏览器、在树中展开定位该文件并在预览里高亮引用的行。
+- **工作台面板**：聊天右侧新增「工作台」面板，聚合本会话的任务进度、碰到的文件（读取 + 改动，点击查看 diff 或在文件浏览器中定位）与引用来源（web 搜索命中与正文链接）；文件与来源覆盖**整个会话历史**（不限于当前已加载的消息），仍能实时反映正在进行的这一轮，数量多时每段独立滚动、向下滚动按需加载。任务进度从输入框上方移到面板内，输入框仅保留一条可点击展开的「运行中 N/M」状态条。面板在本会话首次产生内容时自动出现，关闭后不再自动弹出。 (#259)
+- **项目文件浏览器**：项目设置「文件」标签与主聊天区（标题栏入口、右侧面板，可弹出独立窗口或最大化）提供 VSCode 风格文件浏览器，文件树与预览左右分栏、分隔线可拖拽调宽；支持目录树浏览、新建 / 重命名 / 删除 / 移动 / 拖拽上传，以及代码（Shiki 语法高亮）、Markdown（渲染 / 源码切换）、图片、PDF 原样与 Office（docx/xlsx/pptx）提取内容的只读预览，预览顶部显示文件相对路径；工作目录为 git 仓库时展示当前分支与 worktree 列表，可只读跳转浏览其它 worktree；在预览中选中文本可右键复制或引用到对话，点击输入框的引用卡片会跳回文件浏览器、在树中展开定位该文件并在预览里高亮引用的行。 (#256)
+- **文件操作统一 + 内置预览面板**：Markdown 链接、消息下挂文件、工作台产物文件现在操作完全一致——可预览类型（文本 / 代码 / Markdown、PDF / Office、音视频、图片）点击在右侧面板内预览，其余类型在本机点击「打开」、远端点击「下载」；右键或「⋯」菜单按场景提供预览 / 打开 / 在文件夹中打开（本机）或预览 / 下载（远端）。HTTP / Web 模式下指向工作目录内或会话引用过的本地文件不再被禁用。 (#261)
+- **用户消息附件展示**：用户消息现在也会在气泡下方展示随消息发送的附件，与模型消息附件体验对齐，可点击预览或下载。 (#248)
+- **更新历史页**：「关于」/ 检查更新入口新增更新历史页面，可查看各版本的发布说明，方便升级前后回顾版本变化。 (#245)
+- **Agent 自我诊断与 Issue Reporting**：新增内置 `ha-self-diagnosis` skill 与核心 `issue_report` 工具，支持自查源码 / 架构文档 / 配置 / 日志并整理 bug、需求或改进 issue；Settings → Tools 新增 Issue Reporting 面板，可配置目标仓库、标签映射、GitHub token，并在无 token 时回退到已登录的 `gh` CLI。提交前强制用户确认，issue 正文与标题在截断前统一脱敏常见明文凭据。 (#241)
+- **审批 / 询问用户超时（opt-in）**：新增可选的工具审批超时与 `ask_user_question` 超时设置，超时后按配置自动 deny 或 proceed，避免无人值守时会话被一个待审批/待回答长期卡住。 (#253)
+- **macOS Control 视觉定位 v1**：新增 `mac_control.visual.observe/point`。`observe` 将 display/window 受管截图作为 `__IMAGE_FILE__` 视觉输入返回模型，`point` 把截图像素点或 macOS screen point 映射为可点击 screen point，并返回 AX 命中/最近候选与 `act.click_point` 建议参数；真正点击仍走现有 `act` 审批链。 (#239)
+- **macOS Control OCR 定位 v1**：新增 `mac_control.visual.ocr/find_text`，基于 macOS Vision Framework 识别受管截图中的文字，并返回 OCR 文字块、image pixel / screen point 坐标、AX 命中候选与 `act.click_point` 建议参数；无匹配时返回空候选而不是盲点。 (#239)
+- **macOS Control 标注截图**：`mac_control.visual.observe` 新增 `annotate=true` 与 `uiMapLimit`，可返回带 AX element id 边框的标注截图和紧凑 `uiMap`，让模型优先用 `elementId` 精确点击，减少盲坐标操作。 (#239)
+- **macOS Control AX action 执行**：`mac_control.act.perform_action` 新增命名 AX action 调用，支持对明确目标执行 `AXPress`、`AXShowMenu`、`AXIncrement`、`AXDecrement` 等常见动作；常用别名会规范化，合法命名 action 会直接交给 Accessibility 尝试执行，并继续走普通 macOS 控制审批。 (#247)
+- **macOS Control Dock / Spaces 基础能力**：新增 `mac_control.dock.list/launch/hide/show/menu/select_menu` 与 `spaces.list/switch/move_window`。Dock 列表读取持久项并返回 `dockItemId`、label、bundleId、path、running/active 状态；Dock hide/show 写入 autohide 并重启 Dock；Dock menu 可打开并选择 Dock item 菜单；Spaces 列表优先读取 SkyLight/CGS 实时状态，切换相邻 Space 优先走 Mission Control `Control+Left/Right`，非相邻精确目标再 fallback 到 Control+数字或 SkyLight/CGS，窗口移动通过 SkyLight/CGS best-effort 执行并返回校验结果。 (#247)
+- **macOS Control Dialog 高层能力**：`mac_control.dialog` 新增 `list/click/input/file`。`list` 是 `inspect` 的语义别名并返回 `fields[]`；`click` 按可见按钮文本点击；`input` 可按 field/fieldIndex/elementId 填写弹窗文本框；`file` 可通过 macOS Go to Folder 输入文件选择器路径、填写保存文件名并点击默认或指定按钮。 (#247)
 
 ### Changed
 
-- **项目统一工作目录**：每个项目现在都有一个真实工作目录（未设置时自动使用 `~/.hope-agent/projects/<id>/workspace/`），上传文件直接落入该目录，agent 与文件浏览器都围绕它工作。**破坏性变更**：旧的项目文件上传机制（独立存储与自动文本提取）已移除，升级后历史上传的项目文件不再注入模型或在界面显示。
-- **会话侧边栏显示模式**：新增简约 / 详细显示切换；简约模式隐藏会话、Agent 与项目的头像和 emoji，压缩列表信息密度，并支持从设置页或侧边栏顶部快速切换。
-- **彩色文件类型图标**：工作台、消息下挂文件、项目文件浏览器的文件图标改用按格式区分的彩色图标（Word / Excel / PPT / PDF / 图片 / 音视频 / 压缩包 / 各编程语言等），替代原先的单色线性图标，更易一眼辨识文件类型。
+- **项目统一工作目录**：每个项目现在都有一个真实工作目录（未设置时自动使用 `~/.hope-agent/projects/<id>/workspace/`），上传文件直接落入该目录，agent 与文件浏览器都围绕它工作。**破坏性变更**：旧的项目文件上传机制（独立存储与自动文本提取）已移除，升级后历史上传的项目文件不再注入模型或在界面显示。 (#256)
+- **会话侧边栏显示模式**：新增简约 / 详细显示切换；简约模式隐藏会话、Agent 与项目的头像和 emoji，压缩列表信息密度，并支持从设置页或侧边栏顶部快速切换。 (#249)
+- **彩色文件类型图标**：工作台、消息下挂文件、项目文件浏览器的文件图标改用按格式区分的彩色图标（Word / Excel / PPT / PDF / 图片 / 音视频 / 压缩包 / 各编程语言等），替代原先的单色线性图标，更易一眼辨识文件类型。 (#261)
+- **macOS Control v3 控制稳定性升级**：完成 Peekaboo 对齐后的桌面控制强化：`visual.point/find_text` 会返回 AX 优先的 `suggestedActions[]`，必要时再坐标兜底；`act` 支持 `snapshotId + elementId` 稳定重定位、observe→act→verify 校验、自动 fallback 与审批后焦点恢复；窗口、文本输入、菜单、dialog、鼠标移动/拖拽/滑动等突变动作返回 verification；新增 `diagnostics.summary/export`、`act.dry_run dryRunOp` 与 explain 预览，便于模型在执行前看清将控制的对象。 (#247)
+- **macOS Control 审批焦点恢复**：`mac_control` 触发工具审批前会捕获当前前台 App，审批通过或超时继续后在真正执行动作前按 `pid -> bundleId -> appName` best-effort 恢复焦点，避免审批窗口让 Hope Agent 抢前台后把键盘、菜单或 frontmost 依赖动作送错窗口。 (#247)
+- **聊天模型默认值作用域优化**：Agent 级 Think / reasoning effort 默认值现在可随 Agent 配置持久化，并在桌面、HTTP、IM、Cron 与 Subagent 路径中按「会话覆盖 > Agent 默认 > 全局默认」解析；Quick Chat 与主聊天恢复会话时同步恢复对应模型与 Think 状态。 (#236)
+- **会话列表置顶与 Agent 排序**：会话列表支持右键置顶 / 取消置顶，Agent 筛选列表支持拖拽排序，方便把常用 Agent 固定在前面。 (#242)
+- **模型消息文件附件体验**：模型消息下方挂载的文件现在会收集 `send_attachment`、`image_generate` 等工具产物；桌面与 HTTP/Web 模式都支持点击预览或下载，可预览文件也保留下载入口。 (#242)
+- **右侧面板交互与动画打磨**：右侧 Browser / Plan / Diff / Canvas / Team / Workspace / Mac Control 面板新增折叠开关、改为标签式切换器，并对面板切换与交互动效整体打磨；面板打开时左侧会话侧边栏保持展开、不再被强制收起。 (#240, #252, #260, #262)
+- **菜单栏图标交互**：单击菜单栏小图标时与右键一致打开托盘菜单，不再直接唤起主窗口；动态状态刷新不再因为 uptime 变化打断已展开的菜单。 (#242)
+- **审批弹层倒计时**：审批弹层的倒计时圆环左侧新增剩余时间文字，超时前状态更直观。 (#242)
+- **会话输入草稿保留**：切换会话时会保留每个会话输入区里的文字和待发送附件，切回后继续编辑；未发送的新会话草稿也会保留。 (#242)
+- **完成通知正文隐私开关**：通知设置新增「完成通知显示回复正文」开关，默认关闭；开启后后台完成通知会同时显示会话名和最后一条模型回复短预览。 (#242)
+- **聊天文件与界面视觉细节**：文件 chip 会按文件类型展示不同图标，Markdown 本地文件夹链接改用更清晰的文件夹图标；对话窗口与顶部标题栏恢复白色背景，左侧拖拽分隔线不再溢出到对话区。 (#242)
+- **流式 Markdown 渲染性能优化**：重做流式 Markdown 的增量渲染（改用 Streamdown 按块 memo + 动画插件错峰揭示），根治长回复后段掉帧；侧边栏会话列表禁用纵向 overscroll 橡皮筋。 (#258)
+
+### Fixed
+
+- **Tooltip 被裁切修复**：补全 Tooltip 的 Radix Portal 结构，tooltip 不再被祖先容器的 `overflow:hidden` 裁切（如侧边栏靠右按钮的提示右半截被截断）；修复对全项目所有 tooltip 生效。 (#258)
+- **subagent 与父 Agent 流式修复**：修复父 Agent 流式渲染、subagent 完成结果注入与父流收尾缓冲 flush 等一组问题，并暴露 subagent run 详情。 (#251)
+- **AllowAlways 权限作用域修复**：修复「始终允许」权限的作用域匹配（含 Windows 权限路径），避免授权被错误地放大或失效。 (#244)
+- **macOS Control 共享 schema 参数预检**：`mac_control` 现在在权限判断和审批前会按 `action/op` sanitize + preflight 参数，避免 `spaces.switch direction=right` 这类调用被 Provider 默认补出的 `spaceIndex=1` 污染成冲突参数，也避免缺少必要目标的无效突变弹出审批后才失败。 (#247)
+- **macOS Control Spaces 切换可靠性**：`spaces.switch direction=left|right` 和相邻 `spaceIndex/spaceId` 现在优先走 Mission Control `Control+Left/Right`，避免 SkyLight/CGS 只改内部 active id 却不切可见桌面；非相邻精确目标再 fallback 到 Control+数字或 SkyLight/CGS，执行后校验 current Space，未切到目标时返回明确 warning。 (#247)
+- **macOS Control Spaces 当前状态修正**：`spaces.list` 不再用 `defaults export com.apple.spaces` 作为首选 current Space 来源，避免偏好文件里的 `Current Space` 与肉眼桌面状态不同步；现在优先用 `CGSGetActiveSpace` 判定 current，并用 `CGSCopyManagedDisplaySpaces` / `CGSCopySpaces` 枚举实时状态。 (#247)
+- **会话置顶迁移兼容**：旧 session 数据库启动时会补齐 `pinned_at` 列后再创建索引，避免升级后因缺列导致应用无法打开。 (#242)
+- **Web Search fallback 诊断不再污染缓存**：搜索 provider fallback 时会区分无结果与 provider 不可用，且临时失败 / 限流诊断只出现在本次响应中，不再写入结果缓存。 (#236)
 
 ## [0.4.0] - 2026-05-22
 
 ### Added
 
-- **会话列表置顶与 Agent 排序**：会话列表支持右键置顶 / 取消置顶，Agent 筛选列表支持拖拽排序，方便把常用 Agent 固定在前面。 (#242)
-- **模型消息文件附件体验**：模型消息下方挂载的文件现在会收集 `send_attachment`、`image_generate` 等工具产物；桌面与 HTTP/Web 模式都支持点击预览或下载，可预览文件也保留下载入口。 (#242)
-- **Agent 自我诊断与 Issue Reporting**：新增内置 `ha-self-diagnosis` skill 与核心 `issue_report` 工具，支持自查源码 / 架构文档 / 配置 / 日志并整理 bug、需求或改进 issue；Settings → Tools 新增 Issue Reporting 面板，可配置目标仓库、标签映射、GitHub token，并在无 token 时回退到已登录的 `gh` CLI。提交前强制用户确认，issue 正文与标题在截断前统一脱敏常见明文凭据。
 - **macOS Control 截图能力 v2**：`mac_control.snapshot(includeScreenshot=true)` 支持 `screenshotTarget=display|window`，可按 `displayId` 采集指定显示器，或按 `windowId`/当前前台窗口采集窗口截图；截图与右侧镜像 frame 现在返回目标类型、display/window id、窗口标题、bounds 与 scale，便于模型区分多屏、Retina 和窗口级视觉上下文。 (#231)
-- **macOS Control 视觉定位 v1**：新增 `mac_control.visual.observe/point`。`observe` 将 display/window 受管截图作为 `__IMAGE_FILE__` 视觉输入返回模型，`point` 把截图像素点或 macOS screen point 映射为可点击 screen point，并返回 AX 命中/最近候选与 `act.click_point` 建议参数；真正点击仍走现有 `act` 审批链。 (#239)
-- **macOS Control 标注截图**：`mac_control.visual.observe` 新增 `annotate=true` 与 `uiMapLimit`，可返回带 AX element id 边框的标注截图和紧凑 `uiMap`，让模型优先用 `elementId` 精确点击，减少盲坐标操作。
-- **macOS Control AX action 执行**：`mac_control.act.perform_action` 新增命名 AX action 调用，支持对明确目标执行 `AXPress`、`AXShowMenu`、`AXIncrement`、`AXDecrement` 等常见动作；常用别名会规范化，合法命名 action 会直接交给 Accessibility 尝试执行，并继续走普通 macOS 控制审批。
-- **macOS Control 审批焦点恢复**：`mac_control` 触发工具审批前会捕获当前前台 App，审批通过或超时继续后在真正执行动作前按 `pid -> bundleId -> appName` best-effort 恢复焦点，避免审批窗口让 Hope Agent 抢前台后把键盘、菜单或 frontmost 依赖动作送错窗口。
-- **macOS Control Dock / Spaces 基础能力**：新增 `mac_control.dock.list/launch/hide/show/menu/select_menu` 与 `spaces.list/switch/move_window`。Dock 列表读取持久项并返回 `dockItemId`、label、bundleId、path、running/active 状态；Dock hide/show 写入 autohide 并重启 Dock；Dock menu 可打开并选择 Dock item 菜单；Spaces 列表优先读取 SkyLight/CGS 实时状态，切换相邻 Space 优先走 Mission Control `Control+Left/Right`，非相邻精确目标再 fallback 到 Control+数字或 SkyLight/CGS，窗口移动通过 SkyLight/CGS best-effort 执行并返回校验结果。
-- **macOS Control Dialog 高层能力**：`mac_control.dialog` 新增 `list/click/input/file`。`list` 是 `inspect` 的语义别名并返回 `fields[]`；`click` 按可见按钮文本点击；`input` 可按 field/fieldIndex/elementId 填写弹窗文本框；`file` 可通过 macOS Go to Folder 输入文件选择器路径、填写保存文件名并点击默认或指定按钮。
-- **macOS Control OCR 定位 v1**：新增 `mac_control.visual.ocr/find_text`，基于 macOS Vision Framework 识别受管截图中的文字，并返回 OCR 文字块、image pixel / screen point 坐标、AX 命中候选与 `act.click_point` 建议参数；无匹配时返回空候选而不是盲点。 (#239)
 - **macOS Control 菜单范围**：`mac_control.menu.list/click` 新增 `scope=app|system`，默认继续操作前台 App 菜单；`system` 用于读取和点击 macOS 菜单栏 extras/status items，并在菜单项摘要中补充 `description`、`value` 与可执行 actions，减少状态栏入口无标题时的误判。 (#231)
 - **macOS Control 跨 App 窗口发现**：`mac_control.windows.list` 新增 `windowScope=frontmost|all`，默认保持前台 App 行为；显式 `all` 时可列出所有运行中 App 的窗口，并返回可复用的 `win_<pid>_<index>` id，便于模型先发现后台窗口再聚焦、移动、缩放、最小化或关闭。 (#231)
 - **macOS Control 剪贴板文本**：`mac_control.clipboard` 新增 `get/set/clear` 三个文本操作；`get` 支持 `maxChars` 截断，`set` 不在结果中回显写入内容，三者均作为隐私/副作用动作走审批，避免模型静默读取或改写用户剪贴板。 (#231)
 - **macOS Control 粘贴输入**：`mac_control.act` 新增 `op=paste`，用于长文本或 `AXValue` 不稳定的输入场景；执行时临时写入 pasteboard、触发系统粘贴，并备份/恢复原 pasteboard items，结果只报告恢复状态、不回显旧剪贴板或待粘贴文本。 (#231)
 - **macOS Control 目标消歧**：`mac_control.act` 在 AX 元素候选最高分并列时不再默认操作第一个匹配项，而是返回带候选提示的歧义错误，要求模型用 `elementId`、窗口标题、role 或更具体文本重试，降低点错相似按钮/输入框的风险。 (#231)
 - **macOS Control 元素检索**：`mac_control.elements.find` 新增只读 AX 元素检索，按 target 过滤并返回排序候选、score、reasons 和所在窗口，方便模型在点击/输入前先确认 `elementId`。 (#231)
-- **macOS Control 动作预解析**：`mac_control.act.dry_run` 新增只读目标解析，可在点击、设置值或拖拽前验证将命中的 AX 元素和歧义状态；`dryRunOp` 与 `explain=true` 可预览更接近真实动作的执行路径、风险和 fallback，不产生 UI 副作用。 (#231)
+- **macOS Control 动作预解析**：`mac_control.act.dry_run` 新增只读目标解析，可在点击、设置值或拖拽前验证将命中的 AX 元素和歧义状态，不产生 UI 副作用。 (#231)
 - **macOS Control 结果收敛**：`mac_control.act`、`wait`、`dialog` 默认不再返回完整 AX snapshot，只返回目标、命中或对话框摘要；调试或确需完整树时可显式传 `includeSnapshot=true`。 (#231)
 - **IM 渠道媒体附件发送**：Signal / Slack / iMessage / WhatsApp 渠道新增媒体附件发送，并支持把公共媒体链接直接路由给渠道。 (#232)
 - **聊天斜杠命令动作卡片**：斜杠命令动作结果以卡片形式渲染，新增 Recap 进度卡片与 Skill Fork 状态卡片。 (#232)
@@ -51,23 +76,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **macOS Control v3 控制稳定性升级**：完成 Peekaboo 对齐后的桌面控制强化：`visual.point/find_text` 会返回 AX 优先的 `suggestedActions[]`，必要时再坐标兜底；`act` 支持 `snapshotId + elementId` 稳定重定位、observe→act→verify 校验、自动 fallback 与审批后焦点恢复；窗口、文本输入、菜单、dialog、鼠标移动/拖拽/滑动等突变动作返回 verification；新增 `diagnostics.summary/export`、`act.dry_run dryRunOp` 与 explain 预览，便于模型在执行前看清将控制的对象。
-- **菜单栏图标交互**：单击菜单栏小图标时与右键一致打开托盘菜单，不再直接唤起主窗口；动态状态刷新不再因为 uptime 变化打断已展开的菜单。 (#242)
-- **审批弹层倒计时**：审批弹层的倒计时圆环左侧新增剩余时间文字，超时前状态更直观。 (#242)
-- **会话输入草稿保留**：切换会话时会保留每个会话输入区里的文字和待发送附件，切回后继续编辑；未发送的新会话草稿也会保留。 (#242)
-- **完成通知正文隐私开关**：通知设置新增「完成通知显示回复正文」开关，默认关闭；开启后后台完成通知会同时显示会话名和最后一条模型回复短预览。 (#242)
-- **聊天文件与界面视觉细节**：文件 chip 会按文件类型展示不同图标，Markdown 本地文件夹链接改用更清晰的文件夹图标；对话窗口与顶部标题栏恢复白色背景，左侧拖拽分隔线不再溢出到对话区。 (#242)
-- **聊天模型默认值作用域优化**：Agent 级 Think / reasoning effort 默认值现在可随 Agent 配置持久化，并在桌面、HTTP、IM、Cron 与 Subagent 路径中按「会话覆盖 > Agent 默认 > 全局默认」解析；Quick Chat 与主聊天恢复会话时同步恢复对应模型与 Think 状态。 (#236)
 - **聊天右侧面板交互统一**：Browser / Plan / Diff / Canvas / Team / Mac Control 面板强制互斥、可在已打开面板间一键切换并共享同一宽度。 (#232)
 - **IM 渠道稳定性整体加固**：Discord gateway 状态、Slack socket 断线重连、QQ Bot gateway 元数据、Signal daemon 就绪轮询、IRCv3 能力协商、iMessage RPC、LINE push 幂等重试、WhatsApp 轮询退避、Telegram 请求节流、飞书 token singleflight 与卡片动作 toast、IM callback origin 校验等多渠道修复。 (#232)
 
 ### Fixed
 
-- **macOS Control 共享 schema 参数预检**：`mac_control` 现在在权限判断和审批前会按 `action/op` sanitize + preflight 参数，避免 `spaces.switch direction=right` 这类调用被 Provider 默认补出的 `spaceIndex=1` 污染成冲突参数，也避免缺少必要目标的无效突变弹出审批后才失败。
-- **macOS Control Spaces 切换可靠性**：`spaces.switch direction=left|right` 和相邻 `spaceIndex/spaceId` 现在优先走 Mission Control `Control+Left/Right`，避免 SkyLight/CGS 只改内部 active id 却不切可见桌面；非相邻精确目标再 fallback 到 Control+数字或 SkyLight/CGS，执行后校验 current Space，未切到目标时返回明确 warning。
-- **macOS Control Spaces 当前状态修正**：`spaces.list` 不再用 `defaults export com.apple.spaces` 作为首选 current Space 来源，避免偏好文件里的 `Current Space` 与肉眼桌面状态不同步；现在优先用 `CGSGetActiveSpace` 判定 current，并用 `CGSCopyManagedDisplaySpaces` / `CGSCopySpaces` 枚举实时状态。
-- **会话置顶迁移兼容**：旧 session 数据库启动时会补齐 `pinned_at` 列后再创建索引，避免升级后因缺列导致应用无法打开。 (#242)
-- **Web Search fallback 诊断不再污染缓存**：搜索 provider fallback 时会区分无结果与 provider 不可用，且临时失败 / 限流诊断只出现在本次响应中，不再写入结果缓存。 (#236)
 - **聊天「停止」状态稳定保留**：重做 chat engine 活动 turn / 持久化 / 流序号管线，按下停止后会话状态正确保留，不再丢失或错乱（覆盖 failover 与 subagent 路径）。 (#230)
 - **流式 JSON 渲染修复**：流式输出过程中的 JSON 代码块渲染正确，不再中途错乱。 (#233)
 - **review followup 杂项修复**：IM 审批原因渲染、斜杠命令选择器去重、权限模式事件同步、NSIS 中文安装语言恢复、Release webview 右键菜单抑制等。 (#232)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3223,7 +3223,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.4.0"
+version = "0.5.0"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.4.0"
+version = "0.5.0"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.5.0.en.md
+++ b/docs/release-notes/v0.5.0.en.md
@@ -1,0 +1,44 @@
+# Hope Agent 0.5.0 — Hooks System · Workspace & File Subsystem · macOS Control v3
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.5.0/docs/release-notes/v0.5.0.md) · **English**
+
+> Release date: 2026-06-02
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.5.0/CHANGELOG.md#050---2026-06-02) for the full list.
+
+v0.5 is a release that pairs new capabilities with workflow polish. The Hooks system lets you wire custom automation into the key lifecycle events of a conversation; a new Workspace panel on the right aggregates a task's progress, the files it touched, and the sources it referenced; the project file subsystem has been rebuilt around a real working directory, a VSCode-style browser, and unified file actions with built-in preview; and macOS desktop control advances to v3 with visual / OCR targeting and a systematic reliability pass.
+
+## Hooks System (field-aligned to the Claude Code hooks protocol)
+
+Attach custom handlers to **28 lifecycle events** — across conversations, tool calls, context compaction, permission decisions, and more — to weave external automation into the chat:
+
+- **Five handler types**: `command` (run a command) / `http` (SSRF-checked HTTP callback) / `mcp_tool` (invoke an MCP tool) / `prompt` (side-query) / `agent` (spawn a sub-agent)
+- **Four scopes that stack**: user / managed / project / local. Project-scope hooks can ship with the repo for the whole team; for supply-chain safety they are **off by default** and must be enabled explicitly in Settings → Hooks
+- **Visual settings panel**: configure under Settings → Hooks, with hot reload on change
+- **Fine-grained control**: conditional execution (`if`, matched by tool + argument pattern), run-once-per-session (`once`), a runtime desktop hint (`statusMessage`), and `asyncRewake` for async command hooks to feed their result back as a reminder on the next turn when they exit with code 2
+
+## Workspace Panel & File Subsystem
+
+- **Workspace panel**: the right side of the chat now aggregates the session's task progress, the files it touched (reads + edits — click to view the diff or locate them in the file browser), and referenced sources (web-search hits and in-body links). Files and sources cover the **entire session history** while still reflecting the in-flight turn in real time; task progress moves from above the input box into the panel, leaving only a "Running N/M" status bar. It appears automatically the first time it has content, and won't re-open on its own once dismissed
+- **Project file browser**: both the project Settings "Files" tab and the main chat area offer a VSCode-style browser (titlebar entry + right panel, openable as a standalone window or maximized), with a resizable split between tree and preview; it supports create / rename / delete / move / drag-and-drop upload, plus read-only preview of code (Shiki highlighting), Markdown, images, PDF, and Office (docx/xlsx/pptx). When the working directory is a git repo it shows the current branch and worktree list with read-only navigation; selected text in a preview can be copied or referenced into the conversation
+- **Unified file actions + built-in preview**: Markdown links, message attachments, and workspace artifact files now behave identically — previewable types open in the right-side preview panel, everything else opens locally or downloads remotely. Local files inside the working directory or referenced by the session are no longer disabled in HTTP / Web mode
+- **Colored file-type icons**: the workspace, message attachments, and file browser all switch to per-format colored icons for at-a-glance recognition
+
+> ⚠️ **Breaking change**: every project now has a real working directory (default `~/.hope-agent/projects/<id>/workspace/`), and uploaded files land directly in it. The old project-file upload mechanism (separate storage + automatic text extraction) has been removed; after upgrading, previously uploaded project files are no longer injected into the model or shown in the UI.
+
+## macOS Desktop Control v3
+
+Building on v2's "can click and type", v3 adds visual awareness and hardens execution reliability:
+
+- **Visual / OCR targeting v1**: `visual.observe/point` returns a managed screenshot as visual input and maps pixels to clickable screen points; `visual.ocr/find_text` recognizes on-screen text via the Vision Framework and returns clickable coordinates; `observe` supports `annotate=true` to return an annotated screenshot with AX element-id boxes
+- **Higher-level actions**: `act.perform_action` runs named AX actions (`AXPress` / `AXShowMenu` / `AXIncrement`, etc.); `dialog` gains `list/click/input/file`; new `dock` and `spaces` families manage Dock items and desktop Spaces
+- **Reliability hardening**: `visual.point/find_text` return AX-first `suggestedActions[]`; `act` supports stable re-targeting via `snapshotId + elementId`, observe→act→verify checks, and post-approval focus restoration; arguments are sanitized + preflighted before approval; Spaces switching and current-state detection move to more reliable implementations
+
+## Experience Polish & Fixes
+
+- **Approval / ask-user timeouts (opt-in)**: optional timeouts for tool approval and `ask_user_question`; on timeout the session auto-denies or proceeds per your config, so it won't get stuck when unattended
+- **Sidebar display modes**: a new compact / detailed toggle, with compact mode tightening list density
+- **User message attachments** are now shown alongside the model's; a new **update history page** lets you revisit each version's release notes
+- **Right-panel interaction & animation polish**: panels gain a collapse toggle and a tab-style switcher, and the left session sidebar stays open when a panel is open
+- **Streaming Markdown render performance**: fixes dropped frames late in long replies; fixes project-wide tooltips being clipped by an ancestor's `overflow`
+- **A batch of fixes**: subagent / parent-agent streaming, AllowAlways permission scopes, pinned-session migration compatibility, Web Search fallback diagnostics no longer polluting the cache, and more

--- a/docs/release-notes/v0.5.0.md
+++ b/docs/release-notes/v0.5.0.md
@@ -1,0 +1,44 @@
+# Hope Agent 0.5.0 — Hooks 系统 · 工作台与文件子系统 · macOS 控制 v3
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.5.0/docs/release-notes/v0.5.0.en.md)
+
+> 发布日期：2026-06-02
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.5.0/CHANGELOG.md#050---2026-06-02)。
+
+v0.5 是一次能力扩张与工作流打磨并重的版本。Hooks 系统让你可以在会话的关键生命周期上挂接自定义自动化；右侧新增的工作台面板把一次任务的进度、碰过的文件与引用来源聚合到一处；项目文件子系统全面重构为「真实工作目录 + VSCode 风格浏览器 + 统一的文件操作与内置预览」；macOS 桌面控制推进到 v3，补齐视觉 / OCR 定位并系统加固执行可靠性。
+
+## Hooks 系统（字段级兼容 Claude Code 协议）
+
+可在会话、工具调用、上下文压缩、权限决策等 **28 个生命周期事件**上挂接自定义处理器，把外部自动化编织进对话：
+
+- **五种处理器**：`command`（执行命令）/ `http`（走 SSRF 校验的 HTTP 回调）/ `mcp_tool`（调用 MCP 工具）/ `prompt`（side-query）/ `agent`（spawn 子 Agent）
+- **四层作用域叠加**：user / managed / project / local，项目级 hooks 可随仓库共享给团队；出于供应链安全**默认关闭**，需在设置 → Hooks 显式开启
+- **可视化设置面板**：设置 → Hooks 配置，改动即时热重载
+- **精细控制**：条件执行（`if`，按工具 + 参数模式匹配）、每会话仅运行一次（`once`）、运行时桌面提示（`statusMessage`），以及 async 命令钩子在退出码 2 时把结果作为提醒回注下一轮对话（`asyncRewake`）
+
+## 工作台面板与文件子系统
+
+- **工作台面板**：聊天右侧聚合本会话的任务进度、碰到的文件（读取 + 改动，点击查看 diff 或在文件浏览器中定位）与引用来源（web 搜索命中与正文链接）。文件与来源覆盖**整个会话历史**，仍能实时反映正在进行的这一轮；任务进度从输入框上方移入面板，输入框仅保留一条「运行中 N/M」状态条。首次产生内容时自动出现，关闭后不再自动弹出
+- **项目文件浏览器**：项目设置「文件」标签与主聊天区均提供 VSCode 风格浏览器（标题栏入口 + 右侧面板，可弹独立窗口或最大化），文件树 / 预览左右分栏、分隔线可拖拽；支持新建 / 重命名 / 删除 / 移动 / 拖拽上传，以及代码（Shiki 高亮）、Markdown、图片、PDF 与 Office（docx/xlsx/pptx）的只读预览；工作目录为 git 仓库时展示当前分支与 worktree 列表、可只读跳转；预览中选中文本可右键复制或引用到对话
+- **文件操作统一 + 内置预览面板**：Markdown 链接、消息下挂文件、工作台产物文件操作完全一致——可预览类型点击在右侧面板内预览，其余本机点击「打开」、远端点击「下载」。HTTP / Web 模式下指向工作目录内或会话引用过的本地文件不再被禁用
+- **彩色文件类型图标**：工作台、消息附件、文件浏览器统一改用按格式区分的彩色图标，更易一眼辨识
+
+> ⚠️ **破坏性变更**：每个项目现在都有一个真实工作目录（默认 `~/.hope-agent/projects/<id>/workspace/`），上传文件直接落入该目录。旧的项目文件上传机制（独立存储 + 自动文本提取）已移除，升级后历史上传的项目文件不再注入模型或在界面显示。
+
+## macOS 桌面控制 v3
+
+在 v2「能点能输入」的基础上补齐视觉感知与执行可靠性：
+
+- **视觉 / OCR 定位 v1**：`visual.observe/point` 把受管截图作为视觉输入返回模型并把像素点映射为可点击 screen point；`visual.ocr/find_text` 基于 Vision Framework 识别截图文字并给出可点击坐标；`observe` 支持 `annotate=true` 返回带 AX element id 边框的标注截图
+- **更高层动作**：`act.perform_action` 支持命名 AX action（`AXPress` / `AXShowMenu` / `AXIncrement` 等）；`dialog` 新增 `list/click/input/file`；新增 `dock` 与 `spaces` 系列管理 Dock 项与桌面空间
+- **稳定性加固**：`visual.point/find_text` 返回 AX 优先的 `suggestedActions[]`，`act` 支持 `snapshotId + elementId` 稳定重定位与 observe→act→verify 校验、审批后焦点恢复；参数在审批前 sanitize + preflight；Spaces 切换 / 当前状态判定改用更可靠的实现
+
+## 体验打磨与修复
+
+- **审批 / 询问用户超时（opt-in）**：可选的工具审批与 `ask_user_question` 超时，超时后按配置自动 deny 或 proceed，避免无人值守时被卡住
+- **会话侧边栏显示模式**：新增简约 / 详细切换，简约模式压缩列表信息密度
+- **用户消息附件展示** 与模型消息对齐；新增**更新历史页**可回顾各版本发布说明
+- **右侧面板交互与动画打磨**：面板新增折叠开关、改为标签式切换器，打开时左侧会话侧边栏保持展开
+- **流式 Markdown 渲染性能优化**：根治长回复后段掉帧；修复全项目 Tooltip 被祖先 `overflow` 裁切
+- **一组修复**：subagent / 父 Agent 流式渲染、AllowAlways 权限作用域、会话置顶迁移兼容、Web Search fallback 诊断不污染缓存等

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.4.0"
+version = "0.5.0"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
本次 minor 发版 PR(0.4.0 → 0.5.0),三件套齐全:

- **CHANGELOG**:新增 `## [0.5.0]` 段,覆盖 v0.4.0 tag 以来全部 24 个 commit 的真实变更。同时将 `## [0.4.0]` 段**还原为 tag 时刻的发布基准**——此前误把 #236 / #239 / #241 / #242 这 4 个 v0.4.0 tag 之后才合并的 PR 写进了 0.4.0 段,现已迁移到 0.5.0 段,使 CHANGELOG 与已发布的 v0.4.0 release notes 一致。
- **双语 release notes**:`docs/release-notes/v0.5.0.md` + `v0.5.0.en.md`,主题 = Hooks 系统 · 工作台与文件子系统 · macOS 控制 v3,链接均用 tag-pin 绝对 URL。
- **版本号同步**:`pnpm version 0.5.0 --no-git-tag-version` 同步 package.json / 两个 Cargo.toml / tauri.conf.json / Cargo.lock 五处,`pnpm release:verify -- --tag v0.5.0` 已通过。

合并后:在 main HEAD 打 `v0.5.0` tag 触发 release.yml,审阅 draft Release 后 publish,再 `git branch release/v0.5 v0.5.0 && git push -u origin release/v0.5`。