### PR TITLE
[codex] Improve sidebar conversation search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **会话搜索置顶并显示 Project 归属**：侧边栏会话搜索入口移到顶部固定位置，搜索结果会携带并展示 `projectId` / Project 名称与图标，项目会话命中时可直接看出来源；搜索态不再受隐藏的 Agent 筛选静默影响，避免结果被不可见过滤条件收窄。
 - **Skill requirements 分级注入语义**：`requires.os` 不匹配这类硬不兼容 skill 不再进入模型 catalog / 斜杠菜单；缺少可安装/可配置依赖（`bins` / `anyBins` / `env` / `config`）的 skill 仍可见，但在 `skill({name})` 或 `/skill-name` 激活前返回缺失项与安装/配置诊断，不再直接加载 SKILL.md。Settings 技能面板同步展示 `Incompatible` / `Needs setup` 状态、缺失 binaries / env / config 与当前 OS 信息。
 - **Skill 激活上下文包含包目录元数据**：inline 与 fork 激活返回的 skill 内容前会注入 skill name 与 skill directory，方便内置脚本、references、assets 通过 skill 目录稳定定位，无需模型猜测路径。
 

--- a/crates/ha-core/src/session/db.rs
+++ b/crates/ha-core/src/session/db.rs
@@ -2889,7 +2889,7 @@ impl SessionDB {
             "SELECT m.id, m.session_id, m.role,
                     snippet(messages_fts, 0, '\x02', '\x03', '…', 16) AS snippet,
                     m.timestamp,
-                    s.title, s.agent_id, s.is_cron, s.parent_session_id,
+                    s.title, s.agent_id, s.is_cron, s.parent_session_id, s.project_id,
                     cc.channel_id, cc.chat_type,
                     fts.rank
              FROM messages_fts fts
@@ -2918,9 +2918,10 @@ impl SessionDB {
                 agent_id: row.get(6)?,
                 is_cron: row.get::<_, i64>(7).unwrap_or(0) != 0,
                 parent_session_id: row.get(8)?,
-                channel_type: row.get(9)?,
-                channel_chat_type: row.get(10)?,
-                relevance_rank: row.get::<_, f64>(11).unwrap_or(0.0),
+                project_id: row.get(9)?,
+                channel_type: row.get(10)?,
+                channel_chat_type: row.get(11)?,
+                relevance_rank: row.get::<_, f64>(12).unwrap_or(0.0),
             })
         })?;
 
