### PR TITLE
docs: 🦭 ha-self-diagnosis 同步最新子系统 + AGENTS 索引同步契约

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,6 +432,7 @@ ha-core 主要领域：`agent/` `chat_engine/` `context_compact/` `memory/` `kno
 | 技术栈/架构/规范变更                                | `AGENTS.md`                                                           |
 | 已有子系统架构变更                                  | `docs/architecture/` 对应文档                                         |
 | 新增架构级能力                                      | `docs/architecture/` 新建文档 + `docs/README.md` 索引                 |
+| 新增/删除子系统、架构文档、运行时 DB 或稳定 log category | [`skills/ha-self-diagnosis/references/`](skills/ha-self-diagnosis/references/)（`source-map.md` 索引 + `diagnostic-playbook.md` 子系统速查） |
 | 新增/删除 Tauri 命令、HTTP 路由、`COMMAND_MAP` 条目 | [`api-reference.md`](docs/architecture/api-reference.md) 对应表格     |
 | 功能变化导致 README 过时                            | `README.md` + `README.en.md`（同一 PR 双语同步）                      |
 | 新增调研/对比分析                                   | `docs/research/` 新建调研文档                                         |
@@ -440,6 +441,7 @@ ha-core 主要领域：`agent/` `chat_engine/` `context_compact/` `memory/` `kno
 
 - **AGENTS.md 是契约面**——只放跨 PR 必守的规则、红线、文件入口；**实现细节、内部数据结构、迁移逻辑、边角行为一律下沉到对应 architecture 文档**
 - **架构文档强制**：子系统边界 / 数据流 / 持久化格式 / 跨模块 contract 改动须更新对应 `docs/architecture/`；新增架构级能力（新子系统 / 协议层）须同 PR 新建文档并登记到 `docs/README.md`
+- **ha-self-diagnosis 索引同步**：新增 / 删除子系统、`docs/architecture/` 文档、`~/.hope-agent/` 运行时 DB（`paths.rs`）或稳定 log `category` 时，同步更新 [`skills/ha-self-diagnosis/references/`](skills/ha-self-diagnosis/references/) 的 `source-map.md`（文档 / 目录 / DB 索引）与 `diagnostic-playbook.md`（Subsystem Reference：入口模块 / DB·config / log category / 故障 gotcha）。此处是 agent 自查与排障的 fallback 真相源，过时会直接误导诊断；新增的 log `category` 须为稳定字符串便于 grep
 - **README 双语同步**：根目录 `README.md`（中文）+ `README.en.md`（英文），任一改动同次提交同步另一份
 - **Release Notes 双语同步**：每版本 `vX.Y.Z.md` + `vX.Y.Z.en.md`，顶部互加 `简体中文 · English` 切换链接
 - **CHANGELOG entry 单行**：每条 changelog 一句话讲用户感知 + `(#PR)` 引用，**不放**文件路径 / 数据结构 / 单测数 / 实现取舍——那些写 PR description 或 [`docs/architecture/`](docs/architecture/)。涉及契约 / 红线变更可加一行用户操作影响（如「首次启动自动迁移」），仍不展开实现。Release notes 可以稍长一段，但同样面向用户视角而不是实现叙事

--- a/skills/ha-self-diagnosis/SKILL.md
+++ b/skills/ha-self-diagnosis/SKILL.md
@@ -32,7 +32,7 @@ Workflow:
 3. Cross-check runtime/config behavior with `get_settings` when useful.
 4. Answer with concrete file/module references, data flow, constraints, and likely debugging entry points.
 
-If the source tree is not available, use `references/source-map.md` and the bundled architecture notes in this skill as the fallback map. Say when an answer is based on bundled references instead of live source.
+If the source tree is not available, use `references/source-map.md` and `references/diagnostic-playbook.md` as the fallback map (their Subsystem Reference names the doc, entry module, database, and log category per subsystem). Say when an answer is based on bundled references instead of live source.
 
 ### issue-report
 
@@ -56,7 +56,7 @@ Never bypass the `issue_report(action="create")` confirmation. Never paste raw s
 Use these in order:
 
 1. Live source and docs in the current working directory.
