### PR TITLE
fix: 🦭 v0.10.1 安装版内置技能随包发布

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-06-12
+
+### Fixed
+
+- **修复安装版内置技能不可用**：Office 三件套 / 浏览器 / Mac 控制等随包内置技能此前未被打入桌面安装包，导致安装版里输入框 `@` 提及的「技能」段为空、`skill` 工具与内置斜杠命令也找不到这些技能（开发模式与 Docker 自托管不受影响）。现已将内置技能随安装包发布，安装版可正常使用。
+
 ## [0.10.0] - 2026-06-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3238,7 +3238,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.10.0"
+version = "0.10.1"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.10.0"
+version = "0.10.1"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.10.1.en.md
+++ b/docs/release-notes/v0.10.1.en.md
@@ -1,0 +1,14 @@
+# Hope Agent 0.10.1 — Fix Built-in Skills in Installed Builds
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.10.1/docs/release-notes/v0.10.1.md) · **English**
+
+> Released: 2026-06-12
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.10.1/CHANGELOG.md#0101---2026-06-12) for details.
+
+v0.10.1 is a patch for v0.10.0 that fixes the bundled built-in skills failing to load in the desktop installed build.
+
+## Fixes
+
+- **Built-in skills now work in installed builds**: the bundled skills — the Office trio (Word / PPT / Excel), browser control, and Mac control — were not packaged into the desktop installer, so in an installed build the `@`-mention "Skills" section was empty and the `skill` tool and built-in slash commands couldn't find them either. The built-in skills now ship with the installer, so `@`-mentioning a built-in skill works and the model can invoke them as expected.
+  - Development mode (`pnpm tauri dev`) and Docker self-hosting were not affected by this issue, and this fix doesn't change their behavior.

--- a/docs/release-notes/v0.10.1.md
+++ b/docs/release-notes/v0.10.1.md
@@ -1,0 +1,14 @@
+# Hope Agent 0.10.1 — 修复安装版内置技能
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.10.1/docs/release-notes/v0.10.1.en.md)
+
+> 发布日期：2026-06-12
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.10.1/CHANGELOG.md#0101---2026-06-12)。
+
+v0.10.1 是 v0.10.0 的补丁版，修复了桌面安装版里随包内置技能加载不到的问题。
+
+## 修复
+
+- **安装版内置技能现已可用**：Office 三件套（Word / PPT / Excel）、浏览器控制、Mac 控制等随包内置技能此前没有被打入桌面安装包，导致安装版里输入框 `@` 提及的「技能」段为空，`skill` 工具与内置斜杠命令也找不到这些技能。现已把内置技能随安装包一起发布——安装版输入框 `@` 即可挂载内置技能，模型也能正常调用。
+  - 开发模式（`pnpm tauri dev`）与 Docker 自托管此前不受此问题影响，本次修复对它们无变化。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.10.0"
+version = "0.10.1"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -8,6 +8,29 @@ use std::sync::Arc;
 pub(crate) fn app_setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // Store global AppHandle for event emission
     let _ = APP_HANDLE.set(app.handle().clone());
+
+    // Bundled skills ship as a Tauri resource (`bundle.resources` → `skills/`).
+    // ha-core's skill resolver finds the bundled dir from this env override
+    // first, so point it at the real on-disk resource location. This is robust
+    // across the differing per-platform layouts (macOS `Contents/Resources`,
+    // Linux `/usr/lib/<app>`, Windows next to the exe) that the resolver's
+    // `current_exe()` heuristic can't reliably cover. Without it, packaged
+    // builds find no bundled skills and the `@skill` menu / skill tool / office
+    // + browser + mac-control skills all come up empty. Set before any skill
+    // access (the first lands via frontend commands, after `.setup()`). Guarded
+    // on `is_dir()` so `tauri dev` (resources not staged) falls through to the
+    // debug-only workspace-root fallback.
+    {
+        use tauri::Manager;
+        if let Ok(skills_dir) = app
+            .path()
+            .resolve("skills", tauri::path::BaseDirectory::Resource)
+        {
+            if skills_dir.is_dir() {
+                std::env::set_var("HOPE_AGENT_BUNDLED_SKILLS_DIR", &skills_dir);
+            }
+        }
+    }
     if cfg!(debug_assertions) {
         app.handle().plugin(
             tauri_plugin_log::Builder::default()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",
@@ -46,6 +46,9 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
+    "resources": {
+      "../skills": "skills"
+    },
     "shortDescription": "Local-first AI assistant with cross-device sessions and IM channel routing",
     "longDescription": "Hope Agent is a local-first AI assistant desktop app. Sessions hand off seamlessly across your devices and chats; memory accumulates over time and recurring work crystallizes into reusable skills. The single binary runs in three modes: desktop GUI, HTTP/WS daemon for headless deployment, and ACP stdio for IDE integrations. Built-in templates for mainstream LLM providers (Anthropic, OpenAI, Codex, plus local LLM via Ollama) cover the typical setup with a paste-the-API-key flow; IM channel integration covers Slack, Discord, Telegram, Feishu, WhatsApp, LINE, and more.",
     "icon": [

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -2,7 +2,10 @@
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
     "targets": ["nsis"],
-    "resources": ["resources/vc_redist.x64.exe"],
+    "resources": {
+      "resources/vc_redist.x64.exe": "resources/vc_redist.x64.exe",
+      "../skills": "skills"
+    },
     "windows": {
       "nsis": {
         "installerHooks": "./windows/installer-hooks.nsh"


### PR DESCRIPTION
## 问题

v0.10.0 是首个含 `@` 提及内置技能的**打包版**。桌面安装包此前从未把 `skills/` 打入 `bundle.resources`，release 构建又关掉了 dev 的 `#[cfg(debug_assertions)]` workspace 兜底，导致 `bundled_skills_dir()` 返回 `None`——安装版里 Office 三件套 / 浏览器 / Mac 控制等内置技能全部加载不到：`@` 提及技能段为空、`skill` 工具与内置斜杠命令也找不到。

> 这是 0.1.0 以来桌面安装版的潜伏问题，因 dev / Docker（显式 set 了 `HOPE_AGENT_BUNDLED_SKILLS_DIR`）始终可用、且 skill 缺失静默降级而长期未暴露；`@` 提及是第一个把它摆到用户面前的入口。

## 修复

- `tauri.conf.json` + `tauri.windows.conf.json`：`skills/` 加入 `bundle.resources`
- `setup.rs`：启动早期用 Tauri 资源路径解析出 skills 目录并 set `HOPE_AGENT_BUNDLED_SKILLS_DIR`，让 ha-core resolver 跨平台稳定命中（不依赖各平台 exe 布局；macOS 的 `../Resources/skills` 启发式也已能命中，双保险）

## 验证

本地 `pnpm tauri build --bundles app` → `Hope Agent.app/Contents/Resources/skills/` 含全部 **22 个**内置技能（office-docx/pptx/xlsx · ha-browser · ha-mac-control 等齐全）。

Release notes：[docs/release-notes/v0.10.1.md](docs/release-notes/v0.10.1.md)。合并后 cherry-pick 回 main。