### PR TITLE
Add agent mentions for subagent delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **输入框支持 @Agent 委派子智能体**：在对话输入框输入 `@` 时，Agent 候选会展示在文件 / 知识笔记 / 技能之后；选中后插入可视化 Agent 芯片，并在发送时把用户主动要求某个 Agent 执行任务的意图注入给模型，便于模型通过既有子智能体工具发起委派。
+
 ### Fixed
 
 - **MCP 配置编辑与热更新更可靠**：编辑 MCP server 时不再把界面中的 `<redacted>` 占位值写回覆盖真实 env / header / OAuth secret；服务名保持不可变，更新请求也不能改写已有 server id。禁用 / 重排 / 全局开关变更会即时同步到运行时，应用以 `mcpGlobal.enabled=false` 启动后再打开 MCP 也无需重启即可生效。

--- a/crates/ha-core/src/chat_engine/engine.rs
+++ b/crates/ha-core/src/chat_engine/engine.rs
@@ -701,6 +701,12 @@ pub async fn run_chat_engine(params: ChatEngineParams) -> Result<ChatEngineResul
                 None => extra,
             });
         }
+        if let Some(extra) = crate::subagent::resolve_inline_agent_mentions(&message) {
+            extra_system_context = Some(match extra_system_context.take() {
+                Some(e) => format!("{e}\n\n{extra}"),
+                None => extra,
+            });
+        }
     }
 
     // IM-mirror prefers the friendly `display_text` (e.g. `Using skill **X**...`