-2. Local runtime data under `~/.hope-agent/`, especially `logs.db`, `sessions.db`, and `async_jobs.db`.
+2. Local runtime data under `~/.hope-agent/` (full DB table in `references/source-map.md`): start with `logs.db` and `sessions.db`, then the subsystem-specific store — `memory.db`, `knowledge/index.db`, `cron.db`, `async_jobs.db`, `local_model_jobs.db`, `recap/recap.db`, `canvas/canvas.db` — and non-DB state like `crash_journal.json` / `config.json`.
 3. Settings via `get_settings`.
 4. Bundled references in this skill:
    - `references/source-map.md`

--- a/skills/ha-self-diagnosis/references/diagnostic-playbook.md
+++ b/skills/ha-self-diagnosis/references/diagnostic-playbook.md
@@ -4,8 +4,9 @@
 
 1. Capture the user's symptom in one sentence.
 2. Determine run mode: desktop, server, ACP, IM channel, cron, subagent, or MCP.
-3. Check settings relevant to the subsystem with `get_settings`.
-4. Query recent logs read-only:
+3. Locate the subsystem in the **Subsystem Reference** below — it names the doc, entry module, the right database, and the stable log category to grep.
+4. Check settings relevant to the subsystem with `get_settings`.
+5. Query recent logs read-only (the log `category` for each subsystem is in the reference):
 
 ```bash
 sqlite3 -readonly -cmd ".headers on" -cmd ".mode column" ~/.hope-agent/logs.db \
@@ -16,7 +17,9 @@ sqlite3 -readonly -cmd ".headers on" -cmd ".mode column" ~/.hope-agent/logs.db \
     LIMIT 80;"
 ```
 
-5. If the issue is session-specific, inspect messages/tool rows:
+   Narrow by subsystem with `AND category = '<category>'` (e.g. `knowledge`, `hooks`, `browser`, `failover`, `cron`).
+
+6. If the issue is session-specific, inspect messages/tool rows:
 
 ```bash
 sqlite3 -readonly -cmd ".headers on" -cmd ".mode column" ~/.hope-agent/sessions.db \
@@ -28,17 +31,107 @@ sqlite3 -readonly -cmd ".headers on" -cmd ".mode column" ~/.hope-agent/sessions.
     LIMIT 80;"
 ```
 
