### PR TITLE
[codex] Polish sidebar context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **对话列表右键菜单更贴近输入框浮层风格**：侧边栏会话、项目、Agent 与分组筛选的右键菜单改用与对话输入框模型选择器一致的浮层样式；项目右键菜单里的「新建会话」文案也更短，避免菜单过宽。
+
 ## [0.14.0] - 2026-06-29
 
 ### Added

--- a/src/components/chat/project/ProjectSection.tsx
+++ b/src/components/chat/project/ProjectSection.tsx
@@ -460,7 +460,7 @@ function ProjectGroup({
             )}
           </div>
         </ContextMenuTrigger>
-        <ContextMenuContent>
+        <ContextMenuContent variant="floating">
           {!archivedView && (
             <ContextMenuItem onClick={() => onNewChatInProject(project.id)}>
               <MessageSquarePlus className="h-3 w-3 mr-2" />

--- a/src/components/chat/sidebar/AgentSection.tsx
+++ b/src/components/chat/sidebar/AgentSection.tsx
@@ -196,7 +196,7 @@ function SortableAgentCard({
           </ContextMenuTrigger>
           <TooltipContent>{agent.description || agent.name}</TooltipContent>
         </Tooltip>
-        <ContextMenuContent>
+        <ContextMenuContent variant="floating">
           <ContextMenuItem onClick={() => onNewChat(agent.id, { incognito: true })}>
             <Ghost className="h-3 w-3 mr-2" />
             {t("chat.newIncognitoChat")}

--- a/src/components/chat/sidebar/SessionItem.tsx
+++ b/src/components/chat/sidebar/SessionItem.tsx
@@ -401,6 +401,7 @@ export default function SessionItem({
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent
+        variant="floating"
         onCloseAutoFocus={(e) => {
           if (renameTriggeredRef.current) {
             e.preventDefault()

--- a/src/components/chat/sidebar/SessionList.tsx
+++ b/src/components/chat/sidebar/SessionList.tsx
@@ -217,7 +217,7 @@ export default function SessionList({
                   )}
                 </button>
               </ContextMenuTrigger>
-              <ContextMenuContent>
+              <ContextMenuContent variant="floating">
                 <ContextMenuItem onClick={handleMarkAllRead} disabled={isSearching || count === 0}>
                   {t("chat.markAllRead") || "全部已读"}
                 </ContextMenuItem>

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -6,57 +6,109 @@ import { cn } from "@/lib/utils"
 const ContextMenu = ContextMenuPrimitive.Root
 const ContextMenuTrigger = ContextMenuPrimitive.Trigger
 const ContextMenuSub = ContextMenuPrimitive.Sub
+type ContextMenuVariant = "default" | "floating"
+
+const ContextMenuVariantContext = React.createContext<ContextMenuVariant>("default")
+
+const contentVariantClass: Record<ContextMenuVariant, string> = {
+  default:
+    "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80",
+  floating:
+    "z-50 min-w-[9.5rem] overflow-visible rounded-floating border border-border-soft bg-surface-floating/95 p-1.5 text-popover-foreground shadow-floating backdrop-blur-xl animate-in fade-in-0 zoom-in-95 duration-150",
+}
+
+const subContentVariantClass: Record<ContextMenuVariant, string> = {
+  default:
+    "z-50 min-w-[10rem] max-h-[300px] overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80",
+  floating:
+    "z-50 min-w-[10rem] max-h-[300px] overflow-y-auto rounded-floating border border-border-soft bg-surface-floating/95 p-1.5 text-popover-foreground shadow-floating backdrop-blur-xl animate-in fade-in-0 zoom-in-95 duration-150",
+}
+
+const itemVariantClass: Record<ContextMenuVariant, string> = {
+  default:
+    "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+  floating:
+    "relative flex cursor-default select-none items-center rounded-md px-2.5 py-1.5 text-[13px] leading-5 text-foreground/80 outline-none transition-all duration-150 focus:bg-secondary/60 focus:text-foreground data-[state=open]:bg-secondary data-[state=open]:text-foreground data-[state=open]:shadow-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:shrink-0",
+}
+
+const subTriggerVariantClass: Record<ContextMenuVariant, string> = {
+  default:
+    "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none focus:bg-accent data-[state=open]:bg-accent",
+  floating:
+    "flex cursor-default select-none items-center rounded-md px-2.5 py-1.5 text-[13px] leading-5 text-foreground/80 outline-none transition-all duration-150 focus:bg-secondary/60 focus:text-foreground data-[state=open]:bg-secondary data-[state=open]:text-foreground data-[state=open]:shadow-sm [&_svg]:shrink-0",
+}
+
+const separatorVariantClass: Record<ContextMenuVariant, string> = {
+  default: "-mx-1 my-1 h-px bg-border",
+  floating: "-mx-1 my-1.5 h-px bg-border-soft",
+}
 
 const ContextMenuSubTrigger = React.forwardRef<
   React.ComponentRef<typeof ContextMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
     inset?: boolean
+    variant?: ContextMenuVariant
   }
->(({ className, inset, children, ...props }, ref) => (
-  <ContextMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none focus:bg-accent data-[state=open]:bg-accent",
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRight className="ml-auto h-3.5 w-3.5" />
-  </ContextMenuPrimitive.SubTrigger>
-))
+>(({ className, inset, variant, children, ...props }, ref) => {
+  const inheritedVariant = React.useContext(ContextMenuVariantContext)
+  const resolvedVariant = variant ?? inheritedVariant
+  return (
+    <ContextMenuPrimitive.SubTrigger
+      ref={ref}
+      className={cn(
+        subTriggerVariantClass[resolvedVariant],
+        inset && (resolvedVariant === "floating" ? "pl-9" : "pl-8"),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight
+        className={cn(
+          "ml-auto",
+          resolvedVariant === "floating" ? "h-4 w-4 opacity-60" : "h-3.5 w-3.5",
+        )}
+      />
+    </ContextMenuPrimitive.SubTrigger>
+  )
+})
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
 
 const ContextMenuSubContent = React.forwardRef<
   React.ComponentRef<typeof ContextMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      "z-50 min-w-[10rem] max-h-[300px] overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80",
-      className,
-    )}
-    {...props}
-  />
-))
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent> & {
+    variant?: ContextMenuVariant
+  }
+>(({ className, variant, ...props }, ref) => {
+  const inheritedVariant = React.useContext(ContextMenuVariantContext)
+  const resolvedVariant = variant ?? inheritedVariant
+  return (
+    <ContextMenuVariantContext.Provider value={resolvedVariant}>
+      <ContextMenuPrimitive.SubContent
+        ref={ref}
+        className={cn(subContentVariantClass[resolvedVariant], className)}
+        {...props}
+      />
+    </ContextMenuVariantContext.Provider>
+  )
+})
 ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
 
 const ContextMenuContent = React.forwardRef<
   React.ComponentRef<typeof ContextMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.Portal>
-    <ContextMenuPrimitive.Content
-      ref={ref}
-      className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80",
-        className,
-      )}
-      {...props}
-    />
-  </ContextMenuPrimitive.Portal>
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content> & {
+    variant?: ContextMenuVariant
+  }
+>(({ className, variant = "default", ...props }, ref) => (
+  <ContextMenuVariantContext.Provider value={variant}>
+    <ContextMenuPrimitive.Portal>
+      <ContextMenuPrimitive.Content
+        ref={ref}
+        className={cn(contentVariantClass[variant], className)}
+        {...props}
+      />
+    </ContextMenuPrimitive.Portal>
+  </ContextMenuVariantContext.Provider>
 ))
 ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName
 
@@ -64,30 +116,41 @@ const ContextMenuItem = React.forwardRef<
   React.ComponentRef<typeof ContextMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
     inset?: boolean
+    variant?: ContextMenuVariant
   }
->(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-xs outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      inset && "pl-8",
-      className,
-    )}
-    {...props}
-  />
-))
+>(({ className, inset, variant, ...props }, ref) => {
+  const inheritedVariant = React.useContext(ContextMenuVariantContext)
+  const resolvedVariant = variant ?? inheritedVariant
+  return (
+    <ContextMenuPrimitive.Item
+      ref={ref}
+      className={cn(
+        itemVariantClass[resolvedVariant],
+        inset && (resolvedVariant === "floating" ? "pl-9" : "pl-8"),
+        className,
+      )}
+      {...props}
+    />
+  )
+})
 ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName
 
 const ContextMenuSeparator = React.forwardRef<
   React.ComponentRef<typeof ContextMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-border", className)}