@@ -3629,6 +3630,8 @@ pub struct SessionSearchResult {
     pub relevance_rank: f64,
     pub is_cron: bool,
     pub parent_session_id: Option<String>,
+    /// Project id when this hit belongs to a project-bound chat session.
+    pub project_id: Option<String>,
     /// Source channel plugin id (e.g. "telegram", "wechat"), when this session
     /// originates from an IM channel.
     pub channel_type: Option<String>,

--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -11,8 +11,9 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { IconTip } from "@/components/ui/tooltip"
+import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
-import { Bot, MessageSquarePlus, PanelLeft } from "lucide-react"
+import { Bot, MessageSquarePlus, PanelLeft, Search, X } from "lucide-react"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import type { SessionSearchResult } from "@/types/chat"
@@ -140,12 +141,25 @@ export default function ChatSidebar({
   const [searchQuery, setSearchQuery] = useState("")
   const [searchResults, setSearchResults] = useState<SessionSearchResult[] | null>(null)
   const [searching, setSearching] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const searchTruncated = (searchResults?.length ?? 0) >= SEARCH_LIMIT
+  const isHistorySearching = searchQuery.trim().length > 0
 
   useEffect(() => {
     if (searchFocusSignal === undefined || searchFocusSignal === 0) return
     onSidebarCollapsedChange(false)
   }, [searchFocusSignal, onSidebarCollapsedChange])
+
+  useEffect(() => {
+    if (searchFocusSignal === undefined || searchFocusSignal === 0 || sidebarCollapsed) return
+    const frame = window.requestAnimationFrame(() => {
+      const input = searchInputRef.current
+      if (!input) return
+      input.focus({ preventScroll: true })
+      input.select()
+    })
+    return () => window.cancelAnimationFrame(frame)
+  }, [searchFocusSignal, sidebarCollapsed])
 
   useEffect(() => {
     let cancelled = false
@@ -181,7 +195,6 @@ export default function ChatSidebar({
       try {
         const results = await getTransport().call<SessionSearchResult[]>("search_sessions_cmd", {
           query: q,
-          agentId: selectedAgentId ?? undefined,
           limit: SEARCH_LIMIT,
         })
         setSearchResults(sortSessionSearchResults(results ?? []))
@@ -193,7 +206,7 @@ export default function ChatSidebar({
       }
     }, 300)
     return () => clearTimeout(timer)
-  }, [searchQuery, selectedAgentId])
+  }, [searchQuery])
 
   const filteredSessions = (() => {
     const list =
@@ -322,6 +335,69 @@ export default function ChatSidebar({
     setDeleteConfirmSessionId(null)
   }
 
+  const focusSearchInput = useCallback(() => {
+    searchInputRef.current?.focus({ preventScroll: true })
+  }, [])
+
+  const handleSearchSurfaceMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const target = e.target as HTMLElement | null
+      if (target?.closest("button")) return
+      if (target !== searchInputRef.current) {
+        e.preventDefault()
+      }
+      focusSearchInput()
+    },
+    [focusSearchInput],
+  )
+
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key !== "Escape") return
+      e.preventDefault()
+      if (searchQuery.length > 0) {
+        setSearchQuery("")
+      } else {
+        searchInputRef.current?.blur()
+      }
+    },
+    [searchQuery],
+  )
+
+  const sessionListNode = (
+    <SessionList
+      sessions={sessions}
+      filteredSessions={filteredSessions}
+      sessionFilter={sessionFilter}
+      setSessionFilter={setSessionFilter}
+      selectedAgentId={selectedAgentId}
+      currentSessionId={currentSessionId}
+      loadingSessionIds={loadingSessionIds}
+      loadingMoreSessions={loadingMoreSessions}
+      onSwitchSession={onSwitchSession}
+      onDeleteClick={handleDeleteClick}
+      onMarkAllRead={onMarkAllRead}
+      renamingSessionId={renamingSessionId}
+      renameValue={renameValue}
+      renameInputRef={renameInputRef}
+      onStartRename={startRename}
+      onRenameValueChange={setRenameValue}
+      onCommitRename={commitRename}
+      onCancelRename={cancelRename}
+      getAgentInfo={getAgentInfo}
+      formatRelativeTime={formatRelativeTime}
+      searchQuery={searchQuery}
+      searchResults={searchResults}
+      searchTruncated={searchTruncated}
+      searching={searching}
+      agents={agents}
+      projects={projects}
+      onMoveToProject={onMoveSessionToProject}
+      onToggleSessionPinned={onToggleSessionPinned}
+      displayMode={sidebarDisplayMode}
+    />
+  )
+
   return (
     <>
       <div
@@ -414,9 +490,34 @@ export default function ChatSidebar({
               </div>
             </div>
 
+            <div className="shrink-0 border-b border-border/40 px-3 pb-2 pt-1">
+              <div className="relative" onMouseDown={handleSearchSurfaceMouseDown}>
+                <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/60 pointer-events-none" />
+                <Input
+                  ref={searchInputRef}
+                  aria-label={t("chat.searchPlaceholder") || ""}
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onKeyDown={handleSearchKeyDown}
+                  placeholder={t("chat.searchPlaceholder")}
+                  className="h-7 pl-7 pr-7 text-xs border-none shadow-none bg-muted/50 rounded-md focus-visible:ring-0 focus-visible:bg-muted/80 placeholder:text-muted-foreground/50"
+                />
+                {searchQuery && (
+                  <button
+                    onClick={() => setSearchQuery("")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    aria-label={t("common.clear") || "Clear"}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
+            </div>
+
             <div
               className="flex-1 overflow-y-auto overflow-x-hidden [overscroll-behavior-y:none]"
               onScroll={(e) => {
+                if (isHistorySearching) return
                 if (!hasMoreSessions || loadingMoreSessions || !onLoadMoreSessions) return
                 const el = e.currentTarget
                 // Trigger when scrolled within 100px of the bottom
@@ -425,88 +526,62 @@ export default function ChatSidebar({
                 }
               }}
             >
-              {/* Projects section — shown above agents so users reach their
-                  active workspace first. Falls back silently when no handler
-                  is wired (backwards-compat). */}
-              {(projects.length > 0 || onAddProject) && (
-                <ProjectSection
-                  projects={projects}
-                  sessions={sessions}
-                  agents={agents}
-                  currentSessionId={currentSessionId}
-                  loadingSessionIds={loadingSessionIds}
-                  expanded={projectsExpanded}
-                  setExpanded={setProjectsExpanded}
-                  onAddProject={() => onAddProject?.()}
-                  onOpenProjectSettings={(p) => onOpenProjectSettings?.(p)}
-                  onNewChatInProject={(pid, opts) => onNewChatInProject?.(pid, opts)}
-                  onArchiveProject={(pid, archived) => onArchiveProject?.(pid, archived)}
-                  onSwitchSession={onSwitchSession}
-                  onDeleteSession={handleDeleteClick}
-                  onMarkAllRead={onMarkAllRead}
-                  renamingSessionId={renamingSessionId}
-                  renameValue={renameValue}
-                  renameInputRef={renameInputRef}
-                  onStartRename={startRename}
-                  onRenameValueChange={setRenameValue}
-                  onCommitRename={commitRename}
-                  onCancelRename={cancelRename}
-                  onMoveSessionToProject={onMoveSessionToProject}
-                  onToggleSessionPinned={onToggleSessionPinned}
-                  getAgentInfo={getAgentInfo}
-                  formatRelativeTime={formatRelativeTime}
-                  displayMode={sidebarDisplayMode}
-                />
+              {isHistorySearching ? (
+                sessionListNode
+              ) : (
+                <>
+                  {/* Projects section — shown above agents so users reach their
+                      active workspace first. Falls back silently when no handler
+                      is wired (backwards-compat). */}
+                  {(projects.length > 0 || onAddProject) && (
+                    <ProjectSection
+                      projects={projects}
+                      sessions={sessions}
+                      agents={agents}
+                      currentSessionId={currentSessionId}
+                      loadingSessionIds={loadingSessionIds}
+                      expanded={projectsExpanded}
+                      setExpanded={setProjectsExpanded}
+                      onAddProject={() => onAddProject?.()}
+                      onOpenProjectSettings={(p) => onOpenProjectSettings?.(p)}
+                      onNewChatInProject={(pid, opts) => onNewChatInProject?.(pid, opts)}
+                      onArchiveProject={(pid, archived) => onArchiveProject?.(pid, archived)}
+                      onSwitchSession={onSwitchSession}
+                      onDeleteSession={handleDeleteClick}
+                      onMarkAllRead={onMarkAllRead}
+                      renamingSessionId={renamingSessionId}
+                      renameValue={renameValue}
+                      renameInputRef={renameInputRef}
+                      onStartRename={startRename}
+                      onRenameValueChange={setRenameValue}
+                      onCommitRename={commitRename}
+                      onCancelRename={cancelRename}
+                      onMoveSessionToProject={onMoveSessionToProject}
+                      onToggleSessionPinned={onToggleSessionPinned}
+                      getAgentInfo={getAgentInfo}
+                      formatRelativeTime={formatRelativeTime}
+                      displayMode={sidebarDisplayMode}
+                    />
+                  )}
+
+                  {/* Collapsible Agents section */}
+                  <AgentSection
+                    agents={agents}
+                    agentsExpanded={agentsExpanded}
+                    setAgentsExpanded={setAgentsExpanded}
+                    selectedAgentId={selectedAgentId}
+                    toggleAgentFilter={toggleAgentFilter}
+                    onNewChat={onNewChat}
+                    onEditAgent={onEditAgent}
+                    onReorderAgents={onReorderAgents}
+                    panelWidth={panelWidth}
+                    displayMode={sidebarDisplayMode}
+                  />
+
+                  {/* Session filter tabs + session list */}
+                  {sessionListNode}
+                </>
               )}
-
-              {/* Collapsible Agents section */}
-              <AgentSection
-                agents={agents}
-                agentsExpanded={agentsExpanded}
-                setAgentsExpanded={setAgentsExpanded}
-                selectedAgentId={selectedAgentId}
-                toggleAgentFilter={toggleAgentFilter}
-                onNewChat={onNewChat}
-                onEditAgent={onEditAgent}
-                onReorderAgents={onReorderAgents}
-                panelWidth={panelWidth}
-                displayMode={sidebarDisplayMode}
-              />
-
-              {/* Session filter tabs + session list */}
-              <SessionList
-                sessions={sessions}
-                filteredSessions={filteredSessions}
-                sessionFilter={sessionFilter}
-                setSessionFilter={setSessionFilter}
-                selectedAgentId={selectedAgentId}
-                currentSessionId={currentSessionId}
-                loadingSessionIds={loadingSessionIds}
-                loadingMoreSessions={loadingMoreSessions}
-                onSwitchSession={onSwitchSession}
-                onDeleteClick={handleDeleteClick}
-                onMarkAllRead={onMarkAllRead}
-                renamingSessionId={renamingSessionId}
-                renameValue={renameValue}
-                renameInputRef={renameInputRef}
-                onStartRename={startRename}
-                onRenameValueChange={setRenameValue}
-                onCommitRename={commitRename}
-                onCancelRename={cancelRename}
-                getAgentInfo={getAgentInfo}
-                formatRelativeTime={formatRelativeTime}
-                searchQuery={searchQuery}
-                onSearchQueryChange={setSearchQuery}
-                searchResults={searchResults}
-                searchTruncated={searchTruncated}
-                searching={searching}
-                agents={agents}
-                projects={projects}
-                onMoveToProject={onMoveSessionToProject}
-                onToggleSessionPinned={onToggleSessionPinned}
-                searchFocusSignal={sidebarCollapsed ? 0 : searchFocusSignal}
-                displayMode={sidebarDisplayMode}
-              />
             </div>
           </div>
         </div>

--- a/src/components/chat/sidebar/SearchResultItem.tsx
+++ b/src/components/chat/sidebar/SearchResultItem.tsx
@@ -10,7 +10,9 @@ import type {
   SessionMeta,
   SessionSearchResult,
 } from "@/types/chat"
+import type { ProjectMeta } from "@/types/project"
 import type { SidebarDisplayMode } from "./types"
+import ProjectIcon from "../project/ProjectIcon"
 
 interface SearchResultItemProps {
   result: SessionSearchResult
@@ -18,6 +20,8 @@ interface SearchResultItemProps {
   agent: AgentSummaryForSidebar | undefined
   agents: AgentSummaryForSidebar[]
   sessionMeta: SessionMeta | undefined
+  project: ProjectMeta | undefined
+  projectId: string | null
   onSwitch: () => void
   formatRelativeTime: (dateStr: string) => string
   displayMode: SidebarDisplayMode
@@ -29,6 +33,8 @@ export default function SearchResultItem({
   agent,
   agents,
   sessionMeta,
+  project,
+  projectId,
   onSwitch,
   formatRelativeTime,
   displayMode,
@@ -79,6 +85,7 @@ export default function SearchResultItem({
   const agentLabel = agent?.name ?? result.agentId
   // Locate agent avatar even if not in sidebar agents (e.g. subagent)
   const resolvedAgent = agent ?? agents.find((a) => a.id === result.agentId)
+  const projectLabel = project?.name ?? projectId
 
   return (
     <div
@@ -121,9 +128,16 @@ export default function SearchResultItem({
       <div className="flex-1 min-w-0">
         <div className="text-[13px] font-medium text-foreground truncate flex items-center gap-1">
           {typeChip}
+          {project && (
+            <IconTip label={project.name}>
+              <span className="shrink-0">
+                <ProjectIcon project={project} size="xs" withColorChip />
+              </span>
+            </IconTip>
+          )}
           <span className="truncate">{title}</span>
         </div>
-        <div className="text-[10px] text-muted-foreground/70 mt-0.5 flex items-center gap-1 truncate">
+        <div className="text-[10px] text-muted-foreground/70 mt-0.5 flex min-w-0 items-center gap-1 truncate">
           {displayMode === "detailed" && (
             <>
               <span className="truncate">{agentLabel}</span>
@@ -131,6 +145,14 @@ export default function SearchResultItem({
             </>
           )}
           <span className="shrink-0">{formatRelativeTime(result.timestamp)}</span>
+          {projectLabel && (
+            <>
+              <span>·</span>
+              <span className="inline-flex min-w-0 items-center gap-1 truncate text-muted-foreground/80">
+                <span className="truncate">{projectLabel}</span>
+              </span>
+            </>
+          )}
         </div>
         <div className="text-[11px] text-muted-foreground mt-1 line-clamp-2 leading-snug break-words">
           {/* Re-center on the first hit so the highlighted token isn't

--- a/src/components/chat/sidebar/SessionList.tsx
+++ b/src/components/chat/sidebar/SessionList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react"
+import { useMemo } from "react"
 import { parseHighlightTerms } from "@/lib/inlineHighlight"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
@@ -10,12 +10,10 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
-import { Input } from "@/components/ui/input"
 import {
   MessageSquare,
   Loader2,
   Search,
-  X,
 } from "lucide-react"
 import type {
   SessionMeta,
@@ -69,7 +67,6 @@ interface SessionListProps {
   formatRelativeTime: (dateStr: string) => string
   // Search
   searchQuery: string
-  onSearchQueryChange: (q: string) => void
   searchResults: SessionSearchResult[] | null
   /** True when the result set hit the backend limit and may have been
    *  truncated. Surfaced as a hint above the result list. */
@@ -80,9 +77,6 @@ interface SessionListProps {
   projects?: ProjectMeta[]
   onMoveToProject?: (sessionId: string, projectId: string | null) => void
   onToggleSessionPinned?: (sessionId: string, pinned: boolean) => void
-  /** Monotonic counter — focuses + selects the search input on each tick.
-   *  Driven by `Cmd+Shift+F` in `ChatScreen`. */
-  searchFocusSignal?: number
   displayMode: SidebarDisplayMode
 }
 
@@ -108,7 +102,6 @@ export default function SessionList({
   getAgentInfo,
   formatRelativeTime,
   searchQuery,
-  onSearchQueryChange,
   searchResults,
   searchTruncated = false,
   searching,
@@ -116,52 +109,11 @@ export default function SessionList({
   projects = [],
   onMoveToProject,
   onToggleSessionPinned,
-  searchFocusSignal,
   displayMode,
 }: SessionListProps) {
   const { t } = useTranslation()
-  const searchInputRef = useRef<HTMLInputElement>(null)
 
   const isSearching = searchQuery.trim().length > 0
-  const focusSearchInput = useCallback(() => {
-    searchInputRef.current?.focus({ preventScroll: true })
-  }, [])
-
-  const handleSearchSurfaceMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLElement | null
-    if (target?.closest("button")) return
-    if (target !== searchInputRef.current) {
-      e.preventDefault()
-    }
-    focusSearchInput()
-  }
-
-  // External focus trigger (Cmd+Shift+F → ChatScreen → ChatSidebar →
-  // here). Re-runs on every signal tick so a second press from anywhere in
-  // the app re-focuses + selects whatever is in the input. Skip the initial
-  // mount tick (signal undefined or 0) so the sidebar doesn't auto-focus on
-  // every chat open.
-  useEffect(() => {
-    if (searchFocusSignal === undefined || searchFocusSignal === 0) return
-    const input = searchInputRef.current
-    if (!input) return
-    input.focus({ preventScroll: true })
-    input.select()
-  }, [searchFocusSignal])
-
-  const handleSearchKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key !== "Escape") return
-      e.preventDefault()
-      // Esc: clear non-empty query first, blur on the second press.
-      if (searchQuery.length > 0) {
-        onSearchQueryChange("")
-      } else {
-        searchInputRef.current?.blur()
-      }
-    },
-    [searchQuery, onSearchQueryChange],
-  )
 
   // Client-side second-level filter by session type for search results.
   const visibleResults = useMemo(() => {
@@ -174,32 +126,10 @@ export default function SessionList({
     () => parseHighlightTerms(searchQuery),
     [searchQuery],
   )
+  const projectsById = useMemo(() => new Map(projects.map((p) => [p.id, p])), [projects])
 
   return (
     <>
-      {/* Search input */}
-      <div className="relative px-3 pt-2 pb-1.5" onMouseDown={handleSearchSurfaceMouseDown}>
-        <Search className="absolute left-5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/60 pointer-events-none" />
-        <Input
-          ref={searchInputRef}
-          aria-label={t("chat.searchPlaceholder") || ""}
-          value={searchQuery}
-          onChange={(e) => onSearchQueryChange(e.target.value)}
-          onKeyDown={handleSearchKeyDown}
-          placeholder={t("chat.searchPlaceholder")}
-          className="h-7 pl-7 pr-7 text-xs border-none shadow-none bg-muted/50 rounded-md focus-visible:ring-0 focus-visible:bg-muted/80 placeholder:text-muted-foreground/50"
-        />
-        {searchQuery && (
-          <button
-            onClick={() => onSearchQueryChange("")}
-            className="absolute right-5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            aria-label={t("common.clear") || "Clear"}
-          >
-            <X className="h-3 w-3" />
-          </button>
-        )}
-      </div>
-
       {/* Session type filter tabs */}
       <div className="flex items-center gap-0.5 px-3 py-1.5 border-b border-border/40 overflow-x-auto scrollbar-none">
         {(["all", "session", "cron", "subagent"] as const).map((filter) => {
@@ -311,24 +241,30 @@ export default function SessionList({
                   {t("chat.searchTruncatedHint", { count: visibleResults.length })}
                 </div>
               )}
-              {visibleResults.map((result) => (
-                <SearchResultItem
-                  key={`${result.sessionId}-${result.messageId}`}
-                  result={result}
-                  isActive={result.sessionId === currentSessionId}
-                  agent={getAgentInfo(result.agentId)}
-                  agents={agents}
-                  sessionMeta={sessions.find((s) => s.id === result.sessionId)}
-                  onSwitch={() =>
-                    onSwitchSession(result.sessionId, {
-                      targetMessageId: result.messageId,
-                      highlightTerms,
-                    })
-                  }
-                  formatRelativeTime={formatRelativeTime}
-                  displayMode={displayMode}
-                />
-              ))}
+              {visibleResults.map((result) => {
+                const sessionMeta = sessions.find((s) => s.id === result.sessionId)
+                const projectId = result.projectId ?? sessionMeta?.projectId ?? null
+                return (
+                  <SearchResultItem
+                    key={`${result.sessionId}-${result.messageId}`}
+                    result={result}
+                    isActive={result.sessionId === currentSessionId}
+                    agent={getAgentInfo(result.agentId)}
+                    agents={agents}
+                    sessionMeta={sessionMeta}
+                    project={projectId ? projectsById.get(projectId) : undefined}
+                    projectId={projectId}
+                    onSwitch={() =>
+                      onSwitchSession(result.sessionId, {
+                        targetMessageId: result.messageId,
+                        highlightTerms,
+                      })
+                    }
+                    formatRelativeTime={formatRelativeTime}
+                    displayMode={displayMode}
+                  />
+                )
+              })}
             </>
           )}
         </div>

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -409,6 +409,7 @@ export interface SessionSearchResult {
   relevanceRank: number
   isCron: boolean
   parentSessionId: string | null
+  projectId: string | null
   channelType: string | null
   channelChatType: string | null
 }


### PR DESCRIPTION
## Summary

- Move the conversation search entry to the top of the sidebar.
- Include `projectId` in session search results and render the matching Project name/icon in the UI.
- Keep search global when the Agent picker is hidden so results are not silently narrowed by an invisible filter.
- Document the search UX change in `CHANGELOG.md`.

## Validation

- `cargo check -p ha-core`
- `pnpm typecheck`
- `git diff --check`
- Pre-push hook: `cargo fmt --all --check`
- Pre-push hook: `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- Pre-push hook: `pnpm typecheck`
- Pre-push hook: `pnpm lint` (2 existing warnings, 0 errors)
- Pre-push hook: `pnpm test`
- Pre-push hook: `cargo test -p ha-core -p ha-server --locked`