### PR TITLE
build: apply CodeMirror patch in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,10 @@ COPY src ./src
 COPY public ./public
 COPY scripts ./scripts
 
+# Docker installs dependencies with --ignore-scripts, so apply the
+# CodeMirror EditContext patch explicitly before bundling the web UI.
+RUN node scripts/patch-codemirror-edit-context.mjs
+
 RUN pnpm build && \
     # Sanity check — the rust stage assumes /work/dist/index.html exists
     # and is the REAL build output, not `crates/ha-server/build.rs`'s


### PR DESCRIPTION
## Summary

- Run `scripts/patch-codemirror-edit-context.mjs` explicitly in the Docker frontend build stage after `scripts/` is copied.
- Keep the self-hosted/server web UI aligned with the Windows Sogou IME fix from #322 even though Docker installs frontend dependencies with `pnpm install --ignore-scripts`.

## Root Cause

The Windows IME fix relies on patching `@codemirror/view` so CodeMirror can use the EditContext path when `FORCE_CODEMIRROR_EDIT_CONTEXT` is enabled. Local installs run this via `postinstall`, but the Dockerfile deliberately skips lifecycle scripts during dependency installation. Without an explicit patch step, the Docker-built web UI can still bundle unpatched CodeMirror.

## Validation

- Dockerfile-only change; no TypeScript or Rust checks run locally.
- Verified the patch command runs after `COPY scripts ./scripts` and before `pnpm build`, so the bundle is produced from patched dependencies.