### PR TITLE
feat(cron): 定时任务面板优化 — 任务列表分栏 + 状态 tooltip + 修复一次性任务误判已过期

### DIFF
--- a/crates/ha-core/src/cron/db.rs
+++ b/crates/ha-core/src/cron/db.rs
@@ -1402,6 +1402,11 @@ impl CronDB {
     ///   may have partially executed, so it is missed, never re-fired — the
     ///   one-shot side-effect-safety choice).
     ///
+    /// Only `running_at IS NULL` jobs are eligible: an `At` job mid-execution also
+    /// has `next_run_at IS NULL` (cleared at claim) but is running, not a zombie,
+    /// and must not be reaped. Claimed-then-crashed jobs become eligible after
+    /// startup's `clear_all_running` resets their stale `running_at`.
+    ///
     /// `At` jobs past-due by no more than `grace_secs` are LEFT active so the
     /// startup catch-up can late-fire them (slot-aware via §4's `dispatch_due_jobs`).
     /// `grace_secs = 0` ⇒ strict: any past-due `At` is missed (pre-§7 behavior).
@@ -1414,9 +1419,21 @@ impl CronDB {
             .conn
             .lock()
             .map_err(|e| anyhow::anyhow!("CronDB lock poisoned: {e}"))?;
+        // `running_at IS NULL` guard (red line): a one-shot `At` that is CURRENTLY
+        // EXECUTING has its `next_run_at` cleared to NULL at claim (see
+        // `claim_scheduled_job_for_execution`) while `status` stays `active`.
+        // Without this guard, the per-tick reap fires while the run is in flight
+        // (tick interval 15s, so any run ≳15s spans a tick) and the running job —
+        // `status='active'` + `next_run_at IS NULL` — matches the NULL branch and
+        // is wrongly marked `missed`; the subsequent successful `update_after_run`
+        // is then a no-op (its `status='active'` guard fails) and the job is stuck
+        // `missed` despite a `success` run log. Claimed-then-crashed zombies are
+        // NOT lost: startup recovery runs `clear_all_running` (resetting their
+        // `running_at` to NULL) BEFORE `mark_missed_at_jobs`, so they still match.
         let count = conn.execute(
             "UPDATE cron_jobs SET status='missed', updated_at=?1
-             WHERE status='active' AND schedule_json LIKE '%\"type\":\"at\"%'
+             WHERE status='active' AND running_at IS NULL
+               AND schedule_json LIKE '%\"type\":\"at\"%'
                AND (next_run_at IS NULL OR next_run_at < ?2)",
             params![now_str, cutoff],
         )?;
@@ -3335,6 +3352,7 @@ mod tests {
         let beyond = mk_at("beyond"); // past-due beyond grace → missed
         let zombie = mk_at("zombie"); // next_run_at NULL (claimed-then-crashed) → missed
         let future = mk_at("future"); // not yet due → stays active
+        let running = mk_at("running"); // in-flight (running_at set, next_run_at NULL) → stays active
 
         {
             let conn = db.conn.lock().unwrap();
@@ -3355,6 +3373,14 @@ mod tests {
                 Some((now - chrono::Duration::seconds(1000)).to_rfc3339()),
             );
             set(&zombie.id, None);
+            // In-flight one-shot: next_run_at cleared at claim, but running_at set.
+            // Matches the NULL branch yet must NOT be reaped (it's running).
+            conn.execute(
+                "UPDATE cron_jobs SET running_at=?1 WHERE id=?2",
+                params![now.to_rfc3339(), running.id],
+            )
+            .unwrap();
+            set(&running.id, None);
             // `future` keeps its ~1h-ahead next_run_at from add_job.
         }
 
@@ -3365,6 +3391,80 @@ mod tests {
         assert_eq!(status(&beyond.id), CronJobStatus::Missed);
         assert_eq!(status(&zombie.id), CronJobStatus::Missed);
         assert_eq!(status(&future.id), CronJobStatus::Active);
+        // Regression: an in-flight one-shot (running_at set) is never reaped even
+        // though its next_run_at is NULL — otherwise a run ≳15s gets marked
+        // `missed` mid-execution and the later success can't recover it.
+        assert_eq!(status(&running.id), CronJobStatus::Active);
+
+        cleanup_db_files(&path);
+    }
+
+    #[test]
+    fn inflight_at_survives_reap_then_success_completes() {
+        // End-to-end pin for the "success run-log yet job stuck `missed`" race
+        // across mark_missed_at_jobs (reap) and update_after_run (terminalize):
+        // an in-flight one-shot must survive a mid-run reap tick AND then be
+        // terminalized `completed` by its successful run. Both guards are
+        // load-bearing — the reap's `running_at IS NULL` keeps the status
+        // `active` so update_after_run's `status='active'` success branch can
+        // fire. If either regresses, this test catches the stuck-`missed` bug.
+        let path = temp_db_path("inflight-reap-success");
+        let db = CronDB::open(&path).expect("open db");
+        let job = db
+            .add_job(&NewCronJob {
+                name: "one-shot".into(),
+                description: None,
+                project_id: None,
+                schedule: CronSchedule::At {
+                    timestamp: (Utc::now() + chrono::Duration::hours(1)).to_rfc3339(),
+                },
+                payload: CronPayload::AgentTurn {
+                    prompt: "do once".into(),
+                    agent_id: None,
+                },
+                max_failures: Some(5),
+                notify_on_complete: None,
+                delivery_targets: None,
+                prefix_delivery_with_name: None,
+                job_timeout_secs: None,
+                permission_mode_override: None,
+                sandbox_mode_override: None,
+            })
+            .expect("add job");
+
+        // Simulate claim_scheduled_job_for_execution: running_at set, next_run_at
+        // cleared to NULL (the one-shot in-flight shape), status still active.
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE cron_jobs SET running_at=?1, next_run_at=NULL WHERE id=?2",
+                params![Utc::now().to_rfc3339(), job.id],
+            )
+            .unwrap();
+        }
+
+        // A reap tick fires mid-execution — must NOT touch the running job.
+        let marked = db.mark_missed_at_jobs(300).expect("mark");
+        assert_eq!(marked, 0, "in-flight one-shot must not be reaped");
+        assert_eq!(
+            db.get_job(&job.id).unwrap().unwrap().status,
+            CronJobStatus::Active
+        );
+
+        // Run finishes successfully → update_after_run terminalizes it.
+        assert!(!db
+            .update_after_run(&job.id, true, &job.schedule)
+            .expect("upd"));
+        let final_job = db.get_job(&job.id).unwrap().unwrap();
+        assert_eq!(
+            final_job.status,
+            CronJobStatus::Completed,
+            "a successful in-flight one-shot must end `completed`, not `missed`"
+        );
+        assert!(
+            final_job.next_run_at.is_none(),
+            "completed one-shot has no next run"
+        );
 
         cleanup_db_files(&path);
     }

--- a/src/components/cron/CronCalendarView.tsx
+++ b/src/components/cron/CronCalendarView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useMemo } from "react"
 import { getTransport } from "@/lib/transport-provider"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
