### PR TITLE
[codex] fix project sidebar controls

### DIFF
--- a/src/components/chat/project/ProjectSection.tsx
+++ b/src/components/chat/project/ProjectSection.tsx
@@ -58,6 +58,7 @@ import SidebarSectionHeader from "../sidebar/SidebarSectionHeader"
 import ProjectIcon from "./ProjectIcon"
 import { PROJECT_SESSION_PAGE_SIZE } from "../hooks/constants"
 import { useProjectSessions } from "./hooks/useProjectSessions"
+import { PROJECT_TEXT_COLOR_MAP } from "./colors"
 
 interface ProjectSectionProps {
   projects: ProjectMeta[]
@@ -331,6 +332,8 @@ function ProjectGroup({
   })
   const showPaginationFooter = childTotal > PROJECT_SESSION_PAGE_SIZE
   const ProjectToggleIcon = groupExpanded ? FolderOpen : Folder
+  const projectFolderColorClass =
+    (project.color && PROJECT_TEXT_COLOR_MAP[project.color]) || "text-muted-foreground/70"
 
   const handleMarkProjectRead = useCallback(async () => {
     if (project.unreadCount === 0) return
@@ -369,7 +372,12 @@ function ProjectGroup({
               }
             }}
           >
-            <ProjectToggleIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70 transition-colors duration-150" />
+            <ProjectToggleIcon
+              className={cn(
+                "h-3.5 w-3.5 shrink-0 transition-colors duration-150",
+                projectFolderColorClass,
+              )}
+            />
             {displayMode === "detailed" && (
               <div className="relative shrink-0">
                 <ProjectIcon project={project} size="sm" withColorChip />
@@ -396,7 +404,7 @@ function ProjectGroup({
             </div>
             {/* Hover-only action buttons. Match `AgentSection.tsx` styling so
                 the two sections feel consistent. */}
-            <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 pointer-events-none transition-opacity group-hover/project:pointer-events-auto group-hover/project:opacity-100 group-focus-within/project:pointer-events-auto group-focus-within/project:opacity-100">
+            <div className="absolute right-2 top-1/2 z-10 flex -translate-y-1/2 items-center gap-1 opacity-0 pointer-events-none transition-opacity group-hover/project:pointer-events-auto group-hover/project:opacity-100 group-focus-within/project:pointer-events-auto group-focus-within/project:opacity-100">
               {!archivedView && (
                 <IconTip label={t("project.newChatInProject")}>
                   <button
@@ -436,14 +444,14 @@ function ProjectGroup({
               )}
             </div>
             {displayMode === "compact" && projectUnreadCount > 0 && (
-              <span className="absolute right-3 top-1/2 inline-flex h-[15px] min-w-[15px] -translate-y-1/2 items-center justify-center rounded-full bg-destructive px-1 text-[9px] font-semibold leading-none text-destructive-foreground tabular-nums transition-opacity group-hover/project:opacity-0 group-focus-within/project:opacity-0">
+              <span className="pointer-events-none absolute right-3 top-1/2 inline-flex h-[15px] min-w-[15px] -translate-y-1/2 items-center justify-center rounded-full bg-destructive px-1 text-[9px] font-semibold leading-none text-destructive-foreground tabular-nums transition-opacity group-hover/project:opacity-0 group-focus-within/project:opacity-0">
                 {projectUnreadCount > 99 ? "99+" : projectUnreadCount}
               </span>
             )}
             {project.sessionCount > 0 && !(displayMode === "compact" && projectUnreadCount > 0) && (
               <span
                 className={cn(
-                  "absolute right-3 top-1/2 -translate-y-1/2 text-[10px] tabular-nums transition-opacity",
+                  "pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[10px] tabular-nums transition-opacity",
                   "text-muted-foreground/70 group-hover/project:opacity-0 group-focus-within/project:opacity-0",
                 )}
               >

--- a/src/components/chat/project/colors.ts
+++ b/src/components/chat/project/colors.ts
@@ -8,3 +8,14 @@ export const PROJECT_COLOR_MAP: Record<string, string> = {
   indigo: "bg-indigo-500/15 text-indigo-600 dark:text-indigo-400",
   slate: "bg-slate-500/15 text-slate-600 dark:text-slate-400",
 }
+
+/** Text-only project color classes for inline icons. Keyed by `Project.color`. */
+export const PROJECT_TEXT_COLOR_MAP: Record<string, string> = {
+  amber: "text-amber-600 dark:text-amber-400",
+  violet: "text-violet-600 dark:text-violet-400",
+  sky: "text-sky-600 dark:text-sky-400",
+  emerald: "text-emerald-600 dark:text-emerald-400",
+  rose: "text-rose-600 dark:text-rose-400",
+  indigo: "text-indigo-600 dark:text-indigo-400",
+  slate: "text-slate-600 dark:text-slate-400",
+}


### PR DESCRIPTION
## Summary

- Tint the project expand/collapse folder icon with the configured project color.
- Keep the folder icon muted when a project has no custom color.
- Fix hover action hit testing so the settings/new-chat buttons are not covered by the invisible session count or unread badge.

## Root Cause

Project sidebar action buttons appeared on hover, but the right-aligned count/badge remained in the pointer hit area after fading out. Clicks on the covered portion bubbled to the project row and toggled expansion instead of activating the settings button.

## Validation

- `pnpm typecheck`
- pre-push hook passed after rebasing onto `origin/main`: `cargo fmt --all --check`, `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `cargo test -p ha-core -p ha-server --locked`

Note: `pnpm lint` reported an existing React hook dependency warning in `useChatStream.ts`; no lint errors.