### PR TITLE
fix: 🦭 安装版内置技能随包发布（backport #310 to main）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-06-12
+
+### Fixed
+
+- **修复安装版内置技能不可用**：Office 三件套 / 浏览器 / Mac 控制等随包内置技能此前未被打入桌面安装包，导致安装版里输入框 `@` 提及的「技能」段为空、`skill` 工具与内置斜杠命令也找不到这些技能（开发模式与 Docker 自托管不受影响）。现已将内置技能随安装包发布，安装版可正常使用。
+
 ## [0.10.0] - 2026-06-12
 
 ### Added

--- a/docs/release-notes/v0.10.1.en.md
+++ b/docs/release-notes/v0.10.1.en.md
@@ -1,0 +1,14 @@
+# Hope Agent 0.10.1 — Fix Built-in Skills in Installed Builds
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.10.1/docs/release-notes/v0.10.1.md) · **English**
+
+> Released: 2026-06-12
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.10.1/CHANGELOG.md#0101---2026-06-12) for details.
+
+v0.10.1 is a patch for v0.10.0 that fixes the bundled built-in skills failing to load in the desktop installed build.
+
+## Fixes
+
+- **Built-in skills now work in installed builds**: the bundled skills — the Office trio (Word / PPT / Excel), browser control, and Mac control — were not packaged into the desktop installer, so in an installed build the `@`-mention "Skills" section was empty and the `skill` tool and built-in slash commands couldn't find them either. The built-in skills now ship with the installer, so `@`-mentioning a built-in skill works and the model can invoke them as expected.
+  - Development mode (`pnpm tauri dev`) and Docker self-hosting were not affected by this issue, and this fix doesn't change their behavior.

--- a/docs/release-notes/v0.10.1.md
+++ b/docs/release-notes/v0.10.1.md
@@ -1,0 +1,14 @@
+# Hope Agent 0.10.1 — 修复安装版内置技能
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.10.1/docs/release-notes/v0.10.1.en.md)
+
+> 发布日期：2026-06-12
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.10.1/CHANGELOG.md#0101---2026-06-12)。
+
+v0.10.1 是 v0.10.0 的补丁版，修复了桌面安装版里随包内置技能加载不到的问题。
+
+## 修复
+
+- **安装版内置技能现已可用**：Office 三件套（Word / PPT / Excel）、浏览器控制、Mac 控制等随包内置技能此前没有被打入桌面安装包，导致安装版里输入框 `@` 提及的「技能」段为空，`skill` 工具与内置斜杠命令也找不到这些技能。现已把内置技能随安装包一起发布——安装版输入框 `@` 即可挂载内置技能，模型也能正常调用。
+  - 开发模式（`pnpm tauri dev`）与 Docker 自托管此前不受此问题影响，本次修复对它们无变化。

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -8,6 +8,29 @@ use std::sync::Arc;
 pub(crate) fn app_setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     // Store global AppHandle for event emission
     let _ = APP_HANDLE.set(app.handle().clone());
+
+    // Bundled skills ship as a Tauri resource (`bundle.resources` → `skills/`).
+    // ha-core's skill resolver finds the bundled dir from this env override
+    // first, so point it at the real on-disk resource location. This is robust
+    // across the differing per-platform layouts (macOS `Contents/Resources`,
+    // Linux `/usr/lib/<app>`, Windows next to the exe) that the resolver's
+    // `current_exe()` heuristic can't reliably cover. Without it, packaged
+    // builds find no bundled skills and the `@skill` menu / skill tool / office
+    // + browser + mac-control skills all come up empty. Set before any skill
+    // access (the first lands via frontend commands, after `.setup()`). Guarded
+    // on `is_dir()` so `tauri dev` (resources not staged) falls through to the
+    // debug-only workspace-root fallback.
+    {
+        use tauri::Manager;
+        if let Ok(skills_dir) = app
+            .path()
+            .resolve("skills", tauri::path::BaseDirectory::Resource)
+        {
+            if skills_dir.is_dir() {
+                std::env::set_var("HOPE_AGENT_BUNDLED_SKILLS_DIR", &skills_dir);
+            }
+        }
+    }
     if cfg!(debug_assertions) {
         app.handle().plugin(
             tauri_plugin_log::Builder::default()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,6 +46,9 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": "all",
+    "resources": {
+      "../skills": "skills"
+    },
     "shortDescription": "Local-first AI assistant with cross-device sessions and IM channel routing",
     "longDescription": "Hope Agent is a local-first AI assistant desktop app. Sessions hand off seamlessly across your devices and chats; memory accumulates over time and recurring work crystallizes into reusable skills. The single binary runs in three modes: desktop GUI, HTTP/WS daemon for headless deployment, and ACP stdio for IDE integrations. Built-in templates for mainstream LLM providers (Anthropic, OpenAI, Codex, plus local LLM via Ollama) cover the typical setup with a paste-the-API-key flow; IM channel integration covers Slack, Discord, Telegram, Feishu, WhatsApp, LINE, and more.",
     "icon": [

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -2,7 +2,10 @@
   "$schema": "https://schema.tauri.app/config/2",
   "bundle": {
     "targets": ["nsis"],
-    "resources": ["resources/vc_redist.x64.exe"],
+    "resources": {
+      "resources/vc_redist.x64.exe": "resources/vc_redist.x64.exe",
+      "../skills": "skills"
+    },
     "windows": {
       "nsis": {
         "installerHooks": "./windows/installer-hooks.nsh"


### PR DESCRIPTION
cherry-pick 自 `release/v0.10` #310（v0.10.1 修复），把内置技能随包发布的修复回种 main，避免下个 minor 回归。

## 内容
- `tauri.conf.json` + `tauri.windows.conf.json`：`skills/` 加入 `bundle.resources`
- `setup.rs`：启动期 set `HOPE_AGENT_BUNDLED_SKILLS_DIR` 让 ha-core resolver 跨平台命中
- CHANGELOG `[0.10.1]` 段 + 双语 release notes（历史记录）

## 与 #310 的差异
**main 版本号保持 0.10.0 不降到 patch 线**——已还原 `package.json` / `Cargo.toml` ×3 / `Cargo.lock` / `tauri.conf.json#version`，仅保留代码修复 + 文档。`release:verify` = 0.10.0。

修复已在本地 `tauri build` 验证（`.app/Contents/Resources/skills` 含全部 22 个内置技能）。