### PR TITLE
[codex] Smooth processed step collapsing

### DIFF
--- a/src/components/chat/message/MessageContent.test.tsx
+++ b/src/components/chat/message/MessageContent.test.tsx
@@ -120,18 +120,20 @@ describe("AssistantContentBlocks processed grouping", () => {
     expect(screen.queryByTestId("tool-block")).toBeNull()
   })
 
-  test("folds multiple completed process units and mounts details only after expand", () => {
+  test("folds multiple completed process units after text arrives", () => {
     renderContentBlocks([
       { type: "thinking", content: "first thought" },
       { type: "tool_call", tool: tool("call-1") },
       { type: "tool_call", tool: tool("call-2") },
       { type: "thinking", content: "second thought" },
+      { type: "text", content: "visible answer" },
     ])
 
     const processed = screen.getByRole("button", { name: /已处理/ })
     expect(processed.getAttribute("aria-expanded")).toBe("false")
     expect(screen.queryByTestId("thinking-block")).toBeNull()
     expect(screen.queryByTestId("tool-group")).toBeNull()
+    expect(screen.getByTestId("markdown").textContent).toBe("visible answer")
 
     fireEvent.click(processed)
 
@@ -153,7 +155,7 @@ describe("AssistantContentBlocks processed grouping", () => {
     expect(screen.getByTestId("tool-block").textContent).toBe("read:call-1")
   })
 
-  test("folds the completed prefix while streaming, leaving the live tail unfolded", () => {
+  test("keeps completed process units visible while streaming before text arrives", () => {
     renderContentBlocks(
       [
         { type: "thinking", content: "first thought" },
@@ -164,23 +166,40 @@ describe("AssistantContentBlocks processed grouping", () => {
       { loading: true, isLast: true },
     )
 
-    // First thought + the two completed tools fold into one 已处理 group; the
-    // trailing thinking block is the live tail and stays expanded.
+    // No text_delta has arrived yet, so completing the tools/thinking should
+    // not replace the visible steps with an 已处理 header.
+    expect(screen.queryByRole("button", { name: /已处理/ })).toBeNull()
+    expect(screen.getAllByTestId("thinking-block")).toHaveLength(2)
+    expect(screen.getByTestId("tool-group").textContent).toBe("call-1,call-2")
+  })
+
+  test("folds the completed prefix while streaming once text arrives", () => {
+    renderContentBlocks(
+      [
+        { type: "thinking", content: "first thought" },
+        { type: "tool_call", tool: tool("call-1") },
+        { type: "tool_call", tool: tool("call-2") },
+        { type: "thinking", content: "second thought" },
+        { type: "text", content: "partial answer" },
+      ],
+      { loading: true, isLast: true },
+    )
+
     const processed = screen.getByRole("button", { name: /已处理/ })
     expect(processed.getAttribute("aria-expanded")).toBe("false")
-    expect(screen.getByTestId("thinking-block").textContent).toBe("second thought")
+    expect(screen.getByTestId("markdown").textContent).toBe("partial answer")
     expect(screen.queryByTestId("tool-group")).toBeNull()
 
     fireEvent.click(processed)
-    // first thought + tool group live inside the folded prefix.
     expect(screen.getByTestId("tool-group").textContent).toBe("call-1,call-2")
     expect(screen.getAllByTestId("thinking-block")).toHaveLength(2)
   })
 
-  test("folds a fully-completed run even while the message is flagged streaming", () => {
+  test("does not fold a completed run while the message is flagged streaming without text", () => {
     // Mirrors an abnormally interrupted turn: `loading` stays stuck true after
     // the stream_end was missed, but every step has already finished. Folding
-    // must not depend on the loading flag — the completed steps still collapse.
+    // still waits for assistant text so completed tool events do not cause a
+    // one-frame collapse flash.
     renderContentBlocks(
       [
         { type: "thinking", content: "first thought" },
@@ -191,10 +210,9 @@ describe("AssistantContentBlocks processed grouping", () => {
       { loading: true, isLast: true },
     )
 
-    // Last block is a tool_call → a non-complete `__loading__` tail unit is
-    // appended, so the three tools + thinking fold into one 已处理 group.
-    screen.getByRole("button", { name: /已处理/ })
-    expect(screen.queryByTestId("tool-group")).toBeNull()
+    expect(screen.queryByRole("button", { name: /已处理/ })).toBeNull()
+    expect(screen.getByTestId("thinking-block").textContent).toBe("first thought")
+    expect(screen.getByTestId("tool-group").textContent).toBe("call-1,call-2,call-3")
   })
 
   test("folds a single completed tool while streaming and keeps the live text tail visible", () => {
@@ -220,7 +238,7 @@ describe("AssistantContentBlocks processed grouping", () => {
     expect(screen.getByTestId("thinking-block").textContent).toBe("mid thought")
   })
 
-  test("folds the completed prefix in timeline mode while streaming", () => {
+  test("does not fold the completed prefix in timeline mode before text arrives", () => {
     renderContentBlocks(
       [
         { type: "thinking", content: "first thought" },
@@ -231,10 +249,25 @@ describe("AssistantContentBlocks processed grouping", () => {
       { loading: true, isLast: true, displayMode: "timeline" },
     )
 
-    // Same folding as bubble mode: completed prefix → one 已处理 timeline item,
-    // trailing thinking stays as the live tail.
+    expect(screen.queryByRole("button", { name: /已处理/ })).toBeNull()
+    expect(screen.getAllByTestId("thinking-block")).toHaveLength(2)
+    expect(screen.getByTestId("tool-group").textContent).toBe("call-1,call-2")
+  })
+
+  test("folds the completed prefix in timeline mode once text arrives", () => {
+    renderContentBlocks(
+      [
+        { type: "thinking", content: "first thought" },
+        { type: "tool_call", tool: tool("call-1") },
+        { type: "tool_call", tool: tool("call-2") },
+        { type: "thinking", content: "second thought" },
+        { type: "text", content: "partial answer" },
+      ],
+      { loading: true, isLast: true, displayMode: "timeline" },
+    )
+
     screen.getByRole("button", { name: /已处理/ })
-    expect(screen.getByTestId("thinking-block").textContent).toBe("second thought")
+    expect(screen.getByTestId("markdown").textContent).toBe("partial answer")
     expect(screen.queryByTestId("tool-group")).toBeNull()
   })
 })

--- a/src/components/chat/message/MessageContent.tsx
+++ b/src/components/chat/message/MessageContent.tsx
@@ -8,6 +8,10 @@ import TaskBlock from "./TaskBlock"
 import ProcessedBlockGroup from "./ProcessedBlockGroup"
 import InterruptedMark from "./InterruptedMark"
 import {
+  AnimatedCollapse,
+  AnimatedPresenceBox,
+} from "@/components/ui/animated-presence"
+import {
   MessageTimeline,
   MessageTimelineItem,
   type MessageTimelineTone,
@@ -158,6 +162,14 @@ function processUnitToolsComplete(tools: ToolCall[]): boolean {
   return tools.every((tool) => getToolExecutionState(tool) !== "running")
 }
 
+function hasTextFrom(blocks: ContentBlock[], start: number): boolean {
+  for (let i = start; i < blocks.length; i++) {
+    const block = blocks[i]
+    if (block.type === "text" && block.content.length > 0) return true
+  }
+  return false
+}
+
 /**
  * Build the collapsed `ProcessedBlockGroup` node for a run of completed units.
  * Total time sums every unit's own elapsed (tool durations + thinking); media
@@ -190,6 +202,39 @@ function buildProcessedGroup(group: RenderUnit[]): {
   }
 }
 
+function isProcessUnit(unit: RenderUnit): boolean {
+  return unit.isProcessComplete !== undefined
+}
+
+function ProcessedRunTransition({ units }: { units: RenderUnit[] }) {
+  const folded = units.length >= 2 && units.every((unit) => unit.isProcessComplete)
+  const built = folded ? buildProcessedGroup(units) : null
+
+  if (units.length < 2) {
+    return <>{units.map((unit) => unit.node)}</>
+  }
+
+  return (
+    <div className="min-w-0">
+      <AnimatedPresenceBox
+        open={folded}
+        enterFromClassName="opacity-0 -translate-y-1 scale-[0.99]"
+        enterClassName="opacity-100 translate-y-0 scale-100"
+        exitClassName="opacity-0 -translate-y-1 scale-[0.99] pointer-events-none"
+      >
+        {built?.node}
+      </AnimatedPresenceBox>
+      <AnimatedCollapse open={!folded}>
+        <div className="min-w-0">
+          {units.map((unit) => (
+            <React.Fragment key={unit.key}>{unit.node}</React.Fragment>
+          ))}
+        </div>
+      </AnimatedCollapse>
+    </div>
+  )
+}
+
 /** Bubble layout: collapse runs of ≥2 completed units into a ProcessedBlockGroup. */
 function collapseProcessedUnits(units: RenderUnit[]): React.ReactNode[] {
   const nodes: React.ReactNode[] = []
@@ -197,21 +242,23 @@ function collapseProcessedUnits(units: RenderUnit[]): React.ReactNode[] {
 
   while (i < units.length) {
     const unit = units[i]
-    if (!unit.isProcessComplete) {
+    if (!isProcessUnit(unit)) {
       nodes.push(unit.node)
       i++
       continue
     }
 
-    const group: RenderUnit[] = [unit]
+    const run: RenderUnit[] = [unit]
     let j = i + 1
-    while (j < units.length && units[j].isProcessComplete) {
-      group.push(units[j])
+    while (j < units.length && isProcessUnit(units[j])) {
+      run.push(units[j])
       j++
     }
 
-    if (group.length >= 2) {
-      nodes.push(buildProcessedGroup(group).node)
+    if (run.length >= 2) {
+      nodes.push(
+        <ProcessedRunTransition key={`process-run-${run[0].key}`} units={run} />,
+      )
     } else {
       nodes.push(unit.node)
     }
@@ -233,10 +280,9 @@ interface TimelineRenderItem {
  * Timeline layout: same collapsing as {@link collapseProcessedUnits}, but each
  * run of ≥2 completed units folds into a SINGLE timeline item (one dot) holding
  * a ProcessedBlockGroup — so a finished tool/thinking sequence reads as one
- * "processed" entry. Per-unit completion drives folding (not a whole-message
- * streaming flag), so the completed prefix folds even mid-turn; only the live
- * trailing unit (a streaming text/thinking block or the `__loading__` dots)
- * stays unfolded and carries the active dot.
+ * "processed" entry. A process unit only becomes foldable after text appears
+ * later in the message, so a tool/thinking step completing in-between model
+ * rounds does not flash into "processed" before the assistant starts speaking.
  */
 function collapseProcessedTimelineUnits(
   units: RenderUnit[],
@@ -359,13 +405,13 @@ export function AssistantContentBlocks({
 
     if (block.type === "thinking") {
       const isLastBlock = i === blocks.length - 1
+      const hasLaterText = hasTextFrom(blocks, i + 1)
       units.push({
         key: `thinking-${i}`,
-        // A thinking block is "done" the moment a later block exists after it.
-        // Only the block actively streaming at the tail stays unfolded — this
-        // is what lets the completed prefix fold into 已处理 even mid-turn
-        // (and after an abnormal interruption that left `loading` stuck true).
-        isProcessComplete: !(isStreamingMessage && isLastBlock),
+        // Fold thinking/tool work only once the assistant has begun emitting
+        // text after it. This keeps completed tool rounds visible while the
+        // model is between tool_result and the next text_delta.
+        isProcessComplete: hasLaterText && !(isStreamingMessage && isLastBlock),
         elapsedMs: block.durationMs,
         node: (
           <ThinkingBlock
@@ -556,6 +602,7 @@ export function AssistantContentBlocks({
       }
 
       const isLastToolGroup = loading && isLast && j === blocks.length
+      const hasLaterText = hasTextFrom(blocks, j)
       if (group.length >= 2) {
         // Render as a collapsed group
         const tools = group.map(
@@ -564,12 +611,7 @@ export function AssistantContentBlocks({
         units.push({
           key: `grp-${tools[0].callId}`,
           processTools: tools,
-          // Fold once every tool in the group has finished, regardless of
-          // whether the message is still streaming. While streaming, the live
-          // tail is carried by the `__loading__` unit (last block is a
-          // tool_call) or the actively-streaming trailing text/thinking unit,
-          // so a completed tool group is never the active item.
-          isProcessComplete: processUnitToolsComplete(tools),
+          isProcessComplete: hasLaterText && processUnitToolsComplete(tools),
           elapsedMs: getToolsWallClockMs(tools),
           node: (
             <ToolCallGroup
@@ -585,7 +627,8 @@ export function AssistantContentBlocks({
         units.push({
           key: block.tool.callId,
           processTools: [block.tool],
-          isProcessComplete: getToolExecutionState(block.tool) !== "running",
+          isProcessComplete:
+            hasLaterText && getToolExecutionState(block.tool) !== "running",
           elapsedMs: block.tool.durationMs,
           node: (
             <ToolCallBlock
@@ -624,9 +667,8 @@ export function AssistantContentBlocks({
   if (displayMode === "timeline") {
     const activeIndex = isStreamingMessage ? units.length - 1 : -1
     // Fold consecutive completed tool/thinking steps into one "processed"
-    // timeline entry (matches the bubble layout). The trailing unit while
-    // streaming is non-complete by construction, so it stays 1:1 and the live
-    // active dot tracks the last step.
+    // timeline entry (matches the bubble layout). Completion is gated by a
+    // later text block, not by tool/thinking completion alone.
     const items = collapseProcessedTimelineUnits(units, activeIndex)
     return (
       <MessageTimeline>

--- a/src/components/chat/message/ProcessedBlockGroup.tsx
+++ b/src/components/chat/message/ProcessedBlockGroup.tsx
@@ -30,7 +30,7 @@ export default function ProcessedBlockGroup({
   const elapsedText = totalElapsedMs != null && totalElapsedMs > 0 ? formatDuration(totalElapsedMs) : null
 
   return (
-    <div className="my-1 text-xs">
+    <div className="my-1 text-xs animate-in fade-in-0 duration-200 motion-reduce:animate-none">
       <button
         type="button"
         aria-expanded={expanded}

--- a/src/components/ui/animated-presence.tsx
+++ b/src/components/ui/animated-presence.tsx
@@ -159,11 +159,12 @@ export function AnimatedCollapse({
   if (!present && !open && unmountOnExit) return null
 
   const allowOverflow = overflow === "visible-when-open" && visible
+  const timingFunction = visible ? UI_EASING.emphasized : UI_EASING.accelerate
 
   return (
     <div
       className={cn(
-        "transition-[height,opacity] ease-out motion-reduce:transition-none",
+        "transition-[height,opacity] motion-reduce:transition-none",
         allowOverflow ? "overflow-visible" : "overflow-hidden",
         visible ? "opacity-100" : "opacity-0 pointer-events-none",
         className,
@@ -171,6 +172,8 @@ export function AnimatedCollapse({
       style={{
         height: height === "auto" ? "auto" : `${height}px`,
         transitionDuration: `${durationMs}ms`,
+        transitionTimingFunction: timingFunction,
+        willChange: "height, opacity",
       }}
       aria-hidden={open ? undefined : true}
       inert={open ? undefined : true}

--- a/src/components/ui/motion.ts
+++ b/src/components/ui/motion.ts
@@ -2,7 +2,7 @@ export const UI_MOTION = {
   popover: 220,
   popoverEnter: 220,
   popoverExit: 180,
-  collapse: 200,
+  collapse: 240,
   panelWidth: 250,
   panelSurface: 300,
   panelContentEnter: 200,


### PR DESCRIPTION
## Summary

- Delay automatic folding of thinking/tool steps until assistant text has started streaming.
- Add a smooth transition for multi-step processed runs so visible steps collapse into the processed header instead of hard-swapping.
- Tune the shared collapse easing/duration and add regression coverage for pre-text vs post-text folding behavior.

## Why

The previous processed-state transition folded tool/thinking blocks as soon as they completed. During streaming this caused visible flashing before the model emitted text. A later layout-animation attempt also risked measuring exiting content and could create extra blank space.

## Validation

- `pnpm typecheck`
- `git diff --check`

Draft PR for UI review of the motion feel.