-6. Map symptoms to source files using `references/source-map.md` and `docs/architecture/`.
-7. Check whether a newer release may already fix it with `app_update(action="check")` when appropriate.
-8. For issue reporting, include only relevant, redacted evidence.
+7. Map symptoms to source files using the **Subsystem Reference**, `references/source-map.md`, and `docs/architecture/`.
+8. Check whether a newer release may already fix it with `app_update(action="check")` when appropriate.
+9. For issue reporting, include only relevant, redacted evidence.
+
+## Subsystem Reference
+
+Per subsystem: the architecture doc, the diagnostic entry module(s), the
+runtime state (DB / config), the stable `logs.db` `category` to grep, and the
+gotcha that most often explains a failure. Open every DB read-only.
+
+### Knowledge Base (知识空间) — `knowledge-base.md`
+
+- Entry: `knowledge/access.rs` (access), `knowledge/service.rs` (owner plane), `knowledge/search.rs`, `tools/note.rs`.
+- State: `knowledge/index.db` (rebuildable cache); registry + attach bindings in `sessions.db` (`knowledge_bases` / `session_knowledge_bases` / `project_knowledge_bases`). Config: `knowledge_embedding`, `knowledge_search`, `knowledge_passive_recall`.
+- Grep: `category='knowledge'` (sources: `service` / `index` / `reembed` / `embedding` / `maintenance::cycle`).
+- Gotcha: access is deny-by-default via `effective_kb_access`; an agent that "can't see notes" usually has no attach — `SELECT kb_id,access FROM session_knowledge_bases WHERE session_id=?`. Empty search results → check `knowledge_embedding.enabled` (vector search degrades to FTS-only, never falls back to memory). Index drift → compare on-disk `.md` count vs `SELECT count(*) FROM note WHERE kb_id=?`.
+
+### Hooks — `hooks.md`
+
+- Entry: `hooks/mod.rs` (`HookDispatcher::dispatch`), `hooks/scopes.rs`, `hooks/runner/`, `hooks/parse.rs`; block points `agent/preflight.rs` (UserPromptSubmit) and `tools/execution.rs::fire_pre_tool_use_hook` (PreToolUse).
+- State: `AppConfig.hooks`, `disable_all_hooks` (kill switch), `hooks_allow_project_scope` (gates project/local `.hope-agent/hooks.json`, default false).
+- Grep: `category='hooks'` (source `dispatch` logs event/handler-count/decision/duration).
+- Gotcha: project/local hooks not firing → `hooks_allow_project_scope` is off by default. Matcher normalizes Claude aliases (`Bash`→`exec`) but the payload `.tool_name` stays the internal name, so a script matching `.tool_name=="Bash"` never fires. Only `UserPromptSubmit`/`PreToolUse`/`PreCompact` actually block; the other 21 events are observation-only.
+
+### Chat Engine / Session / Compaction / Memory — `chat-engine.md`, `session.md`, `context-compact.md`, `memory.md`
+
+- Entry: `chat_engine/engine.rs`, `chat_engine/finalize/`, `session/db.rs`, `context_compact/compact.rs`, `memory/sqlite/`, `memory_extract.rs`.
+- State: `sessions.db` (`context_json` snapshot, `messages.stream_status`, `chat_turns`), `memory.db`. Config: `compact.*` (`cacheTtlSecs=300`, override at usage ≥0.95), `memoryExtract.*`, `memory_embedding`.
+- Grep: `category IN ('chat_engine','memory')`; compaction logs under `category='context'` (source `compact`) plus `category='agent'` (`reactive_microcompact`).
+- Gotcha: Anthropic 400 on tool_use/tool_result → API-round (`_oc_round`) boundary broke; `prepare_messages_for_api()` strips metadata. Leftover partials → `SELECT id,stream_status FROM messages WHERE stream_status IN ('streaming','orphaned')`; stale turns → `SELECT status,interrupt_reason FROM chat_turns WHERE status IN ('running','cancelling')`. `recall_memory` excludes Project scope by design. `memory_embedding.enabled=false` → recall is FTS5-only.
+
+### Provider / Failover / Side-query / Local LLM — `provider-system.md`, `failover.md`, `side-query.md`, `local-model-loading.md`
+
+- Entry: `failover/executor.rs` (`execute_with_failover`), `chat_engine/engine.rs`, `agent/side_query.rs`, `provider/crud.rs`, `local_llm/management.rs`.
+- State: `config.json` (`providers` / `active_model` / `fallback_models`); `sessions.db` (`provider_id` / `model_id` pin, `context_json`); `local_model_jobs.db`, `local_llm_library_cache.db`; `credentials/auth.json` (Codex OAuth).
+- Grep: `source='failover'` (profile_rotation / codex_auth_expired / model_fallback); `category IN ('local_llm','local_model_jobs')`.
+- Gotcha: model precedence is `plan_model > model_override > session pin > agent.primary > active_model`. Codex is force-excluded from profile rotation. OpenAIResponses must use `store:false` and never replay reasoning items (`rs_*` 404s) — check `context_json` for leaked `type:reasoning` items.
+
+### Tools / Permissions / MCP / IM Channel / Skills / Logging — `tool-system.md`, `permission-system.md`, `mcp.md`, `im-channel.md`, `skill-system.md`, `logging.md`
+
+- Entry: `tools/dispatch.rs` (visibility), `tools/execution.rs`, `permission/engine.rs` (`resolve_async`), `mcp/invoke.rs`, `channel/worker/dispatcher.rs`, `logging/db.rs`.
+- State: `sessions.db` (`channel_conversations`, `sessions.permission_mode`, `learning_events`), `async_jobs.db`, `permission/*.json`, `credentials/mcp/{id}.json`. Config: `mcp_global.enabled`, `permission.global_yolo`, `deferredTools.enabled`.
+- Grep: `category IN ('tool','mcp','channel','skills','permission')` (permission decisions log under `permission`).
+- Gotcha: tool not callable → trace `resolve_tool_fate` (visibility) then `resolve_async` (Decision); check `sessions.permission_mode` (`default|smart|yolo`) and `permission.global_yolo`. Hiding a tool is never a security boundary. MCP handshake 401/403 → `ServerState::NeedsAuth` (no retry loop). IM not replying / wrong session → `SELECT * FROM channel_conversations WHERE session_id=?` (1:1 attach both ways).
+
+### Subagent / Team / Cron — `subagent.md`, `agent-team.md`, `cron.md`
+
+- Entry: `subagent/injection.rs`, `team/coordinator.rs`, `cron/scheduler.rs`, `cron/executor.rs`, `session/subagent_db.rs`.
+- State: `cron.db` (`cron_jobs` + `cron_run_logs`), `sessions.db` (`subagent_runs`, `teams`/`team_*`), `async_jobs.db`. Config: `subagents.enabled`/`max_spawn_depth`, `team.*`.
+- Grep: `category IN ('subagent','team','cron')`.
+- Gotcha: cron `status='disabled'` ← `consecutive_failures>=5`; non-null `running_at` after restart = orphan (`clear_all_running` should clear it); `cron_run_logs.status='timeout'` = exceeded 300s. `subagent_runs.child_agent_id` prefix `tool_job:` = async-tool injection (not a real subagent), `team:` = team member; stuck `Running` cleaned by `cleanup_orphan_runs`.
+
+### File ops / Project / Canvas — `file-operations.md`, `project.md`, `canvas.md`
+
+- Entry: `filesystem/workspace.rs` (`WorkspaceScope`), `filesystem/ops.rs`, `ha-server/routes/sessions.rs`, `project/files.rs`, `tools/canvas/`.
+- State: `sessions.db` (projects/sessions), `memory.db` (project memory), `canvas/canvas.db`. Config: `filesystem.allow_remote_writes` (default false), `canvas.*`.
+- Grep: `category='tool'` source `canvas` / file-op traces.
+- Gotcha: HTTP `/api/fs/*` write 403 in server mode → `filesystem.allow_remote_writes` is off. Preview-by-path 403 → path neither referenced-by-tool-msg nor inside the session working dir (remote arbitrary-read guard). `for_path` scope is read-only — writes always rejected. Canvas snapshot/eval timeout on non-html content types is expected.
+
+### Browser / macOS control — `browser.md`, `macos-control.md`
+
+- Entry: `tools/browser/`, `browser/cdp_backend.rs`, `browser_state.rs`, `mac_control.rs`, `tools/mac_control.rs`, `src-tauri/src/macos_control.rs`.
+- State: no SQLite — `browser-profiles/` + `browser/{managed-runner,user-attach,runtime}/`, `mac-control/snapshots/` + `mac-control/diagnostics/`. Config: `AppConfig.browser` (`launchCircuit`, `profiles[*]`).
+- Grep: `category IN ('browser','mac_control')`.
+- Gotcha: desktop-only — `mac_control` returns `supported=false` off macOS-Tauri and needs live TCC perms (Accessibility + Screen Recording); start with `action='status'`/`'permissions'`. Browser launch failures → `launch_circuit.rs` trip + 3-tier fallback. Missing `browser:frame`/`mac_control:frame` EventBus frames = capture failed. Stale `el_N`/`ref_id` only valid within their originating snapshot.
+
+### Dashboard / Recap / Awareness — `dashboard.md`, `recap.md`, `behavior-awareness.md`
+
+- Entry: `dashboard/`, `recap/`, `awareness/`, `agent/mod.rs`.
+- State: `recap/recap.db` (rebuildable, keyed by `last_message_ts`), `sessions.db` (`learning_events`), `logs.db`, `cron.db`. Config: `awareness.enabled`/`mode` (hard-gate), `recap.analysisAgent`/`language`.
+- Grep: `category IN ('awareness','recap')`.
+- Gotcha: Dashboard stats must filter `is_cron=0 AND parent_session_id IS NULL`. Awareness short-circuits for incognito sessions (also excluded from stats); digest auto-clears after 3 consecutive side_query failures. `awareness.enabled=false` is a hard-gate that ignores per-session overrides.
+
+### Ask-user / Prompt system / Image generation — `ask-user.md`, `prompt-system.md`, `image-generation.md`
+
+- Entry: `tools/ask_user_question.rs`, `ask_user/questions.rs`, `channel/worker/ask_user.rs`, `system_prompt/build.rs`, `tools/image_generate/`.
+- State: `sessions.db` (`ask_user_questions`). Config: `ask_user_question_timeout_enabled` (default false = wait forever) / `_secs`, `imageGenerate` (ordered `providers[]` = failover priority).
+- Grep: `category='ask_user'`; image generation logs under `category='tool'` (source `image_generate`); IM ask_user uses `category='channel'` with an `ask_user:` prefix.
+- Gotcha: pending ask-user is in-memory (`PENDING_ASK_USER_QUESTIONS` oneshot); startup flips all DB pending→answered, so a DB pending surviving a restart is an orphan (answering returns "No pending request"). Image gen failures return a transparent per-provider `failover_log`.
+
+### Reliability / Security / Sandbox / Platform — `reliability.md`, `security.md`, `sandbox.md`, `platform.md`
+
+- Entry: `guardian.rs`, `self_diagnosis.rs`, `crash_journal.rs`, `security/ssrf.rs`, `security/dangerous.rs`, `platform/mod.rs`, `docker/`.
+- State: `crash_journal.json` (not SQLite), `backups/{ts}/` + `backups/autosave/`. Config: `guardian.enabled`, `dangerous_skip_all_approvals`, `ssrf{}`, `searxng_docker_use_proxy`.
+- Grep: SearXNG / Docker sandbox → `category='sandbox'` (source `docker` / `searxng`); permission decisions → `category='permission'`. Crash recovery / Guardian / `self_diagnosis` have **no** `logs.db` category — read `crash_journal.json` directly (the primary signal).
+- Gotcha: crash/restart loop → read `crash_journal.json` (`crashes[].signal`, last `diagnosis_result`); Guardian does not supervise `server`/`acp`. Dangerous-skip must be checked via `security::dangerous::is_dangerous_skip_active()` (CLI flag OR config), never the raw field. All outbound HTTP must pass `ssrf::check_url`.
+
+### ACP / CLI / Slash commands / Config / Self-update — `acp.md`, `cli.md`, `slash-commands.md`, `config-system.md`, `self-update.md`
+
+- Entry: `acp/agent.rs`, `slash_commands/handlers/`, `config/persistence.rs`, `updater/self_contained.rs`, `tools/app_update.rs`, `src-tauri/src/main.rs`.
+- State: `sessions.db` (ACP shares SessionDB), `config.json`, `credentials/auth.json`. Config: `auto_update.*`, `permission.global_yolo`.
+- Grep: `category IN ('self_update','acp','slash_cmd')`; config writes emit no log but fire the `config:changed` event.
+- Gotcha: "UI save not taking effect until restart" class bugs ← a write that bypassed `mutate_config`. Binary swap must use `platform::atomic_replace_binary` + `--version` smoke test + auto-rollback. `MINISIGN_PUBKEY_BASE64` must equal `tauri.conf.json#plugins.updater.pubkey` or desktop startup panics. Headless auto-update loop only runs when `!is_desktop()`.
 
 ## Self-Study
 
