### PR TITLE
[codex] Fix update history release list

### DIFF
--- a/src/components/settings/UpdateHistoryPanel.tsx
+++ b/src/components/settings/UpdateHistoryPanel.tsx
@@ -1,9 +1,10 @@
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { CalendarDays, ExternalLink } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
 import { HOPE_AGENT_URLS, useAppVersion } from "@/lib/appMeta"
+import { logger } from "@/lib/logger"
 import { getTransport } from "@/lib/transport-provider"
 import { cn } from "@/lib/utils"
 
@@ -18,18 +19,56 @@ interface ReleaseNoteEntry {
   zh?: string
   en?: string
   date?: string
+  remoteBody?: string
+  htmlUrl?: string
+}
+
+interface GitHubReleaseEntry {
+  version: string
+  date?: string
+  body?: string
+  htmlUrl?: string
+}
+
+interface ParsedVersion {
+  core: number[]
+  prerelease: string | null
+}
+
+const GITHUB_RELEASES_API =
+  "https://api.github.com/repos/shiwenwen/hope-agent/releases?per_page=100"
+const RELEASE_TAG_RE = /^v?([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)$/
+
+function parseVersion(version: string): ParsedVersion | null {
+  const [withoutBuild] = version.split("+")
+  const [corePart, prerelease = null] = withoutBuild.split("-", 2)
+  if (!corePart) return null
+  const coreParts = corePart.split(".")
+  if (coreParts.length === 0 || coreParts.some((part) => !/^[0-9]+$/.test(part))) return null
+  const core = coreParts.map((part) => Number(part))
+  return { core, prerelease }
 }
 
 function compareVersionsDesc(a: string, b: string): number {
-  const left = a.split(".").map((part) => Number(part) || 0)
-  const right = b.split(".").map((part) => Number(part) || 0)
-  const maxLen = Math.max(left.length, right.length)
+  const left = parseVersion(a)
+  const right = parseVersion(b)
+
+  if (!left || !right) return b.localeCompare(a, undefined, { numeric: true })
+  const maxLen = Math.max(left.core.length, right.core.length)
 
   for (let i = 0; i < maxLen; i += 1) {
-    const diff = (right[i] ?? 0) - (left[i] ?? 0)
+    const diff = (right.core[i] ?? 0) - (left.core[i] ?? 0)
     if (diff !== 0) return diff
   }
-  return 0
+
+  if (left.prerelease === right.prerelease) return 0
+  if (!left.prerelease) return -1
+  if (!right.prerelease) return 1
+  return right.prerelease.localeCompare(left.prerelease, undefined, { numeric: true })
+}
+
+function normalizeReleaseVersion(tagName: string): string | null {
+  return tagName.trim().match(RELEASE_TAG_RE)?.[1] ?? null
 }
 
 function extractDate(content: string): string | undefined {
@@ -41,7 +80,7 @@ function buildReleaseNotes(): ReleaseNoteEntry[] {
   const byVersion = new Map<string, ReleaseNoteEntry>()
 
   for (const [path, content] of Object.entries(releaseNoteModules)) {
-    const match = path.match(/v([0-9]+(?:\.[0-9]+)+)(?:\.(en))?\.md$/)
+    const match = path.match(/\/v([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)(?:\.(en))?\.md$/)
     if (!match) continue
 
     const [, version, englishSuffix] = match
@@ -58,6 +97,102 @@ function buildReleaseNotes(): ReleaseNoteEntry[] {
   return Array.from(byVersion.values()).sort((a, b) => compareVersionsDesc(a.version, b.version))
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function readStringField(value: Record<string, unknown>, key: string): string | undefined {
+  const raw = value[key]
+  return typeof raw === "string" && raw.trim() ? raw : undefined
+}
+
+function dateFromPublishedAt(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const date = value.slice(0, 10)
+  return /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(date) ? date : undefined
+}
+
+function toGitHubReleaseEntry(value: unknown): GitHubReleaseEntry | null {
+  if (!isRecord(value) || value.draft === true) return null
+
+  const version = normalizeReleaseVersion(readStringField(value, "tag_name") ?? "")
+  if (!version) return null
+
+  return {
+    version,
+    date: dateFromPublishedAt(readStringField(value, "published_at")),
+    body: readStringField(value, "body"),
+    htmlUrl: readStringField(value, "html_url"),
+  }
+}
+
+async function fetchGitHubReleasePage(
+  page: number,
+  signal: AbortSignal,
+): Promise<{ entries: GitHubReleaseEntry[]; rawCount: number }> {
+  const url = new URL(GITHUB_RELEASES_API)
+  url.searchParams.set("page", String(page))
+  const response = await fetch(url, {
+    headers: {
+      Accept: "application/vnd.github+json",
+    },
+    signal,
+  })
+
+  if (!response.ok) {
+    throw new Error(`GitHub releases request failed: ${response.status} ${response.statusText}`)
+  }
+
+  const raw: unknown = await response.json()
+  if (!Array.isArray(raw)) throw new Error("GitHub releases response was not an array")
+
+  return {
+    entries: raw.flatMap((item) => {
+      const entry = toGitHubReleaseEntry(item)
+      return entry ? [entry] : []
+    }),
+    rawCount: raw.length,
+  }
+}
+
+async function fetchGitHubReleases(signal: AbortSignal): Promise<GitHubReleaseEntry[]> {
+  const entries: GitHubReleaseEntry[] = []
+
+  for (let page = 1; page <= 10; page += 1) {
+    const result = await fetchGitHubReleasePage(page, signal)
+    entries.push(...result.entries)
+    if (result.rawCount < 100) break
+  }
+
+  return entries
+}
+
+function mergeReleaseNotes(
+  localNotes: ReleaseNoteEntry[],
+  remoteReleases: GitHubReleaseEntry[],
+): ReleaseNoteEntry[] {
+  const byVersion = new Map<string, ReleaseNoteEntry>()
+
+  for (const note of localNotes) {
+    byVersion.set(note.version, { ...note })
+  }
+
+  for (const release of remoteReleases) {
+    const existing = byVersion.get(release.version)
+    byVersion.set(release.version, {
+      ...existing,
+      version: release.version,
+      date: existing?.date ?? release.date,
+      zh: existing?.zh,
+      en: existing?.en,
+      remoteBody: existing?.remoteBody ?? release.body,
+      htmlUrl: existing?.htmlUrl ?? release.htmlUrl,
+    })
+  }
+
+  return Array.from(byVersion.values()).sort((a, b) => compareVersionsDesc(a.version, b.version))
+}
+
 async function openExternal(url: string) {
   try {
     await getTransport().call("open_url", { url })
@@ -69,25 +204,47 @@ async function openExternal(url: string) {
 export default function UpdateHistoryPanel() {
   const { t, i18n } = useTranslation()
   const appVersion = useAppVersion()
-  const releaseNotes = useMemo(() => buildReleaseNotes(), [])
+  const normalizedAppVersion = normalizeReleaseVersion(appVersion) ?? appVersion
+  const localReleaseNotes = useMemo(() => buildReleaseNotes(), [])
+  const [remoteReleases, setRemoteReleases] = useState<GitHubReleaseEntry[]>([])
+  const releaseNotes = useMemo(
+    () => mergeReleaseNotes(localReleaseNotes, remoteReleases),
+    [localReleaseNotes, remoteReleases],
+  )
   const [selectedVersion, setSelectedVersion] = useState<string | null>(null)
   const activeRelease =
     releaseNotes.find((item) => item.version === selectedVersion) ?? releaseNotes[0] ?? null
   const preferChinese = i18n.language.startsWith("zh")
   const activeContent = activeRelease
     ? preferChinese
-      ? activeRelease.zh ?? activeRelease.en
-      : activeRelease.en ?? activeRelease.zh
+      ? (activeRelease.zh ?? activeRelease.en ?? activeRelease.remoteBody)
+      : (activeRelease.en ?? activeRelease.zh ?? activeRelease.remoteBody)
     : null
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    fetchGitHubReleases(controller.signal)
+      .then((entries) => {
+        if (controller.signal.aborted) return
+        setRemoteReleases(entries)
+      })
+      .catch((e: unknown) => {
+        if (controller.signal.aborted) return
+        logger.warn("settings", "UpdateHistoryPanel::fetchGitHubReleases", "Failed to load", e)
+      })
+
+    return () => {
+      controller.abort()
+    }
+  }, [])
 
   return (
     <div className="flex-1 overflow-hidden">
       <div className="mx-auto flex h-full w-full max-w-6xl flex-col gap-4 p-6">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">
-              {t("about.updateHistory")}
-            </h2>
+            <h2 className="text-lg font-semibold text-foreground">{t("about.updateHistory")}</h2>
             <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
               {t("about.updateHistoryDesc")}
             </p>
@@ -113,7 +270,7 @@ export default function UpdateHistoryPanel() {
               <div className="space-y-1">
                 {releaseNotes.map((item, index) => {
                   const isActive = item.version === activeRelease?.version
-                  const isCurrent = item.version === appVersion
+                  const isCurrent = item.version === normalizedAppVersion
 
                   return (
                     <button
@@ -130,8 +287,7 @@ export default function UpdateHistoryPanel() {
                       <span className="flex-1">
                         <span className="block text-sm font-medium">v{item.version}</span>
                         <span className="mt-0.5 block text-[11px] text-muted-foreground">
-                          {item.date ??
-                            t("about.updateHistoryUndated")}
+                          {item.date ?? t("about.updateHistoryUndated")}
                         </span>
                       </span>
                       {index === 0 && (
@@ -167,7 +323,10 @@ export default function UpdateHistoryPanel() {
                     size="sm"
                     className="gap-1.5"
                     onClick={() =>
-                      openExternal(`${HOPE_AGENT_URLS.releases}/tag/v${activeRelease.version}`)
+                      openExternal(
+                        activeRelease.htmlUrl ??
+                          `${HOPE_AGENT_URLS.releases}/tag/v${activeRelease.version}`,
+                      )
                     }
                   >
                     GitHub
@@ -179,9 +338,7 @@ export default function UpdateHistoryPanel() {
                 {activeContent ? (
                   <MarkdownRenderer content={activeContent} />
                 ) : (
-                  <p>
-                    {t("about.updateHistoryNoNotes")}
-                  </p>
+                  <p>{t("about.updateHistoryNoNotes")}</p>
                 )}
               </div>
             </section>

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "تفاصيل الخطأ",
     "updateErrorLogHint": "تم تسجيل التتبع الكامل في ~/.hope-agent/logs.db (category: updater). استخدم /ha-logs للتحقيق أو أرفق هذا الملف عند الإبلاغ عن المشكلة.",
     "updateHistory": "سجل التحديثات",
-    "updateHistoryDesc": "تصفّح كل ملاحظات الإصدار المضمّنة دون مغادرة التطبيق.",
+    "updateHistoryDesc": "تصفّح الملاحظات المضمّنة وإصدارات GitHub المتزامنة دون مغادرة التطبيق.",
     "updateHistoryEmpty": "لم يتم العثور على ملاحظات إصدار في هذا البناء.",
     "updateHistoryLatest": "الأحدث",
     "updateHistoryNoNotes": "لا توجد ملاحظات متاحة لهذا الإصدار.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "Error details",
     "updateErrorLogHint": "Full traces are written to ~/.hope-agent/logs.db (category: updater) — run /ha-logs or share that file when reporting an issue.",
     "updateHistory": "Update history",
-    "updateHistoryDesc": "Browse every bundled release note without leaving the app.",
+    "updateHistoryDesc": "Browse bundled notes plus synced GitHub Releases without leaving the app.",
     "updateHistoryEmpty": "No release notes were found in this build.",
     "updateHistoryLatest": "Latest",
     "updateHistoryNoNotes": "No notes are available for this release.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "Detalles del error",
     "updateErrorLogHint": "El registro completo se guardó en ~/.hope-agent/logs.db (category: updater). Usa /ha-logs para revisarlo o adjunta ese archivo al reportar el problema.",
     "updateHistory": "Historial de actualizaciones",
-    "updateHistoryDesc": "Consulta todas las notas de versión incluidas sin salir de la app.",
+    "updateHistoryDesc": "Consulta las notas incluidas y los lanzamientos sincronizados de GitHub sin salir de la app.",
     "updateHistoryEmpty": "No se encontraron notas de versión en esta compilación.",
     "updateHistoryLatest": "Más reciente",
     "updateHistoryNoNotes": "No hay notas disponibles para esta versión.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "エラー詳細",
     "updateErrorLogHint": "完全なトレースは ~/.hope-agent/logs.db に書き込まれています（category: updater）。/ha-logs で確認するか、問題報告の際に該当ファイルを添付してください。",
     "updateHistory": "更新履歴",
-    "updateHistoryDesc": "アプリ内で、このビルドに含まれるすべてのリリースノートを確認できます。",
+    "updateHistoryDesc": "アプリを離れずに、同梱されたノートと同期された GitHub Releases を確認できます。",
     "updateHistoryEmpty": "このビルドにはリリースノートが見つかりません。",
     "updateHistoryLatest": "最新",
     "updateHistoryNoNotes": "このリリースのノートはありません。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "오류 세부정보",
     "updateErrorLogHint": "전체 추적이 ~/.hope-agent/logs.db에 기록되었습니다(category: updater). /ha-logs로 확인하거나 문제 보고 시 해당 파일을 첨부해 주세요.",
     "updateHistory": "업데이트 기록",
-    "updateHistoryDesc": "앱을 떠나지 않고 포함된 모든 릴리스 노트를 확인합니다.",
+    "updateHistoryDesc": "앱을 떠나지 않고 포함된 노트와 동기화된 GitHub Releases를 확인합니다.",
     "updateHistoryEmpty": "이 빌드에서 릴리스 노트를 찾을 수 없습니다.",
     "updateHistoryLatest": "최신",
     "updateHistoryNoNotes": "이 릴리스에 사용할 수 있는 노트가 없습니다.",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "Butiran ralat",
     "updateErrorLogHint": "Jejak penuh telah ditulis ke ~/.hope-agent/logs.db (category: updater). Gunakan /ha-logs untuk menyiasat atau lampirkan fail tersebut semasa melaporkan masalah.",
     "updateHistory": "Sejarah kemas kini",
-    "updateHistoryDesc": "Lihat semua nota keluaran yang dibundel tanpa meninggalkan aplikasi.",
+    "updateHistoryDesc": "Lihat nota yang dibundel serta GitHub Releases yang disegerakkan tanpa meninggalkan aplikasi.",
     "updateHistoryEmpty": "Tiada nota keluaran ditemui dalam binaan ini.",
     "updateHistoryLatest": "Terkini",
     "updateHistoryNoNotes": "Tiada nota tersedia untuk keluaran ini.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "Detalhes do erro",
     "updateErrorLogHint": "O registro completo foi gravado em ~/.hope-agent/logs.db (category: updater). Use /ha-logs para investigar ou anexe esse arquivo ao relatar o problema.",
     "updateHistory": "Histórico de atualizações",
-    "updateHistoryDesc": "Veja todas as notas de versão incluídas sem sair do app.",
+    "updateHistoryDesc": "Veja as notas incluídas e os GitHub Releases sincronizados sem sair do app.",
     "updateHistoryEmpty": "Nenhuma nota de versão foi encontrada nesta compilação.",
     "updateHistoryLatest": "Mais recente",
     "updateHistoryNoNotes": "Não há notas disponíveis para esta versão.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "Подробности ошибки",
     "updateErrorLogHint": "Полный трейс записан в ~/.hope-agent/logs.db (category: updater). Используйте /ha-logs для разбора или приложите этот файл к отчёту о проблеме.",
     "updateHistory": "История обновлений",
-    "updateHistoryDesc": "Просматривайте все встроенные заметки к выпускам, не выходя из приложения.",
+    "updateHistoryDesc": "Просматривайте встроенные заметки и синхронизированные GitHub Releases, не выходя из приложения.",
     "updateHistoryEmpty": "В этой сборке не найдены заметки к выпускам.",
     "updateHistoryLatest": "Последняя",
     "updateHistoryNoNotes": "Для этого выпуска нет доступных заметок.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "Hata ayrıntıları",
     "updateErrorLogHint": "Tam izleme ~/.hope-agent/logs.db dosyasına yazıldı (category: updater). Araştırmak için /ha-logs kullanın veya sorunu bildirirken bu dosyayı ekleyin.",
     "updateHistory": "Güncelleme geçmişi",
-    "updateHistoryDesc": "Uygulamadan ayrılmadan pakete dahil edilen tüm sürüm notlarına göz atın.",
+    "updateHistoryDesc": "Uygulamadan ayrılmadan paketlenmiş notlara ve senkronize GitHub Releases kayıtlarına göz atın.",
     "updateHistoryEmpty": "Bu derlemede sürüm notu bulunamadı.",
     "updateHistoryLatest": "En yeni",
     "updateHistoryNoNotes": "Bu sürüm için not yok.",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "Chi tiết lỗi",
     "updateErrorLogHint": "Toàn bộ trace đã được ghi vào ~/.hope-agent/logs.db (category: updater). Dùng /ha-logs để tra cứu hoặc đính kèm tệp đó khi báo lỗi.",
     "updateHistory": "Lịch sử cập nhật",
-    "updateHistoryDesc": "Xem mọi ghi chú phát hành được đóng gói mà không rời ứng dụng.",
+    "updateHistoryDesc": "Xem ghi chú được đóng gói cùng GitHub Releases đã đồng bộ mà không rời ứng dụng.",
     "updateHistoryEmpty": "Không tìm thấy ghi chú phát hành trong bản dựng này.",
     "updateHistoryLatest": "Mới nhất",
     "updateHistoryNoNotes": "Không có ghi chú nào cho bản phát hành này.",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "錯誤詳情",
     "updateErrorLogHint": "完整堆疊已寫入 ~/.hope-agent/logs.db（category: updater），可透過 /ha-logs 排查或在回報問題時附上該檔案。",
     "updateHistory": "更新歷史",
-    "updateHistoryDesc": "在應用內查看隨目前版本打包的所有發布說明。",
+    "updateHistoryDesc": "在應用內查看隨目前版本打包並從 GitHub Releases 同步的發布記錄。",
     "updateHistoryEmpty": "目前建置中沒有找到發布說明。",
     "updateHistoryLatest": "最新",
     "updateHistoryNoNotes": "這個版本暫時沒有可顯示的發布說明。",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -25,7 +25,7 @@
     "updateErrorDetails": "错误详情",
     "updateErrorLogHint": "完整堆栈已写入 ~/.hope-agent/logs.db（category: updater），可通过 /ha-logs 排查或在反馈时附上该文件。",
     "updateHistory": "更新历史",
-    "updateHistoryDesc": "在应用内查看随当前版本打包的所有发布说明。",
+    "updateHistoryDesc": "在应用内查看随当前版本打包并从 GitHub Releases 同步的发布记录。",
     "updateHistoryEmpty": "当前构建中没有找到发布说明。",
     "updateHistoryLatest": "最新",
     "updateHistoryNoNotes": "这个版本暂时没有可显示的发布说明。",


### PR DESCRIPTION
## Summary

- Merge bundled `docs/release-notes` entries with GitHub Releases so patch releases without bundled markdown still appear in Update history.
- Add release tag normalization, semver-ish descending sort, remote release body/date/link fallback, and offline fallback to bundled notes.
- Update `about.updateHistoryDesc` across all 12 locales to reflect the new bundled + GitHub Releases behavior.

## Root Cause

The Update history panel only globbed local markdown files from `docs/release-notes/*.md`, so any GitHub Release that did not have a bundled note file was omitted from the in-app history.

## Validation

- `pnpm typecheck`
- `node scripts/sync-i18n.mjs --check`
- pre-push hook passed: `cargo fmt --all --check`, `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `cargo test -p ha-core -p ha-server --locked`