### PR TITLE
backport: v0.6.1 fixes to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Office OOXML 包结构稳定性**：修复 DOCX helper 在最终 `w:sectPr` 之后追加内容的问题，避免 Word/LibreOffice 打开时修复或忽略新增段落；水印 helper 不再覆盖既有 `word/header1.xml`，会分配新的 header part 和 relationship id；PPTX slide 重排不再重建并丢弃 slide master/theme/view properties 等非 slide relationships，避免源 deck 样式丢失。
+- **项目会话新建归属修复**：当前会话属于某个 Project 时，`Cmd/Ctrl+N` 与托盘「新建对话」创建的新会话会继续归属同一个 Project，避免首条消息丢失项目记忆、文件与指令上下文。
 
 ## [0.6.0] - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Office OOXML 包结构稳定性**：修复 DOCX helper 在最终 `w:sectPr` 之后追加内容的问题，避免 Word/LibreOffice 打开时修复或忽略新增段落；水印 helper 不再覆盖既有 `word/header1.xml`，会分配新的 header part 和 relationship id；PPTX slide 重排不再重建并丢弃 slide master/theme/view properties 等非 slide relationships，避免源 deck 样式丢失。
-- **项目会话新建归属修复**：当前会话属于某个 Project 时，`Cmd/Ctrl+N` 与托盘「新建对话」创建的新会话会继续归属同一个 Project，避免首条消息丢失项目记忆、文件与指令上下文。
+
+## [0.6.1] - 2026-06-06
+
+### Fixed
+
+- **项目会话新建归属修复**：当前会话属于某个 Project 时，`Cmd/Ctrl+N` 与托盘「新建对话」创建的新会话会继续归属同一个 Project，避免首条消息丢失项目记忆、文件与指令上下文。 (#283)
+- **输入框弹出菜单裁剪回归修复**：修复 v0.6.0 聊天响应式布局优化后，输入框外层 dock 重新裁剪模型选择、Think/思考强度、温度、权限模式、Awareness、`/` 斜杠菜单与 `@` 文件菜单的问题；补充回归测试，防止后续布局改动再次把工具栏弹层裁掉。 (#284)
 
 ## [0.6.0] - 2026-06-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3223,7 +3223,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.6.0"
+version = "0.6.1"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.6.0"
+version = "0.6.1"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.6.1.en.md
+++ b/docs/release-notes/v0.6.1.en.md
@@ -1,0 +1,17 @@
+# Hope Agent 0.6.1 — Input Popover Regression Fix
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.6.1/docs/release-notes/v0.6.1.md) · **English**
+
+> Release date: 2026-06-06
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.6.1/CHANGELOG.md#061---2026-06-06) for the full list.
+
+v0.6.1 is an emergency patch for the chat input popover clipping regression reintroduced by the v0.6.0 responsive layout polish.
+
+## Fixes
+
+- Fixes new chats created from a Project session via `Cmd/Ctrl+N` or the tray menu not inheriting the current Project, which could drop project memory, files, and instructions from the first message. (#283)
+- Fixes the chat input dock clipping menus that open upward. (#284)
+- Restores full display for the model picker, Think / reasoning effort, temperature, permission mode, Awareness, `/` slash command, and `@` file mention menus.
+- Keeps the v0.6.0 narrow-window toolbar stacking and minimum-width behavior while removing the parent overflow clipping that cut off popovers.
+- Adds a regression test that keeps the input dock overflow-visible for toolbar menus.

--- a/docs/release-notes/v0.6.1.md
+++ b/docs/release-notes/v0.6.1.md
@@ -1,0 +1,17 @@
+# Hope Agent 0.6.1 — 输入框弹出菜单回归修复
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.6.1/docs/release-notes/v0.6.1.en.md)
+
+> 发布日期：2026-06-06
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.6.1/CHANGELOG.md#061---2026-06-06)。
+
+v0.6.1 是一个紧急修复版本，处理 v0.6.0 响应式布局优化后重新出现的输入框弹出菜单裁剪问题。
+
+## 修复
+
+- 修复项目会话里通过 `Cmd/Ctrl+N` 或托盘「新建对话」创建会话时没有继承当前 Project 的问题，避免新会话首条消息丢失项目记忆、文件和指令上下文。 (#283)
+- 修复聊天输入框外层 dock 裁剪向上展开菜单的问题。 (#284)
+- 恢复模型选择、Think/思考强度、温度、权限模式、Awareness、`/` 斜杠菜单与 `@` 文件菜单的完整显示。
+- 保留 v0.6.0 的窄窗口工具栏堆叠与最小宽度优化，只取消会裁剪弹层的父级 overflow。
+- 补充回归测试，锁定输入框 dock 必须允许工具栏菜单向外溢出。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.6.0"
+version = "0.6.1"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -484,6 +484,21 @@ export default function ChatScreen({
     [handleNewChat],
   )
 
+  const handleStartNewChatFromCurrentContext = useCallback(async () => {
+    const projectId = currentSessionMeta?.projectId
+    if (projectId) {
+      setDraftIncognito(false)
+      await handleNewChatInProject(projectId, currentAgentId, false)
+      return
+    }
+    await handleStartNewChat(currentAgentId)
+  }, [
+    currentAgentId,
+    currentSessionMeta?.projectId,
+    handleNewChatInProject,
+    handleStartNewChat,
+  ])
+
   /**
    * Title-bar agent switch handler. Backend rejects the switch when the
    * session already has user/assistant messages (defense layer); the UI
@@ -854,8 +869,8 @@ export default function ChatScreen({
     return () => window.removeEventListener("keydown", handler)
   }, [currentSessionId, openSessionSearch, focusGlobalSearch])
 
-  // Cmd/Ctrl+N: start a fresh draft chat with the current agent, matching the
-  // sidebar New Chat button and tray "new-session" behavior.
+  // Cmd/Ctrl+N: start a fresh chat with the current agent. When the active
+  // session belongs to a Project, keep the new session in that Project too.
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const modKey = e.metaKey || e.ctrlKey
@@ -866,18 +881,18 @@ export default function ChatScreen({
       if (target?.isContentEditable) return
 
       e.preventDefault()
-      void handleStartNewChat(currentAgentId)
+      void handleStartNewChatFromCurrentContext()
     }
     window.addEventListener("keydown", handler)
     return () => window.removeEventListener("keydown", handler)
-  }, [handleStartNewChat, currentAgentId])
+  }, [handleStartNewChatFromCurrentContext])
 
   // Listen for tray "new-session" event to trigger new chat
   useEffect(() => {
     return getTransport().listen("new-session", () => {
-      void handleStartNewChat(currentAgentId)
+      void handleStartNewChatFromCurrentContext()
     })
-  }, [handleStartNewChat, currentAgentId])
+  }, [handleStartNewChatFromCurrentContext])
 
   // Listen for tray "focus-session" event — emitted when the user clicks an
   // in-progress regular conversation entry inside the system tray dropdown.

--- a/src/components/chat/input/ChatInput.test.tsx
+++ b/src/components/chat/input/ChatInput.test.tsx
@@ -185,6 +185,16 @@ describe("ChatInput", () => {
     expect(onSend).toHaveBeenCalledTimes(1)
   })
 
+  test("keeps the input dock from clipping upward toolbar menus", () => {
+    renderChatInput()
+
+    const inputDock = screen.getByRole("textbox").closest(".rounded-input-dock")
+
+    expect(inputDock).toBeTruthy()
+    expect(inputDock?.className).toContain("overflow-visible")
+    expect(inputDock?.className).not.toContain("overflow-hidden")
+  })
+
   test.each([
     ["default", "smart"],
     ["smart", "yolo"],

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -641,7 +641,7 @@ export default function ChatInput({
       <div
         ref={inputShellRef}
         className={cn(
-          "relative min-w-0 overflow-hidden rounded-input-dock border border-border-soft bg-surface-floating shadow-input-dock",
+          "relative min-w-0 overflow-visible rounded-input-dock border border-border-soft bg-surface-floating shadow-input-dock",
           hero && "shadow-floating",
         )}
       >


### PR DESCRIPTION
## Summary
- backport #283 project new-chat context fix to main
- backport #284 input popover clipping fix and v0.6.1 release notes/version sync to main

## Verification
- pnpm release:verify -- --tag v0.6.1
- pnpm typecheck
- git diff --check origin/main..HEAD
- pre-push hook: cargo fmt, clippy, pnpm typecheck, eslint, vitest, cargo test