### PR TITLE
[codex] Guard manual compaction stale saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **主动上下文压缩在桌面 / HTTP Server / IM 中行为对齐**：`compact_context_now` 与 `/compact` 不再在 HTTP/server 模式返回「不支持」或仅做同步清理，而是会按会话模型恢复历史、绕过节流并尽量执行 Tier 3 摘要；桌面端压缩期间不再临时清空全局 Agent，避免并发入口误报「No active agent」。主动压缩失败 / 无消息 / 取消等提示也补齐多语言文案。
+- **主动上下文压缩在桌面 / HTTP Server / IM 中行为对齐**：`compact_context_now` 与 `/compact` 不再在 HTTP/server 模式返回「不支持」或仅做同步清理，而是会按会话模型恢复历史、绕过节流并尽量执行 Tier 3 摘要；桌面端压缩期间不再临时清空全局 Agent，避免并发入口误报「No active agent」，且同会话并发回合不会被旧压缩快照覆盖。主动压缩失败 / 无消息 / 取消等提示也补齐多语言文案。
 - **异常中断恢复提示不再反复刷屏**：启动恢复已处理过的中断流式片段后，会把相关消息标记为 recovered；再次打开同一会话不再重复追加「上次会话异常中断」提示，前端也会在同一轮内折叠重复的恢复提示。
 - **个人资料设置入口不再显示 i18n key 错误**：修复 `settings.profile` 同时被记忆画像对象占用后，设置侧栏、个人资料页标题和左侧头像 tooltip 显示 `key 'settings.profile'...` 的问题。
 - **记忆断言回填弹层不再横向溢出**：回填历史记忆的预览弹层现在限制在视口内，说明文字自动换行，统计卡响应式排列，候选列表长内容截断并在弹层内滚动。

