### PR TITLE
[codex] tune chat responsive window sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **聊天左右面板窄窗口响应式与动画优化**：窗口缩小时右侧工作面板会先自动折叠，继续缩小时左侧会话栏再自动折叠，窗口变宽后仅恢复由响应式路径自动折叠的面板，不覆盖用户手动折叠选择；聊天输入框保留最小交互宽度，极窄宽度下工具栏改为上下布局。自动折叠阈值改用 `matchMedia` 监听，避免拖拽窗口时每个 resize 像素都触发 React 重渲染；左右面板动画拆为短布局占位过渡与 `transform`/`opacity` 视觉滑动，降低重排压力。
+- **聊天左右面板窄窗口响应式与动画优化**：窗口缩小时右侧工作面板会先自动折叠，继续缩小时左侧会话栏再自动折叠，窗口变宽后仅恢复由响应式路径自动折叠的面板，不覆盖用户手动折叠选择；右侧面板自动折叠阈值会参考用户当前面板宽度并设置舒适上限，避免超宽面板被硬挤压或轻微缩窗就过激收起；主窗口默认启动尺寸小幅调大，聊天输入框保留最小交互宽度，极窄宽度下工具栏改为上下布局。自动折叠阈值改用 `matchMedia` 监听，避免拖拽窗口时每个 resize 像素都触发 React 重渲染；左右面板动画拆为短布局占位过渡与 `transform`/`opacity` 视觉滑动，降低重排压力。
 - **浏览器脚本执行审批接入统一权限引擎**：`browser.control.evaluate` 不再绕过 session 权限模式单独走 `ask_user_question`，而是作为 `BrowserEvaluate` soft approval 进入统一工具审批链；Default 继续弹审批，Smart 可按高置信标记或 judge model 自动放行，Yolo / Global YOLO / 自动批准工具场景直接放行，同时保留 SSRF 字面量扫描。
 
 ### Fixed

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,8 +20,8 @@
           "x": 8,
           "y": 18
         },
-        "width": 1360,
-        "height": 860,
+        "width": 1440,
+        "height": 900,
         "minWidth": 840,
         "minHeight": 480,
         "resizable": true,

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -157,6 +157,7 @@ const EXCLUSIVE_RIGHT_PANEL_ICONS: Record<ExclusiveRightPanel, LucideIcon> = {
 const DEFAULT_RIGHT_PANEL_WIDTH = 520
 const CHAT_MAIN_MIN_INTERACTIVE_WIDTH = 420
 const RIGHT_PANEL_AUTO_COLLAPSE_MIN_WIDTH = 360
+const RIGHT_PANEL_AUTO_COLLAPSE_MAX_WIDTH = 640
 const SIDEBAR_AUTO_COLLAPSE_GUTTER = 180
 const RESPONSIVE_PANEL_HYSTERESIS = 120
 
@@ -167,6 +168,15 @@ interface MacControlFrameOpenHint {
 
 function clampChatSidebarWidth(width: number): number {
   return Math.min(CHAT_SIDEBAR_MAX_WIDTH, Math.max(CHAT_SIDEBAR_MIN_WIDTH, width))
+}
+
+function clampResponsiveRightPanelWidth(width: number): number {
+  return Math.round(
+    Math.min(
+      RIGHT_PANEL_AUTO_COLLAPSE_MAX_WIDTH,
+      Math.max(RIGHT_PANEL_AUTO_COLLAPSE_MIN_WIDTH, width),
+    ),
+  )
 }
 
 function useViewportMediaQuery(query: string): boolean {
@@ -1603,10 +1613,11 @@ export default function ChatScreen({
   }, [hasOpenExclusiveRightPanel, rightPanelCollapsed])
 
   const preferredSidebarWidthForResponsive = userSidebarCollapsedPreferenceRef.current ? 0 : panelWidth
+  const responsiveRightPanelWidth = clampResponsiveRightPanelWidth(rightPanelWidth)
   const rightPanelCollapseAt =
     preferredSidebarWidthForResponsive +
     CHAT_MAIN_MIN_INTERACTIVE_WIDTH +
-    RIGHT_PANEL_AUTO_COLLAPSE_MIN_WIDTH
+    responsiveRightPanelWidth
   const rightPanelExpandAt = rightPanelCollapseAt + RESPONSIVE_PANEL_HYSTERESIS
   const sidebarCollapseAt =
     panelWidth + CHAT_MAIN_MIN_INTERACTIVE_WIDTH + SIDEBAR_AUTO_COLLAPSE_GUTTER


### PR DESCRIPTION
## Summary

- Make the right panel responsive collapse threshold follow the user's current panel width, capped to a comfortable maximum.
- Slightly increase the default main window size to better fit the default chat layout.
- Update the changelog entry for the responsive sizing behavior.

## Validation

- `pnpm typecheck`
- `node -e "JSON.parse(require('fs').readFileSync('src-tauri/tauri.conf.json','utf8'))"`
- `git push` pre-push hook: `cargo fmt --all --check`, `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`, `pnpm typecheck`, `pnpm lint`, updater pubkey verify, `pnpm test`, `cargo test -p ha-core -p ha-server --locked`

Note: `pnpm lint` still reports the existing `ChatScreen.tsx` missing `stream` dependency warning.