### PR TITLE
[codex] Improve tray session menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **菜单栏会话列表更接近应用内侧边栏**：系统托盘 / 菜单栏会话区现在用双行摘要展示会话，包含运行中、待响应、未读、失败、置顶等状态，以及 Agent、模型、更新时间和消息数；没有进行中会话时会显示最近 5 个普通会话，方便从菜单栏快速回到最近对话。
+
+### Fixed
+
+- **打开菜单栏会话列表时不再被后台刷新打断**：点开系统托盘 / 菜单栏菜单后，会暂缓替换原生菜单结构，避免会话列表更新导致 macOS 上已打开的菜单自动关闭；点击菜单项后会立即恢复刷新。
+
 ## [0.12.0] - 2026-06-23
 
 ### Added

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -5,7 +5,9 @@ use ha_core::session::{ProjectFilter, SessionMeta};
 use ha_core::{app_debug, app_info, app_warn};
 use serde_json::json;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder, PredefinedMenuItem};
 use tauri::tray::{TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Emitter, Manager, Runtime};
@@ -14,8 +16,9 @@ use tauri_plugin_dialog::{DialogExt, MessageDialogButtons, MessageDialogKind};
 const TRAY_STATUS_LINE_COUNT: usize = 5;
 const TRAY_STATUS_UPTIME_LINE_INDEX: usize = 2;
 const TRAY_SESSION_PREFIX: &str = "tray_session:";
+const TRAY_SESSION_DETAIL_PREFIX: &str = "tray_session_detail:";
 const TRAY_SESSION_MORE_ID: &str = "tray_session_more";
-/// Cap on dynamic active-session entries shown directly in the tray menu.
+/// Cap on dynamic regular-session entries shown directly in the tray menu.
 /// Beyond this we render a single disabled "… {N} more" line so the menu
 /// stays compact even with many concurrent streams.
 const TRAY_ACTIVE_SESSIONS_CAP: usize = 5;
@@ -24,7 +27,13 @@ const TRAY_ACTIVE_SESSIONS_CAP: usize = 5;
 const TRAY_RECENT_SCAN_LIMIT: u32 = 50;
 /// UTF-8 byte budget for the title shown inside a tray menu item. macOS and
 /// Windows both render long menu items poorly; clamp to keep the menu narrow.
-const TRAY_TITLE_BYTES: usize = 60;
+const TRAY_TITLE_BYTES: usize = 72;
+const TRAY_AGENT_BYTES: usize = 28;
+const TRAY_MODEL_BYTES: usize = 36;
+/// Native tray menus close on macOS when their backing menu is replaced. After
+/// the user opens the tray menu, defer structural menu refreshes briefly so
+/// session metadata changes do not close the menu while it is being read.
+const TRAY_MENU_REFRESH_HOLD_MS: u64 = 5 * 60_000;
 
 /// Show and focus the main window if it already exists.
 fn show_main_window(app_handle: &AppHandle) {
@@ -33,6 +42,24 @@ fn show_main_window(app_handle: &AppHandle) {
         let _ = window.unminimize();
         let _ = window.set_focus();
     }
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}
+
+fn hold_tray_menu_refresh(hold_until_ms: &AtomicU64) {
+    hold_until_ms.store(
+        now_millis().saturating_add(TRAY_MENU_REFRESH_HOLD_MS),
+        Ordering::Relaxed,
+    );
+}
+
+fn is_tray_menu_refresh_held(hold_until_ms: &AtomicU64) -> bool {
+    hold_until_ms.load(Ordering::Relaxed) > now_millis()
 }
 
 /// Set up the system tray icon with context menu.
@@ -51,14 +78,20 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     let show_menu_on_left_click = true;
     let initial_tooltip = build_tray_tooltip(&status_lines);
     let initial_signature = TraySnapshotSig::from(&status_lines, &[], 0);
+    let menu_refresh_hold_until_ms = Arc::new(AtomicU64::new(0));
 