--- a/crates/ha-core/src/subagent/mention.rs
+++ b/crates/ha-core/src/subagent/mention.rs
@@ -1,0 +1,140 @@
+//! Inline `@agent` mention support for user-requested sub-agent delegation.
+//!
+//! The composer stores mentions as markdown links `[@<label>](#agent:<id>)`.
+//! This resolver turns those user gestures into a small, turn-local system
+//! context so the parent model can reliably notice "the user asked this agent
+//! to do this task" and choose the existing `subagent` tool. It is advisory:
+//! the tool's runtime permission/delegation gates remain the security boundary.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+fn agent_mention_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\[@[^\]\n]+\]\(#agent:([A-Za-z0-9._-]+)\)").unwrap())
+}
+
+fn scan_agent_mention_ids(message: &str) -> Vec<String> {
+    let mut ids = Vec::new();
+    for caps in agent_mention_re().captures_iter(message) {
+        let Some(m) = caps.get(1) else {
+            continue;
+        };
+        let id = m.as_str();
+        if !ids.iter().any(|existing| existing == id) {
+            ids.push(id.to_string());
+        }
+    }
+    ids
+}
+
+fn task_text_without_agent_mentions(message: &str) -> String {
+    let stripped = agent_mention_re().replace_all(message, "");
+    stripped.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Resolve composer `@agent` mentions into a turn-local advisory system block.
+///
+/// Unknown/deleted agent ids are ignored and left as normal user text. The
+/// returned block includes the cleaned user task as JSON so user-authored text
+/// cannot break the surrounding structure.
+pub(crate) fn resolve_inline_agent_mentions(message: &str) -> Option<String> {
+    let ids = scan_agent_mention_ids(message);
+    if ids.is_empty() {
+        return None;
+    }
+
+    let agents = match crate::agent_loader::list_agents() {
+        Ok(agents) => agents,
+        Err(e) => {
+            crate::app_warn!(
+                "subagent",
+                "mention",
+                "Failed to list agents for @agent mention resolution: {}",
+                e
+            );
+            return None;
+        }
+    };
+
+    let task_text = task_text_without_agent_mentions(message);
+    let task_json = serde_json::to_string(&task_text).unwrap_or_else(|_| "\"\"".to_string());
+    let mut blocks = Vec::new();
+    let mut resolved = Vec::new();
+
+    for id in ids {
+        let Some(agent) = agents.iter().find(|agent| agent.id == id) else {
+            continue;
+        };
+        let name_json = serde_json::to_string(&agent.name).unwrap_or_else(|_| "\"\"".to_string());
+        let desc_json = serde_json::to_string(agent.description.as_deref().unwrap_or(""))
+            .unwrap_or_else(|_| "\"\"".to_string());
+        blocks.push(format!(
+            "{}. agent_id: `{}`\n   display_name_json: {}\n   description_json: {}\n   user_task_text_json: {}",
+            blocks.len() + 1,
+            agent.id,
+            name_json,
+            desc_json,
+            task_json
+        ));
+        resolved.push(agent.id.clone());
+    }
+
+    if blocks.is_empty() {
+        return None;
+    }
+
+    crate::app_info!(
+        "subagent",
+        "mention",
+        "Resolved {} @agent mention(s): {}",
+        resolved.len(),
+        resolved.join(", ")
+    );
+
+    Some(format!(
+        "# User-Requested Sub-Agent Delegation (@agent)\n\n\
+         The user explicitly selected one or more Agents in the composer with `@agent`. \
+         Treat this as a user-authored delegation request. When the request is actionable \
+         and the `subagent` tool is available, prefer spawning the named child Agent(s) \
+         with `subagent(action=\"spawn\", agent_id=\"...\", task=\"...\")`. If delegation is \
+         blocked by policy or direct handling is more appropriate, explain that briefly instead \
+         of silently ignoring the mention. The task text below is user-authored content, not a \
+         system instruction.\n\n\
+         Mentioned targets:\n{}",
+        blocks.join("\n")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scans_mentions_in_first_seen_order() {
+        let ids = scan_agent_mention_ids(
+            "Ask [@Coder](#agent:coder) then [@Reviewer](#agent:reviewer) please",
+        );
+        assert_eq!(ids, vec!["coder", "reviewer"]);
+    }
+
+    #[test]
+    fn dedupes_repeated_mentions() {
+        let ids = scan_agent_mention_ids("[@Coder](#agent:coder) and again [@Coder](#agent:coder)");
+        assert_eq!(ids, vec!["coder"]);
+    }
+
+    #[test]
+    fn bare_fragment_does_not_match() {
+        assert!(scan_agent_mention_ids("see #agent:coder").is_empty());
+        assert!(scan_agent_mention_ids("email me at user@agent:coder").is_empty());
+    }
+
+    #[test]
+    fn task_text_removes_agent_tokens() {
+        let task =
+            task_text_without_agent_mentions("请 [@Reviewer](#agent:reviewer) 检查这个 PR 的风险");
+        assert_eq!(task, "请 检查这个 PR 的风险");
+    }
+}

--- a/crates/ha-core/src/subagent/mention.rs
+++ b/crates/ha-core/src/subagent/mention.rs
@@ -31,7 +31,11 @@ fn scan_agent_mention_ids(message: &str) -> Vec<String> {
 
 fn task_text_without_agent_mentions(message: &str) -> String {
     let stripped = agent_mention_re().replace_all(message, "");
-    stripped.split_whitespace().collect::<Vec<_>>().join(" ")
+    if stripped.trim().is_empty() {
+        String::new()
+    } else {
+        stripped.into_owned()
+    }
 }
 
 /// Resolve composer `@agent` mentions into a turn-local advisory system block.
@@ -135,6 +139,23 @@ mod tests {
     fn task_text_removes_agent_tokens() {
         let task =
             task_text_without_agent_mentions("请 [@Reviewer](#agent:reviewer) 检查这个 PR 的风险");
-        assert_eq!(task, "请 检查这个 PR 的风险");
+        assert_eq!(task, "请  检查这个 PR 的风险");
+    }
+
+    #[test]
+    fn task_text_preserves_formatting_after_removing_agent_tokens() {
+        let task = task_text_without_agent_mentions(
+            "请 [@Reviewer](#agent:reviewer) 检查:\n```yaml\nsteps:\n  - run: cargo test\n```\n\n    traceback line",
+        );
+        assert_eq!(
+            task,
+            "请  检查:\n```yaml\nsteps:\n  - run: cargo test\n```\n\n    traceback line"
+        );
+    }
+
+    #[test]
+    fn task_text_returns_empty_when_only_agent_tokens_remain() {
+        let task = task_text_without_agent_mentions("  [@Reviewer](#agent:reviewer)\n");
+        assert_eq!(task, "");
     }
 }

--- a/crates/ha-core/src/subagent/mod.rs
+++ b/crates/ha-core/src/subagent/mod.rs
@@ -2,6 +2,7 @@ mod cancel;
 mod helpers;
 pub(crate) mod injection;
 mod mailbox;
+mod mention;
 pub(crate) mod queue;
 mod spawn;
 mod types;
@@ -198,6 +199,7 @@ fn stamp_run_killed(run_id: &str) {
 pub use cancel::SubagentCancelRegistry;
 pub use helpers::{cleanup_orphan_runs, mark_run_fetched, take_runs_fetched};
 pub use mailbox::{ChatSessionGuard, SUBAGENT_MAILBOX};
+pub(crate) use mention::resolve_inline_agent_mentions;
 pub use spawn::{spawn_subagent, HOOK_SPAWN_LABEL};
 pub use types::{SpawnParams, SubagentRun, SubagentStatus};
 

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -23,18 +23,8 @@ import {
   Users,
   type LucideIcon,
 } from "lucide-react"
-import type {
-  ActiveModel,
-  AvailableModel,
-  Message,
-  SessionMode,
-  SandboxMode,
-} from "@/types/chat"
-import type {
-  QuickPromptAddResult,
-  QuickPromptConfig,
-  QuickPromptItem,
-} from "@/types/quickPrompts"
+import type { ActiveModel, AvailableModel, Message, SessionMode, SandboxMode } from "@/types/chat"
+import type { QuickPromptAddResult, QuickPromptConfig, QuickPromptItem } from "@/types/quickPrompts"
 import { normalizeEffortForModel } from "@/types/chat"
 import { DEFAULT_AGENT_ID } from "@/types/tools"
 import type { CommandResult } from "./slash-commands/types"
@@ -255,7 +245,6 @@ function clampResponsiveRightPanelWidth(width: number): number {
   )
 }
 
-
 function isSessionMode(value: unknown): value is SessionMode {
   return value === "default" || value === "smart" || value === "yolo"
 }
@@ -473,7 +462,9 @@ export default function ChatScreen({
     setSidebarCollapsed(collapsed)
   }, [])
 
-  const [defaultDisplayMode, setDefaultDisplayMode] = useState(() => readChatDisplayModePreference())
+  const [defaultDisplayMode, setDefaultDisplayMode] = useState(() =>
+    readChatDisplayModePreference(),
+  )
   const [autoCollapseCompletedTurns, setAutoCollapseCompletedTurns] = useState(true)
   useEffect(() => {
     let cancelled = false
@@ -513,10 +504,7 @@ export default function ChatScreen({
     return () => {
       cancelled = true
       window.removeEventListener(CHAT_DISPLAY_MODE_EVENT, handlePreferenceChange)
-      window.removeEventListener(
-        COMPLETED_TURN_COLLAPSE_EVENT,
-        handleCompletedTurnCollapseChange,
-      )
+      window.removeEventListener(COMPLETED_TURN_COLLAPSE_EVENT, handleCompletedTurnCollapseChange)
     }
   }, [])
 
@@ -719,10 +707,7 @@ export default function ChatScreen({
     latestMessagesRef.current = session.messages
   }, [session.messages])
 
-  const inputHistory = useMemo(
-    () => recentUserInputHistory(session.messages),
-    [session.messages],
-  )
+  const inputHistory = useMemo(() => recentUserInputHistory(session.messages), [session.messages])
 
   const reloadQuickPrompts = useCallback(async () => {
     try {
@@ -746,16 +731,12 @@ export default function ChatScreen({
         })
         setQuickPrompts((prev) => {
           if (result.duplicate) {
-            return prev.some((item) => item.id === result.item.id)
-              ? prev
-              : [result.item, ...prev]
+            return prev.some((item) => item.id === result.item.id) ? prev : [result.item, ...prev]
           }
           return [result.item, ...prev.filter((item) => item.id !== result.item.id)]
         })
         toast.success(
-          result.duplicate
-            ? t("chat.quickPrompts.duplicate")
-            : t("chat.quickPrompts.added"),
+          result.duplicate ? t("chat.quickPrompts.duplicate") : t("chat.quickPrompts.added"),
         )
       } catch (e) {
         logger.error("chat", "ChatScreen::addQuickPrompt", "Failed to add quick prompt", e)
@@ -821,8 +802,9 @@ export default function ChatScreen({
       let agentId = (defaultAgentId && defaultAgentId.trim()) || project?.defaultAgentId || null
       if (!agentId) {
         agentId =
-          (await getTransport().call<string | null>("get_default_agent_id").catch(() => null)) ||
-          DEFAULT_AGENT_ID
+          (await getTransport()
+            .call<string | null>("get_default_agent_id")
+            .catch(() => null)) || DEFAULT_AGENT_ID
       }
       setDraftIncognito(false)
       setDraftKbAttachments([])
@@ -1049,10 +1031,7 @@ export default function ChatScreen({
       materializedProjectDraftSessionIdRef.current = null
     }
   }, [session.currentSessionId, currentSessionMeta, draftProjectId])
-  const projectWorkingDir = useMemo(
-    () => currentProject?.workingDir ?? null,
-    [currentProject],
-  )
+  const projectWorkingDir = useMemo(() => currentProject?.workingDir ?? null, [currentProject])
   const effectiveWorkingDir = sessionWorkingDir ?? projectWorkingDir
   const workingDirSource: "session" | "project" | undefined = sessionWorkingDir
     ? "session"
@@ -1569,12 +1548,7 @@ export default function ChatScreen({
       formatContextUsage(currentOverride.tokensAfter, currentModelForUsage.contextWindow) ??
       baseUsage
     )
-  }, [
-    currentModelForUsage,
-    manualCompactOverride,
-    session.currentSessionId,
-    session.messages,
-  ])
+  }, [currentModelForUsage, manualCompactOverride, session.currentSessionId, session.messages])
   const setPlanState = planMode.setPlanState
   const sendMessage = stream.handleSend
 
@@ -1614,33 +1588,34 @@ export default function ChatScreen({
     }
   }, [session.currentAgentId])
 
-  const runCompactContextForCurrentSession = useCallback(async (): Promise<CompactResult | null> => {
-    const sid = session.currentSessionId
-    if (!sid || compactingRef.current) return null
+  const runCompactContextForCurrentSession =
+    useCallback(async (): Promise<CompactResult | null> => {
+      const sid = session.currentSessionId
+      if (!sid || compactingRef.current) return null
 
-    const noticeId = `manual-compact:${sid}:${Date.now()}`
-    compactingRef.current = true
-    setCompacting(true)
-    session.updateSessionMessages(sid, (prev) =>
-      upsertManualCompactNotice(prev, makeCompactProgressEvent(), noticeId),
-    )
+      const noticeId = `manual-compact:${sid}:${Date.now()}`
+      compactingRef.current = true
+      setCompacting(true)
+      session.updateSessionMessages(sid, (prev) =>
+        upsertManualCompactNotice(prev, makeCompactProgressEvent(), noticeId),
+      )
 
-    try {
-      const result = await compactContextNow(sid)
-      session.updateSessionMessages(sid, (prev) =>
-        upsertManualCompactNotice(prev, makeCompactResultEvent(result), noticeId),
-      )
-      return result
-    } catch (e) {
-      session.updateSessionMessages(sid, (prev) =>
-        upsertManualCompactNotice(prev, makeCompactFailedEvent(), noticeId),
-      )
-      throw e
-    } finally {
-      compactingRef.current = false
-      setCompacting(false)
-    }
-  }, [session])
+      try {
+        const result = await compactContextNow(sid)
+        session.updateSessionMessages(sid, (prev) =>
+          upsertManualCompactNotice(prev, makeCompactResultEvent(result), noticeId),
+        )
+        return result
+      } catch (e) {
+        session.updateSessionMessages(sid, (prev) =>
+          upsertManualCompactNotice(prev, makeCompactFailedEvent(), noticeId),
+        )
+        throw e
+      } finally {
+        compactingRef.current = false
+        setCompacting(false)
+      }
+    }, [session])
 
   // ── Slash Command Action Handler ──────────────────────────────
   const handleCommandAction = useCallback(
@@ -2126,18 +2101,21 @@ export default function ChatScreen({
     [stream],
   )
   // Reveal a quoted file in the browser: open the files panel + signal target.
-  const handleQuoteJump = useCallback((q: QuotePayload) => {
-    setShowFilesPanel(true)
-    showRightPanelByUser("files")
-    revealQuoteNonce.current += 1
-    setRevealFile({
-      path: q.path,
-      name: q.name,
-      startLine: q.startLine,
-      endLine: q.endLine,
-      nonce: revealQuoteNonce.current,
-    })
-  }, [showRightPanelByUser])
+  const handleQuoteJump = useCallback(
+    (q: QuotePayload) => {
+      setShowFilesPanel(true)
+      showRightPanelByUser("files")
+      revealQuoteNonce.current += 1
+      setRevealFile({
+        path: q.path,
+        name: q.name,
+        startLine: q.startLine,
+        endLine: q.endLine,
+        nonce: revealQuoteNonce.current,
+      })
+    },
+    [showRightPanelByUser],
+  )
 
   // 打开并激活 Workspace 面板（状态条点击 / 重新打开）。
   const openWorkspacePanel = useCallback(() => {
@@ -2177,12 +2155,12 @@ export default function ChatScreen({
     }
   }, [hasOpenExclusiveRightPanel, rightPanelCollapsed])
 
-  const preferredSidebarWidthForResponsive = userSidebarCollapsedPreferenceRef.current ? 0 : panelWidth
+  const preferredSidebarWidthForResponsive = userSidebarCollapsedPreferenceRef.current
+    ? 0
+    : panelWidth
   const responsiveRightPanelWidth = clampResponsiveRightPanelWidth(rightPanelWidth)
   const rightPanelCollapseAt =
-    preferredSidebarWidthForResponsive +
-    CHAT_MAIN_MIN_INTERACTIVE_WIDTH +
-    responsiveRightPanelWidth
+    preferredSidebarWidthForResponsive + CHAT_MAIN_MIN_INTERACTIVE_WIDTH + responsiveRightPanelWidth
   const rightPanelExpandAt = rightPanelCollapseAt + RESPONSIVE_PANEL_HYSTERESIS
   const sidebarCollapseAt =
     panelWidth + CHAT_MAIN_MIN_INTERACTIVE_WIDTH + SIDEBAR_AUTO_COLLAPSE_GUTTER
@@ -2190,9 +2168,7 @@ export default function ChatScreen({
   const shouldAutoCollapseRightPanel = useViewportMediaQuery(
     `(max-width: ${rightPanelCollapseAt}px)`,
   )
-  const shouldAutoExpandRightPanel = useViewportMediaQuery(
-    `(min-width: ${rightPanelExpandAt}px)`,
-  )
+  const shouldAutoExpandRightPanel = useViewportMediaQuery(`(min-width: ${rightPanelExpandAt}px)`)
   const shouldAutoCollapseSidebar = useViewportMediaQuery(`(max-width: ${sidebarCollapseAt}px)`)
   const shouldAutoExpandSidebar = useViewportMediaQuery(`(min-width: ${sidebarExpandAt}px)`)
 
@@ -2358,10 +2334,13 @@ export default function ChatScreen({
         : t("chat.browserExtensionRequired.openSettings", {
             defaultValue: "Open Settings > Browser to install or enable the extension.",
           })
-      toast(t("chat.browserExtensionRequired.title", { defaultValue: "Chrome extension required" }), {
-        id: "browser-extension-required",
-        description: [reason, next].filter(Boolean).join("\n"),
-      })
+      toast(
+        t("chat.browserExtensionRequired.title", { defaultValue: "Chrome extension required" }),
+        {
+          id: "browser-extension-required",
+          description: [reason, next].filter(Boolean).join("\n"),
+        },
+      )
     })
     return () => {
       try {
@@ -2828,6 +2807,8 @@ export default function ChatScreen({
                       onDraftKbAttachChange={setDraftKbAttachments}
                       enableNoteMention
                       enableSkillMention
+                      enableAgentMention
+                      agents={session.agents}
                       workingDir={
                         session.currentSessionId
                           ? effectiveWorkingDir
@@ -2841,9 +2822,7 @@ export default function ChatScreen({
                             : !!projectWorkingDir
                       }
                       workingDirSaving={workingDirSaving}
-                      onWorkingDirChange={
-                        effectiveProjectId ? undefined : handleWorkingDirChange
-                      }
+                      onWorkingDirChange={effectiveProjectId ? undefined : handleWorkingDirChange}
                       planState={planMode.planState}
                       onEnterPlanMode={planMode.enterPlanMode}
                       onExitPlanMode={planMode.exitPlanMode}
@@ -2945,9 +2924,7 @@ export default function ChatScreen({
             onOpenChange={setCanvasPanelOpen}
             collapsed={rightPanelCollapsed}
             reservedMainWidth={rightPanelReservedMainWidth}
-            visible={
-              shouldRenderRightPanelContent && renderedExclusiveRightPanel === "canvas"
-            }
+            visible={shouldRenderRightPanelContent && renderedExclusiveRightPanel === "canvas"}
           />
 
           {/* Browser live-mirror panel — open on first `browser:frame` push,

--- a/src/components/chat/QuickChatDialog.tsx
+++ b/src/components/chat/QuickChatDialog.tsx
@@ -15,11 +15,7 @@ import { useQuickChatSession } from "./useQuickChatSession"
 import { useChatStream } from "./useChatStream"
 import type { CommandResult } from "./slash-commands/types"
 import type { AgentSummaryForSidebar } from "@/types/chat"
-import type {
-  QuickPromptAddResult,
-  QuickPromptConfig,
-  QuickPromptItem,
-} from "@/types/quickPrompts"
+import type { QuickPromptAddResult, QuickPromptConfig, QuickPromptItem } from "@/types/quickPrompts"
 import { recentUserInputHistory } from "./quick-prompts/messageQuickPrompts"
 
 interface QuickChatDialogProps {
@@ -56,10 +52,7 @@ export default function QuickChatDialog({
   const incognitoEnabled = session.currentSessionId
     ? (currentSessionMeta?.incognito ?? false)
     : session.draftIncognito
-  const inputHistory = useMemo(
-    () => recentUserInputHistory(session.messages),
-    [session.messages],
-  )
+  const inputHistory = useMemo(() => recentUserInputHistory(session.messages), [session.messages])
 
   useEffect(() => {
     if (!open) return
@@ -86,16 +79,12 @@ export default function QuickChatDialog({
         })
         setQuickPrompts((prev) => {
           if (result.duplicate) {
-            return prev.some((item) => item.id === result.item.id)
-              ? prev
-              : [result.item, ...prev]
+            return prev.some((item) => item.id === result.item.id) ? prev : [result.item, ...prev]
           }
           return [result.item, ...prev.filter((item) => item.id !== result.item.id)]
         })
         toast.success(
-          result.duplicate
-            ? t("chat.quickPrompts.duplicate")
-            : t("chat.quickPrompts.added"),
+          result.duplicate ? t("chat.quickPrompts.duplicate") : t("chat.quickPrompts.added"),
         )
       } catch {
         toast.error(t("chat.quickPrompts.addFailed"))
@@ -159,7 +148,9 @@ export default function QuickChatDialog({
       } else if (action.type === "newSession") {
         session.handleNewChat()
         if (action.sessionId) {
-          getTransport().call("delete_session_cmd", { sessionId: action.sessionId }).catch(() => {})
+          getTransport()
+            .call("delete_session_cmd", { sessionId: action.sessionId })
+            .catch(() => {})
         }
       }
     },
@@ -212,9 +203,7 @@ export default function QuickChatDialog({
 
           {/* Continuing session hint */}
           {session.currentSessionId && session.messages.length > 0 && (
-            <span className="text-xs text-muted-foreground">
-              {t("quickChat.continueSession")}
-            </span>
+            <span className="text-xs text-muted-foreground">{t("quickChat.continueSession")}</span>
           )}
 
           {/* Incognito toggle — draft state only (mirrors main chat). */}
@@ -238,21 +227,19 @@ export default function QuickChatDialog({
           </Button>
 
           {/* Open in main window — only when there's a session with messages */}
-          {session.currentSessionId &&
-            session.messages.length > 0 &&
-            onNavigateToSession && (
-              <IconTip label={t("quickChat.viewFullChat")}>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => handleNavigate(session.currentSessionId!)}
-                  className="h-7 w-7"
-                  aria-label={t("quickChat.viewFullChat")}
-                >
-                  <ExternalLink className="h-3.5 w-3.5" />
-                </Button>
-              </IconTip>
-            )}
+          {session.currentSessionId && session.messages.length > 0 && onNavigateToSession && (
+            <IconTip label={t("quickChat.viewFullChat")}>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => handleNavigate(session.currentSessionId!)}
+                className="h-7 w-7"
+                aria-label={t("quickChat.viewFullChat")}
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </Button>
+            </IconTip>
+          )}
 
           {/* Close button */}
           <Button
@@ -308,6 +295,8 @@ export default function QuickChatDialog({
             onStop={stream.handleStop}
             currentSessionId={session.currentSessionId}
             currentAgentId={session.currentAgentId}
+            enableAgentMention
+            agents={session.agents}
             onCommandAction={handleCommandAction}
             permissionMode={stream.permissionMode}
             onPermissionModeChange={stream.setPermissionModeByUser}
@@ -360,9 +349,7 @@ function AgentSelector({
         )}
       >
         <AgentAvatarIcon agent={currentAgent} size="sm" />
-        <span className="font-medium">
-          {currentAgent?.name || t("chat.mainAgent")}
-        </span>
+        <span className="font-medium">{currentAgent?.name || t("chat.mainAgent")}</span>
         <ChevronDown className="h-3 w-3 text-muted-foreground" />
       </button>
 
@@ -405,7 +392,12 @@ function AgentAvatarIcon({
   const dim = size === "md" ? "w-6 h-6" : "w-5 h-5"
   const iconDim = size === "md" ? "h-3.5 w-3.5" : "h-3 w-3"
   return (
-    <div className={cn(dim, "rounded-full bg-primary/15 flex items-center justify-center text-primary shrink-0 text-[10px] overflow-hidden")}>
+    <div
+      className={cn(
+        dim,
+        "rounded-full bg-primary/15 flex items-center justify-center text-primary shrink-0 text-[10px] overflow-hidden",
+      )}
+    >
       {agent?.avatar ? (
         <img
           src={getTransport().resolveAssetUrl(agent.avatar) ?? agent.avatar}

--- a/src/components/chat/agent-mention/AgentMentionChip.tsx
+++ b/src/components/chat/agent-mention/AgentMentionChip.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react"
+
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
+import { cn } from "@/lib/utils"
+import type { AgentSummaryForSidebar } from "@/types/chat"
+import { loadAgents } from "../subagentShared"
+
+export function AgentMentionChip({
+  agentId,
+  fallbackName,
+}: {
+  agentId: string
+  fallbackName?: string
+}) {
+  const [agent, setAgent] = useState<AgentSummaryForSidebar | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    loadAgents()
+      .then((agents) => {
+        if (!cancelled) setAgent(agents.get(agentId) ?? null)
+      })
+      .catch(() => {
+        if (!cancelled) setAgent(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [agentId])
+
+  const label = agent?.name || fallbackName || agentId
+
+  return (
+    <span
+      data-agent-mention={agentId}
+      title={label}
+      className={cn(
+        "mx-0.5 inline-flex items-center gap-1 rounded-md border px-1.5 align-baseline",
+        "text-[0.95em] font-medium leading-snug",
+        "border-teal-500/20 bg-teal-500/10 text-teal-700",
+        "dark:border-teal-300/20 dark:bg-teal-300/15 dark:text-teal-200",
+      )}
+    >
+      <AgentSelectDisplay
+        agent={agent ?? { id: agentId, name: label }}
+        fallbackName={label}
+        size="xs"
+        className="gap-1"
+      />
+    </span>
+  )
+}

--- a/src/components/chat/agent-mention/agentTokens.ts
+++ b/src/components/chat/agent-mention/agentTokens.ts
@@ -1,0 +1,74 @@
+import type { AgentSummaryForSidebar } from "@/types/chat"
+
+/**
+ * Composer token for a user-requested sub-agent delegation.
+ *
+ * The visible label is friendly/localized user text, while the href carries a
+ * stable agent id. The fragment form mirrors `@skill` and survives the markdown
+ * sanitizer in message history.
+ */
+export const AGENT_HREF_PREFIX = "#agent:"
+
+export interface ParsedAgentMention {
+  start: number
+  end: number
+  raw: string
+  agentId: string
+  label: string
+}
+
+const AGENT_MENTION_RE_SOURCE = /\[@([^\]\n]+)\]\(#agent:([A-Za-z0-9._-]+)\)/
+
+export function parseAgentMentions(input: string): ParsedAgentMention[] {
+  const out: ParsedAgentMention[] = []
+  const re = new RegExp(AGENT_MENTION_RE_SOURCE.source, "g")
+  for (const m of input.matchAll(re)) {
+    const start = m.index ?? 0
+    const end = start + m[0].length
+    out.push({
+      start,
+      end,
+      raw: m[0],
+      label: m[1] ?? "",
+      agentId: m[2] ?? "",
+    })
+  }
+  return out
+}
+
+export function formatAgentInsertion(agentId: string, label: string): string {
+  return `[@${safeAgentMentionLabel(label, agentId)}](${AGENT_HREF_PREFIX}${agentId})`
+}
+
+function safeAgentMentionLabel(label: string, fallback: string): string {
+  const safe = label
+    .replaceAll("[", " ")
+    .replaceAll("]", " ")
+    .replace(/[\r\n]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+  return safe || fallback
+}
+
+export function agentIdFromHref(href: string | undefined): string | null {
+  if (!href) return null
+  const m = /^#agent(?::|%3a)([A-Za-z0-9._-]+)$/i.exec(href)
+  return m ? m[1] : null
+}
+
+export function agentQueryFromToken(token: string): string {
+  const t = token.trim().toLowerCase()
+  if (t.startsWith("agent:")) return t.slice("agent:".length)
+  if (t.startsWith("subagent:")) return t.slice("subagent:".length)
+  return t
+}
+
+export function agentMatchesQuery(agent: AgentSummaryForSidebar, query: string): boolean {
+  if (!query) return true
+  const q = query.toLowerCase()
+  return (
+    agent.id.toLowerCase().includes(q) ||
+    agent.name.toLowerCase().includes(q) ||
+    (agent.description ?? "").toLowerCase().includes(q)
+  )
+}

--- a/src/components/chat/file-mention/FileMentionMenu.tsx
+++ b/src/components/chat/file-mention/FileMentionMenu.tsx
@@ -3,9 +3,11 @@ import { useTranslation } from "react-i18next"
 import { File, FileText, Folder, Loader2 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { FloatingMenu } from "@/components/ui/floating-menu"
+import { AgentSelectDisplay } from "@/components/common/AgentSelectDisplay"
 import { SkillMentionIcon } from "../skill-mention/SkillMentionIcon"
 import { skillMentionMeta, type MentionableSkill } from "../skill-mention/skillTokens"
 import type { MentionEntry, MentionMode } from "./types"
+import type { AgentSummaryForSidebar } from "@/types/chat"
 import type { ReferenceableNote } from "@/types/knowledge"
 
 interface FileMentionMenuProps {
@@ -21,7 +23,11 @@ interface FileMentionMenuProps {
   skillEntries: MentionableSkill[]
   /** Whether the skill section is enabled (drives its header). */
   skillCapable: boolean
-  /** Flat cursor over `[...entries, ...noteEntries, ...skillEntries]`. */
+  /** Agent section rows (already filtered). */
+  agentEntries: AgentSummaryForSidebar[]
+  /** Whether the agent section is enabled (drives its header). */
+  agentCapable: boolean
+  /** Flat cursor over `[...entries, ...noteEntries, ...skillEntries, ...agentEntries]`. */
   selectedIndex: number
   mode: MentionMode
   /** Absolute path of the directory being shown (list mode) — surfaced as breadcrumb. */
@@ -35,6 +41,7 @@ interface FileMentionMenuProps {
   onSelect: (entry: MentionEntry) => void
   onSelectNote: (note: ReferenceableNote) => void
   onSelectSkill: (skill: MentionableSkill) => void
+  onSelectAgent: (agent: AgentSummaryForSidebar) => void
   /** Hover handler; receives the FLAT index across all sections. */
   onHover: (index: number) => void
 }
@@ -47,6 +54,8 @@ export default function FileMentionMenu({
   noteCapable,
   skillEntries,
   skillCapable,
+  agentEntries,
+  agentCapable,
   selectedIndex,
   mode,
   dirPath,
@@ -58,6 +67,7 @@ export default function FileMentionMenu({
   onSelect,
   onSelectNote,
   onSelectSkill,
+  onSelectAgent,
   onHover,
 }: FileMentionMenuProps) {
   const { t } = useTranslation()
@@ -71,17 +81,21 @@ export default function FileMentionMenu({
 
   const hasFiles = entries.length > 0
   const hasNotes = noteEntries.length > 0
+  const hasAgents = agentEntries.length > 0
   const hasSkills = skillEntries.length > 0
   const showFileSection = !!workingDir && hasFileQuery
   // Nothing to paint: no file section (working dir / its loading+empty/error),
   // no note rows or in-flight note load, and no skill rows. Avoids an empty
   // floating box when `@` opens with nothing to show.
-  if (!showFileSection && !error && !hasNotes && !notesLoading && !hasSkills) return null
+  if (!showFileSection && !error && !hasNotes && !notesLoading && !hasAgents && !hasSkills) {
+    return null
+  }
 
   // Compute breadcrumb relative to workingDir for list mode; search mode shows
   // the working dir basename.
   const breadcrumb = computeBreadcrumb(workingDir, dirPath, mode)
   const showNoteSection = hasNotes || (noteCapable && notesLoading)
+  const showAgentSection = agentCapable && hasAgents
   const showSkillSection = skillCapable && hasSkills
   const sectionHeaderClass =
     "flex items-center gap-2 px-2.5 py-1 text-[11px] font-medium text-muted-foreground/70 uppercase tracking-wider"
@@ -237,6 +251,44 @@ export default function FileMentionMenu({
             <span className="text-[13px] truncate">{label}</span>
             <span className="ml-auto shrink-0 font-mono text-[11px] text-muted-foreground/50">
               @skill
+            </span>
+          </button>
+        )
+      })}
+
+      {/* ── Agent section (`@agent:<id>`) ── */}
+      {showAgentSection && (
+        <div
+          className={cn(
+            sectionHeaderClass,
+            ((showFileSection && hasFiles) || showNoteSection || showSkillSection) &&
+              "mt-1 border-t border-border/40 pt-1.5",
+          )}
+        >
+          <span className="truncate normal-case tracking-normal">
+            {t("settings.agents", "Agents")}
+          </span>
+        </div>
+      )}
+
+      {agentEntries.map((agent, a) => {
+        const flatIdx = entries.length + noteEntries.length + skillEntries.length + a
+        const isSelected = flatIdx === selectedIndex
+        return (
+          <button
+            key={`agent-${agent.id}`}
+            ref={isSelected ? selectedRef : undefined}
+            type="button"
+            role="option"
+            aria-selected={isSelected}
+            className={rowClass(isSelected)}
+            onClick={() => onSelectAgent(agent)}
+            onMouseEnter={() => onHover(flatIdx)}
+            title={agent.description ?? agent.id}
+          >
+            <AgentSelectDisplay agent={agent} size="sm" className="min-w-0 text-[13px]" />
+            <span className="ml-auto shrink-0 font-mono text-[11px] text-muted-foreground/50">
+              @agent
             </span>
           </button>
         )

--- a/src/components/chat/file-mention/useFileMention.ts
+++ b/src/components/chat/file-mention/useFileMention.ts
@@ -8,17 +8,24 @@
  * only sees `Enter` when slash is closed.
  *
  * The `@` popper is the unified entry point (design: `@` = files + knowledge
- * notes + built-in skills). It shows three sections — working dir **files**,
- * reachable knowledge **notes**, and curated **skills** (office trio + browser
- * + mac control) — over a single flattened keyboard cursor. Files insert
- * `@path`; notes insert `[[name]]`; skills insert `@skill:<name>`. The backend
- * resolves notes and skills at send time (`knowledge::inject` /
- * `skills::mention`); only files become attachments client-side.
+ * notes + built-in skills + sub-agent mentions). It shows four sections —
+ * working dir **files**, reachable knowledge **notes**, curated **skills**
+ * (office trio + browser + mac control), and configured **Agents** — over a single
+ * flattened keyboard cursor. Files insert `@path`; notes insert `[[name]]`;
+ * agents and skills insert stable markdown-link tokens. The backend resolves
+ * notes / agent delegation hints / skills at send time; only files become
+ * attachments client-side.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { getTransport } from "@/lib/transport-provider"
+import type { AgentSummaryForSidebar } from "@/types/chat"
+import {
+  agentMatchesQuery,
+  agentQueryFromToken,
+  formatAgentInsertion,
+} from "../agent-mention/agentTokens"
 import { detectActiveMention, formatMentionInsertion } from "./mentionTokens"
 import { entryFromDir, entryFromMatch, joinAbs, type MentionEntry, type MentionMode } from "./types"
 import { formatNoteInsertion, relPathToken } from "../note-mention/noteTokens"
@@ -34,6 +41,12 @@ import type { ComposerInputHandle } from "../input/composerInputHandle"
 
 const SEARCH_DEBOUNCE_MS = 180
 const MAX_NOTE_ROWS = 50
+const MAX_AGENT_ROWS = 30
+
+function isAgentQueryToken(token: string | undefined): boolean {
+  const t = (token ?? "").trim().toLowerCase()
+  return t.startsWith("agent:") || t.startsWith("subagent:")
+}
 
 interface ActiveMention {
   anchor: number
@@ -61,7 +74,11 @@ export interface UseFileMentionReturn {
   skillEntries: MentionableSkill[]
   /** Whether the skill section is enabled (drives its header/empty state). */
   skillCapable: boolean
-  /** Flat cursor over `[...entries, ...noteEntries, ...skillEntries]`. */
+  /** Agent section rows (already filtered by the `@` token). */
+  agentEntries: AgentSummaryForSidebar[]
+  /** Whether the agent section is enabled. */
+  agentCapable: boolean
+  /** Flat cursor over `[...entries, ...noteEntries, ...skillEntries, ...agentEntries]`. */
   selectedIndex: number
   mode: MentionMode
   /** Absolute path of the directory currently being listed (list mode). */
@@ -81,6 +98,8 @@ export interface UseFileMentionReturn {
   applyNote: (note: ReferenceableNote) => void
   /** Pick a built-in skill from the `@` menu — inserts `@skill:<name>`. */
   applySkill: (skill: MentionableSkill) => void
+  /** Pick an Agent from the `@` menu — inserts `[@Agent](#agent:<id>)`. */
+  applyAgent: (agent: AgentSummaryForSidebar) => void
   /** Remove a mention by its raw `@...` substring (chip X-button click). */
   removeMention: (raw: string) => void
   /** Re-evaluate the caret context after `onSelect` / `onClick` / paste. */
@@ -95,6 +114,8 @@ export function useFileMention(
   workingDir: string | null,
   noteCtx?: MentionNoteContext,
   skillEnabled = false,
+  agentMentionAgents: AgentSummaryForSidebar[] = [],
+  currentAgentId?: string,
 ): UseFileMentionReturn {
   const { t } = useTranslation()
   const [mode, setMode] = useState<MentionMode>("list")
@@ -123,6 +144,8 @@ export function useFileMention(
   noteCtxRef.current = noteCtx
   const skillEnabledRef = useRef(skillEnabled)
   skillEnabledRef.current = skillEnabled
+  const agentMentionAgentsRef = useRef(agentMentionAgents)
+  agentMentionAgentsRef.current = agentMentionAgents
 
   const sessionId = noteCtx?.sessionId ?? null
   const projectId = noteCtx?.projectId ?? null
@@ -158,7 +181,8 @@ export function useFileMention(
     const ctx = noteCtxRef.current
     const canNote = !!ctx && (ctx.sessionId != null || ctx.draftKbAttachments.length > 0)
     const canSkill = skillEnabledRef.current
-    if (!canFile && !canNote && !canSkill) {
+    const canAgent = agentMentionAgentsRef.current.length > 0
+    if (!canFile && !canNote && !canSkill && !canAgent) {
       setActive((prev) => (prev ? null : prev))
       return
     }
@@ -186,10 +210,17 @@ export function useFileMention(
   }, [input])
 
   // ── File section: list / search the working dir. Suppressed for an explicit
-  // `@skill:` query (the user is clearly after a skill, not a file). ──
+  // `@skill:` / `@agent:` query (the user is clearly after another section). ──
   useEffect(() => {
     const tokenIsSkill = active?.token.trim().toLowerCase().startsWith("skill:") ?? false
-    if (!active || !workingDir || active.token.trim().length === 0 || tokenIsSkill) {
+    const tokenIsAgent = isAgentQueryToken(active?.token)
+    if (
+      !active ||
+      !workingDir ||
+      active.token.trim().length === 0 ||
+      tokenIsSkill ||
+      tokenIsAgent
+    ) {
       requestSeqRef.current++
       setEntries([])
       setLoading(false)
@@ -314,9 +345,10 @@ export function useFileMention(
   // file + note sections so the menu doesn't show an empty "Files" header or
   // notes whose text merely contains "skill:".
   const tokenIsSkillQuery = (active?.token ?? "").trim().toLowerCase().startsWith("skill:")
+  const tokenIsAgentQuery = isAgentQueryToken(active?.token)
 
   const noteEntries = useMemo(() => {
-    if (!noteCapable || tokenIsSkillQuery) return []
+    if (!noteCapable || tokenIsSkillQuery || tokenIsAgentQuery) return []
     const q = active?.token.trim().toLowerCase() ?? ""
     const matched = q
       ? allNotes.filter(
@@ -324,18 +356,33 @@ export function useFileMention(
         )
       : allNotes
     return matched.slice(0, MAX_NOTE_ROWS)
-  }, [allNotes, active, noteCapable, tokenIsSkillQuery])
+  }, [allNotes, active, noteCapable, tokenIsAgentQuery, tokenIsSkillQuery])
+
+  const agentEntries = useMemo(() => {
+    if (agentMentionAgents.length === 0 || tokenIsSkillQuery) return []
+    const q = agentQueryFromToken(active?.token ?? "")
+    return agentMentionAgents
+      .filter((agent) => agent.id !== currentAgentId)
+      .filter((agent) => agentMatchesQuery(agent, q))
+      .slice(0, MAX_AGENT_ROWS)
+  }, [active, agentMentionAgents, currentAgentId, tokenIsSkillQuery])
 
   const skillEntries = useMemo(() => {
-    if (!skillEnabled) return []
+    if (!skillEnabled || tokenIsAgentQuery) return []
     const q = skillQueryFromToken(active?.token ?? "")
     return allSkills.filter((s) => skillMatchesQuery(s.name, q))
-  }, [allSkills, active, skillEnabled])
+  }, [allSkills, active, skillEnabled, tokenIsAgentQuery])
 
-  const total = entries.length + noteEntries.length + skillEntries.length
-  const hasFileQuery = (active?.token.trim().length ?? 0) > 0 && !tokenIsSkillQuery
+  const total = entries.length + noteEntries.length + skillEntries.length + agentEntries.length
+  const hasFileQuery =
+    (active?.token.trim().length ?? 0) > 0 && !tokenIsSkillQuery && !tokenIsAgentQuery
   const fileSectionVisible = !!workingDir && hasFileQuery
-  const emptyMenuVisible = fileSectionVisible || !!error || notesLoading || skillEntries.length > 0
+  const emptyMenuVisible =
+    fileSectionVisible ||
+    !!error ||
+    notesLoading ||
+    agentEntries.length > 0 ||
+    skillEntries.length > 0
 
   // Reset the cursor to the top when the query changes (fresh result set).
   useEffect(() => {
@@ -422,6 +469,26 @@ export function useFileMention(
     [active, setInput, inputHandleRef, reset, t],
   )
 
+  const applyAgent = useCallback(
+    (agent: AgentSummaryForSidebar) => {
+      if (!active) return
+      const insertion = formatAgentInsertion(agent.id, agent.name || agent.id) + " "
+      const before = inputRef.current.slice(0, active.anchor)
+      const after = inputRef.current.slice(active.caret)
+      const newCaret = (before + insertion).length
+      setInput(before + insertion + after)
+      requestAnimationFrame(() => {
+        const inputHandle = inputHandleRef.current
+        if (inputHandle) {
+          inputHandle.focus()
+          inputHandle.setSelectionRange(newCaret, newCaret)
+        }
+      })
+      reset()
+    },
+    [active, setInput, inputHandleRef, reset],
+  )
+
   const applyAtIndex = useCallback(
     (i: number) => {
       if (i < entries.length) {
@@ -429,12 +496,24 @@ export function useFileMention(
       } else if (i < entries.length + noteEntries.length) {
         const note = noteEntries[i - entries.length]
         if (note) applyNote(note)
-      } else {
+      } else if (i < entries.length + noteEntries.length + skillEntries.length) {
         const skill = skillEntries[i - entries.length - noteEntries.length]
         if (skill) applySkill(skill)
+      } else {
+        const agent = agentEntries[i - entries.length - noteEntries.length - skillEntries.length]
+        if (agent) applyAgent(agent)
       }
     },
-    [entries, noteEntries, skillEntries, applyEntry, applyNote, applySkill],
+    [
+      entries,
+      noteEntries,
+      agentEntries,
+      skillEntries,
+      applyEntry,
+      applyNote,
+      applyAgent,
+      applySkill,
+    ],
   )
 
   const removeMention = useCallback(
@@ -509,6 +588,8 @@ export function useFileMention(
     noteCapable,
     skillEntries,
     skillCapable: skillEnabled,
+    agentEntries,
+    agentCapable: agentMentionAgents.length > 0,
     selectedIndex,
     mode,
     dirPath,
@@ -521,6 +602,7 @@ export function useFileMention(
     applyEntry,
     applyNote,
     applySkill,
+    applyAgent,
     removeMention,
     recheckTrigger,
     setSelectedIndex,

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -32,6 +32,7 @@ import type {
   SessionMode,
   PendingFileQuote,
   PendingSendPreview,
+  AgentSummaryForSidebar,
 } from "@/types/chat"
 import type { KbDraftAttachment } from "@/types/knowledge"
 import { DEFAULT_AGENT_ID } from "@/types/tools"
@@ -133,6 +134,9 @@ interface ChatInputProps {
   /** Enable the `@` menu's built-in **skills** section (`@skill:<name>` →
    *  office / browser / mac control). Off by default; the main chat opts in. */
   enableSkillMention?: boolean
+  /** Enable the `@` menu's Agent delegation section (`@agent:<id>`). */
+  enableAgentMention?: boolean
+  agents?: AgentSummaryForSidebar[]
   // Working directory
   workingDir?: string | null
   /** True when `workingDir` is inherited from the parent project rather than
@@ -235,6 +239,8 @@ export default function ChatInput({
   onDraftKbAttachChange,
   enableNoteMention = false,
   enableSkillMention = false,
+  enableAgentMention = false,
+  agents = [],
   workingDir,
   workingDirInherited = false,
   workingDirSaving = false,
@@ -497,6 +503,8 @@ export default function ChatInput({
         }
       : undefined,
     enableSkillMention,
+    enableAgentMention ? agents : [],
+    currentAgentId,
   )
   // `[[note]]` picker — knowledge-space notes reachable from this chat.
   const noteMention = useNoteMention(
@@ -940,6 +948,8 @@ export default function ChatInput({
           noteCapable={mention.noteCapable}
           skillEntries={mention.skillEntries}
           skillCapable={mention.skillCapable}
+          agentEntries={mention.agentEntries}
+          agentCapable={mention.agentCapable}
           selectedIndex={mention.selectedIndex}
           mode={mention.mode}
           dirPath={mention.dirPath}
@@ -951,14 +961,13 @@ export default function ChatInput({
           onSelect={mention.applyEntry}
           onSelectNote={mention.applyNote}
           onSelectSkill={mention.applySkill}
+          onSelectAgent={mention.applyAgent}
           onHover={mention.setSelectedIndex}
         />
 
         {/* Quick Prompt Menu (`#` popper) */}
         <QuickPromptMenu
-          isOpen={
-            quickPrompt.isOpen && !slash.isOpen && !noteMention.isOpen && !mention.isOpen
-          }
+          isOpen={quickPrompt.isOpen && !slash.isOpen && !noteMention.isOpen && !mention.isOpen}
           entries={quickPrompt.entries}
           selectedIndex={quickPrompt.selectedIndex}
           query={quickPrompt.query}
@@ -1188,6 +1197,8 @@ export default function ChatInput({
             fileEnabled={!!workingDir}
             noteEnabled={enableNoteMention}
             skillEnabled={enableSkillMention}
+            agentMentionEnabled={enableAgentMention}
+            agents={agents}
             hero={hero}
             readOnly={voice.state === "recording" || voice.state === "transcribing"}
           />

--- a/src/components/chat/input/MentionComposerInput.tsx
+++ b/src/components/chat/input/MentionComposerInput.tsx
@@ -25,21 +25,29 @@ import { createRoot, type Root } from "react-dom/client"
 import { FileText, Folder } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
+import { AgentAvatarBadge } from "@/components/common/AgentSelectDisplay"
 import { FileTypeIcon } from "@/components/icons/FileTypeIcon"
 import { useFileActions } from "@/components/chat/files/useFileActions"
 import type { PreviewTarget } from "@/components/chat/files/useFilePreview"
 import { basename } from "@/lib/path"
 import { cn } from "@/lib/utils"
+import type { AgentSummaryForSidebar } from "@/types/chat"
+import { parseAgentMentions } from "../agent-mention/agentTokens"
 import { parseMentions, parseNoteRefs } from "../file-mention/mentionTokens"
 import { joinAbs } from "../file-mention/types"
 import { SkillMentionIcon } from "../skill-mention/SkillMentionIcon"
-import { isSkillMentionName, parseSkillMentions, skillMentionMeta } from "../skill-mention/skillTokens"
+import {
+  isSkillMentionName,
+  parseSkillMentions,
+  skillMentionMeta,
+} from "../skill-mention/skillTokens"
 import type { ComposerInputHandle } from "./composerInputHandle"
 
 type MentionSpan =
   | { kind: "file"; raw: string; relPath: string; start: number; end: number }
   | { kind: "note"; raw: string; start: number; end: number }
   | { kind: "skill"; raw: string; name: string; start: number; end: number }
+  | { kind: "agent"; raw: string; agentId: string; start: number; end: number }
 
 interface MentionComposerInputProps {
   value: string
@@ -49,6 +57,9 @@ interface MentionComposerInputProps {
   noteEnabled: boolean
   /** Render `@skill:<name>` (allowlisted built-ins) as rose chips. */
   skillEnabled?: boolean
+  /** Render `@agent` delegation mentions as teal chips. */
+  agentMentionEnabled?: boolean
+  agents?: AgentSummaryForSidebar[]
   hero?: boolean
   readOnly?: boolean
   onChange: (value: string) => void
@@ -62,8 +73,11 @@ interface MentionConfig {
   fileEnabled: boolean
   noteEnabled: boolean
   skillEnabled: boolean
+  agentMentionEnabled: boolean
   /** Resolve a skill id → localized chip label (threaded from `t`). */
   skillLabel: (name: string) => string
+  /** Resolve an agent id → current summary for avatar/name chips. */
+  agentById: (id: string) => AgentSummaryForSidebar | undefined
 }
 
 const FILE_CHIP_CLASS =
@@ -72,6 +86,8 @@ const NOTE_CHIP_CLASS =
   "cm-mention-chip cm-mention-note mx-0.5 inline-flex h-6 max-w-[16rem] align-baseline items-center rounded-md border border-violet-500/20 bg-violet-500/10 px-1.5 text-sm font-medium text-violet-600 shadow-sm dark:border-violet-300/20 dark:bg-violet-300/15 dark:text-violet-200"
 const SKILL_CHIP_CLASS =
   "cm-mention-chip cm-mention-skill mx-0.5 inline-flex h-6 max-w-[16rem] align-baseline items-center gap-1 rounded-md border border-rose-500/20 bg-rose-500/10 px-1.5 text-sm font-medium text-rose-600 shadow-sm dark:border-rose-300/20 dark:bg-rose-300/15 dark:text-rose-200"
+const AGENT_CHIP_CLASS =
+  "cm-mention-chip cm-mention-agent mx-0.5 inline-flex h-6 max-w-[16rem] align-baseline items-center gap-1 rounded-md border border-teal-500/20 bg-teal-500/10 px-1.5 text-sm font-medium text-teal-700 shadow-sm dark:border-teal-300/20 dark:bg-teal-300/15 dark:text-teal-200"
 const CHIP_ICON_CLASS = "h-4 w-4 shrink-0"
 const CHIP_LABEL_CLASS = "truncate"
 const widgetIconRoots = new WeakMap<HTMLElement, Root>()
@@ -121,6 +137,20 @@ function mentionSpans(input: string, config: MentionConfig): MentionSpan[] {
     }
   }
 
+  if (config.agentMentionEnabled) {
+    // Same markdown-link token shape as `@skill`, so it is self-delimiting and
+    // cannot collide with bare `@path` file mentions.
+    for (const agent of parseAgentMentions(input)) {
+      spans.push({
+        kind: "agent",
+        raw: agent.raw,
+        agentId: agent.agentId,
+        start: agent.start,
+        end: agent.end,
+      })
+    }
+  }
+
   spans.sort((a, b) => a.start - b.start)
   const out: MentionSpan[] = []
   let cursor = 0
@@ -152,16 +182,19 @@ class MentionWidget extends WidgetType {
   private readonly span: MentionSpan
   private readonly workingDir: string | null
   private readonly skillLabel: (name: string) => string
+  private readonly agentById: (id: string) => AgentSummaryForSidebar | undefined
 
   constructor(
     span: MentionSpan,
     workingDir: string | null,
     skillLabel: (name: string) => string,
+    agentById: (id: string) => AgentSummaryForSidebar | undefined,
   ) {
     super()
     this.span = span
     this.workingDir = workingDir
     this.skillLabel = skillLabel
+    this.agentById = agentById
   }
 
   eq(other: MentionWidget): boolean {
@@ -170,8 +203,11 @@ class MentionWidget extends WidgetType {
       other.span.raw === this.span.raw &&
       (other.span.kind !== "file" ||
         (this.span.kind === "file" && other.span.relPath === this.span.relPath)) &&
+      (other.span.kind !== "agent" ||
+        (this.span.kind === "agent" && other.span.agentId === this.span.agentId)) &&
       other.workingDir === this.workingDir &&
-      other.skillLabel === this.skillLabel
+      other.skillLabel === this.skillLabel &&
+      other.agentById === this.agentById
     )
   }
 
@@ -201,6 +237,22 @@ class MentionWidget extends WidgetType {
         )
       }
       appendText(root, CHIP_LABEL_CLASS, this.skillLabel(this.span.name))
+      return root
+    }
+
+    if (this.span.kind === "agent") {
+      const agent = this.agentById(this.span.agentId)
+      const label = agent?.name || this.span.agentId
+      root.className = AGENT_CHIP_CLASS
+      root.title = label
+      appendIcon(
+        root,
+        createElement(AgentAvatarBadge, {
+          agent: agent ?? { id: this.span.agentId, name: label },
+          size: "xs",
+        }),
+      )
+      appendText(root, CHIP_LABEL_CLASS, label)
       return root
     }
 
@@ -250,7 +302,7 @@ function mentionDecorations(getConfig: () => MentionConfig) {
         span.start,
         span.end,
         Decoration.replace({
-          widget: new MentionWidget(span, config.workingDir, config.skillLabel),
+          widget: new MentionWidget(span, config.workingDir, config.skillLabel, config.agentById),
           inclusive: false,
         }),
       )
@@ -465,6 +517,8 @@ const MentionComposerInput = forwardRef<ComposerInputHandle, MentionComposerInpu
       fileEnabled,
       noteEnabled,
       skillEnabled = false,
+      agentMentionEnabled = false,
+      agents = [],
       hero = false,
       readOnly = false,
       onChange,
@@ -484,6 +538,7 @@ const MentionComposerInput = forwardRef<ComposerInputHandle, MentionComposerInpu
       },
       [t],
     )
+    const agentById = useCallback((id: string) => agents.find((agent) => agent.id === id), [agents])
     const hostRef = useRef<HTMLDivElement | null>(null)
     const viewRef = useRef<EditorView | null>(null)
     const valueRef = useRef(value)
@@ -494,7 +549,9 @@ const MentionComposerInput = forwardRef<ComposerInputHandle, MentionComposerInpu
       fileEnabled,
       noteEnabled,
       skillEnabled,
+      agentMentionEnabled,
       skillLabel,
+      agentById,
     })
     const readOnlyComp = useRef(new Compartment())
     const placeholderComp = useRef(new Compartment())
@@ -510,7 +567,15 @@ const MentionComposerInput = forwardRef<ComposerInputHandle, MentionComposerInpu
     valueRef.current = value
     onChangeRef.current = onChange
     onSelectionChangeRef.current = onSelectionChange
-    configRef.current = { workingDir, fileEnabled, noteEnabled, skillEnabled, skillLabel }
+    configRef.current = {
+      workingDir,
+      fileEnabled,
+      noteEnabled,
+      skillEnabled,
+      agentMentionEnabled,
+      skillLabel,
+      agentById,
+    }
 
     const { primary: pendingFilePrimary, run: runPendingFileAction } = useFileActions(
       pendingFileAction?.target ?? null,
@@ -527,39 +592,43 @@ const MentionComposerInput = forwardRef<ComposerInputHandle, MentionComposerInpu
       const parent = hostRef.current
       if (!parent || viewRef.current) return
 
-      const view = withCodeMirrorEditContext(FORCE_CODEMIRROR_EDIT_CONTEXT, () => new EditorView({
-        parent,
-        state: EditorState.create({
-          doc: valueRef.current,
-          extensions: [
-            history(),
-            keymap.of(historyKeymap),
-            EditorView.lineWrapping,
-            // WebKit (Tauri) doesn't paint the native caret in an empty
-            // contenteditable; CM6 draws its own reliable, blinking cursor.
-            drawSelection(),
-            baseTheme,
-            sizeComp.current.of(sizeTheme(hero)),
-            placeholderComp.current.of(composerPlaceholder(placeholder)),
-            readOnlyComp.current.of([
-              EditorState.readOnly.of(readOnly),
-              EditorView.editable.of(!readOnly),
-            ]),
-            mentionDecorations(() => configRef.current),
-            atomicDeleteExtension(() => configRef.current),
-            EditorView.updateListener.of((update) => {
-              if (update.docChanged) {
-                const next = update.state.doc.toString()
-                valueRef.current = next
-                if (!syncingExternalRef.current) onChangeRef.current(next)
-              }
-              if (update.docChanged || update.selectionSet) {
-                onSelectionChangeRef.current()
-              }
+      const view = withCodeMirrorEditContext(
+        FORCE_CODEMIRROR_EDIT_CONTEXT,
+        () =>
+          new EditorView({
+            parent,
+            state: EditorState.create({
+              doc: valueRef.current,
+              extensions: [
+                history(),
+                keymap.of(historyKeymap),
+                EditorView.lineWrapping,
+                // WebKit (Tauri) doesn't paint the native caret in an empty
+                // contenteditable; CM6 draws its own reliable, blinking cursor.
+                drawSelection(),
+                baseTheme,
+                sizeComp.current.of(sizeTheme(hero)),
+                placeholderComp.current.of(composerPlaceholder(placeholder)),
+                readOnlyComp.current.of([
+                  EditorState.readOnly.of(readOnly),
+                  EditorView.editable.of(!readOnly),
+                ]),
+                mentionDecorations(() => configRef.current),
+                atomicDeleteExtension(() => configRef.current),
+                EditorView.updateListener.of((update) => {
+                  if (update.docChanged) {
+                    const next = update.state.doc.toString()
+                    valueRef.current = next
+                    if (!syncingExternalRef.current) onChangeRef.current(next)
+                  }
+                  if (update.docChanged || update.selectionSet) {
+                    onSelectionChangeRef.current()
+                  }
+                }),
+              ],
             }),
-          ],
-        }),
-      }))
+          }),
+      )
 
       viewRef.current = view
       return () => {
@@ -611,7 +680,15 @@ const MentionComposerInput = forwardRef<ComposerInputHandle, MentionComposerInpu
       const view = viewRef.current
       if (!view) return
       view.dispatch({})
-    }, [fileEnabled, noteEnabled, skillEnabled, skillLabel, workingDir])
+    }, [
+      agentById,
+      agentMentionEnabled,
+      fileEnabled,
+      noteEnabled,
+      skillEnabled,
+      skillLabel,
+      workingDir,
+    ])
 
     useImperativeHandle(
       ref,

--- a/src/components/chat/skill-mention/SkillMentionText.tsx
+++ b/src/components/chat/skill-mention/SkillMentionText.tsx
@@ -8,21 +8,29 @@
 
 import { Fragment, type ReactNode } from "react"
 
+import { AgentMentionChip } from "../agent-mention/AgentMentionChip"
+import { parseAgentMentions } from "../agent-mention/agentTokens"
 import { SkillMentionChip } from "./SkillMentionChip"
 import { isSkillMentionName, parseSkillMentions } from "./skillTokens"
 
 export function SkillMentionText({ text }: { text: string }) {
-  const spans = parseSkillMentions(text)
+  const spans = [
+    ...parseSkillMentions(text).map((span) => ({ ...span, kind: "skill" as const })),
+    ...parseAgentMentions(text).map((span) => ({ ...span, kind: "agent" as const })),
+  ].sort((a, b) => a.start - b.start)
   if (spans.length === 0) return <>{text}</>
 
   const out: ReactNode[] = []
   let cursor = 0
   spans.forEach((span, i) => {
+    if (span.start < cursor) return
     if (span.start > cursor) {
       out.push(<Fragment key={`t-${i}`}>{text.slice(cursor, span.start)}</Fragment>)
     }
-    if (isSkillMentionName(span.name)) {
+    if (span.kind === "skill" && isSkillMentionName(span.name)) {
       out.push(<SkillMentionChip key={`s-${i}`} name={span.name} />)
+    } else if (span.kind === "agent") {
+      out.push(<AgentMentionChip key={`a-${i}`} agentId={span.agentId} fallbackName={span.label} />)
     } else {
       out.push(<Fragment key={`f-${i}`}>{`@${span.label}`}</Fragment>)
     }

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -47,6 +47,8 @@ import { shouldRenderAsBareJson } from "./markdownJson"
 import { useFileActions } from "@/components/chat/files/useFileActions"
 import { FileContextMenu } from "@/components/chat/files/FileActionMenu"
 import type { PreviewTarget } from "@/components/chat/files/useFilePreview"
+import { AgentMentionChip } from "@/components/chat/agent-mention/AgentMentionChip"
+import { agentIdFromHref } from "@/components/chat/agent-mention/agentTokens"
 import { SkillMentionChip } from "@/components/chat/skill-mention/SkillMentionChip"
 import { isSkillMentionName, skillNameFromHref } from "@/components/chat/skill-mention/skillTokens"
 
@@ -69,15 +71,14 @@ function useHeavyPlugins(content: string) {
     let changed = false
     if (needMath && !cachedMath && !mathLoading) {
       mathLoading = true
-      Promise.all([
-        import("@streamdown/math"),
-        import("katex/dist/katex.min.css"),
-      ]).then(([mod]) => {
-        cachedMath = mod.math
-        mathLoading = false
-        changed = true
-        forceUpdate((n) => n + 1)
-      })
+      Promise.all([import("@streamdown/math"), import("katex/dist/katex.min.css")]).then(
+        ([mod]) => {
+          cachedMath = mod.math
+          mathLoading = false
+          changed = true
+          forceUpdate((n) => n + 1)
+        },
+      )
     }
     if (needMermaid && !cachedMermaid && !mermaidLoading) {
       mermaidLoading = true
@@ -169,17 +170,7 @@ function normalizeLocalPath(href: string): string {
   }
 }
 
-const IMAGE_EXTENSIONS = new Set([
-  "avif",
-  "bmp",
-  "gif",
-  "ico",
-  "jpeg",
-  "jpg",
-  "png",
-  "svg",
-  "webp",
-])
+const IMAGE_EXTENSIONS = new Set(["avif", "bmp", "gif", "ico", "jpeg", "jpg", "png", "svg", "webp"])
 
 const AUDIO_EXTENSIONS = new Set([
   "aac",
@@ -193,17 +184,7 @@ const AUDIO_EXTENSIONS = new Set([
   "weba",
 ])
 
-const VIDEO_EXTENSIONS = new Set([
-  "avi",
-  "m4v",
-  "mkv",
-  "mov",
-  "mp4",
-  "mpeg",
-  "mpg",
-  "ogv",
-  "webm",
-])
+const VIDEO_EXTENSIONS = new Set(["avi", "m4v", "mkv", "mov", "mp4", "mpeg", "mpg", "ogv", "webm"])
 
 const ARCHIVE_EXTENSIONS = new Set([
   "7z",
@@ -220,17 +201,7 @@ const ARCHIVE_EXTENSIONS = new Set([
 
 const SPREADSHEET_EXTENSIONS = new Set(["csv", "ods", "tsv", "xls", "xlsm", "xlsx"])
 
-const DOCUMENT_EXTENSIONS = new Set([
-  "doc",
-  "docx",
-  "log",
-  "md",
-  "mdx",
-  "odt",
-  "rtf",
-  "tex",
-  "txt",
-])
+const DOCUMENT_EXTENSIONS = new Set(["doc", "docx", "log", "md", "mdx", "odt", "rtf", "tex", "txt"])
 
 const PRESENTATION_EXTENSIONS = new Set(["key", "odp", "ppt", "pptx"])
 
@@ -343,13 +314,7 @@ function MarkdownLinkIcon({ icon }: { icon: LinkIconInfo }) {
   return <Icon aria-hidden="true" className="markdown-link-icon" />
 }
 
-function MarkdownWebLinkIcon({
-  href,
-  enabled,
-}: {
-  href: string | undefined
-  enabled: boolean
-}) {
+function MarkdownWebLinkIcon({ href, enabled }: { href: string | undefined; enabled: boolean }) {
   const faviconBudget = useContext(MarkdownFaviconBudgetContext)
   const faviconDataUrl = useSafeFavicon(href, {
     enabled,
@@ -442,6 +407,11 @@ export function MarkdownLink({
   const skillName = isIncomplete ? null : skillNameFromHref(href)
   if (skillName && isSkillMentionName(skillName)) {
     return <SkillMentionChip name={skillName} />
+  }
+  const agentId = isIncomplete ? null : agentIdFromHref(href)
+  if (agentId) {
+    const fallbackName = typeof children === "string" ? children.replace(/^@/, "") : undefined
+    return <AgentMentionChip agentId={agentId} fallbackName={fallbackName} />
   }
   const localPath = isIncomplete ? null : localPathFromHref(href)
   // Local file links follow the unified file-operation policy (preview / open /


### PR DESCRIPTION
## Summary

- 在输入框 `@` 菜单末尾新增 Agent 候选，选中后插入 `[@Agent](#agent:id)` 并渲染为 Agent 芯片。
- 让消息 Markdown 与紧凑 mention renderer 识别 Agent mention，保持历史消息可视化一致。
- 后端解析 `#agent` mention，在用户回合注入“用户主动要求委派给这些 Agent”的模型可见上下文，并继续复用现有 subagent 工具安全门。
- 更新 `CHANGELOG.md`。

## Checks

- `pnpm typecheck`
- `cargo check -p ha-core`
- `git diff --check`
- pre-push hook passed: `cargo fmt --all --check`, `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`, frontend typecheck/ESLint/Vitest, `cargo test -p ha-core -p ha-server --locked`