### PR TITLE
[codex] implement tool-loop message insertion queue

### DIFF
--- a/crates/ha-core/src/agent/content.rs
+++ b/crates/ha-core/src/agent/content.rs
@@ -1,6 +1,6 @@
 use serde_json::json;
 
-use super::types::Attachment;
+use super::types::{Attachment, ProviderFormat};
 use crate::file_extract;
 
 /// Process non-image attachments: extract text and images from files (PDF, Word, Excel, PPT, text).
@@ -277,4 +277,18 @@ pub(super) fn build_user_content_responses(
 
     parts.push(json!({ "type": "input_text", "text": full_message }));
     json!(parts)
+}
+
+pub(super) fn build_user_content_for_provider(
+    provider_format: ProviderFormat,
+    message: &str,
+    attachments: &[Attachment],
+) -> serde_json::Value {
+    match provider_format {
+        ProviderFormat::Anthropic => build_user_content_anthropic(message, attachments),
+        ProviderFormat::OpenAIChat => build_user_content_openai_chat(message, attachments),
+        ProviderFormat::OpenAIResponses | ProviderFormat::Codex => {
+            build_user_content_responses(message, attachments)
+        }
+    }
 }

--- a/crates/ha-core/src/agent/streaming_loop.rs
+++ b/crates/ha-core/src/agent/streaming_loop.rs
@@ -20,6 +20,7 @@ use super::events::{
     emit_max_rounds_notice, emit_round_limit_event, emit_tool_call, emit_tool_call_args_rewritten,
     emit_tool_result, emit_usage, extract_media_items,
 };
+use super::content::build_user_content_for_provider;
 use super::streaming_adapter::{ExecutedTool, RoundRequest, StreamingChatAdapter};
 use super::types::{AssistantAgent, ChatUsage};
 use crate::tools::{self, ToolExecContext};
@@ -183,6 +184,155 @@ async fn fire_post_tool_use_hook(
         clean_result.push_str("\n\n<hook-context>\n");
         clean_result.push_str(&extra);
         clean_result.push_str("\n</hook-context>");
+    }
+}
+
+async fn drain_queued_turn_user_messages<F>(
+    agent: &AssistantAgent,
+    adapter: &dyn StreamingChatAdapter,
+    messages: &mut Vec<serde_json::Value>,
+    on_delta: &F,
+) where
+    F: Fn(&str) + Send + Sync,
+{
+    let Some(session_id) = agent.session_id.as_deref() else {
+        return;
+    };
+    let Some(active) = crate::chat_engine::active_turn::current(session_id) else {
+        return;
+    };
+    if !matches!(
+        active.source,
+        crate::chat_engine::stream_seq::ChatSource::Desktop
+            | crate::chat_engine::stream_seq::ChatSource::Http
+    ) {
+        return;
+    }
+
+    let Some(db) = crate::get_session_db() else {
+        return;
+    };
+    let queued = crate::chat_engine::turn_injection::drain(session_id, &active.turn_id);
+    if queued.is_empty() {
+        return;
+    }
+
+    for mut item in queued {
+        if active.cancel.load(Ordering::SeqCst) {
+            break;
+        }
+        let raw_prompt =
+            crate::util::non_empty_trim_or(item.display_text.as_deref(), &item.message);
+        let effective_prompt = match crate::agent::preflight::user_prompt_preflight(
+            crate::agent::preflight::PreflightArgs {
+                session_id,
+                agent_id: Some(&agent.agent_id),
+                raw_prompt,
+            },
+        )
+        .await
+        {
+            crate::agent::preflight::PreflightOutcome::Proceed { effective_prompt } => {
+                if let Some(extra) = crate::hooks::take_user_prompt_context(session_id) {
+                    agent.push_pending_hook_context(extra);
+                }
+                effective_prompt
+            }
+            crate::agent::preflight::PreflightOutcome::Block { reason } => {
+                let notice = if reason.trim().is_empty() {
+                    "🚫 Prompt blocked by a UserPromptSubmit hook.".to_string()
+                } else {
+                    format!("🚫 {reason}")
+                };
+                let _ = db.append_message(
+                    session_id,
+                    &crate::session::NewMessage::event(&notice).with_source(item.source),
+                );
+                if let Ok(event) = serde_json::to_string(&json!({
+                    "type": "queued_user_message_blocked",
+                    "request_id": item.request_id,
+                    "session_id": item.session_id,
+                    "turn_id": item.turn_id,
+                    "reason": notice,
+                })) {
+                    on_delta(&event);
+                }
+                continue;
+            }
+        };
+
+        let attachment_meta = match crate::attachments::persist_chat_user_attachments_meta(
+            session_id,
+            &mut item.attachments,
+        ) {
+            Ok(meta) => meta,
+            Err(err) => {
+                let notice = format!("🚫 Failed to insert queued message attachments: {err}");
+                let _ = db.append_message(
+                    session_id,
+                    &crate::session::NewMessage::event(&notice).with_source(item.source),
+                );
+                if let Ok(event) = serde_json::to_string(&json!({
+                    "type": "queued_user_message_blocked",
+                    "request_id": item.request_id,
+                    "session_id": item.session_id,
+                    "turn_id": item.turn_id,
+                    "reason": notice,
+                })) {
+                    on_delta(&event);
+                }
+                continue;
+            }
+        };
+        let attachments_meta = crate::session::build_chat_user_attachments_meta(
+            item.is_plan_trigger,
+            item.plan_comment.as_ref(),
+            attachment_meta,
+        );
+        let mut user_msg =
+            crate::session::NewMessage::user(&effective_prompt).with_source(item.source);
+        user_msg.attachments_meta = attachments_meta.clone();
+        let message_id = match db.append_message(session_id, &user_msg) {
+            Ok(id) => id,
+            Err(err) => {
+                let notice = format!("🚫 Failed to insert queued message: {err}");
+                let _ = db.append_message(
+                    session_id,
+                    &crate::session::NewMessage::event(&notice).with_source(item.source),
+                );
+                if let Ok(event) = serde_json::to_string(&json!({
+                    "type": "queued_user_message_blocked",
+                    "request_id": item.request_id,
+                    "session_id": item.session_id,
+                    "turn_id": item.turn_id,
+                    "reason": notice,
+                })) {
+                    on_delta(&event);
+                }
+                continue;
+            }
+        };
+
+        let user_content = build_user_content_for_provider(
+            adapter.provider_format(),
+            &item.message,
+            &item.attachments,
+        );
+        AssistantAgent::push_user_message(messages, user_content);
+
+        if let Ok(event) = serde_json::to_string(&json!({
+            "type": "queued_user_message_inserted",
+            "request_id": item.request_id,
+            "session_id": item.session_id,
+            "turn_id": item.turn_id,
+            "message_id": message_id,
+            "content": effective_prompt,
+            "attachments_meta": attachments_meta,
+            "is_plan_trigger": item.is_plan_trigger,
+            "plan_comment": item.plan_comment,
+        })) {
+            on_delta(&event);
+        }
     }
 }
 
@@ -758,6 +908,8 @@ impl AssistantAgent {
             // native shape (Anthropic content blocks / OpenAI tool_calls /
             // Responses function_call+function_call_output items).
             adapter.append_round_to_history(&mut messages, round, &outcome, &executed);
+
+            drain_queued_turn_user_messages(self, adapter, &mut messages, on_delta).await;
 
             self.check_manual_memory_save(&outcome.tool_calls);
 

--- a/crates/ha-core/src/agent/streaming_loop.rs
+++ b/crates/ha-core/src/agent/streaming_loop.rs
@@ -16,11 +16,11 @@ use futures_util::future::join_all;
 use serde_json::json;
 
 use super::api_types::FunctionCallItem;
+use super::content::build_user_content_for_provider;
 use super::events::{
     emit_max_rounds_notice, emit_round_limit_event, emit_tool_call, emit_tool_call_args_rewritten,
     emit_tool_result, emit_usage, extract_media_items,
 };
-use super::content::build_user_content_for_provider;
 use super::streaming_adapter::{ExecutedTool, RoundRequest, StreamingChatAdapter};
 use super::types::{AssistantAgent, ChatUsage};
 use crate::tools::{self, ToolExecContext};

--- a/crates/ha-core/src/agent/types.rs
+++ b/crates/ha-core/src/agent/types.rs
@@ -299,7 +299,7 @@ pub(super) struct CacheSafeParams {
 }
 
 /// Provider format tag for CacheSafeParams, derived from LlmProvider variant.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum ProviderFormat {
     Anthropic,
     OpenAIChat,

--- a/crates/ha-core/src/chat_engine/engine.rs
+++ b/crates/ha-core/src/chat_engine/engine.rs
@@ -156,6 +156,9 @@ impl StreamLifecycle {
         if let Some(ref stream_id) = self.stream_id {
             let released = stream_seq::end_if_stream(&self.session_id, stream_id);
             if !released {
+                if let Some(ref turn_id) = self.turn_id {
+                    super::turn_injection::clear_turn(&self.session_id, turn_id);
+                }
                 self.finished = true;
                 return;
             }
@@ -169,6 +172,9 @@ impl StreamLifecycle {
                     self.terminal_error.as_deref(),
                 );
             }
+        }
+        if let Some(ref turn_id) = self.turn_id {
+            super::turn_injection::clear_turn(&self.session_id, turn_id);
         }
         self.finished = true;
     }