-1. Start with the architecture doc for the subsystem.
+1. Start with the architecture doc for the subsystem (see the Subsystem Reference and `source-map.md`).
 2. Read the source that implements the documented contract.
 3. Prefer public interfaces, command/route adapters, config structs, and tool schemas over isolated helper details.
 4. Explain what happens in desktop and server modes when the behavior crosses transport boundaries.
-5. Call out red lines: config mutation helpers, SSRF checks, provider CRUD helpers, Plan Mode restrictions, and read-only DB rules.
+5. Call out red lines: config mutation helpers, SSRF checks, provider CRUD helpers, failover policies, KB access gating, Plan Mode restrictions, and read-only DB rules.
 
 ## Feature or Improvement Issue
 

--- a/skills/ha-self-diagnosis/references/source-map.md
+++ b/skills/ha-self-diagnosis/references/source-map.md
@@ -1,6 +1,8 @@
 # Hope Agent Source Map
 
-Use this as a fallback map when the live source tree is not available. Prefer live files and `docs/architecture/` whenever possible.
+Use this as a fallback map when the live source tree is not available. Prefer
+live files and `docs/architecture/` whenever possible — the architecture docs
+are the single source of truth and this map only points at them.
 
 ## Runtime Forms
 
@@ -8,50 +10,108 @@ Use this as a fallback map when the live source tree is not available. Prefer li
 - HTTP/WS daemon: `crates/ha-server/`, using axum routes and shared `ha-core`.
 - ACP stdio: `hope-agent acp`, sharing core agent/session/runtime behavior.
 
