### PR TITLE
test(status): 🦭 /status 面板测试固定权限模式,不再依赖本机 agent 配置

### DIFF
--- a/crates/ha-core/src/slash_commands/handlers/utility.rs
+++ b/crates/ha-core/src/slash_commands/handlers/utility.rs
@@ -993,6 +993,13 @@ mod tests {
             .expect("title");
         db.update_session_reasoning_effort(&sid, Some("high"))
             .expect("effort");
+        // Pin the permission mode explicitly: `create_session` inherits the
+        // ha-main agent's configured `default_session_permission_mode` from the
+        // real `~/.hope-agent` config, so without this the assertion below
+        // depends on the developer's local setting (e.g. `yolo`) and fails off
+        // a clean default. Set a known mode so the test is hermetic.
+        db.update_session_permission_mode(&sid, crate::permission::SessionMode::Default)
+            .expect("permission mode");
 
         let now = chrono::Utc::now().to_rfc3339();
         let assistant = crate::session::NewMessage {


### PR DESCRIPTION
## 问题

`slash_commands::handlers::utility::tests::handle_status_renders_full_session_panel` 用 `create_session(DEFAULT_AGENT_ID)`,而 `create_session_full` 会继承 ha-main agent 的 `default_session_permission_mode`——该值读自**真实** `~/.hope-agent/agents/ha-main/agent.json`。开发者把 ha-main 设成 `yolo`(或 `smart`)时,渲染出的面板是 `**Permission Mode**: \`yolo\``,断言 `default` 失败,本地只能 `HA_SKIP_PREPUSH_TEST=1` 绕过(CI 干净环境因默认 default 通过,故此前未暴露)。

## 修复

创建会话后显式 `update_session_permission_mode(&sid, SessionMode::Default)`,让测试不依赖本机 agent 配置、hermetic。本地(yolo 配置下)与 CI 现一致通过,不再需要 skip。

## 验证

- 单测在本机 yolo 配置下 `cargo test ... handle_status_renders_full_session_panel` 通过。
- `slash_commands::handlers::utility` 全模块 9 test 绿。
- 本次 `git push` 的 pre-push 钩子跑**完整** cargo test(未 skip)通过。

仅一处测试改动,不触碰任何业务逻辑。