--- a/crates/ha-core/src/chat_engine/mod.rs
+++ b/crates/ha-core/src/chat_engine/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod quote;
 pub mod sink_registry;
 pub mod stream_broadcast;
 pub mod stream_seq;
+pub mod turn_injection;
 mod types;
 
 use std::sync::Arc;

--- a/crates/ha-core/src/chat_engine/turn_injection.rs
+++ b/crates/ha-core/src/chat_engine/turn_injection.rs
@@ -1,0 +1,298 @@
+//! In-memory user-message injection queue for active desktop / HTTP turns.
+//!
+//! The queue stores intent only. Messages are persisted and added to the
+//! provider-native conversation history at a safe tool-loop boundary, after
+//! assistant tool calls have received their matching tool results.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::Ordering;
+use std::sync::{Mutex, OnceLock};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::agent::Attachment;
+
+use super::active_turn;
+use super::stream_seq::ChatSource;
+
+#[derive(Debug, Clone)]
+pub struct QueuedTurnUserMessage {
+    pub request_id: String,
+    pub session_id: String,
+    pub turn_id: String,
+    pub message: String,
+    pub display_text: Option<String>,
+    pub attachments: Vec<Attachment>,
+    pub is_plan_trigger: bool,
+    pub plan_comment: Option<Value>,
+    pub source: ChatSource,
+}
+
+#[derive(Debug, Clone)]
+pub struct QueueTurnUserMessageArgs {
+    pub request_id: Option<String>,
+    pub session_id: String,
+    pub turn_id: String,
+    pub message: String,
+    pub display_text: Option<String>,
+    pub attachments: Vec<Attachment>,
+    pub is_plan_trigger: bool,
+    pub plan_comment: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueTurnUserMessageResult {
+    pub queued: bool,
+    pub request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelQueuedTurnMessageResult {
+    pub cancelled: bool,
+}
+
+type QueueKey = (String, String);
+
+static QUEUES: OnceLock<Mutex<HashMap<QueueKey, VecDeque<QueuedTurnUserMessage>>>> =
+    OnceLock::new();
+
+fn registry() -> &'static Mutex<HashMap<QueueKey, VecDeque<QueuedTurnUserMessage>>> {
+    QUEUES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn key(session_id: &str, turn_id: &str) -> QueueKey {
+    (session_id.to_string(), turn_id.to_string())
+}
+
+pub fn enqueue(args: QueueTurnUserMessageArgs) -> QueueTurnUserMessageResult {
+    let request_id = args
+        .request_id
+        .filter(|id| !id.trim().is_empty())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    let Some(active) = active_turn::current(&args.session_id) else {
+        return QueueTurnUserMessageResult {
+            queued: false,
+            request_id,
+            reason: Some("no active turn for session".to_string()),
+        };
+    };
+    if active.turn_id != args.turn_id {
+        return QueueTurnUserMessageResult {
+            queued: false,
+            request_id,
+            reason: Some("active turn id does not match".to_string()),
+        };
+    }
+    if active.cancel.load(Ordering::SeqCst) {
+        return QueueTurnUserMessageResult {
+            queued: false,
+            request_id,
+            reason: Some("active turn is cancelling".to_string()),
+        };
+    }
+    if !matches!(active.source, ChatSource::Desktop | ChatSource::Http) {
+        return QueueTurnUserMessageResult {
+            queued: false,
+            request_id,
+            reason: Some("active turn source does not support injection".to_string()),
+        };
+    }
+
+    let item = QueuedTurnUserMessage {
+        request_id: request_id.clone(),
+        session_id: args.session_id.clone(),
+        turn_id: args.turn_id.clone(),
+        message: args.message,
+        display_text: args.display_text,
+        attachments: args.attachments,
+        is_plan_trigger: args.is_plan_trigger,
+        plan_comment: args.plan_comment,
+        source: active.source,
+    };
+    let mut map = registry()
+        .lock()
+        .expect("turn injection registry poisoned");
+    let queue = map.entry(key(&args.session_id, &args.turn_id)).or_default();
+    if queue.iter().any(|existing| existing.request_id == request_id) {
+        return QueueTurnUserMessageResult {
+            queued: true,
+            request_id,
+            reason: None,
+        };
+    }
+    queue.push_back(item);
+
+    QueueTurnUserMessageResult {
+        queued: true,
+        request_id,
+        reason: None,
+    }
+}
+
+pub fn cancel(
+    session_id: &str,
+    turn_id: &str,
+    request_id: &str,
+) -> CancelQueuedTurnMessageResult {
+    let mut map = registry()
+        .lock()
+        .expect("turn injection registry poisoned");
+    let queue_key = key(session_id, turn_id);
+    let (cancelled, empty) = {
+        let Some(queue) = map.get_mut(&queue_key) else {
+            return CancelQueuedTurnMessageResult { cancelled: false };
+        };
+        let before = queue.len();
+        queue.retain(|item| item.request_id != request_id);
+        (queue.len() != before, queue.is_empty())
+    };
+    if empty {
+        map.remove(&queue_key);
+    }
+    CancelQueuedTurnMessageResult { cancelled }
+}
+
+pub(crate) fn drain(session_id: &str, turn_id: &str) -> Vec<QueuedTurnUserMessage> {
+    let mut map = registry()
+        .lock()
+        .expect("turn injection registry poisoned");
+    map.remove(&key(session_id, turn_id))
+        .unwrap_or_default()
+        .into_iter()
+        .collect()
+}
+
+pub(crate) fn clear_turn(session_id: &str, turn_id: &str) {
+    let mut map = registry()
+        .lock()
+        .expect("turn injection registry poisoned");
+    map.remove(&key(session_id, turn_id));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
+    #[test]
+    fn cancel_missing_queue_is_false() {
+        let result = cancel("missing-session", "missing-turn", "missing-request");
+        assert!(!result.cancelled);
+    }
+
+    #[test]
+    fn enqueue_and_drain_preserves_fifo_order() {
+        let session_id = format!("session-{}", uuid::Uuid::new_v4());
+        let turn_id = format!("turn-{}", uuid::Uuid::new_v4());
+        let _guard = active_turn::try_acquire(
+            &session_id,
+            ChatSource::Desktop,
+            turn_id.clone(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("acquire active turn");
+
+        let first = enqueue(QueueTurnUserMessageArgs {
+            request_id: Some("first".to_string()),
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            message: "first message".to_string(),
+            display_text: None,
+            attachments: Vec::new(),
+            is_plan_trigger: false,
+            plan_comment: None,
+        });
+        let second = enqueue(QueueTurnUserMessageArgs {
+            request_id: Some("second".to_string()),
+            session_id: session_id.clone(),
+            turn_id: turn_id.clone(),
+            message: "second message".to_string(),
+            display_text: None,
+            attachments: Vec::new(),
+            is_plan_trigger: false,
+            plan_comment: None,
+        });
+
+        assert!(first.queued);
+        assert!(second.queued);
+        let drained = drain(&session_id, &turn_id);
+        let ids: Vec<_> = drained.iter().map(|item| item.request_id.as_str()).collect();
+        assert_eq!(ids, vec!["first", "second"]);
+        assert!(drain(&session_id, &turn_id).is_empty());
+    }
+
+    #[test]
+    fn cancel_removes_only_matching_request() {
+        let session_id = format!("session-{}", uuid::Uuid::new_v4());
+        let turn_id = format!("turn-{}", uuid::Uuid::new_v4());
+        let _guard = active_turn::try_acquire(
+            &session_id,
+            ChatSource::Http,
+            turn_id.clone(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("acquire active turn");
+
+        for id in ["keep", "drop"] {
+            assert!(
+                enqueue(QueueTurnUserMessageArgs {
+                    request_id: Some(id.to_string()),
+                    session_id: session_id.clone(),
+                    turn_id: turn_id.clone(),
+                    message: id.to_string(),
+                    display_text: None,
+                    attachments: Vec::new(),
+                    is_plan_trigger: false,
+                    plan_comment: None,
+                })
+                .queued
+            );
+        }
+
+        assert!(cancel(&session_id, &turn_id, "drop").cancelled);
+        let drained = drain(&session_id, &turn_id);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].request_id, "keep");
+    }
+
+    #[test]
+    fn enqueue_is_idempotent_by_request_id() {
+        let session_id = format!("session-{}", uuid::Uuid::new_v4());
+        let turn_id = format!("turn-{}", uuid::Uuid::new_v4());
+        let _guard = active_turn::try_acquire(
+            &session_id,
+            ChatSource::Desktop,
+            turn_id.clone(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("acquire active turn");
+
+        for message in ["first", "duplicate"] {
+            assert!(
+                enqueue(QueueTurnUserMessageArgs {
+                    request_id: Some("same-request".to_string()),
+                    session_id: session_id.clone(),
+                    turn_id: turn_id.clone(),
+                    message: message.to_string(),
+                    display_text: None,
+                    attachments: Vec::new(),
+                    is_plan_trigger: false,
+                    plan_comment: None,
+                })
+                .queued
+            );
+        }
+
+        let drained = drain(&session_id, &turn_id);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].request_id, "same-request");
+        assert_eq!(drained[0].message, "first");
+    }
+}

--- a/crates/ha-core/src/chat_engine/turn_injection.rs
+++ b/crates/ha-core/src/chat_engine/turn_injection.rs
@@ -115,11 +115,12 @@ pub fn enqueue(args: QueueTurnUserMessageArgs) -> QueueTurnUserMessageResult {
         plan_comment: args.plan_comment,
         source: active.source,
     };
-    let mut map = registry()
-        .lock()
-        .expect("turn injection registry poisoned");
+    let mut map = registry().lock().expect("turn injection registry poisoned");
     let queue = map.entry(key(&args.session_id, &args.turn_id)).or_default();
-    if queue.iter().any(|existing| existing.request_id == request_id) {
+    if queue
+        .iter()
+        .any(|existing| existing.request_id == request_id)
+    {
         return QueueTurnUserMessageResult {
             queued: true,
             request_id,
@@ -135,14 +136,8 @@ pub fn enqueue(args: QueueTurnUserMessageArgs) -> QueueTurnUserMessageResult {
     }
 }
 
-pub fn cancel(
-    session_id: &str,
-    turn_id: &str,
-    request_id: &str,
-) -> CancelQueuedTurnMessageResult {
-    let mut map = registry()
-        .lock()
-        .expect("turn injection registry poisoned");
+pub fn cancel(session_id: &str, turn_id: &str, request_id: &str) -> CancelQueuedTurnMessageResult {
+    let mut map = registry().lock().expect("turn injection registry poisoned");
     let queue_key = key(session_id, turn_id);
     let (cancelled, empty) = {
         let Some(queue) = map.get_mut(&queue_key) else {
@@ -159,9 +154,7 @@ pub fn cancel(
 }
 
 pub(crate) fn drain(session_id: &str, turn_id: &str) -> Vec<QueuedTurnUserMessage> {
-    let mut map = registry()
-        .lock()
-        .expect("turn injection registry poisoned");
+    let mut map = registry().lock().expect("turn injection registry poisoned");
     map.remove(&key(session_id, turn_id))
         .unwrap_or_default()
         .into_iter()
@@ -169,9 +162,7 @@ pub(crate) fn drain(session_id: &str, turn_id: &str) -> Vec<QueuedTurnUserMessag
 }
 
 pub(crate) fn clear_turn(session_id: &str, turn_id: &str) {
-    let mut map = registry()
-        .lock()
-        .expect("turn injection registry poisoned");
+    let mut map = registry().lock().expect("turn injection registry poisoned");
     map.remove(&key(session_id, turn_id));
 }
 
@@ -223,7 +214,10 @@ mod tests {
         assert!(first.queued);
         assert!(second.queued);
         let drained = drain(&session_id, &turn_id);
-        let ids: Vec<_> = drained.iter().map(|item| item.request_id.as_str()).collect();
+        let ids: Vec<_> = drained
+            .iter()
+            .map(|item| item.request_id.as_str())
+            .collect();
         assert_eq!(ids, vec!["first", "second"]);
         assert!(drain(&session_id, &turn_id).is_empty());
     }

--- a/crates/ha-server/src/lib.rs
+++ b/crates/ha-server/src/lib.rs
@@ -242,6 +242,14 @@ fn build_router_with_cors(
         )
         // Chat
         .route("/chat", post(routes::chat::chat))
+        .route(
+            "/chat/turn-message",
+            post(routes::chat::queue_turn_user_message),
+        )
+        .route(
+            "/chat/turn-message/cancel",
+            post(routes::chat::cancel_queued_turn_user_message),
+        )
         .route("/chat/stop", post(routes::chat::stop_chat))
         .route(
             "/sessions/{sessionId}/tasks",

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -68,6 +68,32 @@ pub struct ChatRequest {
     pub working_dir: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueueTurnUserMessageRequest {
+    #[serde(default)]
+    pub request_id: Option<String>,
+    pub message: String,
+    #[serde(default)]
+    pub attachments: Vec<Attachment>,
+    pub session_id: String,
+    pub turn_id: String,
+    #[serde(default)]
+    pub display_text: Option<String>,
+    #[serde(default)]
+    pub is_plan_trigger: Option<bool>,
+    #[serde(default)]
+    pub plan_comment: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelQueuedTurnUserMessageRequest {
+    pub session_id: String,
+    pub turn_id: String,
+    pub request_id: String,
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChatResponse {
@@ -480,6 +506,40 @@ pub async fn chat(
         turn_id,
         blocked_reason: None,
     }))
+}
+
+/// `POST /api/chat/turn-message` — queue a user message to be injected at the
+/// next safe tool-loop boundary of the active turn.
+pub async fn queue_turn_user_message(
+    Json(body): Json<QueueTurnUserMessageRequest>,
+) -> Result<Json<ha_core::chat_engine::turn_injection::QueueTurnUserMessageResult>, AppError> {
+    validate_http_chat_attachments(&body.attachments)?;
+    let result = ha_core::chat_engine::turn_injection::enqueue(
+        ha_core::chat_engine::turn_injection::QueueTurnUserMessageArgs {
+            request_id: body.request_id,
+            session_id: body.session_id,
+            turn_id: body.turn_id,
+            message: body.message,
+            display_text: body.display_text,
+            attachments: body.attachments,
+            is_plan_trigger: body.is_plan_trigger.unwrap_or(false),
+            plan_comment: body.plan_comment,
+        },
+    );
+    Ok(Json(result))
+}
+
+/// `POST /api/chat/turn-message/cancel` — cancel a not-yet-injected queued
+/// message for an active turn.
+pub async fn cancel_queued_turn_user_message(
+    Json(body): Json<CancelQueuedTurnUserMessageRequest>,
+) -> Result<Json<ha_core::chat_engine::turn_injection::CancelQueuedTurnMessageResult>, AppError> {
+    let result = ha_core::chat_engine::turn_injection::cancel(
+        &body.session_id,
+        &body.turn_id,
+        &body.request_id,
+    );
+    Ok(Json(result))
 }
 
 /// `POST /api/chat/stop` — stop ongoing chat(s).

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -127,6 +127,44 @@ pub async fn save_attachment(
 }
 
 #[tauri::command]
+pub async fn queue_turn_user_message(
+    request_id: Option<String>,
+    message: String,
+    attachments: Vec<Attachment>,
+    session_id: String,
+    turn_id: String,
+    display_text: Option<String>,
+    is_plan_trigger: Option<bool>,
+    plan_comment: Option<serde_json::Value>,
+) -> Result<ha_core::chat_engine::turn_injection::QueueTurnUserMessageResult, CmdError> {
+    Ok(ha_core::chat_engine::turn_injection::enqueue(
+        ha_core::chat_engine::turn_injection::QueueTurnUserMessageArgs {
+            request_id,
+            session_id,
+            turn_id,
+            message,
+            display_text,
+            attachments,
+            is_plan_trigger: is_plan_trigger.unwrap_or(false),
+            plan_comment,
+        },
+    ))
+}
+
+#[tauri::command]
+pub async fn cancel_queued_turn_user_message(
+    session_id: String,
+    turn_id: String,
+    request_id: String,
+) -> Result<ha_core::chat_engine::turn_injection::CancelQueuedTurnMessageResult, CmdError> {
+    Ok(ha_core::chat_engine::turn_injection::cancel(
+        &session_id,
+        &turn_id,
+        &request_id,
+    ))
+}
+
+#[tauri::command]
 pub async fn chat(
     message: String,
     mut attachments: Vec<Attachment>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,6 +173,8 @@ pub fn run() {
             commands::auth::set_reasoning_effort,
             // Chat
             commands::chat::save_attachment,
+            commands::chat::queue_turn_user_message,
+            commands::chat::cancel_queued_turn_user_message,
             commands::chat::chat,
             commands::chat::stop_chat,
             commands::runtime_tasks::cancel_runtime_task,

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -2099,6 +2099,7 @@ export default function ChatScreen({
                     }}
                     onJumpToQuote={handleQuoteJump}
                     pendingMessage={stream.pendingMessage}
+                    pendingSends={stream.pendingSends}
                     onCancelPending={() => {
                       stream.setInput(stream.pendingMessage || "")
                       stream.setPendingMessage(null)
@@ -2106,6 +2107,10 @@ export default function ChatScreen({
                     onDiscardPending={() => {
                       stream.setPendingMessage(null)
                     }}
+                    onEditPending={stream.editPendingSend}
+                    onDiscardPendingItem={stream.discardPendingSend}
+                    onForceInsertPending={stream.forceInsertPendingSend}
+                    onCancelForceInsertPending={stream.cancelForceInsertPendingSend}
                     onStop={stream.handleStop}
                     currentSessionId={session.currentSessionId}
                     currentAgentId={session.currentAgentId}

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -14,6 +14,7 @@ import type {
   Message,
   MessageAttachment,
   PendingFileQuote,
+  PendingSendPreview,
   ActiveModel,
   AgentSummaryForSidebar,
   SessionMode,
@@ -115,10 +116,24 @@ interface SendOptions {
 }
 
 interface PendingSend {
+  id: string
+  createdAt: number
   text: string
+  mode: "queue" | "force_insert"
+  status: "queued" | "waiting_tool_boundary" | "inserted" | "fallback_after_reply"
   options?: SendOptions
   attachedFiles?: File[]
   quotes?: PendingFileQuote[]
+}
+
+interface QueueTurnUserMessageResult {
+  queued: boolean
+  requestId: string
+  reason?: string
+}
+
+interface CancelQueuedTurnUserMessageResult {
+  cancelled: boolean
 }
 
 interface InputDraft {
@@ -189,6 +204,11 @@ export interface UseChatStreamReturn {
   setPendingQuotes: React.Dispatch<React.SetStateAction<PendingFileQuote[]>>
   pendingMessage: string | null
   setPendingMessage: React.Dispatch<React.SetStateAction<string | null>>
+  pendingSends: PendingSendPreview[]
+  editPendingSend: (id: string) => void
+  discardPendingSend: (id: string) => void
+  forceInsertPendingSend: (id: string) => Promise<void>
+  cancelForceInsertPendingSend: (id: string) => Promise<void>
   approvalRequests: ApprovalRequest[]
   showCodexAuthExpired: boolean
   setShowCodexAuthExpired: React.Dispatch<React.SetStateAction<boolean>>
@@ -312,33 +332,75 @@ export function useChatStream({
     setAttachedFilesState(nextDraft.attachedFiles)
   }, [currentSessionId, saveInputDraft])
 
-  // Pending send queued while a response is streaming. Stores the LLM-bound
+  // Pending sends queued while a response is streaming. Stores the LLM-bound
   // `text` plus the original `options` (displayText / planMode / isPlanTrigger)
-  // so the replay path can resend with the exact same metadata — otherwise a
-  // queued plan-mode approve would lose its `isPlanTrigger` flag and render
-  // as a plain user bubble.
-  const [pendingSend, setPendingSendState] = useState<PendingSend | null>(null)
-  const pendingSendRef = useRef<PendingSend | null>(null)
+  // so replay preserves metadata. User-typed sends can additionally request
+  // insertion at the next safe tool boundary.
+  const [pendingSendsState, setPendingSendsState] = useState<PendingSend[]>([])
+  const pendingSendsRef = useRef<PendingSend[]>([])
+  const updatePendingSends = useCallback((updater: React.SetStateAction<PendingSend[]>) => {
+    setPendingSendsState((prev) => {
+      const next =
+        typeof updater === "function"
+          ? (updater as (p: PendingSend[]) => PendingSend[])(prev)
+          : updater
+      pendingSendsRef.current = next
+      return next
+    })
+  }, [])
+  const pendingDisplayText = useCallback(
+    (pending: PendingSend): string =>
+      pending.options?.displayText?.trim() ||
+      pending.text ||
+      (pending.attachedFiles?.length ? t("chat.attachPhotosAndFiles") : ""),
+    [t],
+  )
+  const pendingInputText = useCallback(
+    (pending: PendingSend): string => pending.options?.displayText?.trim() || pending.text,
+    [],
+  )
+  const canForceInsertPending = useCallback(
+    (pending: PendingSend): boolean =>
+      !pending.options &&
+      pending.status === "queued" &&
+      pending.mode !== "force_insert",
+    [],
+  )
   // External views: keep the original `pendingMessage: string | null` API for
-  // ChatScreen / ChatInput, derived from the user-facing displayed text.
-  const pendingMessage = pendingSend
-    ? pendingSend.options?.displayText?.trim() ||
-      pendingSend.text ||
-      (pendingSend.attachedFiles?.length ? t("chat.attachPhotosAndFiles") : "")
-    : null
+  // ChatScreen / QuickChat, derived from the first queued item.
+  const pendingMessage = pendingSendsState[0] ? pendingDisplayText(pendingSendsState[0]) : null
+  const pendingSends: PendingSendPreview[] = pendingSendsState.map((pending) => ({
+    id: pending.id,
+    text: pendingDisplayText(pending),
+    mode: pending.mode,
+    status: pending.status,
+    canForceInsert: canForceInsertPending(pending),
+    attachmentCount: pending.attachedFiles?.length ?? 0,
+    quoteCount: pending.quotes?.length ?? 0,
+  }))
   const setPendingMessage = useCallback<
     React.Dispatch<React.SetStateAction<string | null>>
   >((value) => {
-    setPendingSendState((prev) => {
+    updatePendingSends((prev) => {
+      const first = prev[0]
       const next =
         typeof value === "function"
           ? (value as (p: string | null) => string | null)(
-              prev ? prev.options?.displayText?.trim() || prev.text : null,
+              first ? pendingDisplayText(first) : null,
             )
           : value
-      return next === null ? null : { text: next }
+      if (next === null) return prev.slice(1)
+      return [
+        {
+          id: generateClientId(),
+          createdAt: Date.now(),
+          text: next,
+          mode: "queue",
+          status: "queued",
+        },
+      ]
     })
-  }, [])
+  }, [pendingDisplayText, updatePendingSends])
   const [showCodexAuthExpired, setShowCodexAuthExpired] = useState(false)
   const [permissionMode, setPermissionModeState] = useState<SessionMode>("default")
   const permissionModeRef = useRef<SessionMode>("default")
@@ -456,8 +518,8 @@ export function useChatStream({
 
   // Keep refs in sync
   useEffect(() => {
-    pendingSendRef.current = pendingSend
-  }, [pendingSend])
+    pendingSendsRef.current = pendingSendsState
+  }, [pendingSendsState])
   useEffect(() => {
     permissionModeRef.current = permissionMode
   }, [permissionMode])
@@ -559,6 +621,89 @@ export function useChatStream({
     [],
   )
 
+  const quoteLineLabel = useCallback((q: PendingFileQuote) =>
+    q.startLine === q.endLine ? `${q.startLine}` : `${q.startLine}-${q.endLine}`,
+  [])
+
+  const buildChatAttachments = useCallback(
+    async (
+      text: string,
+      filesToSend: File[],
+      quotesToSend: PendingFileQuote[],
+      targetSessionId: string | null,
+    ): Promise<ChatAttachment[]> => {
+      const attachments: ChatAttachment[] = []
+
+      const sessionWorkingDir =
+        sessions.find((s) => s.id === targetSessionId)?.workingDir ?? null
+      const resolvedWorkingDir = targetSessionId ? sessionWorkingDir : draftWorkingDir
+      const mentionAttachments = expandMentionsToAttachments(text, resolvedWorkingDir ?? null)
+      for (const m of mentionAttachments) {
+        attachments.push(m)
+      }
+
+      const planAttachments = await expandPlanMentionsToAttachments(text)
+      for (const p of planAttachments) {
+        attachments.push(p)
+      }
+
+      for (const file of filesToSend) {
+        try {
+          const mimeType = file.type || "application/octet-stream"
+          const arrayBuffer = await file.arrayBuffer()
+
+          if (mimeType.startsWith("image/")) {
+            const bytes = new Uint8Array(arrayBuffer)
+            let binary = ""
+            const chunkSize = 8192
+            for (let i = 0; i < bytes.length; i += chunkSize) {
+              binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
+            }
+            attachments.push({
+              name: file.name,
+              mime_type: mimeType,
+              source: "upload",
+              data: btoa(binary),
+            })
+          } else {
+            const data = getTransport().prepareFileData(arrayBuffer, mimeType)
+            const filePath = await getTransport().call<string>("save_attachment", {
+              sessionId: targetSessionId,
+              fileName: file.name,
+              mimeType,
+              data,
+            })
+            attachments.push({
+              name: file.name,
+              mime_type: mimeType,
+              source: "upload",
+              file_path: filePath,
+            })
+          }
+        } catch (err) {
+          logger.error("ui", "ChatScreen::attachment", "Failed to process attachment", {
+            fileName: file.name,
+            error: err,
+          })
+        }
+      }
+
+      for (const q of quotesToSend) {
+        attachments.push({
+          name: q.name,
+          mime_type: "text/plain",
+          source: "quote",
+          data: q.content,
+          file_path: q.path,
+          quote_lines: quoteLineLabel(q),
+        })
+      }
+
+      return attachments
+    },
+    [draftWorkingDir, quoteLineLabel, sessions],
+  )
+
   /**
    * Send a message. If `directText` is provided, use it directly instead of the input box.
    * This avoids flashing text in the input (used by Plan Mode approve).
@@ -577,12 +722,19 @@ export function useChatStream({
     if (loading) {
       const queuedFiles = directText ? [] : [...attachedFiles]
       const queuedQuotes = directText ? [] : [...pendingQuotes]
-      setPendingSendState({
-        text: rawText.trim(),
-        options,
-        ...(queuedFiles.length > 0 && { attachedFiles: queuedFiles }),
-        ...(queuedQuotes.length > 0 && { quotes: queuedQuotes }),
-      })
+      updatePendingSends((prev) => [
+        ...prev,
+        {
+          id: generateClientId(),
+          createdAt: Date.now(),
+          text: rawText.trim(),
+          mode: "queue",
+          status: "queued",
+          options,
+          ...(queuedFiles.length > 0 && { attachedFiles: queuedFiles }),
+          ...(queuedQuotes.length > 0 && { quotes: queuedQuotes }),
+        },
+      ])
       if (!directText) {
         setInput("")
         setAttachedFiles([])
@@ -597,8 +749,6 @@ export function useChatStream({
     const filesToSend = directText ? [] : [...attachedFiles]
     const quotesToSend = directText ? [] : [...pendingQuotes]
     const displayed = options?.displayText?.trim() || text
-    const quoteLineLabel = (q: PendingFileQuote) =>
-      q.startLine === q.endLine ? `${q.startLine}` : `${q.startLine}-${q.endLine}`
     const optimisticQuoteAttachments: MessageAttachment[] = quotesToSend.map((q) => ({
       name: q.name,
       mimeType: "text/plain",
@@ -641,80 +791,12 @@ export function useChatStream({
     })
     setLoading(true)
 
-    // Process attached files: images → base64 data, non-images → save to disk via Rust
-    const attachments: ChatAttachment[] = []
-
-    // Expand `@path` mentions into file_path attachments. Working dir resolves
-    // from the current session (committed) or the draft picker (new chat).
-    const sessionWorkingDir =
-      sessions.find((s) => s.id === currentSessionId)?.workingDir ?? null
-    const resolvedWorkingDir = currentSessionId ? sessionWorkingDir : draftWorkingDir
-    const mentionAttachments = expandMentionsToAttachments(text, resolvedWorkingDir ?? null)
-    for (const m of mentionAttachments) {
-      attachments.push(m)
-    }
-    // `@plan:<short>:v<n>` tokens resolve through the backend so we can
-    // address plan files outside the working dir without weakening the
-    // file-mention rules.
-    const planAttachments = await expandPlanMentionsToAttachments(text)
-    for (const p of planAttachments) {
-      attachments.push(p)
-    }
-
-    for (const file of filesToSend) {
-      try {
-        const mimeType = file.type || "application/octet-stream"
-        const arrayBuffer = await file.arrayBuffer()
-
-        if (mimeType.startsWith("image/")) {
-          const bytes = new Uint8Array(arrayBuffer)
-          let binary = ""
-          const chunkSize = 8192
-          for (let i = 0; i < bytes.length; i += chunkSize) {
-            binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize))
-          }
-          attachments.push({
-            name: file.name,
-            mime_type: mimeType,
-            source: "upload",
-            data: btoa(binary),
-          })
-        } else {
-          const data = getTransport().prepareFileData(arrayBuffer, mimeType)
-          const filePath = await getTransport().call<string>("save_attachment", {
-            sessionId: currentSessionId,
-            fileName: file.name,
-            mimeType,
-            data,
-          })
-          attachments.push({
-            name: file.name,
-            mime_type: mimeType,
-            source: "upload",
-            file_path: filePath,
-          })
-        }
-      } catch (err) {
-        logger.error("ui", "ChatScreen::attachment", "Failed to process attachment", {
-          fileName: file.name,
-          error: err,
-        })
-      }
-    }
-
-    // File-browser "quote to chat" references → quote attachments. The model
-    // sees them as <file_reference> (built backend-side in content.rs); the
-    // user only ever sees a friendly quote card.
-    for (const q of quotesToSend) {
-      attachments.push({
-        name: q.name,
-        mime_type: "text/plain",
-        source: "quote",
-        data: q.content,
-        file_path: q.path,
-        quote_lines: quoteLineLabel(q),
-      })
-    }
+    const attachments = await buildChatAttachments(
+      text,
+      filesToSend,
+      quotesToSend,
+      currentSessionId,
+    )
 
     // Empty assistant placeholder we'll stream into. `_clientId` was generated
     // alongside the user-side one above and survives the placeholder→DB
@@ -807,6 +889,24 @@ export function useChatStream({
 
         const sid = targetSid()
         if (shouldDropStreamEvent(event, sid)) return
+
+        if (event.type === "queued_user_message_inserted") {
+          const requestId = typeof event.request_id === "string" ? event.request_id : null
+          if (requestId) {
+            updatePendingSends((prev) =>
+              prev.map((item) =>
+                item.id === requestId
+                  ? { ...item, mode: "force_insert", status: "inserted" }
+                  : item,
+              ),
+            )
+          }
+        } else if (event.type === "queued_user_message_blocked") {
+          const requestId = typeof event.request_id === "string" ? event.request_id : null
+          if (requestId) {
+            updatePendingSends((prev) => prev.filter((item) => item.id !== requestId))
+          }
+        }
 
         handleStreamEvent(event, sid, {
           updateSessionMessages,
@@ -1044,10 +1144,15 @@ export function useChatStream({
       }
       await reloadSessions()
 
-      // Handle pending message after loading finishes
-      const queued = pendingSendRef.current
+      // Handle pending messages after loading finishes. Replays one FIFO item
+      // per completed turn; the rest stay queued for subsequent turns.
+      const queued = pendingSendsRef.current.find((item) => item.status !== "inserted")
+      updatePendingSends((prev) =>
+        queued
+          ? prev.filter((item) => item.status !== "inserted" && item.id !== queued.id)
+          : prev.filter((item) => item.status !== "inserted"),
+      )
       if (queued) {
-        setPendingSendState(null)
         // Restore staged quotes so they ride along with the replayed message
         // (user-draft path) instead of being silently dropped.
         if (queued.quotes?.length) setPendingQuotes(queued.quotes)
@@ -1061,8 +1166,9 @@ export function useChatStream({
           autoSendRef.current = true
         } else {
           // User-typed drafts and non-auto-sent programmatic sends are
-          // restored for editing / confirmation using the user-facing text.
-          setInput(queued.options?.displayText?.trim() || queued.text)
+          // restored for editing / confirmation without turning attachment-only
+          // placeholders into real prompts.
+          setInput(pendingInputText(queued))
           setAttachedFiles(queued.attachedFiles ?? [])
           if (autoSendPendingRef.current) {
             autoSendRef.current = true
@@ -1091,6 +1197,154 @@ export function useChatStream({
     }
   }, [attachedFiles, input, loading]) // eslint-disable-line react-hooks/exhaustive-deps
 
+  const editPendingSend = useCallback(
+    (id: string) => {
+      const item = pendingSendsRef.current.find((pending) => pending.id === id)
+      if (!item) return
+      if (item.mode === "force_insert" && item.status === "waiting_tool_boundary") {
+        const sid = currentSessionIdRef.current
+        const turnId = sid ? activeTurnBySessionRef.current.get(sid) : null
+        if (sid && turnId) {
+          void getTransport()
+            .call<CancelQueuedTurnUserMessageResult>("cancel_queued_turn_user_message", {
+              sessionId: sid,
+              turnId,
+              requestId: id,
+            })
+            .catch(() => {})
+        }
+      }
+      updatePendingSends((prev) => prev.filter((pending) => pending.id !== id))
+      setInput(pendingInputText(item))
+      setAttachedFiles(item.attachedFiles ?? [])
+      setPendingQuotes(item.quotes ?? [])
+    },
+    [currentSessionIdRef, pendingInputText, setInput, updatePendingSends],
+  )
+
+  const discardPendingSend = useCallback(
+    (id: string) => {
+      const item = pendingSendsRef.current.find((pending) => pending.id === id)
+      if (item?.mode === "force_insert" && item.status === "waiting_tool_boundary") {
+        const sid = currentSessionIdRef.current
+        const turnId = sid ? activeTurnBySessionRef.current.get(sid) : null
+        if (sid && turnId) {
+          void getTransport()
+            .call<CancelQueuedTurnUserMessageResult>("cancel_queued_turn_user_message", {
+              sessionId: sid,
+              turnId,
+              requestId: id,
+            })
+            .catch(() => {})
+        }
+      }
+      updatePendingSends((prev) => prev.filter((pending) => pending.id !== id))
+    },
+    [currentSessionIdRef, updatePendingSends],
+  )
+
+  const forceInsertPendingSend = useCallback(
+    async (id: string) => {
+      const item = pendingSendsRef.current.find((pending) => pending.id === id)
+      if (!item || !canForceInsertPending(item)) return
+      const sid = currentSessionIdRef.current ?? currentSessionId
+      const turnId = sid ? activeTurnBySessionRef.current.get(sid) : null
+      if (!sid || !turnId) {
+        updatePendingSends((prev) =>
+          prev.map((pending) =>
+            pending.id === id ? { ...pending, status: "fallback_after_reply" } : pending,
+          ),
+        )
+        return
+      }
+
+      updatePendingSends((prev) =>
+        prev.map((pending) =>
+          pending.id === id
+            ? { ...pending, mode: "force_insert", status: "waiting_tool_boundary" }
+            : pending,
+        ),
+      )
+
+      try {
+        const attachments = await buildChatAttachments(
+          item.text,
+          item.attachedFiles ?? [],
+          item.quotes ?? [],
+          sid,
+        )
+        const latest = pendingSendsRef.current.find((pending) => pending.id === id)
+        if (
+          !latest ||
+          latest.mode !== "force_insert" ||
+          latest.status !== "waiting_tool_boundary"
+        ) {
+          return
+        }
+        const result = await getTransport().call<QueueTurnUserMessageResult>(
+          "queue_turn_user_message",
+          {
+            requestId: id,
+            sessionId: sid,
+            turnId,
+            message: item.text,
+            attachments,
+            displayText: item.options?.displayText,
+            isPlanTrigger: item.options?.isPlanTrigger,
+            planComment: item.options?.planComment,
+          },
+        )
+        if (!result.queued) {
+          updatePendingSends((prev) =>
+            prev.map((pending) =>
+              pending.id === id
+                ? { ...pending, mode: "queue", status: "fallback_after_reply" }
+                : pending,
+            ),
+          )
+        }
+      } catch (e) {
+        logger.warn("chat", "useChatStream::forceInsert", "Failed to queue turn insertion", e)
+        updatePendingSends((prev) =>
+          prev.map((pending) =>
+            pending.id === id
+              ? { ...pending, mode: "queue", status: "fallback_after_reply" }
+              : pending,
+          ),
+        )
+      }
+    },
+    [
+      buildChatAttachments,
+      canForceInsertPending,
+      currentSessionId,
+      currentSessionIdRef,
+      updatePendingSends,
+    ],
+  )
+
+  const cancelForceInsertPendingSend = useCallback(
+    async (id: string) => {
+      const sid = currentSessionIdRef.current ?? currentSessionId
+      const turnId = sid ? activeTurnBySessionRef.current.get(sid) : null
+      if (sid && turnId) {
+        await getTransport()
+          .call<CancelQueuedTurnUserMessageResult>("cancel_queued_turn_user_message", {
+            sessionId: sid,
+            turnId,
+            requestId: id,
+          })
+          .catch(() => undefined)
+      }
+      updatePendingSends((prev) =>
+        prev.map((pending) =>
+          pending.id === id ? { ...pending, mode: "queue", status: "queued" } : pending,
+        ),
+      )
+    },
+    [currentSessionId, currentSessionIdRef, updatePendingSends],
+  )
+
   return {
     input,
     setInput,
@@ -1100,6 +1354,11 @@ export function useChatStream({
     setPendingQuotes,
     pendingMessage,
     setPendingMessage,
+    pendingSends,
+    editPendingSend,
+    discardPendingSend,
+    forceInsertPendingSend,
+    cancelForceInsertPendingSend,
     approvalRequests,
     showCodexAuthExpired,
     setShowCodexAuthExpired,

--- a/src/components/chat/hooks/useStreamEventHandler.ts
+++ b/src/components/chat/hooks/useStreamEventHandler.ts
@@ -1,6 +1,6 @@
 import type React from "react"
 import type { ContentBlock, FallbackEvent, MediaItem, Message, ToolMetadata } from "@/types/chat"
-import { mergeUsageFromEvent } from "../chatUtils"
+import { mergeUsageFromEvent, parseUserAttachmentsMeta } from "../chatUtils"
 import { hasToolError } from "../message/executionStatus"
 
 /** Extract a structured tool_metadata payload from a stream event when present. */
@@ -308,6 +308,50 @@ export function handleStreamEvent(
     return true
   }
 
+  if (event.type === "queued_user_message_inserted") {
+    flushPendingStreamDeltas(sid, deps, true)
+    const requestId = stringField(event, "request_id")
+    const content = stringField(event, "content")
+    const messageIdRaw = event.message_id
+    const dbId =
+      typeof messageIdRaw === "number" && Number.isFinite(messageIdRaw)
+        ? messageIdRaw
+        : undefined
+    const attachmentsMeta =
+      typeof event.attachments_meta === "string" ? event.attachments_meta : null
+    const attachments = parseUserAttachmentsMeta(attachmentsMeta)
+    updateSessionMessages(sid, (prev) => {
+      if (dbId != null && prev.some((msg) => msg.role === "user" && msg.dbId === dbId)) {
+        return prev
+      }
+      const now = new Date().toISOString()
+      const userMessage: Message = {
+        role: "user",
+        content,
+        timestamp: now,
+        ...(dbId != null ? { dbId } : {}),
+        ...(attachments ? { attachments } : {}),
+        ...(event.is_plan_trigger === true ? { isPlanTrigger: true } : {}),
+        ...(event.plan_comment && typeof event.plan_comment === "object"
+          ? {
+              planComment: event.plan_comment as {
+                selectedText: string
+                comment: string
+              },
+            }
+          : {}),
+      }
+      const assistantPlaceholder: Message = {
+        role: "assistant",
+        content: "",
+        timestamp: now,
+        _clientId: requestId ? `queued-assistant:${requestId}` : `queued-assistant:${now}`,
+      }
+      return [...prev, userMessage, assistantPlaceholder]
+    })
+    return true
+  }
+
   // Flush pending thinking/text buffer before tool_call to preserve display order
   if (event.type === "tool_call") {
     flushPendingStreamDeltas(sid, deps, true)
@@ -318,6 +362,7 @@ export function handleStreamEvent(
     event.type === "thinking_auto_disabled" ||
     event.type === "profile_rotation" ||
     event.type === "context_compacted" ||
+    event.type === "queued_user_message_blocked" ||
     event.type === "round_limit_reached"
   ) {
     // Mirror the backend persister for Tier 0/1 noise, but keep Tier 3/4

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -15,12 +15,14 @@ import {
   ClipboardList,
   Pencil,
   Trash2,
-  MoreHorizontal,
   BetweenHorizontalStart,
+  ChevronDown,
+  ChevronUp,
   X,
   Plus,
   FolderPlus,
   Quote,
+  Undo2,
 } from "lucide-react"
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import type {
@@ -29,6 +31,7 @@ import type {
   ChatTurnStatus,
   SessionMode,
   PendingFileQuote,
+  PendingSendPreview,
 } from "@/types/chat"
 import { DEFAULT_AGENT_ID } from "@/types/tools"
 import { useSlashCommands, type SlashCommandActions } from "../slash-commands/useSlashCommands"
@@ -90,8 +93,13 @@ interface ChatInputProps {
   /** Click a staged quote chip to reveal that file in the file browser. */
   onJumpToQuote?: (q: PendingFileQuote) => void
   pendingMessage?: string | null
+  pendingSends?: PendingSendPreview[]
   onCancelPending?: () => void
   onDiscardPending?: () => void
+  onEditPending?: (id: string) => void
+  onDiscardPendingItem?: (id: string) => void
+  onForceInsertPending?: (id: string) => void
+  onCancelForceInsertPending?: (id: string) => void
   onStop?: () => void
   // Slash command support
   currentSessionId?: string | null
@@ -145,8 +153,13 @@ export default function ChatInput({
   onRemoveQuote,
   onJumpToQuote,
   pendingMessage,
+  pendingSends,
   onCancelPending,
   onDiscardPending,
+  onEditPending,
+  onDiscardPendingItem,
+  onForceInsertPending,
+  onCancelForceInsertPending,
   onStop,
   currentSessionId,
   currentAgentId = DEFAULT_AGENT_ID,
@@ -175,6 +188,7 @@ export default function ChatInput({
   const [showOverflowMenu, setShowOverflowMenu] = useState(false)
   const [toolbarCompact, setToolbarCompact] = useState(false)
   const [toolbarStacked, setToolbarStacked] = useState(false)
+  const [pendingExpanded, setPendingExpanded] = useState(false)
 
   const handlePermissionModeChange = useCallback(
     (mode: SessionMode, options?: PermissionModeChangeOptions) => {
@@ -495,6 +509,57 @@ export default function ChatInput({
   // 状态条是否会渲染（WorkspaceStatusBar 内部同款判断）——决定其下方 Plan
   // Banner 是否需要补顶部圆角。
   const hasVisibleTaskBar = shouldShowTaskProgressPanel(taskProgressSnapshot)
+  const pendingQueueItems: PendingSendPreview[] =
+    pendingSends && pendingSends.length > 0
+      ? pendingSends
+      : pendingMessage
+        ? [
+            {
+              id: "__legacy__",
+              text: pendingMessage,
+              mode: "queue",
+              status: "queued",
+              canForceInsert: false,
+              attachmentCount: 0,
+              quoteCount: 0,
+            },
+          ]
+        : []
+  const pendingVisibleItems = pendingExpanded
+    ? pendingQueueItems
+    : pendingQueueItems.slice(0, 2)
+  const hasPendingQueue = loading && pendingQueueItems.length > 0
+
+  const pendingStatusLabel = (item: PendingSendPreview) => {
+    switch (item.status) {
+      case "waiting_tool_boundary":
+        return t("chat.pendingWaitingToolBoundary", "等待工具完成点")
+      case "inserted":
+        return t("chat.pendingInserted", "已插入")
+      case "fallback_after_reply":
+        return t("chat.pendingFallbackAfterReply", "回复后发送")
+      case "queued":
+      default:
+        return t("chat.pendingQueuedShort", "排队中")
+    }
+  }
+
+  const pendingStatusTip = (item: PendingSendPreview) => {
+    switch (item.status) {
+      case "waiting_tool_boundary":
+        return t(
+          "chat.pendingWaitingToolBoundaryTip",
+          "等待最近一次工具调用完成；如果本轮不再调用工具，将改为回复结束后发送。",
+        )
+      case "fallback_after_reply":
+        return t("chat.pendingFallbackAfterReplyTip", "未遇到工具完成点，将在当前回复结束后发送。")
+      case "inserted":
+        return t("chat.pendingInsertedTip", "已在本轮工具完成后插入给模型。")
+      case "queued":
+      default:
+        return t("chat.pendingQueuedTip", "已加入待发送队列，将在当前回复结束后发送。")
+    }
+  }
 
   const renderInlineAddControls = () => (
     <>
@@ -657,49 +722,120 @@ export default function ChatInput({
           </div>
         </AnimatedCollapse>
 
-        {/* Pending message card */}
-        <AnimatedCollapse open={loading && !!pendingMessage}>
+        {/* Pending send queue */}
+        <AnimatedCollapse open={hasPendingQueue}>
           <div className="px-3 pt-2.5 pb-0 animate-in fade-in-0 slide-in-from-top-1 duration-200">
-            <div className="flex items-center gap-2 bg-amber-500/8 border border-amber-500/20 rounded-xl px-3 py-2">
-              <BetweenHorizontalStart className="h-4 w-4 text-amber-500 shrink-0" />
-              <span className="flex-1 text-sm text-foreground/90 truncate">{pendingMessage}</span>
-              <IconTip label={t("chat.pendingDelete")}>
-                <button
-                  className="p-1 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
-                  onClick={onDiscardPending}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                </button>
-              </IconTip>
-              <DropdownMenu.Root>
-                <DropdownMenu.Trigger asChild>
-                  <button className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors">
-                    <MoreHorizontal className="h-3.5 w-3.5" />
-                  </button>
-                </DropdownMenu.Trigger>
-                <DropdownMenu.Portal>
-                  <DropdownMenu.Content
-                    className="min-w-[140px] bg-surface-floating/95 backdrop-blur-xl border border-border-soft rounded-floating shadow-floating p-1.5 z-50 animate-in fade-in-0 zoom-in-95 duration-150"
-                    sideOffset={6}
-                    align="end"
+            <div className="rounded-lg border border-amber-500/20 bg-amber-500/8 px-2.5 py-2">
+              <div className="mb-1.5 flex items-center gap-2">
+                <BetweenHorizontalStart className="h-4 w-4 shrink-0 text-amber-500" />
+                <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground/80">
+                  {t("chat.pendingQueueTitle", "待发送")} · {pendingQueueItems.length}
+                </span>
+                {pendingQueueItems.length > 2 && (
+                  <IconTip
+                    label={
+                      pendingExpanded
+                        ? t("common.collapse", "收起")
+                        : t("common.expand", "展开")
+                    }
                   >
-                    <DropdownMenu.Item
-                      className="flex items-center gap-2 px-2.5 py-1.5 text-[13px] text-foreground/80 rounded-md cursor-pointer transition-colors hover:bg-secondary/60 hover:text-foreground outline-none"
-                      onSelect={onCancelPending}
+                    <button
+                      type="button"
+                      onClick={() => setPendingExpanded((v) => !v)}
+                      className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground"
                     >
-                      <Pencil className="h-3.5 w-3.5" />
-                      {t("chat.pendingEdit")}
-                    </DropdownMenu.Item>
-                    <DropdownMenu.Item
-                      className="flex items-center gap-2 px-2.5 py-1.5 text-[13px] text-foreground/80 rounded-md cursor-pointer transition-colors hover:bg-secondary/60 hover:text-foreground outline-none"
-                      onSelect={onDiscardPending}
+                      {pendingExpanded ? (
+                        <ChevronUp className="h-3.5 w-3.5" />
+                      ) : (
+                        <ChevronDown className="h-3.5 w-3.5" />
+                      )}
+                    </button>
+                  </IconTip>
+                )}
+              </div>
+              <div className="flex flex-col gap-1.5">
+                {pendingVisibleItems.map((item) => {
+                  const edit = () =>
+                    item.id === "__legacy__" ? onCancelPending?.() : onEditPending?.(item.id)
+                  const discard = () =>
+                    item.id === "__legacy__"
+                      ? onDiscardPending?.()
+                      : onDiscardPendingItem?.(item.id)
+                  const readonly = item.status === "inserted"
+                  const canCancelForce =
+                    item.mode === "force_insert" && item.status === "waiting_tool_boundary"
+                  return (
+                    <div
+                      key={item.id}
+                      className="flex min-w-0 items-center gap-1.5 rounded-md bg-background/45 px-2 py-1.5"
                     >
-                      <X className="h-3.5 w-3.5" />
-                      {t("chat.pendingDiscard")}
-                    </DropdownMenu.Item>
-                  </DropdownMenu.Content>
-                </DropdownMenu.Portal>
-              </DropdownMenu.Root>
+                      <IconTip label={pendingStatusTip(item)}>
+                        <span className="shrink-0 rounded-sm bg-amber-500/12 px-1.5 py-0.5 text-[11px] text-amber-700 dark:text-amber-300">
+                          {pendingStatusLabel(item)}
+                        </span>
+                      </IconTip>
+                      <span className="min-w-0 flex-1 truncate text-sm text-foreground/90">
+                        {item.text}
+                        {(item.attachmentCount > 0 || item.quoteCount > 0) && (
+                          <span className="ml-1 text-xs text-muted-foreground">
+                            +{item.attachmentCount + item.quoteCount}
+                          </span>
+                        )}
+                      </span>
+                      {canCancelForce ? (
+                        <IconTip label={t("chat.pendingCancelForceInsert", "取消插入本轮")}>
+                          <button
+                            type="button"
+                            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                            onClick={() => onCancelForceInsertPending?.(item.id)}
+                          >
+                            <Undo2 className="h-3.5 w-3.5" />
+                          </button>
+                        </IconTip>
+                      ) : (
+                        item.canForceInsert && (
+                          <IconTip
+                            label={t(
+                              "chat.pendingForceInsertTip",
+                              "会等正在执行的工具完成后插入给模型，不会打断当前工具。",
+                            )}
+                          >
+                            <button
+                              type="button"
+                              className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                              onClick={() => onForceInsertPending?.(item.id)}
+                            >
+                              <BetweenHorizontalStart className="h-3.5 w-3.5" />
+                            </button>
+                          </IconTip>
+                        )
+                      )}
+                      {!readonly && (
+                        <>
+                          <IconTip label={t("chat.pendingEdit")}>
+                            <button
+                              type="button"
+                              className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+                              onClick={edit}
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                          </IconTip>
+                          <IconTip label={t("chat.pendingDelete")}>
+                            <button
+                              type="button"
+                              className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                              onClick={discard}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          </IconTip>
+                        </>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
             </div>
           </div>
         </AnimatedCollapse>
@@ -707,7 +843,7 @@ export default function ChatInput({
         {/* Plan Mode Banner */}
         <AnimatedCollapse open={planState === "planning"}>
           <div
-            className={`flex items-center gap-2 px-3 py-1.5 bg-blue-500/10 border-b border-blue-500/20 text-blue-600 dark:text-blue-400 text-xs animate-in fade-in slide-in-from-top-1 duration-200${!hasVisibleTaskBar && attachedFiles.length === 0 && !(loading && pendingMessage) ? " rounded-t-2xl" : ""}`}
+            className={`flex items-center gap-2 px-3 py-1.5 bg-blue-500/10 border-b border-blue-500/20 text-blue-600 dark:text-blue-400 text-xs animate-in fade-in slide-in-from-top-1 duration-200${!hasVisibleTaskBar && attachedFiles.length === 0 && !hasPendingQueue ? " rounded-t-2xl" : ""}`}
           >
             <ClipboardList className="h-3.5 w-3.5 shrink-0" />
             <span className="flex-1">{t("planMode.restricted")}</span>
@@ -735,7 +871,7 @@ export default function ChatInput({
             placeholder={
               planState === "planning"
                 ? t("planMode.placeholder")
-                : loading && pendingMessage
+                : hasPendingQueue
                   ? t("chat.pendingQueued")
                   : t("chat.askAnything")
             }
@@ -897,7 +1033,7 @@ export default function ChatInput({
               state={voice.state}
               durationMs={voice.durationMs}
               audioLevel={voice.audioLevel}
-              disabled={loading && !!pendingMessage}
+              disabled={false}
               onStart={() => void startVoice()}
               onStop={() => void handleVoiceStop()}
               onCancel={handleVoiceCancel}
@@ -932,7 +1068,7 @@ export default function ChatInput({
                 size="icon"
                 className="h-8 w-8 rounded-full shrink-0"
                 onClick={onSend}
-                disabled={!hasSendableContent || (loading && !!pendingMessage)}
+                disabled={!hasSendableContent}
                 aria-label={loading && hasSendableContent ? t("chat.queueMessage") : t("chat.send")}
               >
                 <Send className="h-4 w-4" />

--- a/src/lib/transport-http.ts
+++ b/src/lib/transport-http.ts
@@ -104,6 +104,8 @@ const COMMAND_MAP: Record<string, EndpointDef> = {
 
   // -- Chat --
   chat:                            { method: "POST",   path: "/api/chat" },
+  queue_turn_user_message:         { method: "POST",   path: "/api/chat/turn-message" },
+  cancel_queued_turn_user_message: { method: "POST",   path: "/api/chat/turn-message/cancel" },
   stop_chat:                       { method: "POST",   path: "/api/chat/stop" },
   cancel_runtime_task:             { method: "POST",   path: "/api/runtime-tasks/cancel" },
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -51,6 +51,24 @@ export interface PendingFileQuote {
   content: string
 }
 
+export type PendingSendMode = "queue" | "force_insert"
+
+export type PendingSendStatus =
+  | "queued"
+  | "waiting_tool_boundary"
+  | "inserted"
+  | "fallback_after_reply"
+
+export interface PendingSendPreview {
+  id: string
+  text: string
+  mode: PendingSendMode
+  status: PendingSendStatus
+  canForceInsert: boolean
+  attachmentCount: number
+  quoteCount: number
+}
+
 export interface MessageAttachment {
   name: string
   mimeType: string


### PR DESCRIPTION
## Summary

- Upgrade in-flight pending sends from a single item to a FIFO queue.
- Add force-insert support at safe tool-loop boundaries for desktop and HTTP turns.
- Persist inserted user messages and stream `queued_user_message_inserted` events so the UI can split assistant bubbles correctly.

## Validation

- `cargo check -p ha-core`
- `cargo check -p ha-server`
- `cargo check -p hope-agent`
- `git diff --check`
- `pnpm typecheck` attempted locally, but `tsc` was unavailable because `node_modules` is missing in this worktree.