+Detect the active mode with `ha_core::runtime_role()` / `is_desktop()`.
+
 ## Core Contracts
 
-- Business logic belongs in `crates/ha-core/`; Tauri and server crates are thin adapters.
-- Frontend calls go through `src/lib/transport.ts`; every new command needs Tauri and HTTP implementations.
+- Business logic belongs in `crates/ha-core/` (zero Tauri deps); Tauri and server crates are thin adapters.
+- Frontend calls go through `src/lib/transport.ts`; every new command needs both Tauri and HTTP implementations.
 - State is centered on `CoreState`, SQLite databases under `~/.hope-agent/`, and EventBus broadcasts.
-- Outbound HTTP must pass SSRF checks through `security::ssrf::check_url`.
-- Config writes should use `config::mutate_config`; provider writes should use `provider/crud.rs`.
-- Settings rollback snapshots live under `~/.hope-agent/backups/autosave/`.
+- Config reads use `config::cached_config()`; config writes use `config::mutate_config((category, source), …)` (never manual load+save / `Mutex<AppConfig>`).
+- Provider list / `active_model` writes go through `provider/crud.rs` helpers (never `providers.push`/`retain`).
+- Every LLM request goes through `failover::executor::execute_with_failover` (3 policies); Codex never rotates profiles.
+- Outbound HTTP/WS must pass `security::ssrf::check_url`; never hand-write IP checks.
+- Note/knowledge writes use `crate::platform::write_atomic` (never `fs::write`); secrets use `platform::write_secure_file` (0600).
+- Knowledge-base access is deny-by-default through `effective_kb_access`; owner plane (HTTP/Tauri) and agent plane (`note_*` tools) are physically isolated.
+- HTTP preview-by-path is gated by `authorized_canonical_file_path` — remote callers can never read arbitrary host paths.
+- Tool visibility (`dispatch::resolve_tool_fate`) and execution gating (`permission::engine::resolve_async`) are separate; hiding a tool is never a security boundary.
+- Settings rollback / autosave snapshots live under `~/.hope-agent/backups/autosave/`.
 
 ## Important Directories
 
