### PR TITLE
[codex] 用文件夹图标表示项目展开状态

### DIFF
--- a/src/components/chat/project/ProjectSection.tsx
+++ b/src/components/chat/project/ProjectSection.tsx
@@ -24,6 +24,8 @@ import {
   ChevronRight,
   ChevronDown,
   ChevronUp,
+  Folder,
+  FolderOpen,
   Loader2,
   MessageSquarePlus,
   Plus,
@@ -335,6 +337,7 @@ function ProjectGroup({
     sessionCount: project.sessionCount,
   })
   const showPaginationFooter = childTotal > PROJECT_SESSION_PAGE_SIZE
+  const ProjectToggleIcon = groupExpanded ? FolderOpen : Folder
 
   const handleMarkProjectRead = useCallback(async () => {
     if (project.unreadCount === 0) return
@@ -373,12 +376,7 @@ function ProjectGroup({
               }
             }}
           >
-            <ChevronRight
-              className={cn(
-                "h-3 w-3 shrink-0 text-muted-foreground/60 transition-transform duration-150",
-                groupExpanded && "rotate-90",
-              )}
-            />
+            <ProjectToggleIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70 transition-colors duration-150" />
             {displayMode === "detailed" && (
               <div className="relative shrink-0">
                 <ProjectIcon project={project} size="sm" withColorChip />


### PR DESCRIPTION
## 变更

- 将侧边栏项目行的展开/收起指示从旋转箭头改为文件夹开/关图标。
- 保持点击整行展开项目会话列表的交互不变。

## 影响

- 项目折叠时显示关闭文件夹，展开时显示打开文件夹，更贴近侧边栏项目语义。
- 未改动归档分组、分页按钮等非项目行的箭头图标。

## 验证

pre-push 钩子已通过：

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `pnpm typecheck`
- `pnpm lint`（2 个既有 warning，无 error）
- `pnpm test`
- `cargo test -p ha-core -p ha-server --locked`
- `verify-updater-pubkey`