### PR TITLE
fix: 🦭 Windows 子进程统一无窗口启动，消除发消息时 cmd 黑窗一闪 (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Windows 上发消息不再闪黑窗**：修复 Windows 桌面版每次发送消息（及部分工具 / git / docker / MCP 等操作）时一闪而过的 `cmd` 控制台黑窗——子进程现在统一以无窗口方式启动，不再打断操作或抢走输入框焦点。 (#320)
+
 ## [0.10.3] - 2026-06-14
 
 ### Fixed

--- a/crates/ha-core/src/acp_control/health.rs
+++ b/crates/ha-core/src/acp_control/health.rs
@@ -20,12 +20,12 @@ pub fn build_health_status(
 
 /// Check if a binary is executable by running `<binary> --version`.
 pub async fn probe_binary(binary_path: &str) -> AcpHealthStatus {
-    match tokio::process::Command::new(binary_path)
-        .arg("--version")
+    let mut cmd = tokio::process::Command::new(binary_path);
+    cmd.arg("--version")
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-    {
+        .stderr(std::process::Stdio::piped());
+    crate::platform::hide_console_tokio(&mut cmd);
+    match cmd.spawn() {
         Ok(child) => {
             match tokio::time::timeout(std::time::Duration::from_secs(10), child.wait_with_output())
                 .await

--- a/crates/ha-core/src/acp_control/runtime_stdio.rs
+++ b/crates/ha-core/src/acp_control/runtime_stdio.rs
@@ -90,6 +90,9 @@ impl StdioAcpRuntime {
             }
         }
 
+        // Never flash a console window when launching the ACP backend on Windows.
+        crate::platform::hide_console_tokio(&mut cmd);
+
         let child = cmd.spawn().map_err(|e| {
             anyhow::anyhow!(
                 "Failed to spawn ACP backend '{}' ({}): {}",
@@ -194,10 +197,10 @@ impl AcpRuntime for StdioAcpRuntime {
     }
 
     async fn get_version(&self) -> anyhow::Result<String> {
-        let output = tokio::process::Command::new(&self.binary_path)
-            .arg("--version")
-            .output()
-            .await?;
+        let mut cmd = tokio::process::Command::new(&self.binary_path);
+        cmd.arg("--version");
+        crate::platform::hide_console_tokio(&mut cmd);
+        let output = cmd.output().await?;
         let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
         Ok(text)
     }

--- a/crates/ha-core/src/browser/runtime.rs
+++ b/crates/ha-core/src/browser/runtime.rs
@@ -324,9 +324,10 @@ fn chmod_executable(binary: &Path) -> Result<()> {
 }
 
 async fn smoke_test_binary(binary: &Path) -> Result<()> {
-    let output = tokio::process::Command::new(binary)
-        .arg("--version")
-        .kill_on_drop(true)
+    let mut cmd = tokio::process::Command::new(binary);
+    cmd.arg("--version").kill_on_drop(true);
+    crate::platform::hide_console_tokio(&mut cmd);
+    let output = cmd
         .output()
         .await
         .map_err(|e| anyhow!("smoke test (Chromium --version) failed to spawn: {}", e))?;

--- a/crates/ha-core/src/browser/spawn.rs
+++ b/crates/ha-core/src/browser/spawn.rs
@@ -84,6 +84,9 @@ pub fn resolve_chrome_executable(override_path: Option<&str>) -> Result<String> 
 /// can be unit-tested without actually starting a child process.
 pub fn build_chrome_argv(spec: &LaunchSpec<'_>, exec: &str) -> Command {
     let mut cmd = Command::new(exec);
+    // Suppress the transient console window on Windows; Chrome's own window
+    // (headed) or nothing (headless) is unaffected.
+    crate::platform::hide_console(&mut cmd);
     cmd.arg(format!("--remote-debugging-port={}", spec.port));
     cmd.arg("--remote-debugging-address=127.0.0.1");
 

--- a/crates/ha-core/src/channel/process_manager.rs
+++ b/crates/ha-core/src/channel/process_manager.rs
@@ -19,19 +19,20 @@ impl ManagedProcess {
     /// Spawn a child process with the given command and args.
     /// stdout and stderr are captured and forwarded as lines.
     pub fn spawn(program: &str, args: &[&str]) -> Result<Self> {
-        let mut child = Command::new(program)
+        let mut command = Command::new(program);
+        command
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()
-            .with_context(|| {
-                format!(
-                    "Failed to spawn '{}'. Is it installed and in your PATH?",
-                    program
-                )
-            })?;
+            .kill_on_drop(true);
+        crate::platform::hide_console_tokio(&mut command);
+        let mut child = command.spawn().with_context(|| {
+            format!(
+                "Failed to spawn '{}'. Is it installed and in your PATH?",
+                program
+            )
+        })?;
 
         let stdout = child
             .stdout

--- a/crates/ha-core/src/docker/deploy.rs
+++ b/crates/ha-core/src/docker/deploy.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use std::sync::atomic::Ordering;
-use tokio::process::Command;
 
 use super::{
     helpers::*, DeployProgress, DeployProgressSnapshot, CONTAINER_NAME, DEPLOYING, DEPLOY_PROGRESS,
@@ -81,7 +80,7 @@ where
     log(&format!("docker pull {}", IMAGE));
     {
         use tokio::io::{AsyncBufReadExt, BufReader};
-        let mut child = Command::new("docker")
+        let mut child = docker_command()
             .args(["pull", IMAGE])
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -121,7 +120,7 @@ where
     // 3. Remove stale container if exists
     step("removing_old");
     log(&format!("docker rm -f {}", CONTAINER_NAME));
-    let rm_out = Command::new("docker")
+    let rm_out = docker_command()
         .args(["rm", "-f", CONTAINER_NAME])
         .output()
         .await;
@@ -177,7 +176,7 @@ where
         "docker run -d --name {} -p {}:8080 ...",
         CONTAINER_NAME, port
     ));
-    let run = Command::new("docker")
+    let run = docker_command()
         .args(&args)
         .output()
         .await

--- a/crates/ha-core/src/docker/helpers.rs
+++ b/crates/ha-core/src/docker/helpers.rs
@@ -6,10 +6,19 @@ use super::{app_log, info, CONTAINER_NAME, DEFAULT_HOST_PORT, SEARXNG_DIR_NAME};
 
 // ── Internal helpers ─────────────────────────────────────────────
 
+/// A `docker` command that never flashes a console window on Windows
+/// (`CREATE_NO_WINDOW`); a no-op wrapper elsewhere. All docker invocations
+/// in this module go through it.
+pub(super) fn docker_command() -> Command {
+    let mut cmd = Command::new("docker");
+    crate::platform::hide_console_tokio(&mut cmd);
+    cmd
+}
+
 /// Returns (cli_installed, daemon_running).
 pub(super) async fn docker_status() -> (bool, bool) {
     // Check if docker CLI exists
-    let version = Command::new("docker")
+    let version = docker_command()
         .args(["--version"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -20,7 +29,7 @@ pub(super) async fn docker_status() -> (bool, bool) {
         return (false, false);
     }
     // Check if daemon is running
-    let info = Command::new("docker")
+    let info = docker_command()
         .args(["info"])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -38,7 +47,7 @@ pub(super) async fn docker_available() -> bool {
 
 /// Returns (exists, running).
 pub(super) async fn inspect_container() -> (bool, bool) {
-    let out = Command::new("docker")
+    let out = docker_command()
         .args(["inspect", "--format", "{{.State.Running}}", CONTAINER_NAME])
         .output()
         .await;
@@ -53,7 +62,7 @@ pub(super) async fn inspect_container() -> (bool, bool) {
 
 /// Parse the host port from docker inspect.
 pub(super) async fn inspect_port() -> Option<u16> {
-    let out = Command::new("docker")
+    let out = docker_command()
         .args([
             "inspect",
             "--format",
@@ -174,7 +183,7 @@ async fn load_existing_secret_key(settings_path: &std::path::Path) -> Option<Str
 
 /// Fetch recent container logs for diagnostics.
 pub(super) async fn fetch_container_logs(tail: u32) -> String {
-    let out = Command::new("docker")
+    let out = docker_command()
         .args(["logs", "--tail", &tail.to_string(), CONTAINER_NAME])
         .output()
         .await;

--- a/crates/ha-core/src/docker/lifecycle.rs
+++ b/crates/ha-core/src/docker/lifecycle.rs
@@ -1,6 +1,5 @@
 use anyhow::{Context, Result};
 use std::sync::atomic::Ordering;
-use tokio::process::Command;
 
 use super::{app_log, error, helpers::*, info, CONTAINER_NAME, DEPLOYING};
 
@@ -14,7 +13,7 @@ pub async fn start() -> Result<()> {
     // take effect without requiring a full redeploy.
     prepare_searxng_config().await?;
     info("Starting container...");
-    let out = Command::new("docker")
+    let out = docker_command()
         .args(["start", CONTAINER_NAME])
         .output()
         .await
@@ -46,7 +45,7 @@ pub async fn stop() -> Result<()> {
         anyhow::bail!("A deploy operation is in progress");
     }
     info("Stopping container...");
-    let out = Command::new("docker")
+    let out = docker_command()
         .args(["stop", CONTAINER_NAME])
         .output()
         .await
@@ -65,7 +64,7 @@ pub async fn remove() -> Result<()> {
         anyhow::bail!("A deploy operation is in progress");
     }
     info("Removing container...");
-    let out = Command::new("docker")
+    let out = docker_command()
         .args(["rm", "-f", CONTAINER_NAME])
         .output()
         .await

--- a/crates/ha-core/src/filesystem/git.rs
+++ b/crates/ha-core/src/filesystem/git.rs
@@ -48,10 +48,11 @@ pub fn git_info(root: &Path) -> Option<GitInfo> {
 
 /// Cheap probe: is `dir` inside a git work tree?
 pub fn is_inside_work_tree(dir: &Path) -> bool {
-    Command::new("git")
-        .current_dir(dir)
-        .args(["rev-parse", "--is-inside-work-tree"])
-        .output()
+    let mut cmd = Command::new("git");
+    cmd.current_dir(dir)
+        .args(["rev-parse", "--is-inside-work-tree"]);
+    crate::platform::hide_console(&mut cmd);
+    cmd.output()
         .map(|o| o.status.success() && String::from_utf8_lossy(&o.stdout).trim() == "true")
         .unwrap_or(false)
 }
@@ -76,11 +77,10 @@ pub fn is_worktree_of(base: &Path, target_canon: &Path) -> bool {
 }
 
 fn run_git(root: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .current_dir(root)
-        .args(args)
-        .output()
-        .ok()?;
+    let mut cmd = Command::new("git");
+    cmd.current_dir(root).args(args);
+    crate::platform::hide_console(&mut cmd);
+    let output = cmd.output().ok()?;
     if output.status.success() {
         Some(String::from_utf8_lossy(&output.stdout).into_owned())
     } else {

--- a/crates/ha-core/src/hooks/runner/command.rs
+++ b/crates/ha-core/src/hooks/runner/command.rs
@@ -88,6 +88,8 @@ impl CommandHandler {
         for (k, v) in env.as_vars() {
             cmd.env(k, v);
         }
+        // On Windows the default shell is `powershell` — never flash its console.
+        crate::platform::hide_console_tokio(&mut cmd);
         cmd
     }
 }

--- a/crates/ha-core/src/issue_reporting.rs
+++ b/crates/ha-core/src/issue_reporting.rs
@@ -665,6 +665,7 @@ async fn run_gh(args: Vec<String>, stdin: Option<String>) -> Result<std::process
         })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    crate::platform::hide_console_tokio(&mut cmd);
     let mut child = cmd.spawn().context("failed to spawn gh CLI")?;
     if let Some(input) = stdin {
         let mut child_stdin = child.stdin.take().context("failed to open gh stdin")?;

--- a/crates/ha-core/src/local_llm/mod.rs
+++ b/crates/ha-core/src/local_llm/mod.rs
@@ -210,12 +210,13 @@ async fn usable_ollama_binary() -> Option<PathBuf> {
 async fn ollama_binary_responds(path: &Path) -> bool {
     use std::process::Stdio;
 
-    let status = tokio::process::Command::new(path)
-        .arg("--version")
+    let mut cmd = tokio::process::Command::new(path);
+    cmd.arg("--version")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
+        .stderr(Stdio::null());
+    crate::platform::hide_console_tokio(&mut cmd);
+    let status = cmd.status();
 
     matches!(
         tokio::time::timeout(Duration::from_secs(OLLAMA_BINARY_CHECK_TIMEOUT_SECS), status).await,

--- a/crates/ha-core/src/mcp/transport.rs
+++ b/crates/ha-core/src/mcp/transport.rs
@@ -113,6 +113,9 @@ fn build_stdio_command(cfg: &McpServerConfig) -> McpResult<Command> {
             cmd.current_dir(dir);
         }
     }
+    // Stdio MCP servers (node/npx/python/uvx…) are real console processes on
+    // Windows — suppress the console window so connecting one never flashes.
+    crate::platform::hide_console_tokio(&mut cmd);
     Ok(cmd)
 }
 

--- a/crates/ha-core/src/plan/git.rs
+++ b/crates/ha-core/src/plan/git.rs
@@ -6,13 +6,22 @@ use super::store::store;
 // Creates a lightweight git checkpoint before plan execution starts,
 // allowing rollback if execution fails.
 
+/// A `git` command that never flashes a console window on Windows
+/// (`CREATE_NO_WINDOW`); a no-op wrapper elsewhere. Every git invocation in
+/// this module goes through it so a new call site can't silently regress the
+/// console-flash fix.
+fn git_command() -> std::process::Command {
+    let mut cmd = std::process::Command::new("git");
+    crate::platform::hide_console(&mut cmd);
+    cmd
+}
+
 /// Detect the git repository root directory by running `git rev-parse --show-toplevel`.
 /// Returns None if not inside a git repository.
 fn git_repo_root() -> Option<std::path::PathBuf> {
-    let output = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()?;
+    let mut cmd = git_command();
+    cmd.args(["rev-parse", "--show-toplevel"]);
+    let output = cmd.output().ok()?;
     if output.status.success() {
         let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if path.is_empty() {
@@ -29,14 +38,12 @@ fn git_repo_root() -> Option<std::path::PathBuf> {
 /// commit). Cheap probe — `rev-parse --verify --quiet` on a missing ref
 /// returns in a few ms without touching the object database.
 fn ref_exists(git_root: &std::path::Path, rev: &str) -> bool {
-    std::process::Command::new("git")
-        .current_dir(git_root)
+    let mut cmd = git_command();
+    cmd.current_dir(git_root)
         .args(["rev-parse", "--verify", "--quiet", rev])
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
+        .stderr(std::process::Stdio::null());
+    cmd.status().map(|s| s.success()).unwrap_or(false)
 }
 
 /// Create a git checkpoint (branch) at the current HEAD for the working directory.
@@ -67,12 +74,12 @@ pub fn create_git_checkpoint(session_id: &str) -> Option<String> {
         return None;
     }
 
-    let result = std::process::Command::new("git")
-        .current_dir(&git_root)
+    let mut cmd = git_command();
+    cmd.current_dir(&git_root)
         .args(["branch", &branch_name, "HEAD"])
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
+        .stderr(std::process::Stdio::null());
+    let result = cmd.status();
 
     match result {
         Ok(s) if s.success() => {
@@ -134,19 +141,22 @@ pub fn rollback_to_checkpoint(checkpoint_ref: &str) -> Result<String> {
     }
 
     // Get current HEAD for logging
-    let head_before = std::process::Command::new("git")
+    let mut head_cmd = git_command();
+    head_cmd
         .current_dir(&git_root)
-        .args(["rev-parse", "--short", "HEAD"])
+        .args(["rev-parse", "--short", "HEAD"]);
+    let head_before = head_cmd
         .output()
         .ok()
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .unwrap_or_default();
 
     // Reset to checkpoint
-    let result = std::process::Command::new("git")
+    let mut reset_cmd = git_command();
+    reset_cmd
         .current_dir(&git_root)
-        .args(["reset", "--hard", checkpoint_ref])
-        .output()?;
+        .args(["reset", "--hard", checkpoint_ref]);
+    let result = reset_cmd.output()?;
 
     if result.status.success() {
         let msg = format!(
@@ -156,12 +166,13 @@ pub fn rollback_to_checkpoint(checkpoint_ref: &str) -> Result<String> {
         app_info!("plan", "checkpoint", "{}", msg);
 
         // Clean up: delete the checkpoint branch
-        let _ = std::process::Command::new("git")
+        let mut del_cmd = git_command();
+        del_cmd
             .current_dir(&git_root)
             .args(["branch", "-D", checkpoint_ref])
             .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
+            .stderr(std::process::Stdio::null());
+        let _ = del_cmd.status();
 
         Ok(msg)
     } else {
@@ -172,21 +183,14 @@ pub fn rollback_to_checkpoint(checkpoint_ref: &str) -> Result<String> {
 
 /// Clean up a checkpoint branch (e.g., after successful execution).
 pub fn cleanup_checkpoint(checkpoint_ref: &str) {
-    let git_cmd = if let Some(git_root) = git_repo_root() {
-        std::process::Command::new("git")
-            .current_dir(git_root)
-            .args(["branch", "-D", checkpoint_ref])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-    } else {
-        std::process::Command::new("git")
-            .args(["branch", "-D", checkpoint_ref])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-    };
-    let _ = git_cmd;
+    let mut cmd = git_command();
+    if let Some(git_root) = git_repo_root() {
+        cmd.current_dir(git_root);
+    }
+    cmd.args(["branch", "-D", checkpoint_ref])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    let _ = cmd.status();
     app_info!(
         "plan",
         "checkpoint",

--- a/crates/ha-core/src/platform/mod.rs
+++ b/crates/ha-core/src/platform/mod.rs
@@ -129,6 +129,23 @@ pub fn default_shell_command_tokio(cmdline: &str) -> tokio::process::Command {
     imp::default_shell_command_tokio(cmdline)
 }
 
+/// Suppress the transient console window that Windows would otherwise flash
+/// when spawning a console subprocess. No-op on Unix.
+///
+/// Apply this to every `std::process::Command` whose program exists on
+/// Windows and that runs during normal operation — git probes, docker, ACP
+/// backends, etc. — so the user never sees a `cmd`/`conhost` window blink.
+/// On Windows it sets the `CREATE_NO_WINDOW` (0x0800_0000) creation flag;
+/// output pipes still work, only the visible console is suppressed.
+pub fn hide_console(cmd: &mut Command) {
+    imp::hide_console(cmd);
+}
+
+/// `tokio::process::Command` variant of [`hide_console`], for async spawn sites.
+pub fn hide_console_tokio(cmd: &mut tokio::process::Command) {
+    imp::hide_console_tokio(cmd);
+}
+
 /// Return a short, human-readable OS version string for diagnostic /
 /// error reporting (e.g. `"macOS 14.2.1"`, `"Windows 11 (26100)"`,
 /// `"Linux 6.8.0"`). Never fails — returns `"unknown"` as a last resort.

--- a/crates/ha-core/src/platform/unix.rs
+++ b/crates/ha-core/src/platform/unix.rs
@@ -260,6 +260,15 @@ pub(super) fn default_shell_command_tokio(cmdline: &str) -> tokio::process::Comm
     cmd
 }
 
+// No console windows exist on Unix, so hiding one is a no-op. The `&mut`
+// signature mirrors the Windows impl (which mutates `creation_flags`) so
+// callers stay platform-agnostic.
+#[allow(clippy::needless_pass_by_ref_mut)]
+pub(super) fn hide_console(_cmd: &mut Command) {}
+
+#[allow(clippy::needless_pass_by_ref_mut)]
+pub(super) fn hide_console_tokio(_cmd: &mut tokio::process::Command) {}
+
 pub(super) fn find_chrome_executable() -> Option<PathBuf> {
     // macOS-specific .app bundles first; if present, prefer Chrome over
     // Chromium (matches the user's likely daily browser).

--- a/crates/ha-core/src/platform/windows.rs
+++ b/crates/ha-core/src/platform/windows.rs
@@ -89,13 +89,24 @@ pub(super) fn default_shell_command(cmdline: &str) -> Command {
     // `raw_arg` to avoid std's automatic quoting rewriting the user payload.
     let mut cmd = Command::new("cmd");
     cmd.raw_arg("/C").raw_arg(cmdline);
+    // Never flash a `cmd` console window for shell-exec / tool commands.
+    cmd.creation_flags(CREATE_NO_WINDOW);
     cmd
 }
 
 pub(super) fn default_shell_command_tokio(cmdline: &str) -> tokio::process::Command {
     let mut cmd = tokio::process::Command::new("cmd");
     cmd.raw_arg("/C").raw_arg(cmdline);
+    cmd.creation_flags(CREATE_NO_WINDOW);
     cmd
+}
+
+pub(super) fn hide_console(cmd: &mut Command) {
+    cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+pub(super) fn hide_console_tokio(cmd: &mut tokio::process::Command) {
+    cmd.creation_flags(CREATE_NO_WINDOW);
 }
 
 pub(super) fn find_chrome_executable() -> Option<PathBuf> {
@@ -130,6 +141,7 @@ pub(super) async fn chrome_already_running() -> bool {
         let filter = format!("IMAGENAME eq {name}");
         let output = match tokio::process::Command::new("tasklist")
             .args(["/FI", &filter, "/FO", "CSV", "/NH"])
+            .creation_flags(CREATE_NO_WINDOW)
             .kill_on_drop(true)
             .output()
             .await

--- a/crates/ha-core/src/sandbox.rs
+++ b/crates/ha-core/src/sandbox.rs
@@ -647,10 +647,13 @@ pub struct DockerStatus {
 
 pub async fn check_sandbox_available() -> DockerStatus {
     // Check if docker CLI exists
-    let cli_installed = Command::new("docker")
+    let mut docker_cmd = Command::new("docker");
+    docker_cmd
         .args(["--version"])
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    crate::platform::hide_console_tokio(&mut docker_cmd);
+    let cli_installed = docker_cmd
         .status()
         .await
         .map(|s| s.success())

--- a/crates/ha-core/src/session/environment.rs
+++ b/crates/ha-core/src/session/environment.rs
@@ -261,11 +261,10 @@ fn classify_sync_state(
 }
 
 fn run_git(root: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git")
-        .current_dir(root)
-        .args(args)
-        .output()
-        .ok()?;
+    let mut cmd = Command::new("git");
+    cmd.current_dir(root).args(args);
+    crate::platform::hide_console(&mut cmd);
+    let output = cmd.output().ok()?;
     if output.status.success() {
         Some(String::from_utf8_lossy(&output.stdout).into_owned())
     } else {

--- a/crates/ha-core/src/skills/commands.rs
+++ b/crates/ha-core/src/skills/commands.rs
@@ -502,8 +502,10 @@ pub async fn install_skill_dependency(skill_name: &str, spec_index: usize) -> Re
 }
 
 async fn run_install_command(program: &str, args: &[&str]) -> Result<String> {
-    let output = tokio::process::Command::new(program)
-        .args(args)
+    let mut cmd = tokio::process::Command::new(program);
+    cmd.args(args);
+    crate::platform::hide_console_tokio(&mut cmd);
+    let output = cmd
         .output()
         .await
         .map_err(|e| anyhow!("Failed to run {} {}: {}", program, args.join(" "), e))?;

--- a/crates/ha-core/src/system_prompt/helpers.rs
+++ b/crates/ha-core/src/system_prompt/helpers.rs
@@ -2,9 +2,13 @@
 
 /// Get OS version string via `uname -r`.
 pub(super) fn os_version() -> String {
-    std::process::Command::new("uname")
-        .arg("-r")
-        .output()
+    // `uname` is normally Unix-only, but Git-for-Windows / MSYS2 ship a
+    // `uname.exe` that can land on a Windows PATH — hide the console so it
+    // never flashes when it does resolve.
+    let mut cmd = std::process::Command::new("uname");
+    cmd.arg("-r");
+    crate::platform::hide_console(&mut cmd);
+    cmd.output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
@@ -13,8 +17,9 @@ pub(super) fn os_version() -> String {
 
 /// Get machine hostname.
 pub(super) fn hostname() -> String {
-    std::process::Command::new("hostname")
-        .output()
+    let mut cmd = std::process::Command::new("hostname");
+    crate::platform::hide_console(&mut cmd);
+    cmd.output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())
@@ -39,9 +44,12 @@ pub(super) fn find_git_root(start: &str) -> Option<String> {
 /// stays identical throughout the day. Agents can use `exec date` for
 /// the precise time when needed.
 pub(super) fn current_date() -> String {
-    std::process::Command::new("date")
-        .arg("+%Y-%m-%d %Z")
-        .output()
+    // Same as `uname`: a `date.exe` from Git-for-Windows / MSYS2 can resolve
+    // on Windows, so suppress its console window too.
+    let mut cmd = std::process::Command::new("date");
+    cmd.arg("+%Y-%m-%d %Z");
+    crate::platform::hide_console(&mut cmd);
+    cmd.output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.trim().to_string())

--- a/crates/ha-core/src/updater/self_contained.rs
+++ b/crates/ha-core/src/updater/self_contained.rs
@@ -281,13 +281,13 @@ pub async fn install(
 /// start before we restart the service onto it.
 async fn smoke_test(exe: &Path, expected_version: &str) -> Result<()> {
     use std::time::Duration;
-    let output = tokio::time::timeout(
-        Duration::from_secs(5),
-        tokio::process::Command::new(exe).arg("--version").output(),
-    )
-    .await
-    .context("smoke test `--version` timed out after 5s")?
-    .context("spawn new binary for smoke test")?;
+    let mut cmd = tokio::process::Command::new(exe);
+    cmd.arg("--version");
+    crate::platform::hide_console_tokio(&mut cmd);
+    let output = tokio::time::timeout(Duration::from_secs(5), cmd.output())
+        .await
+        .context("smoke test `--version` timed out after 5s")?
+        .context("spawn new binary for smoke test")?;
 
     if !output.status.success() {
         anyhow::bail!("new binary `--version` exited with {}", output.status);

--- a/docs/architecture/platform.md
+++ b/docs/architecture/platform.md
@@ -22,8 +22,10 @@
 | `pdfium_library_candidates() -> &'static [&'static str]` | macOS 返回 Homebrew / `/usr/local` dylib 候选；其他 Unix 返回常见 `.so` 候选 | 返回 `pdfium.dll` |
 | `system_permissions_*` | macOS 走 TCC / framework 原生检查与授权触发；非 macOS 返回 unsupported / NotApplicable | 返回 unsupported / NotApplicable |
 | `service::{install_service, uninstall_service, service_status, stop_server}` | macOS 写 LaunchAgent plist 并通过 `launchctl` 管理；Linux 写 user systemd unit 并通过 `systemctl --user` 管理；`stop_server` 读 `server.pid` 后发 SIGTERM | 通过 Task Scheduler 创建/删除/查询 per-user 登录任务；`stop_server` 读 `server.pid` 后走 `send_graceful_stop` |
-| `default_shell_command(cmdline) -> std::process::Command` | `Command::new("sh").arg("-c").arg(cmdline)` | `Command::new("cmd").raw_arg("/C").raw_arg(cmdline)` —— `raw_arg` 跳过 std 自动加引号，保留 `/C` 后续整段命令的原始语义 |
-| `default_shell_command_tokio(cmdline)` | 同上 std 版，返回 `tokio::process::Command` | 同上 std 版，返回 `tokio::process::Command` |
+| `default_shell_command(cmdline) -> std::process::Command` | `Command::new("sh").arg("-c").arg(cmdline)` | `Command::new("cmd").raw_arg("/C").raw_arg(cmdline)` —— `raw_arg` 跳过 std 自动加引号，保留 `/C` 后续整段命令的原始语义；并 `creation_flags(CREATE_NO_WINDOW)` 防控制台闪窗 |
+| `default_shell_command_tokio(cmdline)` | 同上 std 版，返回 `tokio::process::Command` | 同上 std 版，返回 `tokio::process::Command`（同样带 `CREATE_NO_WINDOW`） |
+| `hide_console(&mut std::process::Command)` | no-op（Unix 无控制台窗口概念） | `creation_flags(CREATE_NO_WINDOW=0x0800_0000)`——抑制 spawn 控制台子进程时一闪而过的 `cmd`/`conhost` 窗口，管道输出不受影响 |
+| `hide_console_tokio(&mut tokio::process::Command)` | no-op | 同上，`tokio::process::Command` 版（异步 spawn 站点） |
 | `os_version_string() -> String` | macOS 优先 `sw_vers -productVersion` → `"macOS 14.2.1"` 形态；其他 Unix 走 `sysinfo::System::long_os_version()` 兜底；都失败时 `"unknown"` | `sysinfo::long_os_version()` + `kernel_version()` 拼成 `"Windows 11 (26100)"` 形态；都缺失时 `"Windows (unknown build)"` |
 | `write_secure_file(path, bytes) -> io::Result<()>` | `OpenOptions::create_new + mode(0o600) + write_all + sync_all` → `fs::set_permissions(0o600)`（防 umask 干扰）→ `rename(tmp, path)`，原子 + 0600 + fsync | 同样 temp file → `sync_all`；rename 前 `if path.exists() { remove_file }`（Windows rename 目标存在会失败）；NTFS DACL 继承自 `~/.hope-agent/` 目录（用户 profile 下默认仅 owner + SYSTEM/Administrators 可读） |
 | `try_acquire_exclusive_lock(path) -> io::Result<Option<File>>` | `flock(LOCK_EX \| LOCK_NB)` 在 `O_CLOEXEC` 打开的文件上加非阻塞独占锁，`fork` 子进程不继承锁 fd；返回 `Ok(None)` 表示已被其他进程持有 | `OpenOptions::share_mode(0)`（`FILE_SHARE_NONE`）走内核独占打开 + `FILE_FLAG_NO_INHERIT_HANDLE`，`Err(io::ErrorKind::PermissionDenied)` 自动映射为 `Ok(None)` 表示锁已被占 |
@@ -51,6 +53,24 @@
 
 **Windows ACL 当前依赖继承**：`~/.hope-agent/` 在用户 profile 下，默认 DACL 已经把"普通用户"挡在外面，但**没有显式 strip 继承的 ACE**。注释里明确点出"hardening to an explicit DACL is a future pass"——威胁建模需要时再加，签名不变向后兼容。
 
+### 隐藏控制台窗口（Windows `CREATE_NO_WINDOW`）
+
+Windows 上用 `std::process::Command` / `tokio::process::Command` spawn 一个**控制台子系统**程序（`git` / `docker` / `node` / `cmd` / `hostname` …）时，即使把 stdout/stderr 重定向走，系统仍会为该子进程**短暂闪出一个 `cmd`/`conhost` 控制台窗口**——在每轮对话都会跑 git/hostname 探测的桌面 GUI 上，表现为"发消息时黑窗一闪而过、还抢输入焦点"。`creation_flags(CREATE_NO_WINDOW)` 让子进程不分配控制台窗口，但保留管道，所以捕获输出照常。
+
+约定：**任何在 Windows 上可能创建进程、且在正常使用路径上会跑的 `Command`，都必须经 `hide_console` / `hide_console_tokio`**（或本就带 flag 的 `run_hidden` / `default_shell_command*`）。`hide_console` 对**找不到程序而返回 `Err` 的调用是零成本 no-op**，所以判定标准取**就低不就高**——只要程序名**有可能**在某些 Windows 环境解析出真进程，就加。
+
+**真正无需加**的只有两类：
+
+1. 被 `#[cfg(unix)]` / `#[cfg(target_os="macos")]` 等非 Windows cfg 包住、根本不在 Windows 编译的站点（如 unix 专属的 `sh` / `pgrep` / `scutil` / `sw_vers` / `launchctl`）
+2. 程序名是 **macOS/Linux 独有、Windows 上任何常见环境都不会有**的 binary（`scutil` / `osascript` / `gsettings` / `defaults` …，`Command::new` 找不到直接 `Err`）
+
+> ⚠️ 不要把 `uname` / `date` / `hostname` 当成"Windows 上不存在"——**Git-for-Windows / MSYS2 / Cygwin / scoop coreutils 都带 `uname.exe` / `date.exe` / `hostname.exe`**（`hostname` 更是 System32 自带）。默认原生 PATH 通常解析不到 `uname` / `date`（落到 fallback），但只要应用从 Git Bash 启动或 PATH 上有 `Git\usr\bin`/MSYS2 就会真 spawn 闪窗。这类"可能解析"的站点（[`system_prompt/helpers.rs`](../../crates/ha-core/src/system_prompt/helpers.rs) 的 `hostname` / `uname` / `date`，每轮系统提示构建都跑）一律加 `hide_console`——加了没坏处，不加就是 Windows 上的偶发闪窗。
+
+**例外（有意不加）**：
+
+- [`guardian.rs`](../../crates/ha-core/src/guardian.rs) 重启自身 binary——前台 `hope-agent server start` 时子进程需要继承父控制台输出，加 flag 会吞掉用户期望看到的日志；桌面 GUI 是 `windows_subsystem=windows` 本就无控制台，与闪窗 bug 无关
+- [`tools/exec.rs`](../../crates/ha-core/src/tools/exec.rs) 的 PTY 路径走 `portable-pty` 的 ConPTY，伪控制台不弹可见窗口，且 `CommandBuilder` 不暴露 `creation_flags` 钩子
+
 ### 系统代理缓存
 
 `detect_system_proxy` 两端都用 `OnceLock<Option<String>>` 进程级缓存。理由：`provider/proxy.rs` / `docker/proxy.rs` 等 caller 每次构建 reqwest client 都会调一次，winreg / `scutil` / `gsettings` / `kreadconfig` 都不应该在 hot path 上重复探测。
@@ -73,6 +93,7 @@
 | `system_permissions_*` | [`permissions.rs`](../../crates/ha-core/src/permissions.rs) v2 系统权限目录的 OS 原生检查 / 请求入口 |
 | `service::{install_service, uninstall_service, service_status, stop_server}` | [`service_install.rs`](../../crates/ha-core/src/service_install.rs) 保持历史 public API，CLI / updater / Tauri 继续从该 wrapper 进入系统服务管理 |
 | `default_shell_command_tokio` | [`tools/exec.rs`](../../crates/ha-core/src/tools/exec.rs) 工具 shell 命令执行 |
+| `hide_console` / `hide_console_tokio` | 所有在 Windows 会真实建进程的 `Command`：git 探测（[`filesystem/git.rs`](../../crates/ha-core/src/filesystem/git.rs) / [`session/environment.rs`](../../crates/ha-core/src/session/environment.rs) / [`plan/git.rs`](../../crates/ha-core/src/plan/git.rs)）、`hostname`（[`system_prompt/helpers.rs`](../../crates/ha-core/src/system_prompt/helpers.rs)）、docker（[`docker/`](../../crates/ha-core/src/docker/) 经 `docker_command()` 统一）、MCP stdio（[`mcp/transport.rs`](../../crates/ha-core/src/mcp/transport.rs)）、ACP backend（[`acp_control/`](../../crates/ha-core/src/acp_control/)）、IM sidecar（[`channel/process_manager.rs`](../../crates/ha-core/src/channel/process_manager.rs)）、Chrome（[`browser/spawn.rs`](../../crates/ha-core/src/browser/spawn.rs)）、`gh`、ollama / skill 安装 / hooks shell / 自升级冷烟自检 等 |
 | `os_version_string` | [`agent/errors.rs`](../../crates/ha-core/src/agent/errors.rs) 错误报告 / 诊断；`self_diagnosis` 日志 |
 | `write_secure_file` | [`mcp/credentials.rs`](../../crates/ha-core/src/mcp/credentials.rs) MCP OAuth token 凭据 0600 原子落盘（**当前唯一调用方**）。注意：主 LLM OAuth `oauth.rs::save_token()` 当前直接用 `std::fs::write` 写 `~/.hope-agent/credentials/auth.json`，**未走** `write_secure_file`——见下文「已知缺口」 |
 | `try_acquire_exclusive_lock` | `runtime_lock.rs` 全局单实例守门：桌面 / `hope-agent server` / `hope-agent acp` 三种运行模式启动时拿同一把锁，防止启动恢复 / "global only-one" 后台循环跑两份 |


### PR DESCRIPTION
Windows 上用 std/tokio Command spawn 控制台程序（git / docker / cmd / hostname …）时，系统会为子进程短暂闪一个 cmd/conhost 控制台窗口，还抢输入
焦点。每轮对话都会跑的工作台 git 探测 + 系统提示里的 hostname / uname / date 是「发消息闪窗」的主因；exec / MCP / ACP / 浏览器 / docker 等子进程同源。

统一新增 platform::hide_console / hide_console_tokio（Unix no-op，Windows 设 CREATE_NO_WINDOW），覆盖所有正常路径上会真创建进程的 spawn 点；docker 经 docker_command()、plan 的 git 经 git_command() 收口。guardian 自重启 （前台 server 需继承控制台）与 exec 的 ConPTY 路径有意不加。