+    let menu_event_refresh_hold = Arc::clone(&menu_refresh_hold_until_ms);
+    let tray_click_refresh_hold = Arc::clone(&menu_refresh_hold_until_ms);
     let tray = TrayIconBuilder::new()
         .tooltip(&initial_tooltip)
         .icon(icon)
         .icon_as_template(icon_as_template)
         .show_menu_on_left_click(show_menu_on_left_click)
         .menu(&initial_menu)
-        .on_menu_event(|app_handle, event| {
+        .on_menu_event(move |app_handle, event| {
+            // A menu item can only be clicked after the native menu closed, so
+            // allow the next poll to apply any pending structure refresh.
+            menu_event_refresh_hold.store(0, Ordering::Relaxed);
             let id = event.id().as_ref();
             app_debug!("tray", "menu", "Tray menu item clicked: {}", id);
 
@@ -67,7 +100,7 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 app_info!(
                     "tray",
                     "focus_session",
-                    "user clicked tray active-session entry session_id={}",
+                    "user clicked tray session entry session_id={}",
                     session_id
                 );
                 show_main_window(app_handle);
@@ -123,13 +156,14 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
                 _ => {}
             }
         })
-        .on_tray_icon_event(|_tray, event| {
+        .on_tray_icon_event(move |_tray, event| {
             if let TrayIconEvent::Click {
                 button,
                 button_state,
                 ..
             } = event
             {
+                hold_tray_menu_refresh(&tray_click_refresh_hold);
                 app_debug!(
                     "tray",
                     "icon",
@@ -153,22 +187,23 @@ pub fn setup_tray(app: &tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     {
         let tray_handle = tray.clone();
         let loop_handle = app_handle.clone();
+        let loop_refresh_hold = Arc::clone(&menu_refresh_hold_until_ms);
         tauri::async_runtime::spawn(async move {
             let mut last_signature: Option<TraySnapshotSig> = Some(initial_signature);
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 let lines = current_tray_status_lines(&status_labels);
-                let (active, more) = compute_active_regular_sessions(&status_labels).await;
-                let signature = TraySnapshotSig::from(&lines, &active, more);
+                let (entries, more) = compute_tray_regular_sessions(&status_labels).await;
+                let signature = TraySnapshotSig::from(&lines, &entries, more);
 
                 let menu_changed = last_signature.as_ref() != Some(&signature);
-                if menu_changed {
+                if menu_changed && !is_tray_menu_refresh_held(&loop_refresh_hold) {
                     match build_tray_menu(
                         &loop_handle,
                         &labels,
                         &status_labels,
                         &lines,
-                        &active,
+                        &entries,
                         more,
                     ) {
                         Ok(menu) => {
@@ -205,9 +240,10 @@ struct TrayRuntimeStatus<'a> {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-struct ActiveRegularSession {
+struct TraySessionEntry {
     session_id: String,
-    label: String,
+    title_label: String,
+    detail_label: String,
 }
 
 /// Tuple used to detect "did the dynamic menu actually change?" so we can
@@ -219,12 +255,12 @@ struct TraySnapshotSig {
     /// excluded because it changes every poll and replacing an open native
     /// tray menu closes it on macOS.
     stable_status_lines: Vec<String>,
-    active: Vec<(String, String)>,
+    entries: Vec<(String, String)>,
     more: usize,
 }
 
 impl TraySnapshotSig {
-    fn from(lines: &[String], active: &[ActiveRegularSession], more: usize) -> Self {
+    fn from(lines: &[String], entries: &[TraySessionEntry], more: usize) -> Self {
         Self {
             stable_status_lines: lines
                 .iter()
@@ -233,9 +269,14 @@ impl TraySnapshotSig {
                     (idx != TRAY_STATUS_UPTIME_LINE_INDEX).then_some(line.clone())
                 })
                 .collect(),
-            active: active
+            entries: entries
                 .iter()
-                .map(|s| (s.session_id.clone(), s.label.clone()))
+                .map(|s| {
+                    (
+                        s.session_id.clone(),
+                        format!("{}\n{}", s.title_label, s.detail_label),
+                    )
+                })
                 .collect(),
             more,
         }
@@ -320,23 +361,35 @@ fn format_short_uptime(secs: u64) -> String {
     }
 }
 
-/// Format a session entry as a tray menu label, including a status glyph
-/// (`▶` streaming / `⏸` waiting on user / `▶⏸` both) and the title with
-/// UTF-8-safe truncation. Falls back to `untitled_session` from the
-/// `TrayStatusLabels` when the session has no title yet.
-fn format_active_session_label(
+/// Format the primary session row for the tray menu. This mirrors the sidebar's
+/// first row as closely as a native menu allows: state badges first, then the
+/// UTF-8-safe title. Detailed metadata is rendered as a disabled second row.
+fn format_active_session_title_label(
     s: &SessionMeta,
     streaming: bool,
     pending: bool,
     labels: &TrayStatusLabels,
 ) -> String {
-    let glyph = match (streaming, pending) {
-        (true, true) => "▶⏸",
-        (true, false) => "▶",
-        (false, true) => "⏸",
-        // Should not occur — caller filters out sessions that match neither.
-        (false, false) => "•",
-    };
+    let mut badges = Vec::new();
+    if streaming {
+        badges.push("▶".to_string());
+    }
+    if pending {
+        badges.push(format_count_badge("⏸", s.pending_interaction_count));
+    }
+    if s.unread_count > 0 {
+        badges.push(format_count_badge("●", s.unread_count));
+    }
+    if s.has_error {
+        badges.push("⚠".to_string());
+    }
+    if s.pinned_at.is_some() {
+        badges.push("★".to_string());
+    }
+    if badges.is_empty() {
+        badges.push("•".to_string());
+    }
+
     let raw_title = s
         .title
         .as_deref()
@@ -344,23 +397,139 @@ fn format_active_session_label(
         .filter(|t| !t.is_empty())
         .unwrap_or(labels.untitled_session);
     let title = ha_core::truncate_utf8(raw_title, TRAY_TITLE_BYTES);
-    format!("  {glyph} {title}")
+    format!("  {} {title}", badges.join(" "))
 }
 
-/// Resolve the list of "in-progress regular conversations" for the tray
-/// dropdown. Combines two condition sources:
+/// Format the secondary tray row for a session. The sidebar shows agent + time;
+/// the tray also includes the pinned model and message count because there is
+/// no hover state or avatar to carry that context.
+fn format_active_session_detail_label(s: &SessionMeta, agent_name: &str) -> String {
+    let mut parts = Vec::new();
+
+    let agent = agent_name.trim();
+    if !agent.is_empty() {
+        parts.push(ha_core::truncate_utf8(agent, TRAY_AGENT_BYTES).to_string());
+    }
+
+    if let Some(model) = format_model_summary(s) {
+        parts.push(model);
+    }
+
+    if let Some(updated) = format_updated_time_for_tray(&s.updated_at) {
+        parts.push(updated);
+    }
+
+    if s.message_count > 0 {
+        parts.push(format!("#{}", s.message_count));
+    }
+
+    if parts.is_empty() {
+        parts.push(s.id.chars().take(8).collect());
+    }
+
+    format!("    {}", parts.join(" · "))
+}
+
+fn format_count_badge(prefix: &str, count: i64) -> String {
+    if count <= 1 {
+        prefix.to_string()
+    } else if count > 99 {
+        format!("{prefix}99+")
+    } else {
+        format!("{prefix}{count}")
+    }
+}
+
+fn format_model_summary(s: &SessionMeta) -> Option<String> {
+    let provider = s
+        .provider_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty());
+    let model = s
+        .model_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty());
+
+    let summary = match (provider, model) {
+        (Some(provider), Some(model)) => format!("{provider}/{model}"),
+        (Some(provider), None) => provider.to_string(),
+        (None, Some(model)) => model.to_string(),
+        (None, None) => return None,
+    };
+
+    Some(ha_core::truncate_utf8(&summary, TRAY_MODEL_BYTES).to_string())
+}
+
+fn format_updated_time_for_tray(updated_at: &str) -> Option<String> {
+    let updated = chrono::DateTime::parse_from_rfc3339(updated_at)
+        .ok()?
+        .with_timezone(&chrono::Local);
+    Some(updated.format("%m-%d %H:%M").to_string())
+}
+
+fn resolve_agent_display_name(agent_id: &str, cache: &mut HashMap<String, String>) -> String {
+    if let Some(name) = cache.get(agent_id) {
+        return name.clone();
+    }
+
+    let name = ha_core::agent_loader::load_agent(agent_id)
+        .ok()
+        .map(|def| def.config.name.trim().to_string())
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| agent_id.to_string());
+    cache.insert(agent_id.to_string(), name.clone());
+    name
+}
+
+fn select_tray_session_candidates(
+    sessions: Vec<SessionMeta>,
+    streaming_ids: &std::collections::HashSet<String>,
+) -> Vec<(SessionMeta, bool, bool)> {
+    let mut in_progress = Vec::new();
+    let mut recent_idle = Vec::new();
+    for s in sessions {
+        if !s.is_regular_chat() {
+            continue;
+        }
+        let streaming = streaming_ids.contains(&s.id);
+        let pending = s.pending_interaction_count > 0;
+        if streaming || pending {
+            in_progress.push((s, streaming, pending));
+        } else {
+            recent_idle.push((s, false, false));
+        }
+    }
+
+    // Sort newest-first to mirror the sidebar. When no in-progress session
+    // exists, the same ordering gives the tray a compact "recent chats" list.
+    in_progress.sort_by(|a, b| b.0.updated_at.cmp(&a.0.updated_at));
+    recent_idle.sort_by(|a, b| b.0.updated_at.cmp(&a.0.updated_at));
+
+    if in_progress.is_empty() {
+        recent_idle
+    } else {
+        in_progress
+    }
+}
+
+/// Resolve the regular conversations shown in the tray dropdown.
+///
+/// In-progress conversations win. They combine two condition sources:
 ///
 /// 1. **Streaming**: session ids registered in `chat_engine::stream_seq`
 ///    with `source=Desktop` (LLM is currently producing tokens).
 /// 2. **Pending interaction**: `SessionMeta.pending_interaction_count > 0`
 ///    (waiting on a tool approval or an `ask_user_question` answer).
 ///
-/// Then filters to regular sessions only (see [`SessionMeta::is_regular_chat`])
-/// and returns up to [`TRAY_ACTIVE_SESSIONS_CAP`] entries plus the count of
-/// items truncated. Order: by `updated_at DESC` to mirror the sidebar.
-async fn compute_active_regular_sessions(
+/// If there are no in-progress regular conversations, the tray falls back to
+/// the most recent regular conversations. Both modes return up to
+/// [`TRAY_ACTIVE_SESSIONS_CAP`] entries plus the count of items truncated.
+/// Order: by `updated_at DESC` to mirror the sidebar.
+async fn compute_tray_regular_sessions(
     status_labels: &TrayStatusLabels,
-) -> (Vec<ActiveRegularSession>, usize) {
+) -> (Vec<TraySessionEntry>, usize) {
     let streaming_ids: std::collections::HashSet<String> =
         ha_core::chat_engine::stream_seq::active_session_ids_by_source(
             ha_core::chat_engine::stream_seq::ChatSource::Desktop,
@@ -433,30 +602,19 @@ async fn compute_active_regular_sessions(
         );
     }
 
-    // Keep only regular sessions that are streaming OR have a pending
-    // interaction. Both filters are cheap; do them in one pass.
-    let mut filtered: Vec<(SessionMeta, bool, bool)> = sessions
-        .into_iter()
-        .filter_map(|s| {
-            if !s.is_regular_chat() {
-                return None;
-            }
-            let streaming = streaming_ids.contains(&s.id);
-            let pending = s.pending_interaction_count > 0;
-            (streaming || pending).then_some((s, streaming, pending))
-        })
-        .collect();
-
-    // Sort newest-first to mirror the sidebar.
-    filtered.sort_by(|a, b| b.0.updated_at.cmp(&a.0.updated_at));
-
-    let total = filtered.len();
+    let selected = select_tray_session_candidates(sessions, &streaming_ids);
+    let total = selected.len();
     let truncated = total.saturating_sub(TRAY_ACTIVE_SESSIONS_CAP);
-    let kept: Vec<ActiveRegularSession> = filtered
+    let mut agent_names = HashMap::new();
+    let kept: Vec<TraySessionEntry> = selected
         .into_iter()
         .take(TRAY_ACTIVE_SESSIONS_CAP)
-        .map(|(s, streaming, pending)| ActiveRegularSession {
-            label: format_active_session_label(&s, streaming, pending, status_labels),
+        .map(|(s, streaming, pending)| TraySessionEntry {
+            title_label: format_active_session_title_label(&s, streaming, pending, status_labels),
+            detail_label: format_active_session_detail_label(
+                &s,
+                &resolve_agent_display_name(&s.agent_id, &mut agent_names),
+            ),
             session_id: s.id,
         })
         .collect();
@@ -464,11 +622,11 @@ async fn compute_active_regular_sessions(
     (kept, truncated)
 }
 
-/// Build the full tray menu including the dynamic "in-progress regular
-/// conversations" rows. Items appear in this order:
+/// Build the full tray menu including the dynamic regular-conversation rows.
+/// Items appear in this order:
 ///
 /// 1. 5 disabled status rows (unchanged from before).
-/// 2. Per active session: one clickable item with id `tray_session:{id}`.
+/// 2. Per regular session entry: one clickable item with id `tray_session:{id}`.
 /// 3. Optional disabled "… {N} more" line if `more > 0`.
 /// 4. Separator + the existing action items.
 fn build_tray_menu<R: Runtime>(
@@ -476,7 +634,7 @@ fn build_tray_menu<R: Runtime>(
     labels: &TrayLabels,
     status_labels: &TrayStatusLabels,
     status_lines: &[String],
-    active: &[ActiveRegularSession],
+    entries: &[TraySessionEntry],
     more: usize,
 ) -> tauri::Result<Menu<R>> {
     if status_lines.len() != TRAY_STATUS_LINE_COUNT {
@@ -503,11 +661,21 @@ fn build_tray_menu<R: Runtime>(
         .enabled(false)
         .build(manager)?;
 
-    let session_items: Vec<_> = active
+    let session_items: Vec<_> = entries
         .iter()
         .map(|s| {
-            MenuItemBuilder::with_id(format!("{TRAY_SESSION_PREFIX}{}", s.session_id), &s.label)
-                .build(manager)
+            let title = MenuItemBuilder::with_id(
+                format!("{TRAY_SESSION_PREFIX}{}", s.session_id),
+                &s.title_label,
+            )
+            .build(manager)?;
+            let detail = MenuItemBuilder::with_id(
+                format!("{TRAY_SESSION_DETAIL_PREFIX}{}", s.session_id),
+                &s.detail_label,
+            )
+            .enabled(false)
+            .build(manager)?;
+            Ok((title, detail))
         })
         .collect::<tauri::Result<Vec<_>>>()?;
 
@@ -540,8 +708,8 @@ fn build_tray_menu<R: Runtime>(
         .item(&status_uptime)
         .item(&status_connections)
         .item(&status_sessions);
-    for it in &session_items {
-        builder = builder.item(it);
+    for (title, detail) in &session_items {
+        builder = builder.item(title).item(detail);
     }
     if let Some(ref m) = more_item {
         builder = builder.item(m);
@@ -588,6 +756,7 @@ mod tests {
             channel_info: None,
             incognito: false,
             working_dir: None,
+            kind: Default::default(),
         }
     }
 
@@ -645,34 +814,97 @@ mod tests {
     }
 
     #[test]
-    fn format_active_session_label_picks_glyph_by_state() {
+    fn format_active_session_title_label_matches_sidebar_state_badges() {
         let labels = tray_status_labels("en");
-        let s = dummy_session("a", Some("My session"));
+        let mut s = dummy_session("a", Some("My session"));
 
         assert_eq!(
-            format_active_session_label(&s, true, false, &labels),
+            format_active_session_title_label(&s, true, false, &labels),
             "  ▶ My session"
         );
         assert_eq!(
-            format_active_session_label(&s, false, true, &labels),
+            format_active_session_title_label(&s, false, true, &labels),
             "  ⏸ My session"
         );
+        s.pending_interaction_count = 2;
+        s.unread_count = 7;
+        s.has_error = true;
+        s.pinned_at = Some("2026-05-01T01:00:00Z".to_string());
         assert_eq!(
-            format_active_session_label(&s, true, true, &labels),
-            "  ▶⏸ My session"
+            format_active_session_title_label(&s, true, true, &labels),
+            "  ▶ ⏸2 ●7 ⚠ ★ My session"
         );
 
         // Empty title falls back to localized placeholder.
         let untitled = dummy_session("b", None);
         assert_eq!(
-            format_active_session_label(&untitled, true, false, &labels),
+            format_active_session_title_label(&untitled, true, false, &labels),
             "  ▶ Untitled"
         );
         // Whitespace-only title is treated as empty.
         let blank = dummy_session("c", Some("   "));
         assert_eq!(
-            format_active_session_label(&blank, false, true, &labels),
+            format_active_session_title_label(&blank, false, true, &labels),
             "  ⏸ Untitled"
+        );
+    }
+
+    #[test]
+    fn select_tray_sessions_falls_back_to_recent_idle_when_none_in_progress() {
+        let mut older = dummy_session("older", Some("Older"));
+        older.updated_at = "2026-05-01T00:00:00Z".to_string();
+        let mut newer = dummy_session("newer", Some("Newer"));
+        newer.updated_at = "2026-05-02T00:00:00Z".to_string();
+
+        let selected =
+            select_tray_session_candidates(vec![older, newer], &std::collections::HashSet::new());
+
+        assert_eq!(
+            selected
+                .iter()
+                .map(|(s, streaming, pending)| (s.id.as_str(), *streaming, *pending))
+                .collect::<Vec<_>>(),
+            vec![("newer", false, false), ("older", false, false)]
+        );
+    }
+
+    #[test]
+    fn select_tray_sessions_prefers_in_progress_over_recent_idle() {
+        let mut idle_newer = dummy_session("idle-newer", Some("Idle"));
+        idle_newer.updated_at = "2026-05-02T00:00:00Z".to_string();
+        let mut pending_older = dummy_session("pending-older", Some("Pending"));
+        pending_older.updated_at = "2026-05-01T00:00:00Z".to_string();
+        pending_older.pending_interaction_count = 1;
+
+        let selected = select_tray_session_candidates(
+            vec![idle_newer, pending_older],
+            &std::collections::HashSet::new(),
+        );
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].0.id, "pending-older");
+        assert!(!selected[0].1);
+        assert!(selected[0].2);
+    }
+
+    #[test]
+    fn format_active_session_detail_label_adds_agent_model_and_message_context() {
+        let mut s = dummy_session("a", Some("My session"));
+        s.provider_name = Some("OpenAI".to_string());
+        s.model_id = Some("gpt-5.4".to_string());
+        s.message_count = 12;
+
+        let detail = format_active_session_detail_label(&s, "Hope");
+
+        assert!(detail.starts_with("    Hope · OpenAI/gpt-5.4 · "));
+        assert!(detail.ends_with(" · #12"));
+    }
+
+    #[test]
+    fn tray_updated_time_is_stable_for_signature_comparison() {
+        assert_eq!(
+            format_updated_time_for_tray("2026-05-01T00:00:00Z"),
+            format_updated_time_for_tray("2026-05-01T00:00:00Z")
         );
     }
 


### PR DESCRIPTION
## Summary

- Redesign the system tray session entries to better match the in-app sidebar, including state badges and a second metadata row.
- Fall back to the five most recent regular sessions when no session is currently streaming or waiting for user interaction.
- Defer native tray menu structure refreshes after the menu is opened so background session updates do not close the menu on macOS.
- Add an Unreleased changelog entry for the tray menu changes.

## Validation

- `cargo check -p hope-agent --locked`
- Pre-push hook: `cargo fmt --all --check`
- Pre-push hook: `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- Pre-push hook: `pnpm typecheck`
- Pre-push hook: `pnpm lint` (completed with 2 existing React hook dependency warnings, 0 errors)
- Pre-push hook: `pnpm test`
- Pre-push hook: `cargo test -p ha-core -p ha-server --locked`