### PR TITLE
[codex] Add Gemma 4 12B local model recommendation

### DIFF
--- a/crates/ha-core/src/local_llm/mod.rs
+++ b/crates/ha-core/src/local_llm/mod.rs
@@ -1078,11 +1078,11 @@ mod tests {
     #[test]
     fn recommends_largest_fitting_model() {
         // 32 GiB Mac → budget is capped below qwen3.6:27b in this fixture.
-        // gemma4:e4b (9830 MiB) is the largest entry that fits; the next
+        // gemma4:12b (10240 MiB) is the largest entry that fits; the next
         // step up (qwen3.6:27b @ 17408) overshoots.
         let rec = recommend_model(&budget_hw(15 * 1024, BudgetSource::UnifiedMemory));
         let r = rec.recommended.expect("should recommend");
-        assert_eq!(r.id, "gemma4:e4b");
+        assert_eq!(r.id, "gemma4:12b");
         assert_eq!(rec.reason, RecommendationReason::UnifiedMemory);
         assert!(rec
             .alternatives

--- a/crates/ha-core/src/local_llm/types.rs
+++ b/crates/ha-core/src/local_llm/types.rs
@@ -183,6 +183,14 @@ pub fn model_catalog() -> Vec<ModelCandidate> {
             reasoning: true,
         },
         ModelCandidate {
+            id: "gemma4:12b".into(),
+            display_name: "Gemma 4 12B".into(),
+            family: "gemma4".into(),
+            size_mb: 10_240,
+            context_window: 131_072,
+            reasoning: false,
+        },
+        ModelCandidate {
             id: "gemma4:e4b".into(),
             display_name: "Gemma 4 E4B".into(),
             family: "gemma4".into(),


### PR DESCRIPTION
## What changed

- Added `gemma4:12b` to the local LLM recommendation catalog.
- Updated the recommender unit-test expectation so the 15 GiB budget fixture picks Gemma 4 12B instead of Gemma 4 E4B.

## Impact

Users with enough local model budget now see Gemma 4 12B as a recommended Ollama chat model between the larger Qwen/Gemma entries and the smaller Gemma E4B/E2B options.

## Validation

- `cargo check -p ha-core --locked`