-- `docs/architecture/`: source of truth for subsystem behavior.
-- `crates/ha-core/src/tools/`: tool definitions and execution handlers.
-- `crates/ha-core/src/chat_engine/`: chat loop, streaming, IM mirror, finalization.
-- `crates/ha-core/src/session/`: session/message/task SQLite persistence.
-- `crates/ha-core/src/channel/`: IM channel plugins, worker, dispatcher, streaming.
-- `crates/ha-core/src/config/`: persisted `AppConfig` and cache/mutation helpers.
-- `crates/ha-core/src/skills/`: skill discovery, prompt catalog, fork helper, authoring.
-- `src/components/settings/`: desktop/web Settings panels.
-- `src/lib/transport-http.ts` and `src/lib/transport-tauri.ts`: frontend transport adapters.
-- `src-tauri/src/commands/`: Tauri command wrappers.
-- `crates/ha-server/src/routes/`: HTTP route wrappers.
+### Backend (`crates/ha-core/src/`)
 
-## Common Architecture Docs
+- `tools/`: tool definitions (`definitions/core_tools.rs`), `dispatch.rs` (visibility), `execution.rs`; `tools/settings.rs` is the `ha-settings` surface; `tools/note.rs`, `tools/browser/`, `tools/canvas/`, `tools/image_generate/`, `tools/ask_user_question.rs`, `tools/app_update.rs`.
+- `chat_engine/`: chat loop (`engine.rs`), streaming sinks, `im_mirror.rs`, `finalize/`, round accumulator.
+- `session/`: session/message/task SQLite (`db.rs`); `artifacts.rs` (workspace aggregation), `helpers.rs` (effective working dir), `subagent_db.rs`.
+- `config/`: persisted `AppConfig`, `cached_config()` / `mutate_config()`, `persistence.rs`.
+- `provider/`: templates, `crud.rs` write helpers, `local.rs` known local backends.
+- `failover/`: `executor.rs` (`execute_with_failover`), profile rotation; `agent/side_query.rs`.
+- `context_compact/`: 5-tier progressive compaction (`compact.rs`), `ContextEngine` / `CompactionProvider`.
+- `memory/` + `memory_extract.rs`: retrieval/extraction (Project > Agent > Global); vec0 gated on `memory_embedding`.
+- `knowledge/`: `service.rs` (owner plane), `access.rs` (`effective_kb_access`), `index.rs`, `search.rs`, `registry.rs`, `sprite/`, `maintenance/`.
+- `channel/`: IM plugins, `worker/` (`dispatcher.rs`, `streaming.rs`, `eviction_watcher.rs`, `ask_user.rs`), `start_watchdog.rs`, `db.rs`.
+- `hooks/`: `mod.rs` (`HookDispatcher::dispatch`), `scopes.rs` (four-layer scope), `runner/`, `matcher.rs`, `decision.rs`, `parse.rs`.
+- `permission/` + `permissions.rs`: unified permission engine v2 (`engine.rs::resolve_async`).
+- `security/`: `ssrf.rs`, `dangerous.rs` (global YOLO / dangerous-skip).
+- `agent/`: `resolver.rs`, `preflight.rs` (`UserPromptSubmit`), `migration.rs`, `side_query.rs`, `context.rs`, KB access resolution.
+- `plan/`: Plan Mode 5-state machine.
+- `subagent/` (`injection.rs`), `team/` (`coordinator.rs`), `cron/` (`scheduler.rs`, `executor.rs`).
+- `dashboard/` (`insights.rs`), `recap/`, `awareness/`: analytics, deep recap, cross-session behavior awareness.
+- `ask_user/`, `system_prompt/` (`build.rs`, `constants.rs`), `skills/` (discovery, authoring, `mention.rs`).
+- `browser/` + `browser_state.rs`, `mac_control.rs`: browser automation (8-action, dual backend) and macOS control.
+- `filesystem/`: `workspace.rs` (`WorkspaceScope`), `ops.rs`.
+- `updater/`: `keys.rs`, `download.rs`, `self_contained.rs`, `auto_check.rs`, `backup.rs`, `staging.rs`.
+- `guardian.rs`, `self_diagnosis.rs`, `crash_journal.rs`: reliability / crash self-heal.
+- `local_llm/` + `local_model_jobs.rs`, `docker/` (SearXNG sandbox), `platform/`, `logging/`, `mcp/`, `acp/`, `slash_commands/`.
 
