### PR TITLE
release: v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-07
+
 ### Added
 
 - **文件浏览器搜索**：项目 / 会话文件浏览器新增按文件名与路径的模糊搜索，支持搜索结果停留、键盘上下选择、回车预览、目录结果展开定位，以及跨 session / project / worktree 的 scope-based 后端搜索，避免 Project 默认工作目录下搜索失败。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,7 +3008,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3223,7 +3223,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.6.1"
+version = "0.7.0"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.6.1"
+version = "0.7.0"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.7.0.en.md
+++ b/docs/release-notes/v0.7.0.en.md
@@ -1,0 +1,32 @@
+# Hope Agent 0.7.0 — Office Document Skills, Refreshed Provider Templates, and Project-Aware Cron
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.7.0/docs/release-notes/v0.7.0.md) · **English**
+
+> Release date: 2026-06-07
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.7.0/CHANGELOG.md#070---2026-06-07) for the full list.
+
+v0.7.0 builds on the v0.6.x line with three productivity-focused capabilities — bundled Office document skills, a large refresh of Provider templates and preset models, and binding cron jobs to Projects — alongside polished chat input, clearer skill-loading semantics, and several reliability fixes.
+
+## Highlights
+
+- **Bundled Office skills**: three new bundled skills — `office-docx` / `office-xlsx` / `office-pptx` — deliver local creation, editing, inspection, and preview of Word, Excel, and PowerPoint documents through skills plus bundled scripts. DOCX covers real Word lists, comments, tracked changes, image alt text, tables of contents, foot/endnotes, watermarks, document protection, content controls, internal links, table export, document merge/compare, and redaction; XLSX covers real Excel tables, formulas, styles, data validation, conditional formatting, charts, CSV/TSV conversion, and formula audit/cache; PPTX covers title/section/text-and-image/metric/table/timeline layouts, native charts, text patching, slide append and duplicate/reorder, and layout audits.
+- **Refreshed Provider templates**: built-in Provider templates grow from 39 to 44 (adding GitHub Copilot, Novita, GMI, OpenCode, KiloCode), preset models expand to 335, and the latest models — Claude Opus 4.8, GPT-5.x, Gemini 3.1, Kimi K2.6, GLM-5.1 — are added with up-to-date context windows, max output, and pricing.
+- **Project-aware cron jobs**: cron jobs can now be bound to a Project, configurable from both the form and the `manage_cron` tool; on execution they create an isolated session with Project context, reusing project instructions, project memory, working directory, and tool cwd resolution. Agent supports `Auto`, resolving in the order explicit Agent → Project default Agent → global default → `ha-main`; if the Project is deleted, the job clears the association and falls back to a regular cron run.
+- **File browser search**: the project / session file browser now supports fuzzy search by filename and path, with persistent results, keyboard up/down selection, Enter to preview, directory-result expansion, and scope-based backend search across session / project / worktree — avoiding failed searches under a Project's default working directory.
+
+## Improvements
+
+- **Polished chat input and menus**: the input's attachment entry is merged into "Add photos and files", with model, thinking effort, and temperature settings collected into a single popover; toolbar layout and height stay steadier at narrow widths so the voice/send buttons are no longer squeezed or hidden; the quick-command, model, permission, and Awareness menus now use a unified soft open/close animation, with smoother sidebar and right-side workspace panel transitions.
+- **Session search pinned to top with Project attribution**: the sidebar's session search moves to a fixed position at the top, and results carry and display `projectId` / Project name and icon; search is no longer silently narrowed by a hidden Agent filter.
+- **Tiered skill requirements injection**: hard-incompatible skills (e.g. `requires.os` mismatch) no longer enter the model catalog / slash menu; skills missing installable/configurable dependencies (`bins` / `anyBins` / `env` / `config`) remain visible but return missing items and install/config diagnostics before activation instead of loading SKILL.md directly. The Settings skills panel now shows `Incompatible` / `Needs setup` status.
+- **Skill activation context includes package directory metadata**: both inline and fork activations prepend the skill name and skill directory to the returned content, so bundled scripts, references, and assets can be located reliably without the model guessing paths.
+
+## Fixes
+
+- **Workspace task progress coordination**: when the right-side Workspace is already expanded, the input's embedded task progress panel now stays collapsed on first appearance, avoiding two task views expanding at once; the collapse-animation timer is also cleaned up to avoid state updates after unmount.
+- **Office OOXML package structure stability**: fixes a DOCX helper that appended content after the final `w:sectPr`, which Word/LibreOffice would repair or ignore; the watermark helper no longer overwrites an existing `word/header1.xml`, allocating a new header part and relationship id instead; PPTX slide reordering no longer drops non-slide relationships such as slide master / theme / view properties, preserving source-deck styling.
+
+## Also Included
+
+- Adds `scripts/office-skill-parity-audit.py` and `scripts/office-skill-smoke-test.py` for Office skill capability auditing and end-to-end create/edit/inspect/render smoke testing, respectively.