@@ -23,11 +23,6 @@ import {
   MessagesSquare,
   Loader2,
   Search,
-  Play,
-  Pause,
-  Trash2,
-  Zap,
-  Pencil,
   Send,
   AlertTriangle,
   Settings,
@@ -39,13 +34,14 @@ import CronConversationsPanel from "./CronConversationsPanel"
 import type { CronJob, CalendarEvent } from "./CronJobForm.types"
 import {
   statusColor,
+  statusLabel,
   runLogDotColor,
   runStatusDisplay,
   formatSchedule,
-  deliveryTargetLabel,
   deliveryStatusColor,
 } from "./cronHelpers"
 import type { ProjectMeta } from "@/types/project"
+import type { AgentSummaryForSidebar } from "@/types/chat"
 import type { SettingsSection } from "@/components/settings/types"
 
 type ViewMode = "calendar" | "list" | "conversations"
@@ -97,6 +93,14 @@ export default function CronCalendarView({
   const [visibleJobsCount, setVisibleJobsCount] = useState(JOBS_PAGE)
   const [pendingDeleteJob, setPendingDeleteJob] = useState<CronJob | null>(null)
   const [deletingJobId, setDeletingJobId] = useState<string | null>(null)
+  // List view is a master-detail: this is the job selected in the left column,
+  // rendered as an embedded CronJobDetail on the right (separate from the
+  // calendar's full-screen detailJobId).
+  const [selectedListJobId, setSelectedListJobId] = useState<string | null>(null)
+  // Agents power message-bubble identities inside CronJobDetail. Fetched once
+  // here (job-independent) and passed down, so re-selecting list rows — which
+  // remounts CronJobDetail via key — doesn't refetch the roster on every click.
+  const [agents, setAgents] = useState<AgentSummaryForSidebar[]>([])
 
   const year = currentDate.getFullYear()
   const month = currentDate.getMonth()
@@ -170,6 +174,15 @@ export default function CronCalendarView({
     })
   }, [fetchEvents, fetchJobs, jobsLoaded])
 
+  // Load the agent roster once (job-independent); shared by both the embedded
+  // and full-screen CronJobDetail so row switches don't refetch it.
+  useEffect(() => {
+    getTransport()
+      .call<AgentSummaryForSidebar[]>("list_agents")
+      .then((list) => setAgents(Array.isArray(list) ? list : []))
+      .catch(() => {})
+  }, [])
+
   function goToday() {
     setCurrentDate(new Date())
     setSelectedDate(null)
@@ -226,13 +239,33 @@ export default function CronCalendarView({
   ]
 
   // Filtered jobs for list view
-  const filteredJobs = jobs.filter((job) => {
-    if (search && !job.name.toLowerCase().includes(search.toLowerCase())) return false
-    if (statusFilter !== "all" && job.status !== statusFilter) return false
-    return true
-  })
+  const filteredJobs = useMemo(
+    () =>
+      jobs.filter((job) => {
+        if (search && !job.name.toLowerCase().includes(search.toLowerCase())) return false
+        if (statusFilter !== "all" && job.status !== statusFilter) return false
+        return true
+      }),
+    [jobs, search, statusFilter],
+  )
   const visibleJobs = filteredJobs.slice(0, visibleJobsCount)
-  const projectMap = new Map(projects.map((p) => [p.id, p]))
+
+  // Master-detail selection. Default to the first job when nothing is selected
+  // (fills the right pane), but drop the selection ONLY when the selected job is
+  // gone from the full `jobs` set (deleted) — never merely because search/filter
+  // hid it. Otherwise typing in the search box would yank the user away from the
+  // job whose run history they're reading.
+  useEffect(() => {
+    if (mode !== "list") return
+    if (selectedListJobId && !jobs.some((j) => j.id === selectedListJobId)) {
+      setSelectedListJobId(null)
+      return
+    }
+    if (!selectedListJobId && filteredJobs.length > 0) {
+      setSelectedListJobId(filteredJobs[0].id)
+    }
+  }, [mode, jobs, filteredJobs, selectedListJobId])
+  const projectMap = useMemo(() => new Map(projects.map((p) => [p.id, p])), [projects])
   const projectLabel = (projectId?: string | null) => {
     if (!projectId) return t("cron.noProject")
     const project = projectMap.get(projectId)
@@ -262,12 +295,6 @@ export default function CronCalendarView({
     refreshAll()
   }
 
-  async function handleToggle(job: CronJob) {
-    const enabled = job.status !== "active"
-    await getTransport().call("cron_toggle_job", { id: job.id, enabled })
-    refreshAll()
-  }
-
   function handleDelete(job: CronJob) {
     setPendingDeleteJob(job)
   }
@@ -284,6 +311,12 @@ export default function CronCalendarView({
       if (detailJobId === job.id) {
         setDetailJobId(null)
       }
+      // Clear the list master-detail selection synchronously too, so the right
+      // pane doesn't keep rendering CronJobDetail for the just-deleted job (and
+      // flash its "job not found" state) until refreshAll's round-trip lands.
+      if (selectedListJobId === job.id) {
+        setSelectedListJobId(null)
+      }
       refreshAll()
       toast.success(t("cron.deleteSuccess", { name: job.name }))
     } catch {
@@ -291,11 +324,6 @@ export default function CronCalendarView({
     } finally {
       setDeletingJobId(null)
     }
-  }
-
-  async function handleRunNow(job: CronJob) {
-    await getTransport().call("cron_run_now", { id: job.id })
-    setTimeout(refreshAll, 2000)
   }
 
   const deleteUi = (
@@ -334,6 +362,7 @@ export default function CronCalendarView({
         <div className="flex flex-col flex-1 min-w-0 h-full bg-background">
           <CronJobDetail
             jobId={detailJobId}
+            agents={agents}
             onBack={() => setDetailJobId(null)}
             onEdit={handleEditJob}
             onDelete={handleDelete}
@@ -361,14 +390,14 @@ export default function CronCalendarView({
     <div className="flex flex-col flex-1 min-w-0 h-full bg-background">
       {/* Top Bar */}
       <div
-        className="flex items-center gap-3 px-5 py-3 border-b border-border shrink-0"
+        className="flex items-center gap-3 px-5 py-3 border-b border-border/60 shrink-0"
         data-tauri-drag-region
       >
         <CalendarDays className="h-5 w-5 text-primary" />
         <h2 className="text-sm font-semibold">{t("cron.title")}</h2>
 
         {/* View mode switcher */}
-        <div className="flex items-center rounded-md border border-border p-0.5 bg-secondary/30">
+        <div className="flex items-center rounded-md border border-border/60 p-0.5 bg-secondary/30">
           <Button
             variant="ghost"
             size="sm"
@@ -438,7 +467,7 @@ export default function CronCalendarView({
               />
             </div>
             <select
-              className="h-7 text-xs rounded-md border border-border bg-background px-2"
+              className="h-7 text-xs rounded-md border border-border/60 bg-background px-2"
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
             >
@@ -541,8 +570,8 @@ export default function CronCalendarView({
 
           {/* Day Detail Sidebar */}
           {selectedDate && (
-            <div className="w-72 border-l border-border flex flex-col bg-card shrink-0">
-              <div className="px-4 py-3 border-b border-border shrink-0">
+            <div className="w-72 border-l border-border/60 flex flex-col bg-muted/20 shrink-0">
+              <div className="px-4 py-3 border-b border-border/60 shrink-0">
                 <h3 className="text-sm font-medium">
                   {selectedDate.toLocaleDateString(undefined, {
                     weekday: "long",
@@ -571,7 +600,7 @@ export default function CronCalendarView({
                       return (
                         <button
                           key={`${evt.jobId}-${i}`}
-                          className="w-full text-left rounded-lg border border-border p-2.5 hover:bg-secondary/50 transition-colors"
+                          className="w-full text-left rounded-lg bg-card p-2.5 hover:bg-secondary/60 transition-colors"
                           onClick={() => setDetailJobId(evt.jobId)}
                         >
                           <div className="flex items-center gap-2">
@@ -627,122 +656,119 @@ export default function CronCalendarView({
           )}
         </div>
       ) : (
-        /* List View */
-        <div className="flex-1 overflow-y-auto">
-          {listLoading && !jobsLoaded ? (
-            <div className="flex items-center justify-center h-32">
-              <div className="animate-spin h-5 w-5 border-2 border-foreground border-t-transparent rounded-full" />
-            </div>
-          ) : filteredJobs.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground text-sm">
-              {jobs.length === 0 ? t("cron.noJobs") : t("cron.noResults")}
-            </div>
-          ) : (
-            <div className="divide-y divide-border">
-              {visibleJobs.map((job) => (
-                <div
-                  key={job.id}
-                  className="flex items-center gap-3 px-5 py-3 hover:bg-secondary/30 transition-colors cursor-pointer"
-                  onClick={() => setDetailJobId(job.id)}
-                >
-                  <span
-                    className={`inline-block w-2 h-2 rounded-full shrink-0 ${statusColor(job.status)}`}
-                  />
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium truncate">{job.name}</div>
-                    <div className="text-xs text-muted-foreground truncate">
-                      {formatSchedule(job.schedule, t)}
-                      {` · ${projectLabel(job.projectId)}`}
-                      {job.nextRunAt &&
-                        ` · ${t("cron.nextRun")}: ${new Date(job.nextRunAt).toLocaleString()}`}
-                    </div>
-                    {(job.deliveryTargets.length > 0 || job.consecutiveFailures > 0) && (
-                      <div className="mt-0.5 flex items-center gap-2 text-[10px] text-muted-foreground">
-                        {job.deliveryTargets.length > 0 && (
-                          <IconTip label={job.deliveryTargets.map(deliveryTargetLabel).join(", ")}>
+        /* List View — master-detail: left job list · right embedded detail */
+        <div className="flex flex-1 min-h-0">
+          {/* Left — job list */}
+          <div className="flex w-80 shrink-0 flex-col border-r border-border/60 bg-muted/20">
+            <div className="flex-1 overflow-y-auto">
+              {listLoading && !jobsLoaded ? (
+                <div className="flex items-center justify-center py-10 text-muted-foreground">
+                  <Loader2 className="h-5 w-5 animate-spin" />
+                </div>
+              ) : filteredJobs.length === 0 ? (
+                <div className="px-4 py-10 text-center text-xs text-muted-foreground">
+                  {jobs.length === 0 ? t("cron.noJobs") : t("cron.noResults")}
+                </div>
+              ) : (
+                <div className="py-1">
+                  {visibleJobs.map((job) => {
+                    const isActive = job.id === selectedListJobId
+                    return (
+                      <button
+                        key={job.id}
+                        onClick={() => setSelectedListJobId(job.id)}
+                        className={cn(
+                          "w-full px-3 py-2.5 text-left transition-colors border-l-2",
+                          isActive
+                            ? "bg-primary/10 border-l-primary"
+                            : "border-l-transparent hover:bg-secondary/50",
+                        )}
+                      >
+                        <div className="flex items-center gap-2">
+                          <IconTip label={statusLabel(job.status, t)}>
                             <span
                               className={cn(
-                                "inline-flex items-center gap-1",
-                                job.deliveryTargets.some((tg) => tg.stale) && "text-red-500",
+                                "inline-block h-2 w-2 shrink-0 rounded-full",
+                                statusColor(job.status),
                               )}
-                            >
-                              <Send className="h-3 w-3" />
-                              {job.deliveryTargets.length}
-                            </span>
+                            />
                           </IconTip>
+                          <span className="flex-1 truncate text-xs font-medium">{job.name}</span>
+                        </div>
+                        <div className="mt-1 truncate pl-4 text-[10px] text-muted-foreground">
+                          {formatSchedule(job.schedule, t)}
+                          {` · ${projectLabel(job.projectId)}`}
+                        </div>
+                        {job.nextRunAt && (
+                          <div className="mt-0.5 truncate pl-4 text-[10px] text-muted-foreground">
+                            {t("cron.nextRun")}: {new Date(job.nextRunAt).toLocaleString()}
+                          </div>
                         )}
-                        {job.consecutiveFailures > 0 && (
-                          <span className="inline-flex items-center gap-1 text-amber-500">
-                            <AlertTriangle className="h-3 w-3" />
-                            {job.consecutiveFailures}/{job.maxFailures}
-                          </span>
+                        {(job.deliveryTargets.length > 0 || job.consecutiveFailures > 0) && (
+                          <div className="mt-1 flex items-center gap-2 pl-4 text-[10px] text-muted-foreground">
+                            {job.deliveryTargets.length > 0 && (
+                              <span
+                                className={cn(
+                                  "inline-flex items-center gap-1",
+                                  job.deliveryTargets.some((tg) => tg.stale) && "text-red-500",
+                                )}
+                              >
+                                <Send className="h-3 w-3" />
+                                {job.deliveryTargets.length}
+                              </span>
+                            )}
+                            {job.consecutiveFailures > 0 && (
+                              <span className="inline-flex items-center gap-1 text-amber-500">
+                                <AlertTriangle className="h-3 w-3" />
+                                {job.consecutiveFailures}/{job.maxFailures}
+                              </span>
+                            )}
+                          </div>
                         )}
-                      </div>
-                    )}
-                  </div>
-                  <div className="flex gap-0.5 shrink-0" onClick={(e) => e.stopPropagation()}>
-                    <IconTip label={t("cron.runNow")}>
+                      </button>
+                    )
+                  })}
+                  {filteredJobs.length > visibleJobs.length && (
+                    <div className="px-3 py-2">
                       <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        onClick={() => handleRunNow(job)}
+                        variant="outline"
+                        size="sm"
+                        className="h-7 w-full text-xs"
+                        onClick={() => setVisibleJobsCount((n) => n + JOBS_PAGE)}
                       >
-                        <Zap className="h-3.5 w-3.5" />
+                        {t("cron.loadMore")}
                       </Button>
-                    </IconTip>
-                    <IconTip label={t("common.edit")}>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        onClick={() => handleEditJob(job)}
-                      >
-                        <Pencil className="h-3.5 w-3.5" />
-                      </Button>
-                    </IconTip>
-                    <IconTip label={job.status === "active" ? t("cron.pause") : t("cron.resume")}>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7"
-                        onClick={() => handleToggle(job)}
-                      >
-                        {job.status === "active" ? (
-                          <Pause className="h-3.5 w-3.5" />
-                        ) : (
-                          <Play className="h-3.5 w-3.5" />
-                        )}
-                      </Button>
-                    </IconTip>
-                    <IconTip label={t("common.delete")}>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-7 w-7 text-red-500 hover:text-red-600"
-                        onClick={() => handleDelete(job)}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    </IconTip>
-                  </div>
-                  <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
-                </div>
-              ))}
-              {filteredJobs.length > visibleJobs.length && (
-                <div className="px-5 py-3">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-7 w-full text-xs"
-                    onClick={() => setVisibleJobsCount((n) => n + JOBS_PAGE)}
-                  >
-                    {t("cron.loadMore")}
-                  </Button>
+                    </div>
+                  )}
                 </div>
               )}
             </div>
-          )}
+          </div>
+
+          {/* Right — embedded detail of the selected job */}
+          <div className="flex flex-1 min-w-0 flex-col">
+            {selectedListJobId ? (
+              <CronJobDetail
+                key={selectedListJobId}
+                jobId={selectedListJobId}
+                agents={agents}
+                embedded
+                onBack={() => setSelectedListJobId(null)}
+                onEdit={handleEditJob}
+                onDelete={handleDelete}
+                onRefresh={refreshAll}
+              />
+            ) : listLoading && !jobsLoaded ? (
+              <div className="flex flex-1 items-center justify-center text-muted-foreground">
+                <Loader2 className="h-5 w-5 animate-spin" />
+              </div>
+            ) : (
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 text-center text-muted-foreground">
+                <ListIcon className="h-10 w-10 opacity-40" />
+                <p className="text-sm">{jobs.length === 0 ? t("cron.noJobs") : t("cron.noResults")}</p>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/src/components/cron/CronConversationsPanel.tsx
+++ b/src/components/cron/CronConversationsPanel.tsx
@@ -155,8 +155,8 @@ export default function CronConversationsPanel() {
   return (
     <div className="flex flex-1 min-h-0">
       {/* Left — timeline list */}
-      <div className="flex w-80 shrink-0 flex-col border-r border-border">
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border shrink-0">
+      <div className="flex w-80 shrink-0 flex-col border-r border-border/60 bg-muted/20">
+        <div className="flex items-center justify-between px-4 py-2.5 border-b border-border/60 shrink-0">
           <span className="text-sm font-medium">{t("cron.conversationsTitle")}</span>
           <Button
             variant="ghost"

--- a/src/components/cron/CronJobDetail.tsx
+++ b/src/components/cron/CronJobDetail.tsx
@@ -24,7 +24,7 @@ import {
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import type { CronJob, CronRunLog } from "./CronJobForm.types"
-import { statusColor, formatSchedule, deliveryTargetLabel } from "./cronHelpers"
+import { statusColor, statusLabel, formatSchedule, deliveryTargetLabel } from "./cronHelpers"
 import type { ProjectMeta } from "@/types/project"
 import type { AgentSummaryForSidebar } from "@/types/chat"
 import CronSessionViewer from "./CronSessionViewer"
@@ -33,18 +33,26 @@ const LOG_PAGE = 50
 
 interface CronJobDetailProps {
   jobId: string
+  /** Agent roster for message-bubble identities, fetched once by the parent
+   *  (job-independent) so row-switch remounts don't refetch it. */
+  agents: AgentSummaryForSidebar[]
   onBack: () => void
   onEdit: (job: CronJob) => void
   onDelete: (job: CronJob) => void
   onRefresh: () => void
+  /** Embedded in a master-detail pane (list view) — hides the back arrow since
+   *  the job list stays visible alongside and selection switches in place. */
+  embedded?: boolean
 }
 
 export default function CronJobDetail({
   jobId,
+  agents,
   onBack,
   onEdit,
   onDelete,
   onRefresh,
+  embedded = false,
 }: CronJobDetailProps) {
   const { t } = useTranslation()
   const [job, setJob] = useState<CronJob | null>(null)
@@ -54,7 +62,6 @@ export default function CronJobDetail({
   const [cancelling, setCancelling] = useState(false)
   // Run conversation shown read-only on the right (no jump to the main chat).
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null)
-  const [agents, setAgents] = useState<AgentSummaryForSidebar[]>([])
   const [logsOffset, setLogsOffset] = useState(0)
   const [logsHasMore, setLogsHasMore] = useState(false)
   const [loadingMoreLogs, setLoadingMoreLogs] = useState(false)
@@ -89,14 +96,6 @@ export default function CronJobDetail({
     fetchData()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [jobId])
-
-  // Agents power the message-bubble identities in the read-only viewer.
-  useEffect(() => {
-    getTransport()
-      .call<AgentSummaryForSidebar[]>("list_agents")
-      .then((list) => setAgents(Array.isArray(list) ? list : []))
-      .catch(() => {})
-  }, [])
 
   // Default to the most recent run that has a session, so opening the detail
   // immediately shows its conversation; never overrides an explicit selection.
@@ -172,13 +171,17 @@ export default function CronJobDetail({
   return (
     <div className="flex flex-col h-full">
       {/* Header */}
-      <div className="flex items-center gap-3 px-5 py-4 border-b border-border">
-        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onBack}>
-          <ArrowLeft className="h-4 w-4" />
-        </Button>
+      <div className="flex items-center gap-3 px-5 py-4 border-b border-border/60">
+        {!embedded && (
+          <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onBack}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+        )}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <span className={`inline-block w-2 h-2 rounded-full ${statusColor(job.status)}`} />
+            <IconTip label={statusLabel(job.status, t)}>
+              <span className={`inline-block w-2 h-2 rounded-full ${statusColor(job.status)}`} />
+            </IconTip>
             <h3 className="text-sm font-medium truncate">{job.name}</h3>
           </div>
           {job.description && (
@@ -233,9 +236,9 @@ export default function CronJobDetail({
 
       {/* Body: left column (info + run history) · right read-only conversation */}
       <div className="flex flex-1 min-h-0">
-        <div className="flex w-96 shrink-0 flex-col overflow-y-auto border-r border-border">
+        <div className="flex w-96 shrink-0 flex-col overflow-y-auto border-r border-border/60 bg-muted/20">
           {/* Info */}
-          <div className="px-5 py-3 border-b border-border text-xs space-y-1.5">
+          <div className="px-5 py-4 text-xs space-y-1.5">
             <div className="flex justify-between">
               <span className="text-muted-foreground">{t("cron.schedule")}</span>
               <span>{formatSchedule(job.schedule, t)}</span>
@@ -351,11 +354,11 @@ export default function CronJobDetail({
                   <div
                     key={log.id}
                     className={cn(
-                      "rounded-lg border p-3 text-xs transition-colors",
+                      "rounded-lg border border-transparent p-3 text-xs transition-colors",
                       log.sessionId && "cursor-pointer",
                       log.sessionId && selectedSessionId === log.sessionId
-                        ? "border-primary bg-primary/5"
-                        : "border-border hover:bg-secondary/50",
+                        ? "bg-primary/5 ring-1 ring-inset ring-primary/40"
+                        : "bg-card hover:bg-secondary/60",
                     )}
                     onClick={() => log.sessionId && setSelectedSessionId(log.sessionId)}
                   >

--- a/src/components/cron/CronSessionViewer.tsx
+++ b/src/components/cron/CronSessionViewer.tsx
@@ -100,7 +100,7 @@ export default function CronSessionViewer({ sessionId, agents }: CronSessionView
   }
 
   return (
-    <div className="flex flex-1 min-h-0 flex-col">
+    <div className="flex flex-1 min-h-0 flex-col pt-3">
       <MessageList
         messages={messages}
         loading={false}

--- a/src/components/cron/cronHelpers.ts
+++ b/src/components/cron/cronHelpers.ts
@@ -137,21 +137,26 @@ export function toLocalDatetimeString(isoString: string): string {
   }
 }
 
+// Single source of truth for job-status presentation. `statusColor` and
+// `statusLabel` both read this map so a new status can't get a dot color but a
+// missing tooltip (or vice versa). Unknown statuses fall back to gray / raw value.
+const STATUS_META: Record<string, { color: string; labelKey: string }> = {
+  active: { color: "bg-blue-500", labelKey: "cron.active" },
+  paused: { color: "bg-amber-500", labelKey: "cron.paused" },
+  disabled: { color: "bg-red-500", labelKey: "cron.disabled" },
+  completed: { color: "bg-emerald-500", labelKey: "cron.completed" },
+  missed: { color: "bg-orange-500", labelKey: "cron.missed" },
+}
+
+/** Localized label for a job status, paired with `statusColor` for the status
+ *  dot tooltip. Unknown statuses (gray dot) fall back to the raw value. */
+export function statusLabel(status: string, t: (key: string) => string): string {
+  const meta = STATUS_META[status]
+  return meta ? t(meta.labelKey) : status
+}
+
 export function statusColor(status: string): string {
-  switch (status) {
-    case "active":
-      return "bg-blue-500"
-    case "paused":
-      return "bg-amber-500"
-    case "disabled":
-      return "bg-red-500"
-    case "completed":
-      return "bg-emerald-500"
-    case "missed":
-      return "bg-orange-500"
-    default:
-      return "bg-gray-400"
-  }
+  return STATUS_META[status]?.color ?? "bg-gray-400"
 }
 
 /**


### PR DESCRIPTION
## 改动

定时任务面板的三处优化（按 commit）：

1. **运行历史对话顶部加 padding** —— 避免对话横幅贴顶
2. **修复 bug：一次性任务执行超过 tick 间隔（15s）被误判为「已过期」** —— `mark_missed_at_jobs` 的 `next_run_at IS NULL` 分支会把*正在执行*的一次性 `At` 任务（claim 时 next_run_at 已清空、status 仍 active）当成 claim 后崩溃的僵尸标为 missed；当单次运行耗时 ≥ 15s 时，执行期间的 per-tick reap 命中它，随后成功结束的 `update_after_run` 因 `status='active'` 守卫失效而无法终态化为 completed，导致「运行历史成功、任务状态却卡在已过期」。加 `AND running_at IS NULL` 守卫排除正在执行的任务（崩溃僵尸仍由启动期 `clear_all_running` 回收，不受影响）。
3. **任务列表改左右分栏 master-detail + 状态点 tooltip** —— 左栏常驻任务列表、右栏嵌入式详情、默认选中第一个；状态点加本地化 tooltip；顺带做了一轮 code-review 修复（删除态同步清选中、搜索不打断查看、右栏加载态、agent 名册提升避免重复请求、STATUS_META 单一来源等）。

> 注：早期版本曾尝试「运行历史对话去分页一次性加载」，经评估改回保留分页（tool-heavy 的长会话仍需增量加载），该 commit 已撤销。

## 验证

- 前端 `pnpm typecheck` + `pnpm lint`
- 后端 `cargo test -p ha-core`（含 2 个 cron 回归测试：in-flight 不被 reap、reap→success→completed 端到端）
- pre-push 8 项门禁全部通过
