### PR TITLE
backport: v0.5.1 input popover fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-03
+
+### Fixed
+
+- **输入框工具栏弹出菜单裁剪修复**：修复 v0.5.0 动画打磨后，聊天输入框里的模型选择、Think/思考强度、温度、权限模式与 Awareness 等弹出菜单被折叠动画容器裁掉的问题。 (#264)
+
 ## [0.5.0] - 2026-06-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3223,7 +3223,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.5.0"
+version = "0.5.1"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.5.0"
+version = "0.5.1"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.5.1.en.md
+++ b/docs/release-notes/v0.5.1.en.md
@@ -1,0 +1,15 @@
+# Hope Agent 0.5.1 — Input Popover Fix
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.5.1/docs/release-notes/v0.5.1.md) · **English**
+
+> Release date: 2026-06-03
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.5.1/CHANGELOG.md#051---2026-06-03) for the full list.
+
+v0.5.1 is an emergency patch for a popover clipping regression introduced by the v0.5.0 input animation polish.
+
+## Fixes
+
+- Fixes the model picker menu in the chat input toolbar not expanding fully.
+- Restores the same toolbar's Think / reasoning effort, temperature, permission mode, and Awareness popovers.
+- Keeps the toolbar collapse animation intact; only the expanded toolbar state now allows popovers to overflow, so other collapsed panels keep their existing clipping behavior.

--- a/docs/release-notes/v0.5.1.md
+++ b/docs/release-notes/v0.5.1.md
@@ -1,0 +1,15 @@
+# Hope Agent 0.5.1 — 输入框弹出菜单修复
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.5.1/docs/release-notes/v0.5.1.en.md)
+
+> 发布日期：2026-06-03
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.5.1/CHANGELOG.md#051---2026-06-03)。
+
+v0.5.1 是一个紧急修复版本，处理 v0.5.0 输入框动画打磨引入的弹出菜单裁剪问题。
+
+## 修复
+
+- 修复聊天输入框工具栏里的模型选择菜单无法完整展开的问题。
+- 同时恢复同一工具栏中的 Think/思考强度、温度、权限模式与 Awareness 等非 Portal 弹出菜单。
+- 保留输入框工具栏的折叠动画；仅在工具栏展开状态允许弹层向外溢出，避免影响其它折叠面板。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.5.0"
+version = "0.5.1"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -730,7 +730,10 @@ export default function ChatInput({
             onStop={() => void handleVoiceStop()}
           />
         </AnimatedCollapse>
-        <AnimatedCollapse open={voice.state !== "recording" && voice.state !== "transcribing"}>
+        <AnimatedCollapse
+          open={voice.state !== "recording" && voice.state !== "transcribing"}
+          overflow="visible-when-open"
+        >
         <div className="flex items-end justify-between gap-2 px-2 pb-2 animate-in fade-in-0 slide-in-from-bottom-1 duration-150">
           <div className="flex items-center gap-1 flex-wrap min-w-0">
             <div className={toolbarCompact ? "hidden" : CHAT_INPUT_INLINE_ADD_ACTIONS_CLASS}>

--- a/src/components/ui/animated-presence.tsx
+++ b/src/components/ui/animated-presence.tsx
@@ -7,6 +7,7 @@ interface AnimatedCollapseProps {
   children: ReactNode
   className?: string
   innerClassName?: string
+  overflow?: "hidden" | "visible-when-open"
   durationMs?: number
   unmountOnExit?: boolean
 }
@@ -16,6 +17,7 @@ export function AnimatedCollapse({
   children,
   className,
   innerClassName,
+  overflow = "hidden",
   durationMs = 200,
   unmountOnExit = true,
 }: AnimatedCollapseProps) {
@@ -100,10 +102,13 @@ export function AnimatedCollapse({
 
   if (!present && !open && unmountOnExit) return null
 
+  const allowOverflow = overflow === "visible-when-open" && visible
+
   return (
     <div
       className={cn(
-        "grid overflow-hidden transition-[grid-template-rows,opacity] ease-out motion-reduce:transition-none",
+        "grid transition-[grid-template-rows,opacity] ease-out motion-reduce:transition-none",
+        allowOverflow ? "overflow-visible" : "overflow-hidden",
         visible
           ? "grid-rows-[1fr] opacity-100"
           : "grid-rows-[0fr] opacity-0 pointer-events-none",
@@ -112,7 +117,13 @@ export function AnimatedCollapse({
       style={{ transitionDuration: `${durationMs}ms` }}
       aria-hidden={open ? undefined : true}
     >
-      <div className={cn("min-h-0 overflow-hidden", innerClassName)}>
+      <div
+        className={cn(
+          "min-h-0",
+          allowOverflow ? "overflow-visible" : "overflow-hidden",
+          innerClassName,
+        )}
+      >
         {open ? children : renderedChildren}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Backport v0.5.1 hotfix from release/v0.5.0 to main
- Preserve the AnimatedCollapse overflow opt-in so chat input toolbar popovers are not clipped
- Carry v0.5.1 version sync and release notes so main stays aligned with the patch release

## Verification
- pnpm release:verify
- pnpm typecheck
- pre-push hook: cargo fmt, clippy, pnpm typecheck, pnpm lint, pnpm test, cargo test