### PR TITLE
fix: keep new chats in current project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **项目会话新建归属修复**：当前会话属于某个 Project 时，`Cmd/Ctrl+N` 与托盘「新建对话」创建的新会话会继续归属同一个 Project，避免首条消息丢失项目记忆、文件与指令上下文。
+
 ## [0.6.0] - 2026-06-06
 
 ### Added

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -482,6 +482,21 @@ export default function ChatScreen({
     [handleNewChat],
   )
 
+  const handleStartNewChatFromCurrentContext = useCallback(async () => {
+    const projectId = currentSessionMeta?.projectId
+    if (projectId) {
+      setDraftIncognito(false)
+      await handleNewChatInProject(projectId, currentAgentId, false)
+      return
+    }
+    await handleStartNewChat(currentAgentId)
+  }, [
+    currentAgentId,
+    currentSessionMeta?.projectId,
+    handleNewChatInProject,
+    handleStartNewChat,
+  ])
+
   /**
    * Title-bar agent switch handler. Backend rejects the switch when the
    * session already has user/assistant messages (defense layer); the UI
@@ -849,8 +864,8 @@ export default function ChatScreen({
     return () => window.removeEventListener("keydown", handler)
   }, [currentSessionId, openSessionSearch, focusGlobalSearch])
 
-  // Cmd/Ctrl+N: start a fresh draft chat with the current agent, matching the
-  // sidebar New Chat button and tray "new-session" behavior.
+  // Cmd/Ctrl+N: start a fresh chat with the current agent. When the active
+  // session belongs to a Project, keep the new session in that Project too.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const modKey = e.metaKey || e.ctrlKey
@@ -861,18 +876,18 @@ export default function ChatScreen({
       if (target?.isContentEditable) return
 
       e.preventDefault()
-      void handleStartNewChat(currentAgentId)
+      void handleStartNewChatFromCurrentContext()
     }
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
-  }, [handleStartNewChat, currentAgentId])
+  }, [handleStartNewChatFromCurrentContext])
 
   // Listen for tray "new-session" event to trigger new chat
   useEffect(() => {
     return getTransport().listen("new-session", () => {
-      void handleStartNewChat(currentAgentId)
+      void handleStartNewChatFromCurrentContext()
     })
-  }, [handleStartNewChat, currentAgentId])
+  }, [handleStartNewChatFromCurrentContext])
 
   // Listen for tray "focus-session" event — emitted when the user clicks an
   // in-progress regular conversation entry inside the system tray dropdown.


### PR DESCRIPTION
## Summary
- Make Cmd/Ctrl+N inherit the active session's Project when creating a new chat.
- Make tray New Session use the same project-aware path.
- Add an Unreleased changelog entry.

## Tests
- git diff --check
- Not run: pnpm typecheck (node_modules missing in this worktree; tsc not found)