### PR TITLE
[codex] 调整侧边栏入口布局

### DIFF
--- a/src/components/common/IconSidebar.tsx
+++ b/src/components/common/IconSidebar.tsx
@@ -37,6 +37,7 @@ import {
   Monitor,
   User,
   CheckCheck,
+  ScrollText,
 } from "lucide-react"
 import { useTheme } from "@/hooks/useTheme"
 import { SUPPORTED_LANGUAGES, isFollowingSystem, setFollowSystemLanguage, setLanguage } from "@/i18n/i18n"
@@ -214,6 +215,24 @@ export default function IconSidebar({
               </ContextMenuContent>
             </ContextMenu>
           </div>
+          {/* Dashboard / Analytics entry, grouped under Scheduled Tasks. */}
+          <div className="w-full flex justify-center">
+            <IconTip label={t("dashboard.title")} side="right">
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "rounded-xl h-8 w-8",
+                  view === "dashboard"
+                    ? "bg-primary/10 text-primary hover:bg-primary/20"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={onOpenDashboard}
+              >
+                <BarChart3 className="h-4 w-4" />
+              </Button>
+            </IconTip>
+          </div>
         </div>
 
         <div className="my-1 h-px w-6 bg-border-soft/80" />
@@ -339,31 +358,26 @@ export default function IconSidebar({
           </IconTip>
         </div>
 
-        {/* Dashboard / Analytics entry */}
-        <div className="w-full flex justify-center mt-1">
-          <IconTip label={t("dashboard.title")} side="right">
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "rounded-xl h-8 w-8",
-                view === "dashboard"
-                  ? "bg-primary/10 text-primary hover:bg-primary/20"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={onOpenDashboard}
-            >
-              <BarChart3 className="h-4 w-4" />
-            </Button>
-          </IconTip>
-        </div>
-
         <div className="my-1 h-px w-6 bg-border-soft/60" />
 
         {/* Browser backend — status indicator + entry to Settings → Browser.
             Green dot when a backend is live; hover shows details. */}
         <div className="w-full flex justify-center mt-1">
           <BrowserStatusIndicator onOpen={() => onOpenSettings("browser")} />
+        </div>
+
+        {/* Logs entry, quick jump to Settings -> Logs near runtime status. */}
+        <div className="w-full flex justify-center mt-1">
+          <IconTip label={t("settings.logs")} side="right">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="rounded-xl h-8 w-8 text-muted-foreground hover:text-foreground"
+              onClick={() => onOpenSettings("logs")}
+            >
+              <ScrollText className="h-4 w-4" />
+            </Button>
+          </IconTip>
         </div>
 
         <div className="flex-1" />


### PR DESCRIPTION
## What changed

- Move the Dashboard sidebar entry directly under Scheduled Tasks / Calendar.
- Add a Logs shortcut below the browser status indicator that opens Settings -> Logs.

## Why

This puts related monitoring surfaces closer together in the sidebar and makes logs reachable without opening the full settings navigation first.

## Validation

- `pnpm typecheck`
- pre-push hook: `cargo fmt --all --check`
- pre-push hook: `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- pre-push hook: `pnpm typecheck`
- pre-push hook: `pnpm lint` (passed with one existing warning in `src/components/chat/hooks/useChatStream.ts`)
- pre-push hook: `pnpm test`
- pre-push hook: `cargo test -p ha-core -p ha-server --locked`