### PR TITLE
[codex] Increase chat sidebar default width

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -111,6 +111,7 @@ import {
 } from "./chatDisplayModePreference"
 import {
   CHAT_SIDEBAR_DEFAULT_WIDTH,
+  CHAT_SIDEBAR_LEGACY_DEFAULT_WIDTH,
   CHAT_SIDEBAR_MAX_WIDTH,
   CHAT_SIDEBAR_MIN_WIDTH,
   CHAT_SIDEBAR_WIDTH_STORAGE_KEY,
@@ -428,6 +429,8 @@ export default function ChatScreen({
     if (!stored) return CHAT_SIDEBAR_DEFAULT_WIDTH
 
     const storedWidth = Number(stored)
+    if (storedWidth === CHAT_SIDEBAR_LEGACY_DEFAULT_WIDTH) return CHAT_SIDEBAR_DEFAULT_WIDTH
+
     return Number.isFinite(storedWidth)
       ? clampChatSidebarWidth(storedWidth)
       : CHAT_SIDEBAR_DEFAULT_WIDTH

--- a/src/components/chat/sidebar/types.ts
+++ b/src/components/chat/sidebar/types.ts
@@ -2,7 +2,8 @@ import type { SessionMeta, AgentSummaryForSidebar } from "@/types/chat"
 import type { ProjectMeta } from "@/types/project"
 
 export const CHAT_SIDEBAR_WIDTH_STORAGE_KEY = "hope.chatSidebarPanelWidth"
-export const CHAT_SIDEBAR_DEFAULT_WIDTH = 260
+export const CHAT_SIDEBAR_LEGACY_DEFAULT_WIDTH = 260
+export const CHAT_SIDEBAR_DEFAULT_WIDTH = 280
 export const CHAT_SIDEBAR_MIN_WIDTH = 220
 export const CHAT_SIDEBAR_MAX_WIDTH = 360
 


### PR DESCRIPTION
## Summary

Increase the default chat conversation sidebar width from 260px to 280px so the conversation list has a little more breathing room by default.

## Details

- Adds an explicit legacy default width constant for the previous 260px value.
- Treats a stored 260px sidebar width as the old default and upgrades it to the new 280px default.
- Preserves user-customized sidebar widths other than the legacy default.

## Validation

- `pnpm typecheck`
- Pre-push hook passed: `cargo fmt --all --check`, `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `cargo test -p ha-core -p ha-server --locked`