### PR TITLE
[codex] Tighten timeline message spacing

### DIFF
--- a/src/components/chat/message/MessageContent.tsx
+++ b/src/components/chat/message/MessageContent.tsx
@@ -14,6 +14,7 @@ import {
 import {
   MessageTimeline,
   MessageTimelineItem,
+  type MessageTimelineMarkerAlign,
   type MessageTimelineTone,
 } from "./MessageTimeline"
 import SubagentGroup, { type SubagentGroupRun } from "@/components/chat/SubagentGroup"
@@ -150,6 +151,7 @@ function synthesizeBlocks(msg: Message): ContentBlock[] {
 
 interface RenderUnit {
   key: string
+  markerAlign: MessageTimelineMarkerAlign
   node: React.ReactNode
   processTools?: ToolCall[]
   isProcessComplete?: boolean
@@ -272,6 +274,7 @@ function collapseProcessedUnits(units: RenderUnit[]): React.ReactNode[] {
 interface TimelineRenderItem {
   key: string
   tone: MessageTimelineTone
+  markerAlign: MessageTimelineMarkerAlign
   active: boolean
   node: React.ReactNode
 }
@@ -294,7 +297,13 @@ function collapseProcessedTimelineUnits(
   while (i < units.length) {
     const unit = units[i]
     if (!unit.isProcessComplete) {
-      items.push({ key: unit.key, tone: getTimelineTone(unit), active: i === activeIndex, node: unit.node })
+      items.push({
+        key: unit.key,
+        tone: getTimelineTone(unit),
+        markerAlign: unit.markerAlign,
+        active: i === activeIndex,
+        node: unit.node,
+      })
       i++
       continue
     }
@@ -308,9 +317,21 @@ function collapseProcessedTimelineUnits(
 
     if (group.length >= 2) {
       const built = buildProcessedGroup(group)
-      items.push({ key: `processed-${group[0].key}`, tone: built.tone, active: false, node: built.node })
+      items.push({
+        key: `processed-${group[0].key}`,
+        tone: built.tone,
+        markerAlign: "control",
+        active: false,
+        node: built.node,
+      })
     } else {
-      items.push({ key: unit.key, tone: getTimelineTone(unit), active: i === activeIndex, node: unit.node })
+      items.push({
+        key: unit.key,
+        tone: getTimelineTone(unit),
+        markerAlign: unit.markerAlign,
+        active: i === activeIndex,
+        node: unit.node,
+      })
     }
 
     i = j
@@ -367,7 +388,9 @@ export function AssistantContentBlocks({
       if (displayMode === "timeline") {
         return (
           <MessageTimeline>
-            <MessageTimelineItem tone="running">{node}</MessageTimelineItem>
+            <MessageTimelineItem tone="running" dense>
+              {node}
+            </MessageTimelineItem>
           </MessageTimeline>
         )
       }
@@ -378,6 +401,7 @@ export function AssistantContentBlocks({
 
   const units: RenderUnit[] = []
   const isStreamingMessage = loading && isLast
+  const isTimelineDisplay = displayMode === "timeline"
   const taskExecutionState = executionState ?? (isStreamingMessage ? "running" : "idle")
 
   // Pre-compute first task_* position + latest task_* tool with a result,
@@ -408,6 +432,7 @@ export function AssistantContentBlocks({
       const hasLaterText = hasTextFrom(blocks, i + 1)
       units.push({
         key: `thinking-${i}`,
+        markerAlign: "text",
         // Fold thinking/tool work only once the assistant has begun emitting
         // text after it. This keeps completed tool rounds visible while the
         // model is between tool_result and the next text_delta.
@@ -417,6 +442,7 @@ export function AssistantContentBlocks({
           <ThinkingBlock
             key={i}
             content={block.content}
+            compact={isTimelineDisplay}
             isStreaming={loading && isLast && isLastBlock}
             durationMs={block.durationMs}
             interrupted={block.interrupted}
@@ -427,6 +453,7 @@ export function AssistantContentBlocks({
     } else if (block.type === "text") {
       units.push({
         key: `text-${i}`,
+        markerAlign: "text",
         node: (
           <div key={i}>
             {contentRenderMode === "markdown" ? (
@@ -450,6 +477,7 @@ export function AssistantContentBlocks({
       if (block.tool.name === "ask_user_question") {
         units.push({
           key: block.tool.callId,
+          markerAlign: "control",
           node: (
             <AskUserQuestionResult
               key={block.tool.callId}
@@ -465,6 +493,7 @@ export function AssistantContentBlocks({
         if (i === firstTaskIdx && latestTaskTool) {
           units.push({
             key: latestTaskTool.callId,
+            markerAlign: "control",
             processTools: [latestTaskTool],
             node: (
               <TaskBlock
@@ -488,6 +517,7 @@ export function AssistantContentBlocks({
         } catch { /* ignore */ }
         units.push({
           key: block.tool.callId,
+          markerAlign: "control",
           node: (
             <SubmitPlanResult
               key={block.tool.callId}
@@ -508,6 +538,7 @@ export function AssistantContentBlocks({
         const isLastTool = loading && isLast && i === blocks.length - 1
         units.push({
           key: block.tool.callId,
+          markerAlign: "control",
           node: (
             <SkillProgressBlock key={block.tool.callId} tool={block.tool} shimmer={isLastTool} />
           ),
@@ -539,6 +570,7 @@ export function AssistantContentBlocks({
             const groupKey = `sgrp-${runs.map((r) => r.runId).join("|")}`
             units.push({
               key: groupKey,
+              markerAlign: "control",
               node: (
                 <SubagentGroup key={groupKey} runs={runs} onSwitchSession={onSwitchSession} />
               ),
@@ -551,6 +583,7 @@ export function AssistantContentBlocks({
             const run = runs[0]
             units.push({
               key: run.runId,
+              markerAlign: "control",
               node: (
                 <SubagentBlock
                   key={run.runId}
@@ -571,6 +604,7 @@ export function AssistantContentBlocks({
         // group below.
         units.push({
           key: block.tool.callId,
+          markerAlign: "control",
           node: (
             <ToolCallBlock key={block.tool.callId} tool={block.tool} onOpenDiff={onOpenDiff} />
           ),
@@ -581,6 +615,7 @@ export function AssistantContentBlocks({
       if (NO_GROUP_TOOLS.has(block.tool.name)) {
         units.push({
           key: block.tool.callId,
+          markerAlign: "control",
           node: (
             <ToolCallBlock key={block.tool.callId} tool={block.tool} onOpenDiff={onOpenDiff} />
           ),
@@ -610,6 +645,7 @@ export function AssistantContentBlocks({
         )
         units.push({
           key: `grp-${tools[0].callId}`,
+          markerAlign: "control",
           processTools: tools,
           isProcessComplete: hasLaterText && processUnitToolsComplete(tools),
           elapsedMs: getToolsWallClockMs(tools),
@@ -626,6 +662,7 @@ export function AssistantContentBlocks({
         // Single tool — render individually
         units.push({
           key: block.tool.callId,
+          markerAlign: "control",
           processTools: [block.tool],
           isProcessComplete:
             hasLaterText && getToolExecutionState(block.tool) !== "running",
@@ -653,6 +690,7 @@ export function AssistantContentBlocks({
     if (lastBlock?.type === "tool_call") {
       units.push({
         key: "__loading__",
+        markerAlign: "text",
         node: (
           <div key="__loading__" className="flex items-center gap-1 py-1 px-2">
             <span className="block w-1.5 h-1.5 rounded-full bg-foreground/50 animate-pulse" />
@@ -673,7 +711,13 @@ export function AssistantContentBlocks({
     return (
       <MessageTimeline>
         {items.map((item) => (
-          <MessageTimelineItem key={item.key} active={item.active} tone={item.tone}>
+          <MessageTimelineItem
+            key={item.key}
+            active={item.active}
+            dense
+            markerAlign={item.markerAlign}
+            tone={item.tone}
+          >
             {item.node}
           </MessageTimelineItem>
         ))}

--- a/src/components/chat/message/MessageTimeline.tsx
+++ b/src/components/chat/message/MessageTimeline.tsx
@@ -10,6 +10,8 @@ export type MessageTimelineTone =
   | "tool"
   | "user"
 
+export type MessageTimelineMarkerAlign = "control" | "text"
+
 const DOT_TONE_CLASSES: Record<MessageTimelineTone, string> = {
   assistant: "bg-teal-500",
   failed: "bg-red-500",
@@ -53,6 +55,8 @@ interface MessageTimelineItemProps {
   className?: string
   contentClassName?: string
   active?: boolean
+  dense?: boolean
+  markerAlign?: MessageTimelineMarkerAlign
   tone?: MessageTimelineTone
 }
 
@@ -61,19 +65,38 @@ export function MessageTimelineItem({
   className,
   contentClassName,
   active = false,
+  dense = false,
+  markerAlign = "text",
   tone = "assistant",
 }: MessageTimelineItemProps) {
+  const markerOffsetClass =
+    dense && markerAlign === "control"
+      ? "pt-[0.625rem]"
+      : dense
+        ? "pt-[0.375rem]"
+        : "pt-[0.45rem]"
+  const lineStartClass =
+    dense && markerAlign === "control"
+      ? "top-[1.225rem]"
+      : dense
+        ? "top-[0.975rem]"
+        : "top-[1.1rem]"
+
   return (
     <div
       className={cn(
-        "group relative col-span-2 grid min-w-0 grid-cols-[1rem_minmax(0,1fr)] gap-x-3 py-1.5",
+        "group relative col-span-2 grid min-w-0 grid-cols-[1rem_minmax(0,1fr)] gap-x-3",
+        dense ? "py-0.5" : "py-1.5",
         className,
       )}
     >
-      <div className="relative flex justify-center pt-[0.45rem]">
+      <div className={cn("relative flex justify-center", markerOffsetClass)}>
         <span
           aria-hidden
-          className="pointer-events-none absolute bottom-0 left-1/2 top-[1.1rem] w-px -translate-x-1/2 bg-sky-500/18 dark:bg-sky-300/12 group-last:hidden"
+          className={cn(
+            "pointer-events-none absolute bottom-0 left-1/2 w-px -translate-x-1/2 bg-sky-500/18 dark:bg-sky-300/12 group-last:hidden",
+            lineStartClass,
+          )}
         />
         <span className="relative flex h-2.5 w-2.5 items-center justify-center">
           {active && (
@@ -103,7 +126,8 @@ export function MessageTimelineItem({
       </div>
       <div
         className={cn(
-          "min-w-0 break-words pb-2 text-sm leading-relaxed text-foreground/85 select-text",
+          "message-markdown-content min-w-0 break-words text-sm leading-relaxed text-foreground/85 select-text",
+          dense ? "pb-0.5" : "pb-2",
           contentClassName,
         )}
       >

--- a/src/components/chat/message/ThinkingBlock.tsx
+++ b/src/components/chat/message/ThinkingBlock.tsx
@@ -10,6 +10,7 @@ import InterruptedMark from "./InterruptedMark"
 
 interface ThinkingBlockProps {
   content: string
+  compact?: boolean
   isStreaming?: boolean
   /** Persisted duration from DB (ms), used to display elapsed time after restart */
   durationMs?: number
@@ -20,6 +21,7 @@ interface ThinkingBlockProps {
 
 export default function ThinkingBlock({
   content,
+  compact,
   isStreaming,
   durationMs,
   interrupted,
@@ -77,10 +79,13 @@ export default function ThinkingBlock({
   if (!content) return null
 
   return (
-    <div className="mb-3">
+    <div className={cn(compact ? "mb-1" : "mb-3")}>
       <button
         onClick={() => setManualOpen((prev) => !(prev ?? (isStreaming ? autoExpand : false)))}
-        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors py-1 group"
+        className={cn(
+          "flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors group",
+          compact ? "py-0.5" : "py-1",
+        )}
       >
         <ChevronRight
           className={cn("h-3.5 w-3.5 transition-transform duration-200", isOpen && "rotate-90")}


### PR DESCRIPTION
## Summary

- Tighten vertical spacing in timeline-mode assistant message items.
- Add separate marker alignment for text/thinking rows versus tool/control rows so timeline dots line up with each visual surface.
- Compact thinking rows in timeline mode while preserving the existing bubble-mode layout.

## Why

Task-mode conversations alternate between assistant text, thinking summaries, and processed/tool blocks. The previous shared spacing and fixed marker offset left large blank gaps and made timeline dots look slightly high or low depending on the row type.

## Validation

- `pnpm typecheck`
- pre-push hook: `cargo fmt --all --check`, `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `cargo test -p ha-core -p ha-server --locked`

Note: ESLint reported two existing `react-hooks/exhaustive-deps` warnings in unrelated files, with no errors.