### PR TITLE
[codex] Make diff file headers sticky

### DIFF
--- a/src/components/chat/diff-panel/DiffPanel.tsx
+++ b/src/components/chat/diff-panel/DiffPanel.tsx
@@ -625,7 +625,7 @@ export function DiffPanel({
                   <div key={section.fileKey} className="bg-background/40">
                     <button
                       type="button"
-                      className="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-secondary/45"
+                      className="sticky top-0 z-10 flex w-full items-center gap-2 border-b border-border/40 bg-surface-panel/95 px-3 py-2 text-left backdrop-blur transition-colors hover:bg-secondary/45"
                       onClick={() => toggleStackedFile(section.fileKey)}
                       aria-expanded={!section.collapsed}
                     >
@@ -646,7 +646,7 @@ export function DiffPanel({
                       />
                     </button>
                     {!section.collapsed && (
-                      <div className="border-t border-border/40">
+                      <div>
                         {c.truncated && (
                           <div className="px-3 py-1.5 text-[11px] text-amber-600">
                             {t("diffPanel.fileTooLarge", "文件过大，仅渲染前 256KB")}


### PR DESCRIPTION
## Summary

- Make each file header in the multi-file diff panel stick to the top of the diff scroll area.
- Move the separator onto the sticky header so diff rows do not visually bleed through while scrolling.

## Impact

This improves navigation in multi-file diffs by keeping the current file path visible as the user scrolls through long changes. Single-file diff behavior is unchanged.

## Validation

- `pnpm typecheck`
- pre-push hook: `cargo fmt --all --check`
- pre-push hook: `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- pre-push hook: `pnpm typecheck`
- pre-push hook: `pnpm lint` (passed with one existing warning in `src/components/chat/hooks/useChatStream.ts`)
- pre-push hook: `pnpm test`
- pre-push hook: `cargo test -p ha-core -p ha-server --locked`