### PR TITLE
fix: 🦭 Docker 构建补 copy pnpm-workspace.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ WORKDIR /work
 
 # Install dependencies in a separate layer keyed on lockfile changes so
 # editing source files doesn't trigger a full `pnpm install`.
-COPY package.json pnpm-lock.yaml .npmrc ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
## 问题
v0.11.0 tag 触发的 Docker workflow 构建失败:`pnpm install --frozen-lockfile` 报 `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`。

## 根因
#328（pnpm v10 overrides 迁移）把 `overrides` 从 `package.json` 移到了新的 `pnpm-workspace.yaml`，但 `Dockerfile` web 阶段的 `COPY package.json pnpm-lock.yaml .npmrc ./` 没把 `pnpm-workspace.yaml` 拷进容器——于是容器内 pnpm 读不到 overrides，而 `pnpm-lock.yaml` 仍记录了 5 条 overrides，frozen install 因此判定配置不一致而失败。Dockerfile 上次改动早于 #328，漏改了它；本地 / CI 因为有 `pnpm-workspace.yaml` 没暴露，Docker 只在 tag push 跑、上次跑还是 v0.10.3（早于 #328）。

## 修复
`Dockerfile` web 阶段 COPY 补上 `pnpm-workspace.yaml`（web 阶段是唯一 `pnpm install` 处）。

> 本修复将并入 v0.11.0（重打 tag）。