--- a/docs/release-notes/v0.7.0.md
+++ b/docs/release-notes/v0.7.0.md
@@ -1,0 +1,32 @@
+# Hope Agent 0.7.0 — Office 文档技能、Provider 模板刷新与定时任务项目化
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.7.0/docs/release-notes/v0.7.0.en.md)
+
+> 发布日期：2026-06-07
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.7.0/CHANGELOG.md#070---2026-06-07)。
+
+v0.7.0 在 v0.6.x 的基础上带来三项面向生产力的能力扩展——内置 Office 文档技能、Provider 模板与预设模型的大规模刷新，以及定时任务与 Project 的绑定；同时打磨了聊天输入交互、技能加载语义与若干稳定性细节。
+
+## 亮点
+
+- **内置 Office 三件套技能**：新增 `office-docx` / `office-xlsx` / `office-pptx` 三个内置技能，以技能 + 随附脚本的形式提供 Word、Excel、PowerPoint 的本地生成、编辑、检查与预览能力。DOCX 覆盖真实 Word 列表、批注、修订、图片 alt、目录、脚注 / 尾注、水印、文档保护、内容控件、内部链接、表格导出、文档合并与对比、脱敏等场景；XLSX 覆盖真实 Excel 表格、公式、样式、数据验证、条件格式、图表、CSV / TSV 转换与公式审计 / 缓存；PPTX 覆盖标题 / 章节 / 图文 / 指标 / 表格 / 时间线、原生图表、文本 patch、slide 追加与复制重排、布局审计等。
+- **Provider 模板扩充刷新**：内置 Provider 模板由 39 个增至 44 个（新增 GitHub Copilot、Novita、GMI、OpenCode、KiloCode），预设模型扩充至 335 个，补齐 Claude Opus 4.8、GPT-5.x、Gemini 3.1、Kimi K2.6、GLM-5.1 等最新模型，并同步各家上下文窗口、最大输出与定价。
+- **定时任务关联 Project**：Cron 任务现可绑定 Project，人工表单与 `manage_cron` 工具均可设置；执行时会创建带 Project 上下文的隔离会话，复用项目指令、项目记忆、工作目录与工具 cwd 解析。Agent 支持 `Auto`，按显式 Agent → Project 默认 Agent → 全局默认 → `ha-main` 顺序解析；Project 被删除后任务会自动清空关联并按普通 Cron 降级执行。
+- **文件浏览器搜索**：项目 / 会话文件浏览器新增按文件名与路径的模糊搜索，支持搜索结果停留、键盘上下选择、回车预览、目录结果展开定位，以及跨 session / project / worktree 的 scope-based 后端检索，避免在 Project 默认工作目录下搜索失败。
+
+## 改进
+
+- **聊天输入框与菜单交互打磨**：输入框附件入口合并为「添加照片和文件」，模型、思考强度与温度设置收入同一浮层；窄宽度下工具栏布局与高度更稳定，语音 / 发送按钮不再被挤压遮挡；快捷指令、模型、权限、Awareness 等菜单改用统一的柔和弹出 / 收起动效，并同步优化左右侧边栏与右侧工作台面板的展开收起体验。
+- **会话搜索置顶并显示 Project 归属**：侧边栏会话搜索入口移至顶部固定位置，搜索结果会携带并展示 `projectId` / Project 名称与图标；搜索态不再受隐藏的 Agent 筛选静默影响，避免结果被不可见过滤条件收窄。
+- **Skill requirements 分级注入语义**：`requires.os` 不匹配这类硬不兼容技能不再进入模型 catalog / 斜杠菜单；缺少可安装 / 可配置依赖（`bins` / `anyBins` / `env` / `config`）的技能仍可见，但在激活前返回缺失项与安装 / 配置诊断，不再直接加载 SKILL.md。Settings 技能面板同步展示 `Incompatible` / `Needs setup` 状态。
+- **Skill 激活上下文包含包目录元数据**：inline 与 fork 激活返回的技能内容前会注入技能名称与技能目录，便于随附脚本、references、assets 稳定定位，无需模型猜测路径。
+
+## 修复
+
+- **工作台任务进度联动**：右侧 Workspace 已展开时，输入框内嵌任务进度面板首次出现也会保持收起，避免两处任务明细同时展开；并补齐折叠动画的定时器清理，避免组件卸载后继续触发状态更新。
+- **Office OOXML 包结构稳定性**：修复 DOCX helper 在最终 `w:sectPr` 之后追加内容的问题，避免 Word / LibreOffice 打开时修复或忽略新增段落；水印 helper 不再覆盖既有 `word/header1.xml`，改为分配新的 header part 与 relationship id；PPTX slide 重排不再丢弃 slide master / theme / view properties 等非 slide relationships，避免源文档样式丢失。
+
+## 其它
+
+- 新增 `scripts/office-skill-parity-audit.py` 与 `scripts/office-skill-smoke-test.py`，分别用于 Office 技能能力面审计与端到端生成 / 编辑 / 检查 / 渲染冒烟测试。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.6.1",
+  "version": "0.7.0",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.6.1"
+version = "0.7.0"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## release: v0.7.0