--- a/crates/ha-core/src/chat_engine/context.rs
+++ b/crates/ha-core/src/chat_engine/context.rs
@@ -55,16 +55,17 @@ pub(super) async fn build_agent_from_snapshot(
 /// at turn-termination time (either runtime convergence in `engine.rs`
 /// or the startup sweep in `app_init`). Restore just loads what's
 /// there and hands it to the agent.
-pub fn restore_agent_context(db: &Arc<SessionDB>, session_id: &str, agent: &AssistantAgent) {
-    let Ok(Some(json_str)) = db.load_context(session_id) else {
-        return;
-    };
+pub fn restore_agent_context_from_json(
+    session_id: &str,
+    json_str: &str,
+    agent: &AssistantAgent,
+) -> bool {
     let history: Vec<serde_json::Value> = match serde_json::from_str(&json_str) {
         Ok(v) => v,
-        Err(_) => return,
+        Err(_) => return false,
     };
     if history.is_empty() {
-        return;
+        return false;
     }
     app_debug!(
         "session",
@@ -74,6 +75,14 @@ pub fn restore_agent_context(db: &Arc<SessionDB>, session_id: &str, agent: &Assi
         session_id
     );
     agent.set_conversation_history(history);
+    true
+}
+
+pub fn restore_agent_context(db: &Arc<SessionDB>, session_id: &str, agent: &AssistantAgent) {
+    let Ok(Some(json_str)) = db.load_context(session_id) else {
+        return;
+    };
+    restore_agent_context_from_json(session_id, &json_str, agent);
 }
 
 /// Save the agent's conversation history to DB.

--- a/crates/ha-core/src/chat_engine/engine.rs
+++ b/crates/ha-core/src/chat_engine/engine.rs
@@ -317,6 +317,14 @@ pub async fn compact_session_now(
         event_sink,
     } = params;
 
+    let _active_turn_guard = super::active_turn::try_acquire(
+        &session_id,
+        source,
+        format!("manual-compact-{}", uuid::Uuid::new_v4()),
+        Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    )
+    .map_err(|e| e.to_string())?;
+
     let provider = providers
         .iter()
         .find(|p| p.id == model.provider_id)
@@ -367,14 +375,35 @@ pub async fn compact_session_now(
         kb_access_source(source),
         None,
     );
-    restore_agent_context(&session_db, &session_id, &agent);
+    let original_context_json = session_db
+        .load_context(&session_id)
+        .map_err(|e| format!("Cannot load context for manual compaction: {e}"))?;
+    if let Some(json_str) = original_context_json.as_deref() {
+        restore_agent_context_from_json(&session_id, json_str, &agent);
+    }
 
     let emit = |delta: &str| {
         let _ = emit_stream_event(&session_db, &event_sink, &session_id, source, None, delta);
     };
     let compact_result = agent.compact_conversation_now(&emit).await;
 
-    save_agent_context(&session_db, &session_id, &agent);
+    let compacted_context_json = serde_json::to_string(&agent.get_conversation_history())
+        .map_err(|e| format!("Cannot serialize compacted context: {e}"))?;
+    if original_context_json.as_deref() != Some(compacted_context_json.as_str()) {
+        let saved = session_db
+            .save_context_if_unchanged(
+                &session_id,
+                original_context_json.as_deref(),
+                &compacted_context_json,
+            )
+            .map_err(|e| format!("Cannot save compacted context: {e}"))?;
+        if !saved {
+            return Err(
+                "Session context changed during manual compaction; skipped stale compacted snapshot"
+                    .to_string(),
+            );
+        }
+    }
     app_info!(
         "context",
         "compact::manual",

--- a/crates/ha-core/src/session/db.rs
+++ b/crates/ha-core/src/session/db.rs
@@ -2958,6 +2958,37 @@ impl SessionDB {
         Ok(())
     }
 
+    /// Save context only if the DB value still matches the caller's snapshot.
+    pub fn save_context_if_unchanged(
+        &self,
+        session_id: &str,
+        expected_context_json: Option<&str>,
+        context_json: &str,
+    ) -> Result<bool> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+        let current = conn
+            .query_row(
+                "SELECT context_json FROM sessions WHERE id = ?1",
+                params![session_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .optional()?;
+        let Some(current) = current else {
+            return Ok(false);
+        };
+        if current.as_deref() != expected_context_json {
+            return Ok(false);
+        }
+        let changed = conn.execute(
+            "UPDATE sessions SET context_json = ?1 WHERE id = ?2",
+            params![context_json, session_id],
+        )?;
+        Ok(changed > 0)
+    }
+
     /// Load the agent's conversation_history JSON for a session.
     /// Returns None if the session has no saved context.
     pub fn load_context(&self, session_id: &str) -> Result<Option<String>> {
@@ -3913,6 +3944,50 @@ mod tests {
             loaded.title_source,
             crate::session_title::TITLE_SOURCE_MANUAL
         );
+
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn save_context_if_unchanged_rejects_stale_snapshot() {
+        let db_path = temp_db_path("session-context-cas");
+        let db = SessionDB::open(&db_path).expect("open session db");
+        ensure_channel_conversations_table(&db);
+
+        let created = db
+            .create_session(crate::agent_loader::DEFAULT_AGENT_ID)
+            .expect("create session");
+
+        db.save_context(&created.id, r#"["old"]"#)
+            .expect("seed context");
+        let saved = db
+            .save_context_if_unchanged(&created.id, Some(r#"["old"]"#), r#"["compact"]"#)
+            .expect("guarded save");
+        assert!(saved);
+        assert_eq!(
+            db.load_context(&created.id)
+                .expect("load context")
+                .as_deref(),
+            Some(r#"["compact"]"#)
+        );
+
+        db.save_context(&created.id, r#"["new turn"]"#)
+            .expect("simulate concurrent turn");
+        let stale = db
+            .save_context_if_unchanged(&created.id, Some(r#"["compact"]"#), r#"["stale"]"#)
+            .expect("stale save should not error");
+        assert!(!stale);
+        assert_eq!(
+            db.load_context(&created.id)
+                .expect("load context")
+                .as_deref(),
+            Some(r#"["new turn"]"#)
+        );
+
+        let missing = db
+            .save_context_if_unchanged("missing-session", None, "[]")
+            .expect("missing row should not error");
+        assert!(!missing);
 
         let _ = std::fs::remove_file(&db_path);
     }


### PR DESCRIPTION
## Summary

- Treat manual compaction as a same-session active turn so local chat entry points reject overlapping turns while the LLM summary is in flight.
- Add `SessionDB::save_context_if_unchanged` and use it before writing compacted `context_json`, preventing stale snapshots from overwriting a newer completed turn.
- Reuse the originally loaded context snapshot for restore so the CAS check matches the exact compaction input.
- Update the changelog note for the new concurrency guard.

## Review Follow-up

Addresses the unresolved Codex review thread on #339: manual compaction could restore `context_json`, await summarization, then unconditionally save a stale compacted snapshot over a newer same-session turn.

## Validation

- `cargo fmt -p ha-core`
- `cargo check -p ha-core --tests`

I did not run `cargo test`; this repo asks agents to confirm before running tests manually.