### PR TITLE
fix: 🦭 修复 macOS 唤醒后空事件帧引发的整页崩溃，前端崩溃接入应用日志

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] - 2026-06-14
+
+### Fixed
+
+- **修复 macOS 睡眠 / 锁屏一段时间唤醒后偶发整页崩溃**：唤醒后个别后台事件帧为空，会击穿界面渲染弹出「undefined is not an object」错误页（需点 Try Again 才能恢复）；现已在事件解析入口统一拦截空 / 异常帧，并把这类前端崩溃记入应用日志便于后续自查。 (#319)
+
 ## [0.10.2] - 2026-06-13
 
 ### Added

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -198,6 +198,7 @@ export default function App() {
 
     const handleSnapshot = (raw: unknown) => {
       const job = parsePayload<LocalModelJobSnapshot>(raw)
+      if (!job) return
       // Reembed / reindex jobs aren't installs — their progress + completion is
       // shown in the memory / knowledge panels. Skip the install-flavored global
       // toast ("{model} 已安装" / "安装失败" 等), which only fits model installs.
@@ -244,6 +245,7 @@ export default function App() {
         outcome?: string
         skill_id?: string | null
       }>(raw)
+      if (!report) return
       if (report.outcome !== "created") return
       const name = report.skill_id || t("skills.toast.unnamedSkill")
       toast.info(t("skills.toast.draftCreated", { name }), {
@@ -263,6 +265,7 @@ export default function App() {
   useEffect(() => {
     const handler = (raw: unknown) => {
       const payload = parsePayload<{ message?: string }>(raw)
+      if (!payload) return
       if (payload.message) toast.info(payload.message)
     }
     const unlisten = getTransport().listen("hook:status", handler)

--- a/src/components/chat/CanvasPanel.tsx
+++ b/src/components/chat/CanvasPanel.tsx
@@ -178,6 +178,7 @@ export default function CanvasPanel({
       getTransport().listen("canvas_show", (raw) => {
         try {
           const data = parsePayload<CanvasShowPayload>(raw)
+          if (!data) return
           // Drop events from other sessions (e.g. cron / IM / subagent tool
           // calls). Older payloads without sessionId still pass through.
           if (data.sessionId && data.sessionId !== currentSessionIdRef.current) {
@@ -208,6 +209,7 @@ export default function CanvasPanel({
       getTransport().listen("canvas_reload", (raw) => {
         try {
           const data = parsePayload<{ projectId: string }>(raw)
+          if (!data) return
           // If it's the current canvas, refresh
           setCanvas((prev) => {
             if (prev && prev.projectId === data.projectId) {
@@ -235,6 +237,7 @@ export default function CanvasPanel({
       getTransport().listen("canvas_deleted", (raw) => {
         try {
           const data = parsePayload<{ projectId: string }>(raw)
+          if (!data) return
           setCanvas((prev) => {
             if (prev && prev.projectId === data.projectId) {
               return null
@@ -252,6 +255,7 @@ export default function CanvasPanel({
       getTransport().listen("canvas_snapshot_request", (raw) => {
         try {
           const data = parsePayload<{ requestId: string }>(raw)
+          if (!data) return
           handleSnapshotRequest(data.requestId)
         } catch {
           /* ignore */
@@ -264,6 +268,7 @@ export default function CanvasPanel({
       getTransport().listen("canvas_eval_request", (raw) => {
         try {
           const data = parsePayload<{ requestId: string; code: string }>(raw)
+          if (!data) return
           handleEvalRequest(data.requestId, data.code)
         } catch {
           /* ignore */

--- a/src/components/chat/hooks/useApprovals.ts
+++ b/src/components/chat/hooks/useApprovals.ts
@@ -27,7 +27,9 @@ export function useApprovals(currentSessionId: string | null): UseApprovalsRetur
   useEffect(() => {
     return getTransport().listen("approval_required", (raw) => {
       try {
-        setAllApprovalRequests((prev) => [...prev, parsePayload<ApprovalRequest>(raw)])
+        const req = parsePayload<ApprovalRequest>(raw)
+        if (!req) return
+        setAllApprovalRequests((prev) => [...prev, req])
       } catch (e) {
         logger.error("ui", "ChatScreen::approval", "Failed to parse approval request", e)
       }
@@ -40,6 +42,7 @@ export function useApprovals(currentSessionId: string | null): UseApprovalsRetur
     return getTransport().listen("approval_timed_out", (raw) => {
       try {
         const payload = parsePayload<{ request_id?: string; requestId?: string }>(raw)
+        if (!payload) return
         const requestId = payload.request_id ?? payload.requestId
         if (!requestId) return
         setAllApprovalRequests((prev) => prev.filter((r) => r.request_id !== requestId))

--- a/src/components/chat/plan-mode/usePlanMode.ts
+++ b/src/components/chat/plan-mode/usePlanMode.ts
@@ -314,6 +314,7 @@ export function usePlanMode(
     const handler = (raw: unknown) => {
       try {
         const group = parsePayload<AskUserQuestionGroup>(raw)
+        if (!group) return
         if (group.sessionId !== currentSessionId) return
         setPendingQuestionGroup(group)
       } catch {
@@ -329,6 +330,7 @@ export function usePlanMode(
     return getTransport().listen("ask_user_timed_out", (raw) => {
       try {
         const payload = parsePayload<{ requestId?: string; sessionId?: string }>(raw)
+        if (!payload) return
         if (payload.sessionId !== currentSessionId) return
         setPendingQuestionGroup((prev) =>
           prev?.requestId === payload.requestId ? null : prev,

--- a/src/components/chat/tasks/TaskProgressPanel.tsx
+++ b/src/components/chat/tasks/TaskProgressPanel.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, ChevronRight, CirclePause, ListChecks, PanelRight, Trash2 
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { getTransport } from "@/lib/transport-provider"
+import { logger } from "@/lib/logger"
 import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import { IconTip } from "@/components/ui/tooltip"
 import type { Task, TaskStatus } from "@/types/chat"
@@ -59,7 +60,7 @@ export default function TaskProgressPanel({
     try {
       await op()
     } catch (err) {
-      console.warn(`[TaskProgressPanel] ${label} failed`, err)
+      logger.warn("chat", "TaskProgressPanel::withBusy", `${label} failed`, err)
     } finally {
       setBusyIds((prev) => {
         const next = new Set(prev)

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { useTranslation } from "react-i18next"
+import { logger } from "@/lib/logger"
 
 interface ErrorBoundaryState {
   hasError: boolean
@@ -21,7 +22,14 @@ class ErrorBoundaryInner extends React.Component<
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo) {
-    console.error("[ErrorBoundary]", error, info.componentStack)
+    // Surface React render crashes into the unified backend log
+    // (`~/.hope-agent/logs.db`) so they're self-diagnosable — the bare
+    // `console.error` only reached the renderer devtools and was lost.
+    // `logger.error` still mirrors to console for dev convenience.
+    logger.error("ui", "ErrorBoundary::componentDidCatch", error.message, {
+      stack: error.stack,
+      componentStack: info.componentStack,
+    })
   }
 
   handleReset = () => {

--- a/src/components/common/StarrySky.tsx
+++ b/src/components/common/StarrySky.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, memo } from "react"
 import { getTransport } from "@/lib/transport-provider"
 import { parsePayload } from "@/lib/transport"
+import { logger } from "@/lib/logger"
 import { classifyWeather, generatePoints } from "./weatherUtils"
 import type { WeatherData } from "./weatherUtils"
 import WeatherCanvas from "./WeatherCanvas"
@@ -87,7 +88,7 @@ function AppBackgroundInner() {
           }
         }
       } catch (e) {
-        console.error("Failed to load background effects data", e)
+        logger.error("ui", "AppBackground::loadData", "Failed to load background effects data", e)
       }
     }
     loadData()

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -1,4 +1,5 @@
 import { formatBytes as formatBytesRaw } from "@/lib/format"
+import { logger } from "@/lib/logger"
 
 export interface DashboardFilter {
   startDate: string | null
@@ -357,8 +358,10 @@ export function chartNumber(value: unknown): number {
       const key = value.length === 0 ? "empty" : typeof value[0]
       if (!chartNumberArrayWarned.has(key)) {
         chartNumberArrayWarned.add(key)
-        console.warn(
-          "[dashboard] chartNumber received an array — only first element is used. " +
+        logger.warn(
+          "dashboard",
+          "types::chartNumber",
+          "chartNumber received an array — only first element is used. " +
             "Stacked tooltips need a dedicated formatter.",
           value,
         )

--- a/src/components/knowledge/KnowledgeGraphView.tsx
+++ b/src/components/knowledge/KnowledgeGraphView.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next"
 import ForceGraph2D, { type ForceGraphMethods } from "react-force-graph-2d"
 
 import { IconTip } from "@/components/ui/tooltip"
+import { logger } from "@/lib/logger"
 import { getTransport } from "@/lib/transport-provider"
 import type { GraphNodePosition, KnowledgeGraph } from "@/types/knowledge"
 
@@ -93,7 +94,7 @@ export default function KnowledgeGraphView({
         if (alive) setFetched({ kbId, refreshKey, graph: g, layout: layout ?? [] })
       })
       .catch((e) => {
-        console.error("kb_graph fetch failed", e)
+        logger.error("knowledge", "KnowledgeGraphView::fetchGraph", "kb_graph fetch failed", e)
         if (alive) {
           setFetched({
             kbId,
@@ -191,7 +192,7 @@ export default function KnowledgeGraphView({
       }
       getTransport()
         .call("kb_graph_layout_save_cmd", { kbId, positions })
-        .catch((e) => console.error("kb_graph_layout save failed", e))
+        .catch((e) => logger.error("knowledge", "KnowledgeGraphView::persistLayout", "kb_graph_layout save failed", e))
     }, SAVE_DEBOUNCE_MS)
   }, [kbId])
 
@@ -219,7 +220,7 @@ export default function KnowledgeGraphView({
     setFetched((prev) => (prev ? { ...prev, layout: [] } : prev))
     getTransport()
       .call("kb_graph_layout_save_cmd", { kbId, positions: [] })
-      .catch((e) => console.error("kb_graph_layout reset failed", e))
+      .catch((e) => logger.error("knowledge", "KnowledgeGraphView::handleReset", "kb_graph_layout reset failed", e))
   }, [kbId])
 
   const nodePaint = useCallback(

--- a/src/components/knowledge/KnowledgeJobsButton.tsx
+++ b/src/components/knowledge/KnowledgeJobsButton.tsx
@@ -108,7 +108,11 @@ export default function KnowledgeJobsButton() {
   // never synchronously in the effect body (no cascading render).
   useEffect(() => {
     void refresh()
-    const onSnap = (raw: unknown) => upsert(parsePayload<LocalModelJobSnapshot>(raw))
+    const onSnap = (raw: unknown) => {
+      const job = parsePayload<LocalModelJobSnapshot>(raw)
+      if (!job) return
+      upsert(job)
+    }
     const un1 = getTransport().listen(LOCAL_MODEL_JOB_EVENTS.created, onSnap)
     const un2 = getTransport().listen(LOCAL_MODEL_JOB_EVENTS.updated, onSnap)
     const un3 = getTransport().listen(LOCAL_MODEL_JOB_EVENTS.completed, onSnap)

--- a/src/components/knowledge/KnowledgeView.tsx
+++ b/src/components/knowledge/KnowledgeView.tsx
@@ -61,6 +61,7 @@ import { Switch } from "@/components/ui/switch"
 import { IconTip } from "@/components/ui/tooltip"
 import ServerDirectoryBrowser from "@/components/chat/input/ServerDirectoryBrowser"
 import { useDirectoryPicker } from "@/components/chat/input/useDirectoryPicker"
+import { logger } from "@/lib/logger"
 import { isTauriMode } from "@/lib/transport"
 import { getTransport } from "@/lib/transport-provider"
 import { cn } from "@/lib/utils"
@@ -500,7 +501,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
           : (list.find((k) => !k.archived)?.id ?? list[0]?.id ?? null),
       )
     } catch (e) {
-      console.error("list_kbs failed", e)
+      logger.error("knowledge", "KnowledgeView::loadKbs", "list_kbs failed", e)
     }
   }, [tx, includeArchived])
 
@@ -510,7 +511,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         const list = await tx.call<Note[]>("list_kb_notes_cmd", { kbId })
         setNotes(list)
       } catch (e) {
-        console.error("list_kb_notes failed", e)
+        logger.error("knowledge", "KnowledgeView::loadNotes", "list_kb_notes failed", e)
         setNotes([])
       }
     },
@@ -522,7 +523,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
       try {
         setDirs(await tx.call<string[]>("kb_list_dirs_cmd", { kbId }))
       } catch (e) {
-        console.error("kb_list_dirs failed", e)
+        logger.error("knowledge", "KnowledgeView::loadDirs", "kb_list_dirs failed", e)
         setDirs([])
       }
     },
@@ -535,7 +536,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
       try {
         setKbTags(await tx.call<string[]>("kb_list_tags_cmd", { kbId }))
       } catch (e) {
-        console.error("kb_list_tags failed", e)
+        logger.error("knowledge", "KnowledgeView::loadTags", "kb_list_tags failed", e)
         setKbTags([])
       }
     },
@@ -567,7 +568,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         setRevealTarget(reveal ? { ...reveal } : null)
         resumeNavRef.current = null // drop any stale parked nav from a prior draft
       } catch (e) {
-        console.error("kb_note_read failed", e)
+        logger.error("knowledge", "KnowledgeView::openNote", "kb_note_read failed", e)
       }
     },
     [tx],
@@ -809,7 +810,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
       setTimeout(() => setSaveStatus("idle"), 2000)
       return true
     } catch (e) {
-      console.error("kb_note_save failed", e)
+      logger.error("knowledge", "KnowledgeView::handleSave", "kb_note_save failed", e)
       if (isRemoteWriteBlocked(e))
         toast.error(t("knowledge.remoteWritesDisabled", "Remote file writing is off."))
       setSaving(false)
@@ -833,7 +834,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
       })
       setHits(res)
     } catch (e) {
-      console.error("kb_search failed", e)
+      logger.error("knowledge", "KnowledgeView::runSearch", "kb_search failed", e)
     }
   }, [tx, query, activeKbId])
 
@@ -851,7 +852,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
       await loadKbs()
       setActiveKbId(kb.id)
     } catch (e) {
-      console.error("create_kb failed", e)
+      logger.error("knowledge", "KnowledgeView::createKb", "create_kb failed", e)
     } finally {
       setKbBusy(false)
     }
@@ -926,7 +927,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         resume?.()
         return true
       } catch (e) {
-        console.error("create note failed", e)
+        logger.error("knowledge", "KnowledgeView::commitDraft", "create note failed", e)
         if (isRemoteWriteBlocked(e))
           toast.error(t("knowledge.remoteWritesDisabled", "Remote file writing is off."))
         setSaving(false)
@@ -969,7 +970,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         await loadNotes(activeKbId)
         await openNote(activeKbId, p)
       } catch (e) {
-        console.error("create note from link failed", e)
+        logger.error("knowledge", "KnowledgeView::createNoteFromRef", "create note from link failed", e)
         if (isRemoteWriteBlocked(e))
           toast.error(t("knowledge.remoteWritesDisabled", "Remote file writing is off."))
       }
@@ -1005,7 +1006,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
       // Surface spawn failures (e.g. vector search on but no embedding model
       // configured) instead of silently swallowing them — otherwise the click
       // looks dead.
-      console.error("reindex failed", e)
+      logger.error("knowledge", "KnowledgeView::reindex", "reindex failed", e)
       toast.error(String(e))
     }
   }, [tx, activeKbId])
@@ -1089,7 +1090,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         if (outcome.linksRewritten > 0)
           toast.success(t("knowledge.linksRewritten", { count: outcome.linksRewritten }))
       } catch (e) {
-        console.error("rename note failed", e)
+        logger.error("knowledge", "KnowledgeView::renameNote", "rename note failed", e)
         toast.error(
           isRemoteWriteBlocked(e)
             ? t("knowledge.remoteWritesDisabled", "Remote file writing is off.")
@@ -1112,7 +1113,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         }
         await loadNotes(activeKbId)
       } catch (e) {
-        console.error("delete note failed", e)
+        logger.error("knowledge", "KnowledgeView::deleteNote", "delete note failed", e)
         if (isRemoteWriteBlocked(e))
           toast.error(t("knowledge.remoteWritesDisabled", "Remote file writing is off."))
       } finally {
@@ -1131,7 +1132,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         const abs = await tx.call<string>("kb_file_resolve_cmd", { kbId: activeKbId, path: rel })
         await tx.call("reveal_in_folder", { path: abs })
       } catch (e) {
-        console.error("reveal note failed", e)
+        logger.error("knowledge", "KnowledgeView::revealNote", "reveal note failed", e)
       }
     },
     [tx, activeKbId, isLocal],
@@ -1172,7 +1173,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
             : cur,
         )
       } catch (e) {
-        console.error("rename/move folder failed", e)
+        logger.error("knowledge", "KnowledgeView::applyFolderMove", "rename/move folder failed", e)
         toast.error(
           isRemoteWriteBlocked(e)
             ? t("knowledge.remoteWritesDisabled", "Remote file writing is off.")
@@ -1222,7 +1223,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         setDraftFolder((cur) => (cur === path || cur.startsWith(`${path}/`) ? "" : cur))
         await Promise.all([loadNotes(activeKbId), loadDirs(activeKbId)])
       } catch (e) {
-        console.error("delete folder failed", e)
+        logger.error("knowledge", "KnowledgeView::deleteFolder", "delete folder failed", e)
         toast.error(
           isRemoteWriteBlocked(e)
             ? t("knowledge.remoteWritesDisabled", "Remote file writing is off.")
@@ -1265,7 +1266,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
       setEditKb(null)
       await loadKbs()
     } catch (e) {
-      console.error("update kb failed", e)
+      logger.error("knowledge", "KnowledgeView::saveEditKb", "update kb failed", e)
     } finally {
       setKbBusy(false)
     }
@@ -1277,7 +1278,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         await tx.call("update_kb_cmd", { id: kb.id, patch: { archived: !kb.archived } })
         await loadKbs()
       } catch (e) {
-        console.error("archive kb failed", e)
+        logger.error("knowledge", "KnowledgeView::toggleArchiveKb", "archive kb failed", e)
       }
     },
     [tx, loadKbs],
@@ -1300,7 +1301,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
       setDeleteKb(null)
       await loadKbs()
     } catch (e) {
-      console.error("delete kb failed", e)
+      logger.error("knowledge", "KnowledgeView::deleteKbConfirm", "delete kb failed", e)
     }
   }, [tx, deleteKb, activeKbId, loadKbs])
 
@@ -1414,7 +1415,7 @@ export default function KnowledgeView({ onBack, onOpenSettings }: KnowledgeViewP
         await tx.call("kb_mkdir_cmd", { kbId: activeKbId, path: folder })
         await loadDirs(activeKbId)
       } catch (e) {
-        console.error("mkdir failed", e)
+        logger.error("knowledge", "KnowledgeView::confirmNewFolder", "mkdir failed", e)
         toast.error(
           isRemoteWriteBlocked(e)
             ? t("knowledge.remoteWritesDisabled", "Remote file writing is off.")

--- a/src/components/knowledge/noteRefFetch.ts
+++ b/src/components/knowledge/noteRefFetch.ts
@@ -5,6 +5,7 @@
 // Keyed by `kbId::normalizedRef`; the whole map clears when `bust` advances (a
 // knowledge:changed tick) so edits to referenced notes show through.
 
+import { logger } from "@/lib/logger"
 import { getTransport } from "@/lib/transport-provider"
 import type { NoteReadResult } from "@/types/knowledge"
 
@@ -27,7 +28,7 @@ export function fetchNoteRef(
     p = tx
       .call<NoteReadResult | null>("kb_note_read_ref_cmd", { kbId, reference })
       .catch((e) => {
-        console.error("kb_note_read_ref failed", e)
+        logger.error("knowledge", "noteRefFetch::fetchNoteRef", "kb_note_read_ref failed", e)
         // Don't pin a transient transport failure as a permanent broken ref —
         // drop the entry so the next access retries. A successful null (genuinely
         // unresolved ref) stays cached.

--- a/src/components/settings/channel-panel/WeChatConnectSection.tsx
+++ b/src/components/settings/channel-panel/WeChatConnectSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 import { getTransport } from "@/lib/transport-provider"
+import { logger } from "@/lib/logger"
 import { QRCodeSVG } from "qrcode.react"
 import { Button } from "@/components/ui/button"
 import { Label } from "@/components/ui/label"
@@ -111,7 +112,7 @@ export default function WeChatConnectSection({
       const result = await getTransport().call<WeChatLoginStartResult>("channel_wechat_start_login", {
         accountId: accountId ?? null,
       })
-      console.log("[WeChat Login] start_login result:", {
+      logger.info("channel", "WeChatConnectSection::handleStart", "start_login result", {
         qrcodeUrl: result.qrcodeUrl ? `${result.qrcodeUrl.substring(0, 80)}... (${result.qrcodeUrl.length} chars)` : null,
         sessionKey: result.sessionKey,
         message: result.message,

--- a/src/components/settings/local-llm/LocalLlmAssistantCard.tsx
+++ b/src/components/settings/local-llm/LocalLlmAssistantCard.tsx
@@ -261,6 +261,7 @@ export default function LocalLlmAssistantCard({
   useEffect(() => {
     const handleSnapshot = (raw: unknown) => {
       const job = parsePayload<LocalModelJobSnapshot>(raw)
+      if (!job) return
       setCurrentJob((current) => {
         if (current?.jobId !== job.jobId) return current
         setDialogFrame(localModelJobToProgressFrame(job, phaseLabel))
@@ -273,6 +274,7 @@ export default function LocalLlmAssistantCard({
 
     const handleLog = (raw: unknown) => {
       const entry = parsePayload<LocalModelJobLogEntry>(raw)
+      if (!entry) return
       setCurrentJob((current) => {
         if (current?.jobId !== entry.jobId) return current
         appendDialogLog(entry.message, entry.createdAt)

--- a/src/components/settings/local-llm/LocalModelsPanel.tsx
+++ b/src/components/settings/local-llm/LocalModelsPanel.tsx
@@ -468,6 +468,7 @@ export default function LocalModelsPanel() {
   useEffect(() => {
     const handleSnapshot = (raw: unknown) => {
       const job = parsePayload<LocalModelJobSnapshot>(raw)
+      if (!job) return
       if (clearAfterCancelJobIdsRef.current.has(job.jobId) && isLocalModelJobTerminal(job)) {
         void clearJobRecord(job.jobId).catch((e) => {
           logger.warn("local-llm", "LocalModelsPanel::clearCancelledJob", "Failed to clear cancelled job", {
@@ -503,6 +504,7 @@ export default function LocalModelsPanel() {
     }
     const handleLog = (raw: unknown) => {
       const entry = parsePayload<LocalModelJobLogEntry>(raw)
+      if (!entry) return
       setCurrentJob((current) => {
         if (current?.jobId !== entry.jobId) return current
         appendDialogLog(entry.message, entry.createdAt)

--- a/src/components/settings/memory-panel/LocalEmbeddingAssistantCard.tsx
+++ b/src/components/settings/memory-panel/LocalEmbeddingAssistantCard.tsx
@@ -251,6 +251,7 @@ export default function LocalEmbeddingAssistantCard({
   useEffect(() => {
     const handleSnapshot = (raw: unknown) => {
       const job = parsePayload<LocalModelJobSnapshot>(raw)
+      if (!job) return
       // 顶层 fire：接力把 currentJob 从 pull 切到 reembed 后，pull.completed 经
       // setCurrentJob 不匹配会丢 result。handleTerminalJob 内部 ownedJobIdsRef +
       // handledCompletedJobs 去重，重复调用安全。
@@ -285,6 +286,7 @@ export default function LocalEmbeddingAssistantCard({
 
     const handleLog = (raw: unknown) => {
       const entry = parsePayload<LocalModelJobLogEntry>(raw)
+      if (!entry) return
       setCurrentJob((current) => {
         if (current?.jobId !== entry.jobId) return current
         appendDialogLog(entry.message, entry.createdAt)

--- a/src/components/settings/memory-panel/useMemoryData.ts
+++ b/src/components/settings/memory-panel/useMemoryData.ts
@@ -97,6 +97,7 @@ export function useMemoryData({ agentId, isAgentMode }: UseMemoryDataParams) {
 
     const handleSnapshot = (raw: unknown): LocalModelJobSnapshot | null => {
       const job = parsePayload<LocalModelJobSnapshot>(raw)
+      if (!job) return null
       if (job.kind !== "memory_reembed") return null
       setReembedJob((current) => {
         // Pick the snapshot we want to track: a new spawn replaces a terminal

--- a/src/components/settings/web-search-panel/SearxngDocker.tsx
+++ b/src/components/settings/web-search-panel/SearxngDocker.tsx
@@ -116,6 +116,7 @@ export function SearxngDockerSection({
 
     const handleProgress = (raw: unknown) => {
       const parsed = parsePayload<{ step?: string; log?: string }>(raw)
+      if (!parsed) return
       if (parsed.step) setDeployStep(parsed.step)
       if (parsed.log) setDeployLogs((prev) => [...prev.slice(-50), parsed.log!])
     }

--- a/src/components/tasks/TaskCenterView.tsx
+++ b/src/components/tasks/TaskCenterView.tsx
@@ -108,10 +108,13 @@ export default function TaskCenterView({ onBack }: { onBack: () => void }) {
 
   useEffect(() => {
     const onSnapshot = (raw: unknown) => {
-      upsertJob(parsePayload<LocalModelJobSnapshot>(raw))
+      const job = parsePayload<LocalModelJobSnapshot>(raw)
+      if (!job) return
+      upsertJob(job)
     }
     const onLog = (raw: unknown) => {
       const entry = parsePayload<LocalModelJobLogEntry>(raw)
+      if (!entry) return
       if (!expandedLogsRef.current[entry.jobId]) return
       setLogs((prev) => {
         const current = prev[entry.jobId] ?? []

--- a/src/hooks/useDesktopAlerts.ts
+++ b/src/hooks/useDesktopAlerts.ts
@@ -51,7 +51,9 @@ export function useDesktopAlerts() {
     ): () => void {
       return transport.listen(event, (raw) => {
         try {
-          const result = build(parsePayload<T>(raw))
+          const parsed = parsePayload<T>(raw)
+          if (!parsed) return
+          const result = build(parsed)
           if (result) notifyIfBackground(result.title, result.body)
         } catch (e) {
           logger.error("ui", source, `Bad ${event} payload`, e)

--- a/src/hooks/useReembedJob.ts
+++ b/src/hooks/useReembedJob.ts
@@ -44,6 +44,7 @@ export function useReembedJob({ kind, onCompleted }: UseReembedJobOptions) {
 
     const handleSnapshot = (raw: unknown): LocalModelJobSnapshot | null => {
       const snap = parsePayload<LocalModelJobSnapshot>(raw)
+      if (!snap) return null
       if (snap.kind !== kind) return null
       setJob((current) => {
         const next = (() => {

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -2,6 +2,7 @@ import i18n from "i18next"
 import { initReactI18next } from "react-i18next"
 import { getTransport } from "@/lib/transport-provider"
 import { parsePayload } from "@/lib/transport"
+import { logger } from "@/lib/logger"
 
 // 仅 en 同步内联作为首屏兜底（fallbackLng）；其余 11 种语言按需懒加载，避免把
 // 12 份翻译（~2.8MB）全量打进主 bundle。其余语言见下方 localeLoaders。
@@ -67,7 +68,7 @@ async function loadAndSetLanguage(code: string): Promise<void> {
   } catch (e) {
     // 懒加载 chunk 失败（弱网 / 缺文件 / 半更新）：保持当前语言，记录后静默
     // 返回。所有调用方（含三处 `void`）都不会因此产生 unhandledrejection。
-    console.error(`[i18n] failed to load locale "${code}", keeping current:`, e)
+    logger.error("i18n", "i18n::loadAndSetLanguage", `failed to load locale "${code}", keeping current`, e)
     return
   }
   // 被更晚发起的语言请求取代 → 放弃,不要覆盖更新的偏好。

--- a/src/lib/desktopUpdater.ts
+++ b/src/lib/desktopUpdater.ts
@@ -1,5 +1,6 @@
 import { isTauriMode } from "@/lib/transport"
 import { getTransport } from "@/lib/transport-provider"
+import { logger } from "@/lib/logger"
 
 export type DesktopUpdateEvent =
   | { event: "Started"; data: { contentLength: number } }
@@ -71,7 +72,7 @@ export async function checkForDesktopUpdate(): Promise<DesktopUpdate | null> {
   if (!import.meta.env.PROD) {
     // Dev builds always report "up to date" — the running binary isn't a
     // .app/.exe the updater can replace, so a real check is meaningless.
-    console.info("[updater] dev mode — skipping real check, reporting up-to-date")
+    logger.info("updater", "desktopUpdater::checkForDesktopUpdate", "dev mode — skipping real check, reporting up-to-date")
     return null
   }
   const { check } = await import("@tauri-apps/plugin-updater")
@@ -160,7 +161,7 @@ export function silentDownload(update: DesktopUpdate): Promise<void> {
       _notify()
     })
     .catch((err) => {
-      console.error("[updater] silent download failed", err)
+      logger.error("updater", "desktopUpdater::silentDownload", "silent download failed", err)
       _downloadStatus = "idle"
       _notify()
     })
@@ -222,7 +223,7 @@ export function requestManualCheck(): void {
     try {
       fn()
     } catch (err) {
-      console.error("[updater] manual-check listener threw", err)
+      logger.error("updater", "desktopUpdater::requestManualCheck", "manual-check listener threw", err)
     }
   })
 }
@@ -234,7 +235,7 @@ export function subscribeManualCheckRequests(listener: () => void): () => void {
     try {
       listener()
     } catch (err) {
-      console.error("[updater] manual-check listener threw on flush", err)
+      logger.error("updater", "desktopUpdater::subscribeManualCheckRequests", "manual-check listener threw on flush", err)
     }
   }
   return () => {

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -610,7 +610,22 @@ export type PickLocalImageFn = () => Promise<PickedImage | null>;
  * but older backend paths that explicitly `serde_json::to_string(...)` before
  * emitting still arrive as a JSON string. This helper handles both shapes so
  * call sites don't need to repeat the `typeof raw === "string"` check.
+ *
+ * Returns `null` for any payload that isn't a decodable object (`undefined` /
+ * `null` / a non-object primitive / an unparseable string). Every call site in
+ * this app expects an object shape, so a malformed or empty frame must surface
+ * as `null` rather than poison downstream `payload.x` access. This guard is the
+ * root-cause fix for crashes like "undefined is not an object (evaluating
+ * 't.jobId')" seen when the macOS WebView flushes a stray event after wake.
  */
-export function parsePayload<T>(raw: unknown): T {
-  return (typeof raw === "string" ? JSON.parse(raw) : raw) as T;
+export function parsePayload<T>(raw: unknown): T | null {
+  let value: unknown = raw;
+  if (typeof raw === "string") {
+    try {
+      value = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+  return value !== null && typeof value === "object" ? (value as T) : null;
 }


### PR DESCRIPTION
## 问题（#316）

macOS 锁屏 / 睡眠一段时间唤醒后偶发整页崩溃：`undefined is not an object (evaluating 't.jobId')`，需点 `Try Again` 才能恢复。HA v0.10.2。

## 根因

全局 `ErrorBoundary` 捕获的渲染期崩溃。唤醒后个别后台事件帧 `payload` 为空，`parsePayload<T>(raw)` 原样把 `undefined` 透传给下游订阅者，渲染期解引用 `.jobId`（job 快照订阅的 `setState` updater 在渲染阶段执行）即崩。本质是事件解析入口缺少空帧防御，`.jobId` 只是众多受害点之一。

## 改动

- **`parsePayload<T>` 收口为 `T | null`**：空 / 非对象 / 不可解析帧统一返回 `null`，从入口堵住整类崩溃（所有调用方泛型都是对象，语义安全）；同时覆盖 Canvas / Browser / approvals 等全部事件订阅，不止 jobId。
- **13 个事件订阅方补 `null` 守卫**（typecheck 逼出的 112 处全修；内联调用抽局部变量再守卫；两个有返回值的 `handleSnapshot` 用 `return null` 保持签名）。
- **`ErrorBoundary` 接应用日志**：`componentDidCatch` 改用 `logger.error` 带 `componentStack` 写入 `~/.hope-agent/logs.db`，此前 `console.error` 只到 devtools、丢失无法自查（仍镜像 console）。
- **清理约 33 处散落 `console.*` → 统一 `logger`**（KnowledgeView/GraphView、desktopUpdater、i18n 等，category/source 稳定命名）；**保留** `transport-tauri.ts`（transport 层故障日志，换 logger 会循环依赖）与 `logger.ts` 自身。
- CHANGELOG `[0.10.3]` Fixed 条目。

## 验证

`pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm test` ✅（44 文件 234 测试）· pre-push 全套门禁通过。

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)