从 `main` 发 minor 版本 v0.7.0（minor 发版流程见 [docs/release-process.md §2](docs/release-process.md)）。

### 本 PR 包含
- 版本号 `0.6.1` → `0.7.0`：同步五处来源（`package.json` / `src-tauri/Cargo.toml` / `tauri.conf.json` / `crates/ha-server/Cargo.toml` / `crates/ha-core/Cargo.toml`）+ `Cargo.lock`
- `CHANGELOG.md`：`[Unreleased]` 定稿为 `## [0.7.0] - 2026-06-07`，顶部补新空 `[Unreleased]`
- 双语 release notes：`docs/release-notes/v0.7.0.md` + `v0.7.0.en.md`（tag-pin 绝对 URL）

### v0.7.0 内容（基于当前 main）
- **Added**：内置 Office 三件套技能（docx/xlsx/pptx）、Provider 模板扩充刷新（44 家 / 335 模型）、定时任务关联 Project、文件浏览器搜索
- **Changed**：聊天输入框交互打磨、会话搜索置顶 + Project 归属、Skill requirements 分级注入、Skill 激活上下文含目录元数据
- **Fixed**：工作台任务进度联动、Office OOXML 包结构稳定性

> 不含「知识空间」——该功能仍在 `feat/knowledge-base-design` 分支未合并，留待后续版本。

### 校验
- `pnpm release:verify -- --tag v0.7.0` ✅
- pre-push 全套门禁（cargo fmt/clippy/test + pnpm typecheck/lint/test）✅