-- Process and crate boundaries: `process-model.md`, `backend-separation.md`, `transport-modes.md`.
-- Tools and permissions: `tool-system.md`, `permission-system.md`.
-- Skills: `skill-system.md`.
-- Chat and streaming: `chat-engine.md`.
-- Context compaction: `context-compact.md`.
-- Memory: `memory.md`.
-- IM channels: `im-channel.md`.
-- Plan Mode: `plan-mode.md`.
-- MCP: `mcp.md`.
-- Self update: `self-update.md`.
-- Logging: `logging.md`.
-- Self diagnosis and GitHub issue reporting: `self-diagnosis-issue-reporting.md`.
+### Frontend (`src/`)
+
+- `lib/transport.ts`, `lib/transport-tauri.ts`, `lib/transport-http.ts`: transport adapters.
+- `components/chat/`: chat UI, `workspace/` (artifacts panel), `files/` (unified file actions + office preview), `diff-panel/`, `project/file-browser/` (`FilePreviewPane`).
+- `components/settings/`, `components/dashboard/`, `components/cron/`: settings panels and analytics UI.
+
+### Adapters
+
+- `src-tauri/src/commands/`: Tauri command wrappers; registered in `src-tauri/src/lib.rs` `invoke_handler!`.
+- `crates/ha-server/src/routes/` + `router.rs`: HTTP/WS route wrappers.
+
+## Architecture Docs
+
+`docs/architecture/` is the source of truth (see `docs/README.md` and
+`overview.md` for the canonical index). Grouped by area:
+
+### System architecture
+
+- `overview.md` — whole-system map, storage table, module dependencies.
+- `backend-separation.md`, `transport-modes.md`, `process-model.md` — three-crate split, EventBus, run modes, Guardian.
+- `api-reference.md` — Tauri ↔ HTTP command parity.
+
+### Core modules
+
+- `chat-engine.md`, `provider-system.md`, `failover.md`, `side-query.md`, `local-model-loading.md`.
+- `prompt-system.md`, `tool-system.md`, `permission-system.md`, `context-compact.md`.
+- `session.md`, `project.md`, `memory.md`, `knowledge-base.md`.
+
+### Agent capabilities
+
+- `plan-mode.md`, `ask-user.md`, `skill-system.md`, `subagent.md`, `agent-team.md`, `behavior-awareness.md`.
+
+### Access layer
+
+- `im-channel.md`, `acp.md`, `slash-commands.md`, `mcp.md`.
+
+### Infrastructure
+
+- `image-generation.md`, `cron.md`, `sandbox.md`, `dashboard.md`, `recap.md`, `logging.md`.
+- `reliability.md` (Guardian / crash journal), `config-system.md`, `security.md`, `platform.md`.
+- `browser.md`, `macos-control.md`, `canvas.md`, `file-operations.md`, `self-update.md`, `self-diagnosis-issue-reporting.md`.
 
 ## Runtime Databases
 
