### PR TITLE
fix: 🦭 macOS Hardened Runtime entitlements 补全 + Homebrew cask 安装源识别修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS 摄像头 / 通讯录 / 日历 / 提醒 / 照片在签名版本可正常使用**：发布包启用 Hardened Runtime 后补全了对应的资源访问授权，这些权限在用户授权后不再被系统拦截。
+- **Homebrew 安装的 macOS 版自更新路径修正**：应用安装到「应用程序」目录的 Homebrew cask 不再被误判为手动拖拽安装，升级正确走 `brew upgrade`，避免与 Homebrew 的安装记录脱节。
+
 ## [0.8.0] - 2026-06-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **macOS 摄像头 / 通讯录 / 日历 / 提醒 / 照片在签名版本可正常使用**：发布包启用 Hardened Runtime 后补全了对应的资源访问授权，这些权限在用户授权后不再被系统拦截。
-- **Homebrew 安装的 macOS 版自更新路径修正**：应用安装到「应用程序」目录的 Homebrew cask 不再被误判为手动拖拽安装，升级正确走 `brew upgrade`，避免与 Homebrew 的安装记录脱节。
+- **macOS 摄像头 / 通讯录 / 日历 / 提醒 / 照片在签名版本可正常使用**：发布包启用 Hardened Runtime 后补全了对应的资源访问授权，这些权限在用户授权后不再被系统拦截。 (#301)
+- **Homebrew 安装的 macOS 版自更新路径修正**：应用安装到「应用程序」目录的 Homebrew cask 不再被误判为手动拖拽安装，升级正确走 `brew upgrade`，避免与 Homebrew 的安装记录脱节。 (#301)
 
 ## [0.8.0] - 2026-06-09
 

--- a/crates/ha-core/src/updater/source_detector.rs
+++ b/crates/ha-core/src/updater/source_detector.rs
@@ -95,15 +95,25 @@ pub fn classify_exe_path(exe: &Path) -> InstallSource {
 
     #[cfg(target_os = "macos")]
     {
-        // brew cask installs land at
-        // `<prefix>/Caskroom/hope-agent/.../Hope Agent.app/Contents/MacOS/hope-agent`,
-        // which also matches the `.app/` substring used to detect a raw
-        // DMG drop. Check brew first so cask installs route to the
-        // package manager rather than the (signing-sensitive) Tauri path.
+        // A brew cask can run from one of two places and the path alone
+        // can't always tell it apart from a hand-dragged DMG:
+        //   1. Some casks run straight out of the Caskroom staging dir
+        //      (`<prefix>/Caskroom/hope-agent/.../Hope Agent.app/...`) — the
+        //      path match below catches those.
+        //   2. The DEFAULT `app` stanza MOVES the bundle to `/Applications`,
+        //      so the running exe is `/Applications/Hope Agent.app/...` —
+        //      byte-for-byte identical to a raw DMG drop. brew only records
+        //      the install under `<prefix>/Caskroom/hope-agent/`, so we probe
+        //      the filesystem for that marker before falling back to Tauri.
+        // Getting this wrong sends cask users down the Tauri self-replace
+        // path, which desyncs brew's Caskroom records from /Applications.
         if let Some(prefix) = brew_prefix_from_path(&s) {
             return InstallSource::Brew { prefix };
         }
         if s.contains("/Applications/Hope Agent.app/") || s.contains("/Hope Agent.app/") {
+            if let Some(prefix) = brew_caskroom_owner() {
+                return InstallSource::Brew { prefix };
+            }
             return InstallSource::TauriBundle;
         }
     }
@@ -166,6 +176,27 @@ fn brew_prefix_from_path(exe_str: &str) -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Probe the filesystem for a Homebrew Caskroom entry, used when the running
+/// app lives in `/Applications` (default `app` stanza) and so can't be told
+/// from a raw DMG drop by path alone. brew keeps the install record at
+/// `<prefix>/Caskroom/hope-agent/` even after moving the bundle out, so the
+/// directory's presence is a reliable cask marker.
+#[cfg(target_os = "macos")]
+fn brew_caskroom_owner() -> Option<PathBuf> {
+    caskroom_owner_in(&["/opt/homebrew", "/usr/local"], |p| p.is_dir())
+}
+
+/// Pure core of [`brew_caskroom_owner`] — the prefix list and the existence
+/// check are injected so the resolution order can be unit-tested without a
+/// real Homebrew install on the runner.
+#[cfg(target_os = "macos")]
+fn caskroom_owner_in(prefixes: &[&str], exists: impl Fn(&Path) -> bool) -> Option<PathBuf> {
+    prefixes.iter().find_map(|prefix| {
+        let caskroom = PathBuf::from(prefix).join("Caskroom/hope-agent");
+        exists(&caskroom).then(|| PathBuf::from(prefix))
+    })
 }
 
 #[cfg(target_os = "linux")]
@@ -231,6 +262,25 @@ mod tests {
             InstallSource::Brew { prefix } => assert_eq!(prefix, PathBuf::from("/usr/local")),
             other => panic!("expected Brew, got {other:?}"),
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn caskroom_probe_detects_applications_cask_install() {
+        // Default `app` stanza moves the bundle to /Applications, so the only
+        // signal left that it's a cask is the Caskroom marker directory.
+        let got = caskroom_owner_in(&["/opt/homebrew", "/usr/local"], |p| {
+            p == Path::new("/opt/homebrew/Caskroom/hope-agent")
+        });
+        assert_eq!(got, Some(PathBuf::from("/opt/homebrew")));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn caskroom_probe_returns_none_for_hand_dragged_dmg() {
+        // No Caskroom marker anywhere ⇒ a raw DMG drop, leave it as TauriBundle.
+        let got = caskroom_owner_in(&["/opt/homebrew", "/usr/local"], |_| false);
+        assert_eq!(got, None);
     }
 
     #[cfg(target_os = "linux")]

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -5,6 +5,24 @@
     <!-- Microphone access for the voice-input feature. NSMicrophoneUsageDescription lives in Info.plist; this entitlement permits the sandbox to expose the device. -->
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <!-- Camera access for visual-input workflows. Required under Hardened Runtime: the Info.plist usage string alone is not enough — without this the process is killed on first camera use. -->
+    <key>com.apple.security.device.camera</key>
+    <true/>
+    <!-- Location for local-weather / location-aware workflows (CLLocationManager). -->
+    <key>com.apple.security.personal-information.location</key>
+    <true/>
+    <!-- Contacts access (CNContactStore). -->
+    <key>com.apple.security.personal-information.addressbook</key>
+    <true/>
+    <!-- Calendar AND Reminders access — both go through EventKit, which shares the calendars resource entitlement. -->
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
+    <!-- Photos library access (PHPhotoLibrary). -->
+    <key>com.apple.security.personal-information.photos-library</key>
+    <true/>
+    <!-- Send Apple Events to other apps for automation (osascript probes, mac_control). NSAppleEventsUsageDescription lives in Info.plist; under Hardened Runtime the entitlement is also required. -->
+    <key>com.apple.security.automation.apple-events</key>
+    <true/>
     <!-- Network client (already required for any LLM API call). -->
     <key>com.apple.security.network.client</key>
     <true/>


### PR DESCRIPTION
## 背景

v0.8.0 起 macOS 发布包用固定自签名证书签名并启用 **Hardened Runtime**。排查一台 brew 装的机器「权限授了还失效」时发现两个遗留问题。

## 改动

### 1. Hardened Runtime 补全资源访问 entitlement

启用 Hardened Runtime 后,仅靠 Info.plist 的 `NS*UsageDescription` 已不足以访问受保护资源——**缺对应 entitlement 会被系统直接终止进程**。原 `Entitlements.plist` 只有 `audio-input` + network,补全:

- `device.camera`(摄像头)
- `personal-information.location`(定位)
- `personal-information.addressbook`(通讯录)
- `personal-information.calendars`(日历 **+ 提醒**,EventKit 共用)
- `personal-information.photos-library`(照片)
- `automation.apple-events`(mac_control / automation_* 发 Apple Events)

屏幕录制 / 辅助功能 / 权限状态检测不需要 entitlement,不受影响。蓝牙(sandbox 专属)、语音识别(无 HR entitlement)故意不加。

### 2. 修正 /Applications 下 Homebrew cask 的安装源识别

标准 cask 的默认 `app` stanza 会把 `.app` 移到 `/Applications`,运行路径与手动拖拽 DMG 完全一致,旧 `source_detector` 据此误判为 `TauriBundle` → brew 安装走 Tauri 自替换更新,与 brew 的 Caskroom 记录脱节。

改为在 `/Applications` bundle 场景下额外探测 `<prefix>/Caskroom/hope-agent/` 标记目录(与 Linux 分支的 dpkg/rpm/pacman 探测同款思路),命中则识别为 `Brew`,升级正确路由到 `brew upgrade`。

## 测试

- `cargo check -p ha-core` 通过
- `cargo test -p ha-core --lib updater::source_detector` 7 测全绿(含 2 个新增:`/Applications` cask 探测命中 / 手拖 DMG 不命中)
- entitlements 为发布签名期生效,本地 adhoc 构建不嵌入,需 CI 签名包验证

## 升级注意(给用户)

从 adhoc 旧版升级到固定签名版后,旧的 TCC 授权记录是孤儿,需 `tccutil reset <service> ai.hopeagent.desktop` 后重授一次,之后随固定签名永久保留。