### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-06
+
 ### Added
 
 - **工作台环境信息面板**：工作台顶部新增只读「环境」区块，按普通会话、项目会话、无痕、IM、Cron、Subagent、Plan Mode 与远端 Server 等场景展示运行位置、工作目录来源、权限模式、计划状态、模型与来源信息；Git 工作区会展示分支 / worktree、变更统计、ahead/behind、upstream 与最后提交，remote URL 展示前会移除凭据、query 与 fragment。新增 Tauri / HTTP 会话级环境快照接口，仅通过会话工作区读取本地状态，不注入模型上下文，也不会主动 `git fetch`。 (#269)
+- **Gemma 4 12B 本地模型推荐**：本地模型助手新增 `gemma4:12b` 候选，32GB 级统一内存设备会优先推荐更合适的 Gemma 4 12B，而不是落到更小的 E4B 档位。 (#266)
+- **Shift+Tab 快速切换权限模式**：聊天输入框支持 `Shift+Tab` 在 `default` / `smart` / `yolo` 三种会话权限模式间循环切换，适合需要频繁切换审批策略的工作流。 (#271)
 
 ### Changed
 
-- **System Prompt 会话状态注入增强**：所有会话现在都会在 system prompt 中看到当前权限审批模式（`default` / `smart` / `yolo`），Smart 模式继续引导 `_confidence: "high"`，YOLO 模式明确本会话审批层已授予全部权限以鼓励更主动执行。绑定 IM chat 的会话新增 `# IM Channel Attachment`，让桌面 / HTTP 发起的回复也知道可能镜像到 IM；IM metadata 以不可信 routing/audience JSON 渲染，避免外部 sender/chat 字段影响 prompt 结构。同步清理未接线的 Awareness 静态 overview prompt builder，保留实际生效的动态 awareness suffix。
-- **聊天左右面板窄窗口响应式与动画优化**：窗口缩小时右侧工作面板会先自动折叠，继续缩小时左侧会话栏再自动折叠，窗口变宽后仅恢复由响应式路径自动折叠的面板，不覆盖用户手动折叠选择；右侧面板自动折叠阈值会参考用户当前面板宽度并设置舒适上限，避免超宽面板被硬挤压或轻微缩窗就过激收起；主窗口默认启动尺寸小幅调大，聊天输入框保留最小交互宽度，极窄宽度下工具栏改为上下布局。自动折叠阈值改用 `matchMedia` 监听，避免拖拽窗口时每个 resize 像素都触发 React 重渲染；左右面板动画拆为短布局占位过渡与 `transform`/`opacity` 视觉滑动，降低重排压力。
-- **异步工具后台任务语义调整**：后台 job 与 `exec` 命令默认不再设置超时（`maxJobSecs=0`、`exec.timeout=0`），模型仍可通过 `job_timeout_secs` / `exec.timeout` 为单次调用主动设置上限；`job_status` 从主动 poll 等待收敛为非阻塞状态快照，完成结果继续通过 `<task-notification>` 自动回注。
-- **浏览器脚本执行审批接入统一权限引擎**：`browser.control.evaluate` 不再绕过 session 权限模式单独走 `ask_user_question`，而是作为 `BrowserEvaluate` soft approval 进入统一工具审批链；Default 继续弹审批，Smart 可按高置信标记或 judge model 自动放行，Yolo / Global YOLO / 自动批准工具场景直接放行，同时保留 SSRF 字面量扫描。
-- **权限模式切换器可同步 Agent 默认值**：聊天输入区的权限模式菜单新增「同时更新 Agent 默认」开关。开启后切换 `default` / `smart` / `yolo` 会同时更新当前 Agent 的新会话默认权限模式；关闭时仍只影响当前会话。
+- **System Prompt 会话状态注入增强**：所有会话现在都会在 system prompt 中看到当前权限审批模式（`default` / `smart` / `yolo`），Smart 模式继续引导 `_confidence: "high"`，YOLO 模式明确本会话审批层已授予全部权限以鼓励更主动执行。绑定 IM chat 的会话新增 `# IM Channel Attachment`，让桌面 / HTTP 发起的回复也知道可能镜像到 IM；IM metadata 以不可信 routing/audience JSON 渲染，避免外部 sender/chat 字段影响 prompt 结构。同步清理未接线的 Awareness 静态 overview prompt builder，保留实际生效的动态 awareness suffix。 (#280)
+- **聊天左右面板窄窗口响应式与动画优化**：窗口缩小时右侧工作面板会先自动折叠，继续缩小时左侧会话栏再自动折叠，窗口变宽后仅恢复由响应式路径自动折叠的面板，不覆盖用户手动折叠选择；右侧面板自动折叠阈值会参考用户当前面板宽度并设置舒适上限，避免超宽面板被硬挤压或轻微缩窗就过激收起；主窗口默认启动尺寸小幅调大，聊天输入框保留最小交互宽度，极窄宽度下工具栏改为上下布局。自动折叠阈值改用 `matchMedia` 监听，避免拖拽窗口时每个 resize 像素都触发 React 重渲染；左右面板动画拆为短布局占位过渡与 `transform`/`opacity` 视觉滑动，降低重排压力。 (#272, #275)
+- **异步工具后台任务语义调整**：后台 job 与 `exec` 命令默认不再设置超时（`maxJobSecs=0`、`exec.timeout=0`），模型仍可通过 `job_timeout_secs` / `exec.timeout` 为单次调用主动设置上限；`job_status` 从主动 poll 等待收敛为非阻塞状态快照，完成结果继续通过 `<task-notification>` 自动回注。 (#279)
+- **浏览器脚本执行审批接入统一权限引擎**：`browser.control.evaluate` 不再绕过 session 权限模式单独走 `ask_user_question`，而是作为 `BrowserEvaluate` soft approval 进入统一工具审批链；Default 继续弹审批，Smart 可按高置信标记或 judge model 自动放行，Yolo / Global YOLO / 自动批准工具场景直接放行，同时保留 SSRF 字面量扫描。 (#273)
+- **权限模式切换器可同步 Agent 默认值**：聊天输入区的权限模式菜单新增「同时更新 Agent 默认」开关。开启后切换 `default` / `smart` / `yolo` 会同时更新当前 Agent 的新会话默认权限模式；关闭时仍只影响当前会话。 (#277)
+- **Issue Reporting 设置面板本地化**：Issue Reporting 工具设置页、连接测试、Token 保存提示与标签配置补齐 i18n 文案，跟随应用语言展示。 (#267)
 
 ### Fixed
 
-- **macOS 系统权限页状态修正**：通知权限现在可从权限页触发原生授权请求；当前未启用的系统音频捕获不再作为待确认权限干扰 Mac Control 就绪状态；媒体资料库继续保留为手动确认，避免调用 macOS 不支持的 `MPMediaLibrary` 状态 API。
-- **ask_user_question 卡片自动滚动**：修复结构化提问卡片出现在消息列表 footer 时，因为没有新增 message 而不会触发自动追底、导致待回答卡片藏在屏幕下方的问题；现在新问题出现时会自动滚到卡片位置，并跟随展开动画保持可见。
-- **上下文压缩进行中状态**：自动 Tier 3 摘要压缩与执行过程中触发的上下文压缩现在会在聊天流中显示「正在压缩上下文」，完成后替换为最终压缩提示；T1/T2 快速本地压缩仍保持静默或仅显示完成提示，避免提示闪烁。
-- **GUI → IM 交班与流式稳定性修复**：修复桌面 / HTTP 会话正在回复时交班到 IM 后目标 chat 无交班提示、无法接入后续流式回复的问题；交班会补发当前用户问题引用并在回复完成时用完整最终答案收尾。IM 端 reply-only 斜杠命令不再伪造 `channel:stream_end`，避免打断 GUI 正在进行的流式回复；会话 detach / 接管后旧 IM chat 不再继续收到后续 mirror 帧。
+- **macOS 系统权限页状态修正**：通知权限现在可从权限页触发原生授权请求；当前未启用的系统音频捕获不再作为待确认权限干扰 Mac Control 就绪状态；媒体资料库继续保留为手动确认，避免调用 macOS 不支持的 `MPMediaLibrary` 状态 API。 (#278)
+- **ask_user_question 卡片自动滚动**：修复结构化提问卡片出现在消息列表 footer 时，因为没有新增 message 而不会触发自动追底、导致待回答卡片藏在屏幕下方的问题；现在新问题出现时会自动滚到卡片位置，并跟随展开动画保持可见。 (#273)
+- **上下文压缩进行中状态**：自动 Tier 3 摘要压缩与执行过程中触发的上下文压缩现在会在聊天流中显示「正在压缩上下文」，完成后替换为最终压缩提示；T1/T2 快速本地压缩仍保持静默或仅显示完成提示，避免提示闪烁。 (#274)
+- **GUI → IM 交班与流式稳定性修复**：修复桌面 / HTTP 会话正在回复时交班到 IM 后目标 chat 无交班提示、无法接入后续流式回复的问题；交班会补发当前用户问题引用并在回复完成时用完整最终答案收尾。IM 端 reply-only 斜杠命令不再伪造 `channel:stream_end`，避免打断 GUI 正在进行的流式回复；会话 detach / 接管后旧 IM chat 不再继续收到后续 mirror 帧。 (#276)
+- **更新历史页拉取线上 Release**：更新历史页现在会合并本地打包的 release notes 与 GitHub 已发布 Release，支持语义化版本排序与更多历史版本展示；GitHub 拉取失败时会记录日志并保留本地历史。 (#268)
 
 ## [0.5.1] - 2026-06-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3223,7 +3223,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.5.1"
+version = "0.6.0"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.5.1"
+version = "0.6.0"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.6.0.en.md
+++ b/docs/release-notes/v0.6.0.en.md
@@ -1,0 +1,31 @@
+# Hope Agent 0.6.0 — Recent Polish and Reliability
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.6.0/docs/release-notes/v0.6.0.md) · **English**
+
+> Release date: 2026-06-06
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.6.0/CHANGELOG.md#060---2026-06-06) for the full list.
+
+v0.6.0 gathers the latest mainline improvements since v0.5.1, with a focus on workspace visibility, responsive chat layout, permission ergonomics, async tools, and GUI ↔ IM handover reliability.
+
+## Highlights
+
+- **Workspace environment panel**: the Workspace panel now includes a read-only environment section with session source, working directory, permission mode, Plan state, model details, and Git branch / worktree / change statistics.
+- **Faster permission mode control**: press `Shift+Tab` in the chat input to cycle through `default` / `smart` / `yolo`; the permission menu can also sync the current mode back to the Agent's default for new sessions.
+- **Better narrow-window chat behavior**: the right workspace panel and left session sidebar collapse progressively as the window narrows, while preserving manual user choices; panel animation and input layout are steadier too.
+- **Clearer async tool semantics**: background jobs and `exec` commands no longer have a forced default timeout, `job_status` is now a non-blocking status snapshot, and completed results still return through `<task-notification>`.
+- **Richer system prompt session context**: models now see the active session permission mode; desktop / HTTP sessions attached to an IM chat also include IM attachment context, reducing ambiguity when replies mirror to IM.
+
+## Fixes
+
+- Browser `evaluate` script execution now goes through the unified permission engine, so Smart / YOLO / auto-approve behavior matches other tools.
+- Automatic context compaction now shows an in-progress state in the chat stream instead of looking stuck.
+- GUI / HTTP replies handed over to IM now send a handover notice and attach the live stream correctly.
+- `ask_user_question` cards automatically scroll into view when they appear.
+- macOS permissions now handle notification requests, inactive system audio capture, and media library status more accurately.
+- Update History combines GitHub published releases with bundled release notes for a fuller version list.
+
+## Also Included
+
+- Adds **Gemma 4 12B** to the local model recommendation catalog.
+- Localizes the Issue Reporting settings panel.

--- a/docs/release-notes/v0.6.0.md
+++ b/docs/release-notes/v0.6.0.md
@@ -1,0 +1,31 @@
+# Hope Agent 0.6.0 — 近期优化与稳定性更新
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.6.0/docs/release-notes/v0.6.0.en.md)
+
+> 发布日期：2026-06-06
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.6.0/CHANGELOG.md#060---2026-06-06)。
+
+v0.6.0 汇总了 v0.5.1 之后主线上的近期优化与修复，重点改善工作台可观测性、聊天响应式、权限体验、异步工具和 GUI ↔ IM 交班稳定性。
+
+## 亮点
+
+- **工作台环境信息面板**：工作台顶部新增只读「环境」区块，展示会话来源、工作目录、权限模式、Plan 状态、模型信息，以及 Git 分支 / worktree / 变更统计等上下文。
+- **权限模式更顺手**：输入框支持 `Shift+Tab` 快速循环切换 `default` / `smart` / `yolo`；权限菜单也可以选择把当前模式同步为 Agent 的新会话默认值。
+- **聊天窄窗口体验优化**：右侧工作面板与左侧会话栏按窗口宽度渐进折叠，自动折叠会尊重用户手动选择；面板动画和输入框布局也更稳。
+- **异步工具语义更清晰**：后台 job 与 `exec` 默认不再硬性超时，`job_status` 收敛为非阻塞状态快照，完成结果继续通过 `<task-notification>` 回注。
+- **System Prompt 会话上下文增强**：模型能看到当前会话权限模式；绑定 IM chat 的桌面 / HTTP 会话会注入 IM attachment 信息，减少 GUI 与 IM 镜像回复时的上下文缺口。
+
+## 修复
+
+- 浏览器 `evaluate` 脚本执行接入统一权限引擎，Smart / YOLO / auto-approve 行为与其它工具一致。
+- 自动上下文压缩会在聊天流里显示进行中状态，长会话压缩时不再像卡住。
+- 桌面 / HTTP 回复过程中交班到 IM 后，目标 chat 能收到交班提示并接住后续流式回复。
+- `ask_user_question` 卡片出现时会自动滚动到可见位置。
+- macOS 权限页修正通知权限请求、系统音频捕获状态和媒体资料库检测。
+- 更新历史页会合并 GitHub 已发布 Release 与本地 release notes，展示更完整的历史版本。
+
+## 其它
+
+- 本地模型助手新增 **Gemma 4 12B** 推荐候选。
+- Issue Reporting 设置面板补齐多语言文案。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.6.0",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.5.1"
+version = "0.6.0"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
把已发布的 v0.6.0 release commit 合回 main，包含版本号同步、CHANGELOG 和双语 release notes。\n\n已发布 Release: https://github.com/shiwenwen/hope-agent/releases/tag/v0.6.0