-- `~/.hope-agent/logs.db`: app logs.
-- `~/.hope-agent/sessions.db`: sessions, messages, tasks, subagent runs, learning events.
-- `~/.hope-agent/async_jobs.db`: async tool jobs.
-- `~/.hope-agent/cron.db`: recurring jobs.
-- `~/.hope-agent/recap/recap.db`: cached recap reports.
+All under `~/.hope-agent/`, centralized in `paths.rs`. **Always open read-only during diagnosis.**
 
-Always open SQLite databases read-only during diagnosis.
+| Database | Purpose |
+|----------|---------|
+| `sessions.db` | Sessions, messages, tasks, `chat_turns`, subagent/ACP/team runs, `learning_events`, `channel_conversations`, `ask_user_questions`, KB registry + access bindings |
+| `memory.db` | Memory entries + FTS5 (`memories_fts`) + vec0 (`memories_vec`) + embedding cache |
+| `knowledge/index.db` | Knowledge-base chunk index (FTS5 + vec0); rebuildable cache — notes' truth is the `.md` files in `knowledge/{id}/notes/` or external vaults |
+| `logs.db` | Structured app logs (query/filter) |
+| `cron.db` | `cron_jobs` + `cron_run_logs` |
+| `async_jobs.db` | Async tool jobs (exec / web_search / image_generate backgrounded) |
+| `local_model_jobs.db` | Local model install / pull background jobs |
+| `local_llm_library_cache.db` | Ollama Library search / tag metadata cache (24h TTL) |
+| `recap/recap.db` | Cached deep-recap reports / facets |
+| `canvas/canvas.db` | `canvas_projects` + `canvas_versions` (orphans persist; no session FK cascade) |
+
+Non-DB state: `config.json` (providers, model chain, global settings), `agents/{id}/agent.json` (per-agent config), `projects/{id}/` (project working dirs / real files), `credentials/` (OAuth + MCP creds, 0600), `plans/`, `channels/`, `attachments/`, `permission/*.json`, `crash_journal.json`, `mac-control/`, `browser-profiles/`.


### PR DESCRIPTION
## 概述

更新 `ha-self-diagnosis` 自查 / 排障技能,使其覆盖近期大量新增子系统;并在 AGENTS.md 立一条「索引同步」契约,防止该技能再次滞后。

## 背景

该技能的 references 是 agent 自查与排障的 **fallback 真相源**——安装包里没有源码、没有 `docs/architecture/`,用户机器上只有技能自带的 references 加 `~/.hope-agent/` 运行时数据。此前内容严重滞后:架构文档索引只列 15 篇(实际 46)、运行时 DB 漏 5 个(含 `memory.db` / `knowledge/index.db`)、重点目录几乎没有近期新增子系统。

## 改动

- **source-map.md**:架构文档索引 15 → 46 篇按 5 类列全;运行时 DB 5 → 10 个权威表(补 `memory.db` / `knowledge/index.db` / `canvas.db` / `local_model_jobs.db` / `local_llm_library_cache.db`,并纠正把 memory 错算进 sessions.db);重点目录补齐 `knowledge/` `hooks/` `browser/` `project/` `updater/` 等;核心 contract 扩到 13 条。
- **diagnostic-playbook.md**:新增 **Subsystem Reference**——12 个子系统各列「架构文档 / 入口模块 / 运行时 DB·config / 可 grep 的 log `category` / 常见故障 gotcha」,排障时可直接定位。
- **SKILL.md**:Diagnostic Sources 的 DB 清单补全 + fallback 措辞修正(指向两个 references)。
- **AGENTS.md**:「文档维护」新增一行表格 + 一条 bullet——新增/删除子系统、`docs/architecture/` 文档、`~/.hope-agent/` 运行时 DB 或稳定 log `category` 时,须同步更新该技能 references。

## 准确性把关

抽取用 12-agent workflow 并行完成,但抽完后**对每个 log `category` 逐个回源码核验**,修正了初稿里 6 处不准:`compact`→`context`、`docker`→`sandbox`、`image_generate`→`tool`,并移除不存在的 `guardian` / `self_diagnosis` / `timeout`(崩溃排障改为直接读 `crash_journal.json`)。28 个引用的模块路径全部确认存在。

## 测试

纯文档改动(skill `.md` + AGENTS.md),无代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
