### PR TITLE
release: 🦭 v0.10.3 稳定性修复（macOS 唤醒崩溃 / Windows 输入法 / 黑窗）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,13 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- **Windows 上发消息不再闪黑窗**：修复 Windows 桌面版每次发送消息（及部分工具 / git / docker / MCP 等操作）时一闪而过的 `cmd` 控制台黑窗——子进程现在统一以无窗口方式启动，不再打断操作或抢走输入框焦点。 (#320)
-
-## [0.10.3] - 2026-06-14
+## [0.10.3] - 2026-06-17
 
 ### Fixed
 
 - **修复 macOS 睡眠 / 锁屏一段时间唤醒后偶发整页崩溃**：唤醒后个别后台事件帧为空，会击穿界面渲染弹出「undefined is not an object」错误页（需点 Try Again 才能恢复）；现已在事件解析入口统一拦截空 / 异常帧，并把这类前端崩溃记入应用日志便于后续自查。 (#319)
-- **修复 Windows 下搜狗拼音无法在对话输入框输入中文**：对话输入框继续保留 CodeMirror 6 与 `@` / `[[ ]]` 内联提及体验，但在 Windows WebView2 上改走 CodeMirror 的 EditContext 输入路径，绕开旧 `contenteditable` 管线与搜狗拼音的兼容性问题；同时 Windows 主窗口恢复原生标题栏与窗口控制按钮。 (#315)
+- **修复 Windows 下搜狗拼音无法在对话输入框输入中文**：对话输入框继续保留 CodeMirror 6 与 `@` / `[[ ]]` 内联提及体验，但在 Windows WebView2 上改走 CodeMirror 的 EditContext 输入路径，绕开旧 `contenteditable` 管线与搜狗拼音的兼容性问题；同时 Windows 主窗口恢复原生标题栏与窗口控制按钮（Docker 自托管构建也已同步应用该输入修复）。 (#322, #323)
+- **Windows 上发消息不再闪黑窗**：修复 Windows 桌面版每次发送消息（及部分工具 / git / docker / MCP 等操作）时一闪而过的 `cmd` 控制台黑窗——子进程现在统一以无窗口方式启动，不再打断操作或抢走输入框焦点。 (#320)
 
 ## [0.10.2] - 2026-06-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,7 +3017,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "aes",
  "anyhow",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -3238,7 +3238,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.10.2"
+version = "0.10.3"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.10.2"
+version = "0.10.3"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.10.3.en.md
+++ b/docs/release-notes/v0.10.3.en.md
@@ -1,0 +1,15 @@
+# Hope Agent 0.10.3 — Stability Fixes (macOS Wake Crash / Windows IME / Console Flash)
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.10.3/docs/release-notes/v0.10.3.md) · **English**
+
+> Released: 2026-06-17
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.10.3/CHANGELOG.md#0103---2026-06-17) for details.
+
+v0.10.3 is a patch for v0.10.0 focused on stability and input-experience fixes on macOS and Windows.
+
+## Fixed
+
+- **Fixed an occasional full-page crash on macOS after waking from sleep / lock**: after waking, some background event frames came through empty, which broke UI rendering and surfaced an "undefined is not an object" error page (requiring a Try Again to recover). Empty / malformed frames are now intercepted at the event-parsing entry point, stopping this whole class of crashes at the source, and such frontend crashes are now recorded in the application log for easier diagnosis. (#319)
+- **Fixed Sogou Pinyin being unable to type Chinese in the chat input on Windows**: the chat input keeps the CodeMirror 6 editor and the `@` / `[[ ]]` inline mention experience, but on Windows WebView2 it now uses CodeMirror's EditContext input path, sidestepping the compatibility issue between the old `contenteditable` pipeline and Sogou Pinyin; the Windows main window also restores the native title bar and window controls. The Docker self-hosted build now applies the same input fix as well. (#322, #323)
+- **No more console flash when sending a message on Windows**: fixed the brief `cmd` console window that flashed on the Windows desktop build every time you sent a message (and during some tool / git / docker / MCP operations) — subprocesses are now started without a window, so they no longer interrupt your work or steal focus from the input box. (#320)

--- a/docs/release-notes/v0.10.3.md
+++ b/docs/release-notes/v0.10.3.md
@@ -1,0 +1,15 @@
+# Hope Agent 0.10.3 — 稳定性修复（macOS 唤醒崩溃 / Windows 输入法 / 黑窗）
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.10.3/docs/release-notes/v0.10.3.en.md)
+
+> 发布日期：2026-06-17
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.10.3/CHANGELOG.md#0103---2026-06-17)。
+
+v0.10.3 是 v0.10.0 的补丁版，集中修复 macOS 与 Windows 上的几处稳定性与输入体验问题。
+
+## 修复
+
+- **修复 macOS 睡眠 / 锁屏一段时间唤醒后偶发整页崩溃**：唤醒后个别后台事件帧为空，会击穿界面渲染、弹出「undefined is not an object」错误页（需点 Try Again 才能恢复）。现已在事件解析入口统一拦截空 / 异常帧，从源头堵住这一类崩溃，并把这类前端崩溃记入应用日志，便于后续自查。(#319)
+- **修复 Windows 下搜狗拼音无法在对话输入框输入中文**：对话输入框继续保留 CodeMirror 6 与 `@` / `[[ ]]` 内联提及体验，但在 Windows WebView2 上改走 CodeMirror 的 EditContext 输入路径，绕开旧 `contenteditable` 管线与搜狗拼音的兼容性问题；同时 Windows 主窗口恢复原生标题栏与窗口控制按钮。Docker 自托管构建也已同步应用该输入修复。(#322, #323)
+- **Windows 上发消息不再闪黑窗**：修复 Windows 桌面版每次发送消息（及部分工具 / git / docker / MCP 等操作）时一闪而过的 `cmd` 控制台黑窗——子进程现在统一以无窗口方式启动，不再打断操作或抢走输入框焦点。(#320)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.10.2"
+version = "0.10.3"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
v0.10.0 的补丁版，集中修复 macOS 与 Windows 上的稳定性与输入体验问题。

## 包含修复

- **#319** 修复 macOS 睡眠 / 锁屏唤醒后空事件帧引发的整页崩溃，前端崩溃接入应用日志
- **#322 / #323** 修复 Windows 搜狗拼音无法在对话输入框输入中文（改走 CodeMirror EditContext），Docker 构建同步应用该补丁
- **#320** Windows 子进程统一无窗口启动，消除发消息时 cmd 黑窗一闪

## 发版材料

- CHANGELOG.md 新增 `[0.10.3] - 2026-06-17` 段
- 双语 release notes：`docs/release-notes/v0.10.3.md` / `v0.10.3.en.md`
- 版本号同步五处来源 + Cargo.lock（`pnpm version 0.10.3 --no-git-tag-version`）

合并后在 release/v0.10 HEAD 打 tag `v0.10.3` 触发 release.yml；随后 cherry-pick 这些修复回 main。