### PR TITLE
fix: repair Windows Sogou IME input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **修复 macOS 睡眠 / 锁屏一段时间唤醒后偶发整页崩溃**：唤醒后个别后台事件帧为空，会击穿界面渲染弹出「undefined is not an object」错误页（需点 Try Again 才能恢复）；现已在事件解析入口统一拦截空 / 异常帧，并把这类前端崩溃记入应用日志便于后续自查。 (#319)
+- **修复 Windows 下搜狗拼音无法在对话输入框输入中文**：对话输入框继续保留 CodeMirror 6 与 `@` / `[[ ]]` 内联提及体验，但在 Windows WebView2 上改走 CodeMirror 的 EditContext 输入路径，绕开旧 `contenteditable` 管线与搜狗拼音的兼容性问题；同时 Windows 主窗口恢复原生标题栏与窗口控制按钮。 (#315)
 
 ## [0.10.2] - 2026-06-13
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "fetch:vcredist": "node scripts/fetch-vcredist.mjs",
     "tauri": "tauri",
     "version": "node scripts/sync-version.mjs",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "node scripts/patch-codemirror-edit-context.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.2",

--- a/scripts/patch-codemirror-edit-context.mjs
+++ b/scripts/patch-codemirror-edit-context.mjs
@@ -1,0 +1,25 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const files = [
+  "node_modules/@codemirror/view/dist/index.js",
+  "node_modules/@codemirror/view/dist/index.cjs",
+]
+
+const original =
+  "if (window.EditContext && browser.android && view.constructor.EDIT_CONTEXT !== false &&"
+const patched =
+  "if (window.EditContext && (browser.android || window.__HOPE_AGENT_CODEMIRROR_EDIT_CONTEXT === true) && view.constructor.EDIT_CONTEXT !== false &&"
+
+for (const relative of files) {
+  const path = resolve(root, relative)
+  const source = readFileSync(path, "utf8")
+  if (source.includes(patched)) continue
+  if (!source.includes(original)) {
+    throw new Error(`Could not find CodeMirror EditContext gate in ${relative}`)
+  }
+  writeFileSync(path, source.replace(original, patched))
+  console.log(`Patched ${relative} to allow Hope Agent scoped EditContext opt-in`)
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,5 +1,21 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "Hope Agent",
+        "width": 1440,
+        "height": 900,
+        "minWidth": 840,
+        "minHeight": 480,
+        "resizable": true,
+        "fullscreen": false,
+        "transparent": false,
+        "decorations": true,
+        "dragDropEnabled": false
+      }
+    ]
+  },
   "bundle": {
     "targets": ["nsis"],
     "resources": {

--- a/src/components/chat/input/MentionComposerInput.tsx
+++ b/src/components/chat/input/MentionComposerInput.tsx
@@ -267,6 +267,15 @@ function mentionDecorations(getConfig: () => MentionConfig) {
       }
 
       update(update: ViewUpdate) {
+        // Never rebuild decorations mid-IME-composition. Swapping the decoration
+        // set (and its atomic ranges) forces CM6 to redraw the line holding the
+        // active composition, which aborts third-party IMEs (e.g. Sogou Pinyin)
+        // on Chromium/WebView2. Keep existing chips aligned by mapping them
+        // through the change; do a full rebuild once composition ends.
+        if (update.view.composing) {
+          if (update.docChanged) this.decorations = this.decorations.map(update.changes)
+          return
+        }
         if (update.docChanged || update.viewportChanged || update.transactions.length > 0) {
           this.decorations = build(update.view)
         }
@@ -303,6 +312,9 @@ function adjacentMentionDeletion(
 function atomicDeleteExtension(getConfig: () => MentionConfig) {
   return EditorView.domEventHandlers({
     keydown(event, view) {
+      // Never intercept deletes during an IME composition. preventDefault() +
+      // dispatch here would abort the composition for third-party Windows IMEs.
+      if (event.isComposing || event.keyCode === 229) return false
       if (
         (event.key !== "Backspace" && event.key !== "Delete") ||
         event.altKey ||
@@ -332,6 +344,43 @@ function atomicDeleteExtension(getConfig: () => MentionConfig) {
     },
   })
 }
+
+const CODEMIRROR_EDIT_CONTEXT_FLAG = "__HOPE_AGENT_CODEMIRROR_EDIT_CONTEXT"
+
+type CodeMirrorEditContextWindow = Window & {
+  __HOPE_AGENT_CODEMIRROR_EDIT_CONTEXT?: boolean
+}
+
+function shouldForceCodeMirrorEditContext(): boolean {
+  if (typeof window === "undefined" || typeof navigator === "undefined") return false
+  if (!("EditContext" in window)) return false
+  const ua = navigator.userAgent
+  if (!/\bWindows NT\b/.test(ua)) return false
+  const version = ua.match(/\b(?:Chrome|Chromium|Edg)\/(\d+)/)?.[1]
+  return version ? Number(version) >= 126 : false
+}
+
+function withCodeMirrorEditContext<T>(enabled: boolean, create: () => T): T {
+  if (!enabled) return create()
+  const target = window as unknown as CodeMirrorEditContextWindow
+  const previous = target[CODEMIRROR_EDIT_CONTEXT_FLAG]
+  target[CODEMIRROR_EDIT_CONTEXT_FLAG] = true
+  try {
+    return create()
+  } finally {
+    if (previous === undefined) {
+      delete target[CODEMIRROR_EDIT_CONTEXT_FLAG]
+    } else {
+      target[CODEMIRROR_EDIT_CONTEXT_FLAG] = previous
+    }
+  }
+}
+
+// CodeMirror ships an EditContext input path, but gates it to Android. The
+// postinstall patch in scripts/patch-codemirror-edit-context.mjs adds this
+// scoped opt-in so the Windows chat composer can bypass Chrome/WebView2's
+// legacy contenteditable IME path without changing the editor surface.
+const FORCE_CODEMIRROR_EDIT_CONTEXT = shouldForceCodeMirrorEditContext()
 
 const baseTheme = EditorView.theme({
   "&": {
@@ -475,10 +524,11 @@ const MentionComposerInput = forwardRef<ComposerInputHandle, MentionComposerInpu
     }, [pendingFileAction, pendingFilePrimary, runPendingFileAction])
 
     useLayoutEffect(() => {
-      if (!hostRef.current || viewRef.current) return
+      const parent = hostRef.current
+      if (!parent || viewRef.current) return
 
-      const view = new EditorView({
-        parent: hostRef.current,
+      const view = withCodeMirrorEditContext(FORCE_CODEMIRROR_EDIT_CONTEXT, () => new EditorView({
+        parent,
         state: EditorState.create({
           doc: valueRef.current,
           extensions: [
@@ -509,7 +559,7 @@ const MentionComposerInput = forwardRef<ComposerInputHandle, MentionComposerInpu
             }),
           ],
         }),
-      })
+      }))
 
       viewRef.current = view
       return () => {
@@ -523,6 +573,11 @@ const MentionComposerInput = forwardRef<ComposerInputHandle, MentionComposerInpu
     useLayoutEffect(() => {
       const view = viewRef.current
       if (!view) return
+      // Never reconcile the external value while an IME composition is active.
+      // Dispatching a doc-replacing transaction mid-composition aborts the
+      // composition. CM6 fires its own docChanged on compositionend, after which
+      // value/doc reconverge and any genuinely-needed sync runs later.
+      if (view.composing) return
       const current = view.state.doc.toString()
       if (value === current) return
 


### PR DESCRIPTION
## Summary

- Opt the chat composer into CodeMirror's EditContext input path on Windows WebView2 so Sogou Pinyin can input Chinese reliably without replacing the CM6 editor.
- Add a postinstall patch for `@codemirror/view` that keeps the upstream Android default but allows Hope Agent's scoped EditContext flag.
- Avoid mutating CM6 mention decorations, atomic delete handling, or controlled-value sync during active IME composition.
- Use the normal opaque/decorated Windows main window config so native window controls and IME focus behavior are sane.

## Root Cause

The chat composer is CodeMirror 6, not a native `<input>`. On Windows WebView2/Chromium 149, Sogou Pinyin fails on CM6's legacy `contenteditable` input path even though plain inputs and bare contenteditable elements work. CodeMirror already ships an EditContext input implementation, but gates it to Android. This PR adds a narrow app-level opt-in only while constructing the Windows chat composer.

## Validation

- `pnpm typecheck`
- Manual Windows 11 verification: Sogou Pinyin now inputs Chinese in the chat composer; Microsoft Pinyin remains working.

Fixes #315.