### PR TITLE
[codex] Harden MCP runtime updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP 配置编辑与热更新更可靠**：编辑 MCP server 时不再把界面中的 `<redacted>` 占位值写回覆盖真实 env / header / OAuth secret；服务名保持不可变，更新请求也不能改写已有 server id。禁用 / 重排 / 全局开关变更会即时同步到运行时，应用以 `mcpGlobal.enabled=false` 启动后再打开 MCP 也无需重启即可生效。
+- **MCP 工具目录与连接状态更稳定**：动态 MCP 工具名现在会处理 `foo-bar` / `foo.bar` 等清洗后重名的碰撞，避免工具互相覆盖；修改 URL / env / header / OAuth / 信任等级 / 并发上限后会重建连接，旧连接不会继续泄漏旧配置或把过期 catalog 写回工具索引；并发冷启动同一 MCP server 时也不会重复 spawn / handshake。
+- **MCP 设置面板细节修复**：切换 transport 后隐藏的 env / header 不会悄悄保存；数字字段清空会回到默认值而不是被保存成最小值；禁用 server 的测试 / 重连 / 授权按钮会置灰，避免点出无效错误。
+
 ## [0.14.0] - 2026-06-29
 
 ### Added

--- a/crates/ha-core/src/agent/mod.rs
+++ b/crates/ha-core/src/agent/mod.rs
@@ -1590,9 +1590,17 @@ impl AssistantAgent {
         // appended section. Suppressed entirely when no MCP server has
         // reached `Ready` — keeps the prompt shape stable for users who
         // don't use MCP.
-        if let Some(snippet) = crate::mcp::catalog::system_prompt_snippet() {
-            prompt.push_str("\n\n");
-            prompt.push_str(&snippet);
+        let mcp_scope_allows_prompt = self
+            .tool_scope
+            .map(|scope| {
+                scope.allows(tools::TOOL_MCP_RESOURCE) || scope.allows(tools::TOOL_MCP_PROMPT)
+            })
+            .unwrap_or(true);
+        if caps.mcp_enabled && app_config.mcp_global.enabled && mcp_scope_allows_prompt {
+            if let Some(snippet) = crate::mcp::catalog::system_prompt_snippet() {
+                prompt.push_str("\n\n");
+                prompt.push_str(&snippet);
+            }
         }
         // Attached knowledge spaces (D7). Appended last, like the MCP snippet:
         // present only when at least one KB is reachable, so non-KB sessions keep

--- a/crates/ha-core/src/mcp/api.rs
+++ b/crates/ha-core/src/mcp/api.rs
@@ -17,7 +17,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::{cached_config, mutate_config};
 
-use super::catalog::namespaced_tool_name;
 use super::client;
 use super::config::{
     McpGlobalSettings, McpOAuthConfig, McpServerConfig, McpTransportSpec, McpTrustLevel,
@@ -25,6 +24,8 @@ use super::config::{
 use super::credentials;
 use super::oauth;
 use super::registry::{McpManager, ServerStatusSnapshot};
+
+const REDACTED: &str = "<redacted>";
 
 // ── Serializable DTOs ────────────────────────────────────────────
 
@@ -83,7 +84,6 @@ impl McpServerSummary {
 /// bake the redaction here so that "add field" stays the single mental
 /// model for schema evolution.
 fn redact_for_response(mut cfg: McpServerConfig) -> McpServerConfig {
-    const REDACTED: &str = "<redacted>";
     if let Some(oauth) = cfg.oauth.as_mut() {
         if oauth.client_secret.is_some() {
             oauth.client_secret = Some(REDACTED.into());
@@ -192,12 +192,11 @@ impl McpServerDraft {
     /// Bake the draft into a persisted [`McpServerConfig`]. `now_secs` is
     /// injected so the test matrix can freeze time.
     pub fn into_config(self, now_secs: i64, existing: Option<&McpServerConfig>) -> McpServerConfig {
-        let id = self
-            .id
-            .or_else(|| existing.map(|e| e.id.clone()))
+        let id = existing
+            .map(|e| e.id.clone())
             .unwrap_or_else(|| uuid::Uuid::new_v4().as_hyphenated().to_string());
         let created_at = existing.map(|e| e.created_at).unwrap_or(now_secs);
-        McpServerConfig {
+        let mut cfg = McpServerConfig {
             id,
             name: self.name,
             enabled: self.enabled,
@@ -221,6 +220,41 @@ impl McpServerDraft {
             created_at,
             updated_at: now_secs,
             trust_acknowledged_at: self.trust_acknowledged_at,
+        };
+        if let Some(existing) = existing {
+            preserve_existing_sensitive_fields(&mut cfg, existing);
+        }
+        cfg
+    }
+}
+
+fn preserve_existing_sensitive_fields(cfg: &mut McpServerConfig, existing: &McpServerConfig) {
+    preserve_redacted_map_values(&mut cfg.env, &existing.env);
+    preserve_redacted_map_values(&mut cfg.headers, &existing.headers);
+
+    match (&mut cfg.oauth, &existing.oauth) {
+        (None, Some(old)) => {
+            cfg.oauth = Some(old.clone());
+        }
+        (Some(new), Some(old))
+            if new.client_secret.as_deref() == Some(REDACTED)
+                || (new.client_secret.is_none() && old.client_secret.is_some()) =>
+        {
+            new.client_secret = old.client_secret.clone();
+        }
+        _ => {}
+    }
+}
+
+fn preserve_redacted_map_values(
+    current: &mut BTreeMap<String, String>,
+    existing: &BTreeMap<String, String>,
+) {
+    for (key, value) in current.iter_mut() {
+        if value == REDACTED {
+            if let Some(old) = existing.get(key) {
+                *value = old.clone();
+            }
         }
     }
 }
@@ -242,13 +276,7 @@ async fn snapshots_by_id() -> std::collections::HashMap<String, ServerStatusSnap
 }
 
 async fn reconcile_from_cache() -> Result<()> {
-    let Some(mgr) = McpManager::global() else {
-        return Ok(());
-    };
-    let cfg = cached_config();
-    mgr.reconcile(cfg.mcp_global.clone(), cfg.mcp_servers.clone())
-        .await
-        .map_err(|e| anyhow!("{e}"))
+    super::reconcile_from_config_cache().await
 }
 
 // ── CRUD commands ────────────────────────────────────────────────
@@ -329,6 +357,12 @@ pub async fn update_server(id: &str, draft: McpServerDraft) -> Result<McpServerS
 
     let new_cfg = draft.into_config(now, Some(&existing));
     new_cfg.validate().map_err(|e| anyhow!("{e}"))?;
+    if new_cfg.name != existing.name {
+        return Err(anyhow!(
+            "MCP server names are immutable; remove and re-add '{}' to rename it",
+            existing.name
+        ));
+    }
 
     let saved = new_cfg.clone();
     mutate_config(("mcp.update", "settings_panel"), |store| {
@@ -402,7 +436,8 @@ pub async fn reorder_servers(new_order: Vec<String>) -> Result<()> {
             store.mcp_servers.push(cfg);
         }
         Ok(())
-    })
+    })?;
+    reconcile_from_cache().await
 }
 
 // ── Connection + diagnostics ─────────────────────────────────────
@@ -536,9 +571,14 @@ pub async fn list_server_tools(id: &str) -> Result<Vec<McpToolSummary>> {
         _ => Vec::new(),
     };
     let cfg_name = handle.config.read().await.name.clone();
+    let namespaced_names = super::catalog::assign_namespaced_tool_names(
+        &cfg_name,
+        tools.iter().map(|t| t.name.as_ref()),
+    );
     Ok(tools
         .iter()
-        .map(|t| {
+        .zip(namespaced_names)
+        .map(|(t, namespaced_name)| {
             let name = t.name.to_string();
             let description = t
                 .description
@@ -546,7 +586,7 @@ pub async fn list_server_tools(id: &str) -> Result<Vec<McpToolSummary>> {
                 .map(|d| d.to_string())
                 .filter(|s| !s.is_empty());
             McpToolSummary {
-                namespaced_name: namespaced_tool_name(&cfg_name, &name),
+                namespaced_name,
                 name,
                 description,
             }
@@ -801,7 +841,7 @@ mod tests {
     #[test]
     fn draft_preserves_id_on_update() {
         let draft = McpServerDraft {
-            id: None,
+            id: Some("ignored-draft-id".into()),
             name: "foo".into(),
             enabled: true,
             transport: McpTransportSpec::Stdio {
@@ -860,5 +900,93 @@ mod tests {
         assert_eq!(cfg.id, "keep-me");
         assert_eq!(cfg.created_at, 100);
         assert_eq!(cfg.updated_at, 200);
+    }
+
+    #[test]
+    fn draft_preserves_redacted_sensitive_values_on_update() {
+        let mut existing = McpServerConfig {
+            id: "keep-me".into(),
+            name: "foo".into(),
+            enabled: true,
+            transport: McpTransportSpec::StreamableHttp {
+                url: "https://example.com/mcp".into(),
+            },
+            env: [("API_KEY".into(), "old-env-secret".into())]
+                .into_iter()
+                .collect(),
+            headers: [("Authorization".into(), "Bearer old-token".into())]
+                .into_iter()
+                .collect(),
+            oauth: Some(McpOAuthConfig {
+                client_id: Some("client".into()),
+                client_secret: Some("old-client-secret".into()),
+                authorization_endpoint: Some("https://example.com/auth".into()),
+                token_endpoint: Some("https://example.com/token".into()),
+                scopes: vec!["read".into()],
+                extra_params: Default::default(),
+            }),
+            allowed_tools: vec![],
+            denied_tools: vec![],
+            connect_timeout_secs: 30,
+            call_timeout_secs: 120,
+            health_check_interval_secs: 60,
+            max_concurrent_calls: 4,
+            auto_approve: false,
+            trust_level: McpTrustLevel::Untrusted,
+            eager: false,
+            deferred_tools: false,
+            project_paths: vec![],
+            description: None,
+            icon: None,
+            created_at: 100,
+            updated_at: 100,
+            trust_acknowledged_at: None,
+        };
+
+        let draft = McpServerDraft {
+            id: None,
+            name: "foo".into(),
+            enabled: true,
+            transport: existing.transport.clone(),
+            env: [("API_KEY".into(), REDACTED.into())].into_iter().collect(),
+            headers: [("Authorization".into(), REDACTED.into())]
+                .into_iter()
+                .collect(),
+            oauth: None,
+            allowed_tools: vec![],
+            denied_tools: vec![],
+            connect_timeout_secs: None,
+            call_timeout_secs: None,
+            health_check_interval_secs: None,
+            max_concurrent_calls: None,
+            auto_approve: false,
+            trust_level: McpTrustLevel::Untrusted,
+            eager: false,
+            deferred_tools: false,
+            project_paths: vec![],
+            description: None,
+            icon: None,
+            trust_acknowledged_at: None,
+        };
+
+        let cfg = draft.into_config(200, Some(&existing));
+        assert_eq!(cfg.env["API_KEY"], "old-env-secret");
+        assert_eq!(cfg.headers["Authorization"], "Bearer old-token");
+        assert_eq!(
+            cfg.oauth.as_ref().and_then(|o| o.client_secret.as_deref()),
+            Some("old-client-secret")
+        );
+
+        existing.oauth.as_mut().unwrap().client_secret = Some("rotated".into());
+        let mut draft_with_oauth = cfg.clone();
+        draft_with_oauth.oauth.as_mut().unwrap().client_secret = Some(REDACTED.into());
+        preserve_existing_sensitive_fields(&mut draft_with_oauth, &existing);
+        assert_eq!(
+            draft_with_oauth
+                .oauth
+                .as_ref()
+                .and_then(|o| o.client_secret.as_deref()),
+            Some("rotated")
+        );
     }
 }

--- a/crates/ha-core/src/mcp/api.rs
+++ b/crates/ha-core/src/mcp/api.rs
@@ -233,13 +233,7 @@ fn preserve_existing_sensitive_fields(cfg: &mut McpServerConfig, existing: &McpS
     preserve_redacted_map_values(&mut cfg.headers, &existing.headers);
 
     match (&mut cfg.oauth, &existing.oauth) {
-        (None, Some(old)) => {
-            cfg.oauth = Some(old.clone());
-        }
-        (Some(new), Some(old))
-            if new.client_secret.as_deref() == Some(REDACTED)
-                || (new.client_secret.is_none() && old.client_secret.is_some()) =>
-        {
+        (Some(new), Some(old)) if new.client_secret.as_deref() == Some(REDACTED) => {
             new.client_secret = old.client_secret.clone();
         }
         _ => {}
@@ -972,13 +966,10 @@ mod tests {
         let cfg = draft.into_config(200, Some(&existing));
         assert_eq!(cfg.env["API_KEY"], "old-env-secret");
         assert_eq!(cfg.headers["Authorization"], "Bearer old-token");
-        assert_eq!(
-            cfg.oauth.as_ref().and_then(|o| o.client_secret.as_deref()),
-            Some("old-client-secret")
-        );
+        assert!(cfg.oauth.is_none());
 
         existing.oauth.as_mut().unwrap().client_secret = Some("rotated".into());
-        let mut draft_with_oauth = cfg.clone();
+        let mut draft_with_oauth = existing.clone();
         draft_with_oauth.oauth.as_mut().unwrap().client_secret = Some(REDACTED.into());
         preserve_existing_sensitive_fields(&mut draft_with_oauth, &existing);
         assert_eq!(
@@ -987,6 +978,17 @@ mod tests {
                 .as_ref()
                 .and_then(|o| o.client_secret.as_deref()),
             Some("rotated")
+        );
+
+        let mut draft_clearing_secret = existing.clone();
+        draft_clearing_secret.oauth.as_mut().unwrap().client_secret = None;
+        preserve_existing_sensitive_fields(&mut draft_clearing_secret, &existing);
+        assert_eq!(
+            draft_clearing_secret
+                .oauth
+                .as_ref()
+                .and_then(|o| o.client_secret.as_deref()),
+            None
         );
     }
 }

--- a/crates/ha-core/src/mcp/catalog.rs
+++ b/crates/ha-core/src/mcp/catalog.rs
@@ -9,6 +9,8 @@
 //!   because some providers reject those at the root (we preserve them
 //!   in nested positions).
 
+use std::collections::{HashMap, HashSet};
+
 use rmcp::model;
 use serde_json::{json, Value};
 
@@ -46,11 +48,59 @@ pub fn sanitize_tool_name(raw: &str) -> String {
 
 /// Join the namespaced tool identifier the LLM sees.
 pub fn namespaced_tool_name(server_name: &str, original_tool_name: &str) -> String {
-    format!(
-        "mcp__{}__{}",
-        server_name,
-        sanitize_tool_name(original_tool_name)
-    )
+    namespaced_tool_name_from_sanitized(server_name, &sanitize_tool_name(original_tool_name))
+}
+
+fn namespaced_tool_name_from_sanitized(server_name: &str, sanitized_tool_name: &str) -> String {
+    format!("mcp__{}__{}", server_name, sanitized_tool_name)
+}
+
+/// Assign collision-safe namespaced tool identifiers for a server catalog.
+///
+/// Sanitization alone can collapse distinct MCP tool names (`foo-bar` and
+/// `foo.bar` both become `foo_bar`). The LLM-visible names must remain unique,
+/// so later collisions get `_2`, `_3`, ... suffixes while staying inside the
+/// provider 64-character tool-name ceiling.
+pub fn assign_namespaced_tool_names<'a, I>(server_name: &str, originals: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut next_ordinal_by_base: HashMap<String, usize> = HashMap::new();
+    let mut used: HashSet<String> = HashSet::new();
+    let mut out = Vec::new();
+
+    for original in originals {
+        let base = sanitize_tool_name(original);
+        let mut ordinal = next_ordinal_by_base
+            .get(&base)
+            .copied()
+            .unwrap_or(0)
+            .saturating_add(1);
+        loop {
+            let tool_part = suffixed_tool_name(&base, ordinal);
+            let namespaced = namespaced_tool_name_from_sanitized(server_name, &tool_part);
+            if used.insert(namespaced.clone()) {
+                next_ordinal_by_base.insert(base.clone(), ordinal);
+                out.push(namespaced);
+                break;
+            }
+            ordinal = ordinal.saturating_add(1);
+        }
+    }
+
+    out
+}
+
+fn suffixed_tool_name(base: &str, ordinal: usize) -> String {
+    if ordinal <= 1 {
+        return base.to_string();
+    }
+    let suffix = format!("_{ordinal}");
+    let keep = TOOL_NAME_CAP.saturating_sub(suffix.len());
+    let mut out = String::with_capacity(TOOL_NAME_CAP);
+    out.push_str(&base[..base.len().min(keep)]);
+    out.push_str(&suffix);
+    out
 }
 
 /// The `prefix_bytes` / `suffix_bytes` constants let callers decide
@@ -228,7 +278,19 @@ fn merge_object_union(variants: &[Value]) -> (serde_json::Map<String, Value>, Ve
 /// per-agent `capabilities.mcp_enabled` flag gates injection.
 pub fn rmcp_tool_to_definition(cfg: &McpServerConfig, tool: &model::Tool) -> ToolDefinition {
     let orig = tool.name.to_string();
-    let name = namespaced_tool_name(&cfg.name, &orig);
+    rmcp_tool_to_definition_with_name(cfg, tool, namespaced_tool_name(&cfg.name, &orig))
+}
+
+/// Build a [`ToolDefinition`] using a pre-assigned namespaced name.
+///
+/// Catalog refresh paths use this after running collision resolution across the
+/// whole server catalog; the single-tool helper above remains for tests and
+/// call sites that do not need cross-tool uniqueness.
+pub fn rmcp_tool_to_definition_with_name(
+    cfg: &McpServerConfig,
+    tool: &model::Tool,
+    name: String,
+) -> ToolDefinition {
     let description_owned: String = tool
         .description
         .as_ref()
@@ -326,6 +388,19 @@ mod tests {
             n,
             n.len()
         );
+    }
+
+    #[test]
+    fn assigned_names_are_collision_safe_and_bounded() {
+        let long = "a".repeat(100);
+        let names =
+            assign_namespaced_tool_names("srv", ["foo-bar", "foo.bar", "foo_bar", long.as_str()]);
+        assert_eq!(names[0], "mcp__srv__foo_bar");
+        assert_eq!(names[1], "mcp__srv__foo_bar_2");
+        assert_eq!(names[2], "mcp__srv__foo_bar_3");
+        assert!(names[3].len() <= 64);
+        let unique: std::collections::HashSet<_> = names.iter().collect();
+        assert_eq!(unique.len(), names.len());
     }
 
     #[test]

--- a/crates/ha-core/src/mcp/client.rs
+++ b/crates/ha-core/src/mcp/client.rs
@@ -27,40 +27,70 @@ use super::transport::{build_transport_for, ConnectedClient};
 /// round under the configured `connect_timeout_secs`.
 pub async fn ensure_connected(manager: &McpManager, handle: Arc<ServerHandle>) -> McpResult<()> {
     // Fast path: already good.
-    {
-        let state = handle.state.lock().await;
-        if matches!(*state, ServerState::Ready { .. }) {
-            return Ok(());
-        }
-        if matches!(*state, ServerState::Disabled) {
-            let cfg = handle.config.read().await;
-            return Err(McpError::NotReady {
-                server: cfg.name.clone(),
-                reason: "server is disabled in config".into(),
-            });
-        }
-        if let ServerState::Failed { retry_at, reason } = &*state {
-            let now = chrono::Utc::now().timestamp();
-            if now < *retry_at {
-                let cfg = handle.config.read().await;
-                return Err(McpError::NotReady {
-                    server: cfg.name.clone(),
-                    reason: format!(
-                        "in backoff after failure ({reason}); retry_at in {}s",
-                        *retry_at - now
-                    ),
-                });
-            }
-        }
+    if !connect_needed_or_error(&handle).await? {
+        return Ok(());
     }
-    connect_now(manager, handle).await
+
+    let _connect_guard = handle.connect_lock.lock().await;
+    // Another caller may have completed the handshake while we were waiting
+    // for the lock. Re-check before doing any work.
+    if !connect_needed_or_error(&handle).await? {
+        return Ok(());
+    }
+    connect_now_inner(manager, handle.clone()).await
 }
 
 /// Force a (re)connect regardless of current state. Used by the user's
 /// "Reconnect" button, by the watchdog after a timer tick, and by Phase 3
 /// CRUD paths that need immediate visibility after a config change.
 pub async fn connect_now(manager: &McpManager, handle: Arc<ServerHandle>) -> McpResult<()> {
+    let _connect_guard = handle.connect_lock.lock().await;
+    connect_now_inner(manager, handle.clone()).await
+}
+
+async fn connect_needed_or_error(handle: &ServerHandle) -> McpResult<bool> {
+    if handle.is_retired() {
+        let cfg = handle.config.read().await;
+        return Err(McpError::NotReady {
+            server: cfg.name.clone(),
+            reason: "server config was replaced or removed".into(),
+        });
+    }
+    let state = handle.state.lock().await;
+    if matches!(*state, ServerState::Ready { .. }) {
+        return Ok(false);
+    }
+    if matches!(*state, ServerState::Disabled) {
+        let cfg = handle.config.read().await;
+        return Err(McpError::NotReady {
+            server: cfg.name.clone(),
+            reason: "server is disabled in config".into(),
+        });
+    }
+    if let ServerState::Failed { retry_at, reason } = &*state {
+        let now = chrono::Utc::now().timestamp();
+        if now < *retry_at {
+            let cfg = handle.config.read().await;
+            return Err(McpError::NotReady {
+                server: cfg.name.clone(),
+                reason: format!(
+                    "in backoff after failure ({reason}); retry_at in {}s",
+                    *retry_at - now
+                ),
+            });
+        }
+    }
+    Ok(true)
+}
+
+async fn connect_now_inner(manager: &McpManager, handle: Arc<ServerHandle>) -> McpResult<()> {
     let cfg = handle.config.read().await.clone();
+    if handle.is_retired() {
+        return Err(McpError::NotReady {
+            server: cfg.name,
+            reason: "server config was replaced or removed".into(),
+        });
+    }
     if !cfg.enabled {
         set_state(&handle, ServerState::Disabled).await;
         return Err(McpError::NotReady {
@@ -76,6 +106,13 @@ pub async fn connect_now(manager: &McpManager, handle: Arc<ServerHandle>) -> Mcp
     let result = timeout(connect_timeout, do_connect(&cfg, &handle)).await;
     match result {
         Ok(Ok(())) => {
+            if handle.is_retired() {
+                disconnect(&handle).await.ok();
+                return Err(McpError::NotReady {
+                    server: cfg.name,
+                    reason: "server config was replaced or removed".into(),
+                });
+            }
             handle
                 .consecutive_failures
                 .store(0, std::sync::atomic::Ordering::Relaxed);
@@ -137,6 +174,12 @@ const TOOLS_PER_SERVER_CAP: usize = 512;
 
 pub async fn refresh_catalog(manager: &McpManager, handle: Arc<ServerHandle>) -> McpResult<()> {
     let cfg = handle.config.read().await.clone();
+    if handle.is_retired() {
+        return Err(McpError::NotReady {
+            server: cfg.name,
+            reason: "server config was replaced or removed".into(),
+        });
+    }
     let peer = handle.peer().await?;
 
     let mut tools = peer
@@ -163,6 +206,13 @@ pub async fn refresh_catalog(manager: &McpManager, handle: Arc<ServerHandle>) ->
     let tool_count = tools.len();
     let resource_count = resources.len();
     let prompt_count = prompts.len();
+
+    if handle.is_retired() {
+        return Err(McpError::NotReady {
+            server: cfg.name,
+            reason: "server config was replaced or removed".into(),
+        });
+    }
 
     rebuild_tool_index_for(manager, &cfg, &tools).await;
 
@@ -222,12 +272,15 @@ async fn rebuild_tool_index_for(
     {
         let mut idx = manager.tool_index.write().await;
         idx.retain(|_, e| e.server_id != cfg.id);
-        for tool in tools {
+        let namespaced_names = super::catalog::assign_namespaced_tool_names(
+            &cfg.name,
+            tools.iter().map(|t| t.name.as_ref()),
+        );
+        for (tool, namespaced) in tools.iter().zip(namespaced_names) {
             let orig = tool.name.to_string();
             if !super::catalog::tool_allowed_by_server_config(cfg, &orig) {
                 continue;
             }
-            let namespaced = super::catalog::namespaced_tool_name(&cfg.name, &orig);
             idx.insert(
                 namespaced,
                 ToolIndexEntry {
@@ -246,8 +299,14 @@ async fn rebuild_tool_index_for(
     //    schema list, or vice versa.
     let defs_for_server: Vec<crate::tools::ToolDefinition> = tools
         .iter()
-        .filter(|tool| super::catalog::tool_allowed_by_server_config(cfg, tool.name.as_ref()))
-        .map(|t| super::catalog::rmcp_tool_to_definition(cfg, t))
+        .zip(super::catalog::assign_namespaced_tool_names(
+            &cfg.name,
+            tools.iter().map(|t| t.name.as_ref()),
+        ))
+        .filter(|(tool, _)| super::catalog::tool_allowed_by_server_config(cfg, tool.name.as_ref()))
+        .map(|(t, namespaced)| {
+            super::catalog::rmcp_tool_to_definition_with_name(cfg, t, namespaced)
+        })
         .collect();
 
     // Merge: keep other servers' defs, replace this server's. Use the

--- a/crates/ha-core/src/mcp/config.rs
+++ b/crates/ha-core/src/mcp/config.rs
@@ -79,7 +79,7 @@ pub enum McpTrustLevel {
 // ── OAuth ────────────────────────────────────────────────────────
 
 /// Per-server OAuth 2.1 + PKCE configuration. Only populated for networked
-/// transports where the server advertises OAuth; stdio transports ignore it.
+/// transports where the server advertises OAuth; stdio transports reject it.
 /// The discovered endpoints (`.well-known/oauth-authorization-server`) may
 /// override any `None` fields at connect time.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -267,6 +267,12 @@ impl McpServerConfig {
         if self.auto_approve && matches!(self.trust_level, McpTrustLevel::Untrusted) {
             return Err(McpError::Config(format!(
                 "server '{}': auto_approve requires trust_level=trusted",
+                self.name
+            )));
+        }
+        if self.oauth.is_some() && !self.transport.is_networked() {
+            return Err(McpError::Config(format!(
+                "server '{}': OAuth is only supported on networked transports",
                 self.name
             )));
         }
@@ -510,6 +516,48 @@ mod tests {
             trust_acknowledged_at: None,
         };
         assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_stdio_oauth() {
+        let cfg = McpServerConfig {
+            id: "id-1".into(),
+            name: "foo".into(),
+            enabled: true,
+            transport: McpTransportSpec::Stdio {
+                command: "true".into(),
+                args: vec![],
+                cwd: None,
+            },
+            env: Default::default(),
+            headers: Default::default(),
+            oauth: Some(McpOAuthConfig {
+                client_id: Some("client".into()),
+                client_secret: None,
+                authorization_endpoint: None,
+                token_endpoint: None,
+                scopes: vec![],
+                extra_params: Default::default(),
+            }),
+            allowed_tools: vec![],
+            denied_tools: vec![],
+            connect_timeout_secs: 30,
+            call_timeout_secs: 120,
+            health_check_interval_secs: 60,
+            max_concurrent_calls: 4,
+            auto_approve: false,
+            trust_level: McpTrustLevel::Untrusted,
+            eager: false,
+            deferred_tools: false,
+            project_paths: vec![],
+            description: None,
+            icon: None,
+            created_at: 0,
+            updated_at: 0,
+            trust_acknowledged_at: None,
+        };
+
+        assert!(cfg.validate().is_err());
     }
 
     #[test]

--- a/crates/ha-core/src/mcp/mod.rs
+++ b/crates/ha-core/src/mcp/mod.rs
@@ -40,6 +40,31 @@ pub use credentials::McpCredentials;
 pub use errors::{McpError, McpResult};
 pub use registry::{McpManager, ServerHandle, ServerState, ServerStatusSnapshot, ToolIndexEntry};
 
+/// Hot-sync the MCP runtime from the current cached app config.
+///
+/// This handles both steady-state edits (`McpManager` already exists) and
+/// the important cold-enable case where the app started with
+/// `mcpGlobal.enabled=false` and the user turns MCP on later without a
+/// restart.
+pub(crate) async fn reconcile_from_config_cache() -> anyhow::Result<()> {
+    let cfg = crate::config::cached_config();
+    if let Some(mgr) = McpManager::global() {
+        mgr.reconcile(cfg.mcp_global.clone(), cfg.mcp_servers.clone())
+            .await
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        return Ok(());
+    }
+
+    if cfg.mcp_global.enabled {
+        McpManager::init_global(cfg.mcp_global.clone(), cfg.mcp_servers.clone());
+        if crate::runtime_lock::is_primary() {
+            watchdog::spawn_watchdog_loop();
+        }
+        events::emit_servers_changed();
+    }
+    Ok(())
+}
+
 /// Look up a server by id or name, returning an `anyhow`-flavored
 /// error so tool handlers can propagate it directly. Wrapper over
 /// [`McpManager::locate`] that also turns "manager not initialized"

--- a/crates/ha-core/src/mcp/registry.rs
+++ b/crates/ha-core/src/mcp/registry.rs
@@ -9,7 +9,7 @@
 //! See `docs/architecture/mcp.md` for the full state machine.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicI64, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use arc_swap::ArcSwap;
@@ -117,6 +117,14 @@ pub struct ServerHandle {
     /// None until the handshake completes. The rmcp `RunningService`
     /// holds the spawned service loop + cancellation token.
     pub client: Mutex<Option<RunningService<RoleClient, ()>>>,
+    /// Serializes connection attempts for this server. Without this,
+    /// concurrent first-use tool calls can all observe `Idle` / `Connecting`
+    /// and spawn duplicate subprocesses or handshakes.
+    pub connect_lock: Mutex<()>,
+    /// Set when this handle has been removed or replaced by a config
+    /// reconcile. In-flight work may still hold an Arc, but it must not
+    /// reconnect or publish catalogs back into the global manager.
+    retired: AtomicBool,
     /// Per-server in-flight cap. Initialized from
     /// `config.max_concurrent_calls` at construction time; callers take a
     /// permit around each `call_tool`.
@@ -139,7 +147,17 @@ impl ServerHandle {
             config: RwLock::new(config),
             state: Mutex::new(ServerState::Idle),
             client: Mutex::new(None),
+            connect_lock: Mutex::new(()),
+            retired: AtomicBool::new(false),
         }
+    }
+
+    pub fn retire(&self) {
+        self.retired.store(true, Ordering::Release);
+    }
+
+    pub fn is_retired(&self) -> bool {
+        self.retired.load(Ordering::Acquire)
     }
 
     /// Clone the rmcp `Peer<RoleClient>` handle used for RPCs
@@ -216,6 +234,10 @@ pub struct McpManager {
     pub(crate) cached_tool_defs: ArcSwap<Vec<ToolDefinition>>,
     /// Global cross-server cap; enforced on top of per-server semaphore.
     pub(crate) global_semaphore: Arc<Semaphore>,
+    /// Actual semaphore capacity after live growth. We do not shrink a tokio
+    /// semaphore in place, so this tracks the real high-water capacity rather
+    /// than the latest configured value.
+    pub(crate) global_capacity: AtomicU32,
     pub(crate) global_settings: RwLock<McpGlobalSettings>,
 }
 
@@ -247,6 +269,7 @@ impl McpManager {
                 tool_index: RwLock::new(HashMap::new()),
                 cached_tool_defs: ArcSwap::from_pointee(Vec::new()),
                 global_semaphore: Arc::new(Semaphore::new(permits)),
+                global_capacity: AtomicU32::new(global.max_concurrent_calls.max(1)),
                 global_settings: RwLock::new(global),
             }
         })
@@ -343,8 +366,8 @@ impl McpManager {
     /// Existing transport state is kept for still-effective servers; removed
     /// servers are disconnected after the registry lock is released.
     ///
-    /// TODO(phase2+): detect transport-critical field diffs (command,
-    /// args, url, env) and force a disconnect + reconnect round.
+    /// Transport / credential / trust / concurrency edits replace the live
+    /// handle so old connections and semaphores cannot linger after save.
     pub async fn reconcile(
         &self,
         new_settings: McpGlobalSettings,
@@ -353,6 +376,14 @@ impl McpManager {
         // Update global settings first — the semaphore is only grown,
         // never shrunk live (shrinking would starve in-flight calls).
         {
+            let actual_permits = self.global_capacity.load(Ordering::Acquire).max(1) as usize;
+            let new_permits = new_settings.max_concurrent_calls.max(1) as usize;
+            if new_permits > actual_permits {
+                self.global_semaphore
+                    .add_permits(new_permits - actual_permits);
+                self.global_capacity
+                    .store(new_settings.max_concurrent_calls.max(1), Ordering::Release);
+            }
             let mut g = self.global_settings.write().await;
             *g = new_settings.clone();
         }
@@ -365,6 +396,7 @@ impl McpManager {
             for cfg in new_servers {
                 if !server_effectively_enabled(&new_settings, &cfg) {
                     if let Some(handle) = servers.remove(&cfg.id) {
+                        handle.retire();
                         removed.push(handle);
                     }
                     continue;
@@ -377,17 +409,27 @@ impl McpManager {
                         cfg.name
                     );
                     if let Some(handle) = servers.remove(&cfg.id) {
+                        handle.retire();
                         removed.push(handle);
                     }
                     continue;
                 }
 
                 active_ids.insert(cfg.id.clone());
-                if let Some(existing) = servers.get(&cfg.id) {
-                    // Replace the config; state/client stay. Ready catalogs
-                    // below are immediately re-indexed against this new config
-                    // so allow/deny edits do not leave the runtime empty.
-                    *existing.config.write().await = cfg;
+                if let Some(existing) = servers.get(&cfg.id).cloned() {
+                    let old_cfg = existing.config.read().await.clone();
+                    if connection_rebuild_required(&old_cfg, &cfg) {
+                        let fresh = Arc::new(ServerHandle::new(cfg.clone()));
+                        servers.insert(cfg.id.clone(), fresh);
+                        existing.retire();
+                        removed.push(existing);
+                    } else {
+                        // Replace the config; state/client stay. Ready catalogs
+                        // below are immediately re-indexed against this new config
+                        // so allow/deny/deferred edits do not leave stale runtime
+                        // visibility.
+                        *existing.config.write().await = cfg;
+                    }
                 } else {
                     servers.insert(cfg.id.clone(), Arc::new(ServerHandle::new(cfg)));
                 }
@@ -400,6 +442,7 @@ impl McpManager {
                 .collect();
             for id in stale_ids {
                 if let Some(handle) = servers.remove(&id) {
+                    handle.retire();
                     removed.push(handle);
                 }
             }
@@ -408,6 +451,7 @@ impl McpManager {
         };
 
         for handle in removed {
+            let _connect_guard = handle.connect_lock.lock().await;
             let _ = super::client::disconnect(&handle).await;
         }
 
@@ -431,22 +475,27 @@ impl McpManager {
                 }
             };
 
-            for tool in tools {
+            let namespaced_names = super::catalog::assign_namespaced_tool_names(
+                &cfg.name,
+                tools.iter().map(|t| t.name.as_ref()),
+            );
+            for (tool, namespaced) in tools.iter().zip(namespaced_names) {
                 let original = tool.name.to_string();
                 if !super::catalog::tool_allowed_by_server_config(&cfg, &original) {
                     continue;
                 }
 
-                let namespaced = super::catalog::namespaced_tool_name(&cfg.name, &original);
                 next_index.insert(
-                    namespaced,
+                    namespaced.clone(),
                     ToolIndexEntry {
                         server_id: cfg.id.clone(),
                         server_name: cfg.name.clone(),
                         original_tool_name: original,
                     },
                 );
-                next_defs.push(super::catalog::rmcp_tool_to_definition(&cfg, &tool));
+                next_defs.push(super::catalog::rmcp_tool_to_definition_with_name(
+                    &cfg, &tool, namespaced,
+                ));
             }
         }
 
@@ -458,6 +507,15 @@ impl McpManager {
 
 fn server_effectively_enabled(global: &McpGlobalSettings, cfg: &McpServerConfig) -> bool {
     global.enabled && cfg.enabled && !global.denied_servers.contains(&cfg.name)
+}
+
+fn connection_rebuild_required(old: &McpServerConfig, new: &McpServerConfig) -> bool {
+    old.transport != new.transport
+        || old.env != new.env
+        || old.headers != new.headers
+        || old.oauth != new.oauth
+        || old.trust_level != new.trust_level
+        || old.max_concurrent_calls.max(1) != new.max_concurrent_calls.max(1)
 }
 
 #[cfg(test)]
@@ -516,6 +574,7 @@ mod tests {
             tool_index: RwLock::new(HashMap::new()),
             cached_tool_defs: ArcSwap::from_pointee(Vec::new()),
             global_semaphore: Arc::new(Semaphore::new(global.max_concurrent_calls.max(1) as usize)),
+            global_capacity: AtomicU32::new(global.max_concurrent_calls.max(1)),
             global_settings: RwLock::new(global),
         }
     }
@@ -600,6 +659,107 @@ mod tests {
         assert_eq!(cached_tool_names(&manager), vec!["mcp__alpha__read"]);
         assert!(manager.lookup_tool("mcp__alpha__read").await.is_some());
         assert!(manager.lookup_tool("mcp__alpha__write").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn ready_catalog_uses_collision_safe_tool_names() {
+        let cfg = sample_stdio_cfg("id-alpha", "alpha");
+        let manager = test_manager(vec![cfg.clone()]);
+        seed_ready_catalog(
+            &manager,
+            "id-alpha",
+            vec![sample_tool("foo-bar"), sample_tool("foo.bar")],
+        )
+        .await;
+
+        assert_eq!(
+            cached_tool_names(&manager),
+            vec!["mcp__alpha__foo_bar", "mcp__alpha__foo_bar_2"]
+        );
+        assert_eq!(
+            manager
+                .lookup_tool("mcp__alpha__foo_bar")
+                .await
+                .unwrap()
+                .original_tool_name,
+            "foo-bar"
+        );
+        assert_eq!(
+            manager
+                .lookup_tool("mcp__alpha__foo_bar_2")
+                .await
+                .unwrap()
+                .original_tool_name,
+            "foo.bar"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_rebuilds_handle_for_connection_critical_edits() {
+        let mut cfg = sample_stdio_cfg("id-alpha", "alpha");
+        let manager = test_manager(vec![cfg.clone()]);
+        seed_ready_catalog(&manager, "id-alpha", vec![sample_tool("read")]).await;
+        let old_handle = manager.get_by_id("id-alpha").await.unwrap();
+        assert!(manager.lookup_tool("mcp__alpha__read").await.is_some());
+
+        cfg.env.insert("TOKEN".into(), "new-token".into());
+        manager
+            .reconcile(McpGlobalSettings::default(), vec![cfg.clone()])
+            .await
+            .unwrap();
+
+        let handle = manager.get_by_id("id-alpha").await.unwrap();
+        assert!(old_handle.is_retired());
+        assert_eq!(handle.snapshot().await.state, "idle");
+        assert_eq!(handle.config.read().await.env["TOKEN"], "new-token");
+        assert!(manager.mcp_tool_definitions().is_empty());
+        assert!(manager.lookup_tool("mcp__alpha__read").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn global_semaphore_does_not_grow_after_shrink_then_partial_raise() {
+        let cfg = sample_stdio_cfg("id-alpha", "alpha");
+        let manager = test_manager(vec![cfg.clone()]);
+        assert_eq!(manager.global_semaphore.available_permits(), 8);
+
+        manager
+            .reconcile(
+                McpGlobalSettings {
+                    max_concurrent_calls: 4,
+                    ..Default::default()
+                },
+                vec![cfg.clone()],
+            )
+            .await
+            .unwrap();
+        assert_eq!(manager.global_capacity.load(Ordering::Acquire), 8);
+        assert_eq!(manager.global_semaphore.available_permits(), 8);
+
+        manager
+            .reconcile(
+                McpGlobalSettings {
+                    max_concurrent_calls: 6,
+                    ..Default::default()
+                },
+                vec![cfg.clone()],
+            )
+            .await
+            .unwrap();
+        assert_eq!(manager.global_capacity.load(Ordering::Acquire), 8);
+        assert_eq!(manager.global_semaphore.available_permits(), 8);
+
+        manager
+            .reconcile(
+                McpGlobalSettings {
+                    max_concurrent_calls: 10,
+                    ..Default::default()
+                },
+                vec![cfg],
+            )
+            .await
+            .unwrap();
+        assert_eq!(manager.global_capacity.load(Ordering::Acquire), 10);
+        assert_eq!(manager.global_semaphore.available_permits(), 10);
     }
 
     #[tokio::test]

--- a/crates/ha-core/src/mcp/registry.rs
+++ b/crates/ha-core/src/mcp/registry.rs
@@ -451,7 +451,6 @@ impl McpManager {
         };
 
         for handle in removed {
-            let _connect_guard = handle.connect_lock.lock().await;
             let _ = super::client::disconnect(&handle).await;
         }
 
@@ -714,6 +713,25 @@ mod tests {
         assert_eq!(handle.config.read().await.env["TOKEN"], "new-token");
         assert!(manager.mcp_tool_definitions().is_empty());
         assert!(manager.lookup_tool("mcp__alpha__read").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn reconcile_does_not_wait_for_retired_connect_lock() {
+        let cfg = sample_stdio_cfg("id-alpha", "alpha");
+        let manager = test_manager(vec![cfg.clone()]);
+        let old_handle = manager.get_by_id("id-alpha").await.unwrap();
+        let _connect_guard = old_handle.connect_lock.lock().await;
+
+        tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            manager.reconcile(McpGlobalSettings::default(), vec![]),
+        )
+        .await
+        .expect("reconcile should not wait for a retired handle's connect lock")
+        .unwrap();
+
+        assert!(old_handle.is_retired());
+        assert!(manager.get_by_id("id-alpha").await.is_none());
     }
 
     #[tokio::test]

--- a/crates/ha-core/src/tools/settings.rs
+++ b/crates/ha-core/src/tools/settings.rs
@@ -1232,12 +1232,7 @@ async fn trigger_backend_hot_reload(category: &str, store: &config::AppConfig) -
             // decision via cached_config(); no in-memory cache to invalidate.
         }
         "mcp_global" => {
-            if let Some(manager) = crate::mcp::McpManager::global() {
-                manager
-                    .reconcile(store.mcp_global.clone(), store.mcp_servers.clone())
-                    .await
-                    .map_err(|e| anyhow::anyhow!("{e}"))?;
-            }
+            crate::mcp::reconcile_from_config_cache().await?;
             crate::app_info!(
                 "settings",
                 "hot_reload",

--- a/src/components/settings/mcp-panel/McpServerEditDialog.tsx
+++ b/src/components/settings/mcp-panel/McpServerEditDialog.tsx
@@ -138,18 +138,34 @@ function formToDraft(form: FormState): McpServerDraft {
         }
       : { kind: form.kind, url: form.url.trim() }
 
-  const env = Object.fromEntries(
-    form.env.filter(([k]) => k.trim().length > 0).map(([k, v]) => [k.trim(), v]),
-  )
-  const headers = Object.fromEntries(
-    form.headers.filter(([k]) => k.trim().length > 0).map(([k, v]) => [k.trim(), v]),
-  )
+  const env =
+    form.kind === "stdio"
+      ? Object.fromEntries(
+          form.env
+            .filter(([k]) => k.trim().length > 0)
+            .map(([k, v]) => [k.trim(), v]),
+        )
+      : {}
+  const headers =
+    form.kind === "stdio"
+      ? {}
+      : Object.fromEntries(
+          form.headers
+            .filter(([k]) => k.trim().length > 0)
+            .map(([k, v]) => [k.trim(), v]),
+        )
 
   const splitList = (s: string) =>
     s
       .split(/\r?\n/)
       .map((x) => x.trim())
       .filter(Boolean)
+  const numberOr = (value: string, fallback: number, min: number) => {
+    const trimmed = value.trim()
+    if (trimmed.length === 0) return fallback
+    const n = Number(trimmed)
+    return Number.isFinite(n) ? Math.max(min, Math.floor(n)) : fallback
+  }
 
   return {
     name: form.name.trim(),
@@ -158,11 +174,9 @@ function formToDraft(form: FormState): McpServerDraft {
     env,
     headers,
     description: form.description.trim() || null,
-    connectTimeoutSecs: Number(form.connectTimeoutSecs) || 30,
-    callTimeoutSecs: Number.isFinite(Number(form.callTimeoutSecs))
-      ? Math.max(0, Math.floor(Number(form.callTimeoutSecs)))
-      : 0,
-    maxConcurrentCalls: Number(form.maxConcurrentCalls) || 4,
+    connectTimeoutSecs: numberOr(form.connectTimeoutSecs, 30, 1),
+    callTimeoutSecs: numberOr(form.callTimeoutSecs, 0, 0),
+    maxConcurrentCalls: numberOr(form.maxConcurrentCalls, 4, 1),
     trustLevel: form.trustLevel,
     autoApprove: form.autoApprove,
     eager: form.eager,
@@ -553,6 +567,7 @@ function KvEditor({
   valuePlaceholder?: string
   hint?: string
 }) {
+  const { t } = useTranslation()
   return (
     <div className="space-y-1.5">
       <Label>{label}</Label>
@@ -582,6 +597,7 @@ function KvEditor({
             <Button
               variant="ghost"
               size="sm"
+              aria-label={t("common.delete")}
               onClick={() => {
                 const next = entries.filter((_, i) => i !== idx)
                 onChange(next)
@@ -599,7 +615,7 @@ function KvEditor({
           className="gap-1.5 h-7"
         >
           <Plus className="h-3 w-3" />
-          {entries.length === 0 ? "Add" : "Add more"}
+          {t("common.add")}
         </Button>
       </div>
       {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
@@ -626,6 +642,7 @@ function TimeoutInput({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         min={min}
+        step={1}
         className="h-9"
       />
     </div>

--- a/src/components/settings/mcp-panel/McpServerEditDialog.tsx
+++ b/src/components/settings/mcp-panel/McpServerEditDialog.tsx
@@ -43,6 +43,7 @@ import {
 import {
   addServer,
   updateServer,
+  type McpOAuthConfig,
   type McpServerDraft,
   type McpServerSummary,
   type McpTransportKind,
@@ -122,7 +123,26 @@ function initialFromSummary(s: McpServerSummary | null): FormState {
   }
 }
 
-function formToDraft(form: FormState): McpServerDraft {
+function preservedOauth(
+  form: FormState,
+  initial: McpServerSummary | null,
+): McpOAuthConfig | null {
+  if (!initial?.oauth || form.kind === "stdio") return null
+  const original = initial.transport
+  if (
+    original.kind === "stdio" ||
+    original.kind !== form.kind ||
+    original.url !== form.url.trim()
+  ) {
+    return null
+  }
+  return initial.oauth
+}
+
+function formToDraft(
+  form: FormState,
+  initial: McpServerSummary | null,
+): McpServerDraft {
   // stdio has its own payload shape; http / sse / ws all carry just a
   // url, so one branch covers the three URL-only kinds.
   const transport: McpServerDraft["transport"] =
@@ -183,7 +203,7 @@ function formToDraft(form: FormState): McpServerDraft {
     deferredTools: form.deferredTools,
     deniedTools: splitList(form.deniedTools),
     allowedTools: splitList(form.allowedTools),
-    oauth: null,
+    oauth: preservedOauth(form, initial),
     projectPaths: [],
     icon: null,
   } as McpServerDraft
@@ -238,7 +258,7 @@ export default function McpServerEditDialog({
       toast.error(t("settings.mcp.autoApproveNeedsTrust"))
       return
     }
-    const draft = formToDraft(form)
+    const draft = formToDraft(form, initial)
     setSaving(true)
     try {
       if (isEditing && initial) {

--- a/src/components/settings/mcp-panel/McpServersPanel.tsx
+++ b/src/components/settings/mcp-panel/McpServersPanel.tsx
@@ -392,6 +392,7 @@ function ServerRow({
   const isFailed = state === "failed"
   const isReady = state === "ready"
   const isNeedsAuth = state === "needsAuth"
+  const actionDisabled = busy || !server.enabled
   // `server.oauth` is only ever set on networked transports (backend +
   // edit dialog reject it on stdio), so a simple presence check is
   // sufficient here.
@@ -442,7 +443,7 @@ function ServerRow({
             variant="ghost"
             size="sm"
             onClick={onTest}
-            disabled={busy}
+            disabled={actionDisabled}
             className="h-7 px-2 gap-1"
           >
             {busy ? (
@@ -457,7 +458,7 @@ function ServerRow({
               variant="ghost"
               size="sm"
               onClick={onReconnect}
-              disabled={busy}
+              disabled={actionDisabled}
               className="h-7 px-2 gap-1"
             >
               <RefreshCw className="h-3 w-3" />
@@ -469,7 +470,7 @@ function ServerRow({
               variant="outline"
               size="sm"
               onClick={onAuthorize}
-              disabled={busy}
+              disabled={actionDisabled}
               className="h-7 px-2 gap-1"
             >
               {busy ? (
@@ -485,7 +486,7 @@ function ServerRow({
               variant="ghost"
               size="sm"
               onClick={onSignOut}
-              disabled={busy}
+              disabled={actionDisabled}
               className="h-7 px-2 gap-1"
             >
               <LogOut className="h-3 w-3" />
@@ -504,6 +505,7 @@ function ServerRow({
             variant="ghost"
             size="sm"
             onClick={onDelete}
+            aria-label={t("common.delete")}
             className="h-7 w-7 p-0 text-destructive hover:text-destructive hover:bg-destructive/10"
           >
             <Trash2 className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- Harden MCP runtime refresh so removed/disabled servers are stopped promptly and catalog snapshots stay consistent.
- Make MCP config editing safer by preserving schema/data shape and avoiding stale draft state in the settings dialog.
- Update `CHANGELOG.md` with the MCP stability fixes.

## Checks
- `git push` pre-push hook passed:
  - `cargo fmt --all --check`
  - `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
  - `cargo test -p ha-core -p ha-server --locked`
  - `pnpm typecheck`
  - `pnpm lint`
  - `pnpm test`

## Notes
- ESLint emitted an existing warning in `src/components/chat/hooks/useChatStream.ts` about `setAttachedFiles`; no lint errors.