-    {...props}
-  />
-))
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator> & {
+    variant?: ContextMenuVariant
+  }
+>(({ className, variant, ...props }, ref) => {
+  const inheritedVariant = React.useContext(ContextMenuVariantContext)
+  const resolvedVariant = variant ?? inheritedVariant
+  return (
+    <ContextMenuPrimitive.Separator
+      ref={ref}
+      className={cn(separatorVariantClass[resolvedVariant], className)}
+      {...props}
+    />
+  )
+})
 ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName
 
 export {

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "وراثة الإعداد العام",
     "memoriesInProject": "{{count}} ذاكرة",
     "moveToProject": "نقل إلى مشروع",
-    "newChatInProject": "جلسة جديدة في المشروع",
+    "newChatInProject": "جلسة جديدة",
     "newProject": "مشروع جديد",
     "noProjects": "لا توجد مشاريع بعد",
     "noSessionsHint": "انقر لإنشاء الجلسة الأولى",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "Inherit global",
     "memoriesInProject": "{{count}} memory",
     "moveToProject": "Move to project",
-    "newChatInProject": "New session in project",
+    "newChatInProject": "New session",
     "newProject": "New Project",
     "noProjects": "No projects yet",
     "noSessionsHint": "Click to create the first session",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "Heredar del global",
     "memoriesInProject": "{{count}} memoria",
     "moveToProject": "Mover a proyecto",
-    "newChatInProject": "Nueva sesión en el proyecto",
+    "newChatInProject": "Nueva sesión",
     "newProject": "Nuevo proyecto",
     "noProjects": "Aún no hay proyectos",
     "noSessionsHint": "Haz clic para crear la primera sesión",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "グローバルを継承",
     "memoriesInProject": "{{count}} 件のメモリ",
     "moveToProject": "プロジェクトへ移動",
-    "newChatInProject": "プロジェクトで新規セッション",
+    "newChatInProject": "新規セッション",
     "newProject": "新規プロジェクト",
     "noProjects": "プロジェクトはまだありません",
     "noSessionsHint": "クリックして最初のセッションを作成",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "전역 설정 상속",
     "memoriesInProject": "{{count}}개 메모리",
     "moveToProject": "프로젝트로 이동",
-    "newChatInProject": "프로젝트에 새 세션",
+    "newChatInProject": "새 세션",
     "newProject": "새 프로젝트",
     "noProjects": "아직 프로젝트가 없습니다",
     "noSessionsHint": "클릭하여 첫 세션 만들기",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "Warisi global",
     "memoriesInProject": "{{count}} memori",
     "moveToProject": "Pindah ke projek",
-    "newChatInProject": "Sesi baharu dalam projek",
+    "newChatInProject": "Sesi baharu",
     "newProject": "Projek baharu",
     "noProjects": "Tiada projek lagi",
     "noSessionsHint": "Klik untuk membuat sesi pertama",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "Herdar global",
     "memoriesInProject": "{{count}} memória",
     "moveToProject": "Mover para projeto",
-    "newChatInProject": "Nova sessão no projeto",
+    "newChatInProject": "Nova sessão",
     "newProject": "Novo projeto",
     "noProjects": "Ainda não há projetos",
     "noSessionsHint": "Clique para criar a primeira sessão",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "Наследовать глобальные",
     "memoriesInProject": "{{count}} записей",
     "moveToProject": "Переместить в проект",
-    "newChatInProject": "Новая сессия в проекте",
+    "newChatInProject": "Новая сессия",
     "newProject": "Новый проект",
     "noProjects": "Проектов пока нет",
     "noSessionsHint": "Нажмите, чтобы создать первую сессию",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "Globali devral",
     "memoriesInProject": "{{count}} bellek",
     "moveToProject": "Projeye taşı",
-    "newChatInProject": "Projede yeni oturum",
+    "newChatInProject": "Yeni oturum",
     "newProject": "Yeni proje",
     "noProjects": "Henüz proje yok",
     "noSessionsHint": "İlk oturumu oluşturmak için tıklayın",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "Kế thừa toàn cục",
     "memoriesInProject": "{{count}} mục nhớ",
     "moveToProject": "Chuyển vào dự án",
-    "newChatInProject": "Phiên mới trong dự án",
+    "newChatInProject": "Phiên mới",
     "newProject": "Dự án mới",
     "noProjects": "Chưa có dự án",
     "noSessionsHint": "Nhấp để tạo phiên đầu tiên",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "沿用全域設定",
     "memoriesInProject": "{{count}} 條記憶",
     "moveToProject": "移動到專案",
-    "newChatInProject": "在此專案新增對話",
+    "newChatInProject": "新建會話",
     "newProject": "新增專案",
     "noProjects": "尚無專案",
     "noSessionsHint": "點擊建立第一個對話",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -2195,7 +2195,7 @@
     "inheritGlobal": "跟随全局",
     "memoriesInProject": "{{count}} 条记忆",
     "moveToProject": "移动到项目",
-    "newChatInProject": "在此项目中新建会话",
+    "newChatInProject": "新建会话",
     "newProject": "新建项目",
     "noProjects": "还没有项目",
     "noSessionsHint": "点击创建第一个会话",


### PR DESCRIPTION
## Summary

- Add a reusable floating context-menu variant that matches the chat input model picker surface.
- Apply the floating style to sidebar session, project, agent, and session-filter context menus.
- Shorten the project menu label from the longer “new session in project” wording to “New session” across all locales.
- Document the UI polish in `CHANGELOG.md` under Unreleased.

## Validation

Pre-push hook passed:

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `pnpm typecheck`
- `pnpm lint` / ESLint completed with 1 existing warning in `src/components/chat/hooks/useChatStream.ts`
- `pnpm test` / Vitest: 51 files, 291 tests passed
- `cargo test -p ha-core -p ha-server --locked`: passed