### PR TITLE
语音转写新增 ElevenLabs / xAI / Groq / Voxtral / DeepInfra 供应商，刷新本地 embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **输入框支持 @Agent 委派子智能体**：在对话输入框输入 `@` 时，Agent 候选会展示在文件 / 知识笔记 / 技能之后；选中后插入可视化 Agent 芯片，并在发送时把用户主动要求某个 Agent 执行任务的意图注入给模型，便于模型通过既有子智能体工具发起委派。
 - **内置 Provider 模板刷新**：为 Anthropic / Anthropic (Vertex AI) / OpenAI / Google Gemini / Moonshot / 智谱 / MiniMax / Kimi Coding 等补齐最新旗舰模型（Claude Fable 5、GPT-5.6 Sol/Terra/Luna、Gemini 3.5 Flash、Kimi K2.7 Code、GLM-5.2、MiniMax M3、kimi-for-coding 等，均置于各供应商列表顶部），修正 Claude Haiku 4.5、MiniMax M2.7 Highspeed 的能力与价格元数据，并新增 OpenCode Zen 旗舰网关模板。 (#412)
+- **语音转写新增供应商与模型刷新**：新增 ElevenLabs Scribe、xAI Grok STT 两个云端 ASR 后端，以及 Groq、Mistral Voxtral、DeepInfra 三个 OpenAI 兼容转写预设，可直接用于语音输入与 IM 自动转写；AssemblyAI 型号更新为 Universal-3 Pro（流式 u3-rt-pro），本地 embedding 目录新增 mxbai-embed-large。 (#413)
 
 ### Fixed
 

--- a/crates/ha-core/src/local_embedding.rs
+++ b/crates/ha-core/src/local_embedding.rs
@@ -50,6 +50,17 @@ pub fn embedding_model_catalog() -> Vec<OllamaEmbeddingModel> {
             recommended: true,
         },
         OllamaEmbeddingModel {
+            id: "mxbai-embed-large:335m".into(),
+            display_name: "Mxbai Embed Large 335M".into(),
+            dimensions: 1_024,
+            size_mb: 670,
+            context_window: 512,
+            languages: vec!["en".into()],
+            min_ollama_version: Some("0.1.26".into()),
+            installed: false,
+            recommended: false,
+        },
+        OllamaEmbeddingModel {
             id: "qwen3-embedding:0.6b".into(),
             display_name: "Qwen3 Embedding 0.6B".into(),
             dimensions: 1_024,

--- a/crates/ha-core/src/stt/engine.rs
+++ b/crates/ha-core/src/stt/engine.rs
@@ -37,6 +37,12 @@ pub async fn transcribe_with(
             )
             .await
         }
+        SttProviderKind::ElevenlabsStt => {
+            providers::elevenlabs::transcribe_batch(provider, model, profile, audio, options).await
+        }
+        SttProviderKind::XaiStt => {
+            providers::xai::transcribe_batch(provider, model, profile, audio, options).await
+        }
         SttProviderKind::DeepgramWs
         | SttProviderKind::AssemblyaiWs
         | SttProviderKind::AzureWs

--- a/crates/ha-core/src/stt/providers/elevenlabs.rs
+++ b/crates/ha-core/src/stt/providers/elevenlabs.rs
@@ -1,0 +1,203 @@
+//! ElevenLabs Scribe `/v1/speech-to-text` batch engine.
+//!
+//! Reference docs:
+//! - <https://elevenlabs.io/docs/api-reference/speech-to-text/convert>
+//! - <https://elevenlabs.io/docs/overview/models>
+//!
+//! Drives `SttProviderKind::ElevenlabsStt`. ElevenLabs is multipart like
+//! OpenAI Whisper but NOT wire-compatible: the endpoint is
+//! `/v1/speech-to-text`, the model field is `model_id` (default
+//! `scribe_v2`), auth is the `xi-api-key` header (not Bearer), and the
+//! response returns the transcript in `text` with per-word timing in
+//! `words` (there is no OpenAI-style `segments` array). Realtime streaming
+//! (`scribe_v2_realtime` over WebSocket) is a future enhancement — this
+//! path is batch (record-then-transcribe) only.
+
+use std::time::Duration;
+
+use crate::provider::{apply_proxy, AuthProfile};
+use crate::security::ssrf::{check_url, SsrfPolicy};
+
+use crate::stt::errors::{SttError, SttResult};
+use crate::stt::types::{
+    AudioPayload, SttModelConfig, SttProviderConfig, SttProviderKind, Transcript, TranscriptOptions,
+};
+
+use super::{classify_http_status, classify_reqwest_error, load_batch_audio};
+
+/// Batch transcription can run long on multi-minute clips; 120s mirrors the
+/// OpenAI batch engine's headroom while still surfacing a stuck request.
+const REQUEST_TIMEOUT_SECS: u64 = 120;
+
+/// Build the `/v1/speech-to-text` URL, trimming a trailing slash so users
+/// can configure either form of the base URL.
+fn speech_to_text_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    format!("{}/v1/speech-to-text", trimmed)
+}
+
+/// One-shot transcription via ElevenLabs Scribe `/v1/speech-to-text`.
+pub async fn transcribe_batch(
+    provider: &SttProviderConfig,
+    model: &SttModelConfig,
+    profile: &AuthProfile,
+    audio: AudioPayload,
+    options: &TranscriptOptions,
+) -> SttResult<Transcript> {
+    debug_assert!(matches!(provider.kind, SttProviderKind::ElevenlabsStt));
+
+    let base_url = provider.resolve_base_url(profile);
+    let url = speech_to_text_url(base_url);
+
+    let cfg = crate::config::cached_config();
+    let policy = if provider.allow_private_network {
+        SsrfPolicy::AllowPrivate
+    } else {
+        cfg.ssrf.default_policy
+    };
+    check_url(&url, policy, &cfg.ssrf.trusted_hosts)
+        .await
+        .map_err(|e| SttError::SsrfBlocked(e.to_string()))?;
+
+    // Disable auto-redirect so a 3xx on the audio upload can't silently
+    // bypass the SSRF check above (mirrors the OpenAI batch engine).
+    let client = apply_proxy(
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .user_agent("hope-agent/stt")
+            .redirect(reqwest::redirect::Policy::none()),
+    )
+    .build()
+    .map_err(|e| SttError::Network(format!("HTTP client build failed: {e}")))?;
+
+    let form = build_multipart_form(model, audio, options).await?;
+
+    let response = client
+        .post(&url)
+        .header("xi-api-key", profile.api_key.clone())
+        .header("Accept", "application/json")
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| classify_reqwest_error(&e))?;
+
+    let status = response.status();
+    if status.is_redirection() {
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("<unknown>")
+            .to_string();
+        return Err(SttError::SsrfBlocked(format!(
+            "ElevenLabs redirected ({status}) to {location}; redirects are disabled to prevent SSRF bypass"
+        )));
+    }
+    let body = response
+        .text()
+        .await
+        .map_err(|e| SttError::Network(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(classify_http_status(status, &body));
+    }
+
+    parse_transcript(provider, model, &body)
+}
+
+async fn build_multipart_form(
+    model: &SttModelConfig,
+    audio: AudioPayload,
+    options: &TranscriptOptions,
+) -> SttResult<reqwest::multipart::Form> {
+    let (bytes, mime_type, filename) = load_batch_audio(audio).await?;
+
+    let part = reqwest::multipart::Part::bytes(bytes)
+        .file_name(filename)
+        .mime_str(&mime_type)
+        .map_err(|e| SttError::UnsupportedAudio(format!("MIME {mime_type:?} rejected: {e}")))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .part("file", part)
+        .text("model_id", model.id.clone());
+
+    if let Some(lang) = &options.language {
+        if !lang.is_empty() {
+            form = form.text("language_code", lang.clone());
+        }
+    }
+
+    Ok(form)
+}
+
+fn parse_transcript(
+    provider: &SttProviderConfig,
+    model: &SttModelConfig,
+    body: &str,
+) -> SttResult<Transcript> {
+    let value: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| SttError::Other(format!("Invalid JSON from provider: {e}")))?;
+
+    let text = value
+        .get("text")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| SttError::Other("Provider response missing `text` field".to_string()))?
+        .to_string();
+
+    // ElevenLabs returns `language_code` (ISO 639) rather than OpenAI's
+    // `language`. There is no `segments` array — timing is per-word in
+    // `words`, which we don't surface as coarse segments.
+    let language = value
+        .get("language_code")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    Ok(Transcript {
+        text,
+        language,
+        duration_ms: None,
+        segments: Vec::new(),
+        provider_id: provider.id.clone(),
+        model_id: model.id.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn speech_to_text_url_trims_trailing_slash() {
+        assert_eq!(
+            speech_to_text_url("https://api.elevenlabs.io/"),
+            "https://api.elevenlabs.io/v1/speech-to-text"
+        );
+    }
+
+    #[test]
+    fn parse_transcript_extracts_text_and_language() {
+        let provider = SttProviderConfig::new(
+            "ElevenLabs",
+            SttProviderKind::ElevenlabsStt,
+            "https://api.elevenlabs.io",
+        );
+        let model = SttModelConfig::new("scribe_v2", "Scribe v2");
+        let body = r#"{"language_code":"en","language_probability":0.99,"text":"hello world"}"#;
+        let t = parse_transcript(&provider, &model, body).unwrap();
+        assert_eq!(t.text, "hello world");
+        assert_eq!(t.language.as_deref(), Some("en"));
+        assert!(t.segments.is_empty());
+    }
+
+    #[test]
+    fn parse_transcript_rejects_response_missing_text() {
+        let provider = SttProviderConfig::new(
+            "ElevenLabs",
+            SttProviderKind::ElevenlabsStt,
+            "https://api.elevenlabs.io",
+        );
+        let model = SttModelConfig::new("scribe_v2", "Scribe v2");
+        let err = parse_transcript(&provider, &model, r#"{"detail":"oops"}"#).unwrap_err();
+        assert_eq!(err.code(), "other");
+    }
+}

--- a/crates/ha-core/src/stt/providers/mod.rs
+++ b/crates/ha-core/src/stt/providers/mod.rs
@@ -27,8 +27,10 @@ pub mod assemblyai;
 pub mod azure;
 pub mod chat_completions_asr;
 pub mod deepgram;
+pub mod elevenlabs;
 pub mod openai;
 pub mod volcengine;
+pub mod xai;
 pub mod xunfei;
 
 /// WS frame caps shared across every WS provider, matching the

--- a/crates/ha-core/src/stt/providers/openai.rs
+++ b/crates/ha-core/src/stt/providers/openai.rs
@@ -37,9 +37,22 @@ const REQUEST_TIMEOUT_SECS: u64 = 120;
 
 /// Build the `/v1/audio/transcriptions` URL given the provider's base URL.
 /// Trim a trailing slash so users can configure either form.
+///
+/// Most compatible bases are the API root *without* the version segment
+/// (OpenAI `api.openai.com`, Groq `api.groq.com/openai`, the local
+/// backends), so we append the full `/v1/audio/transcriptions`. A few
+/// providers hand out a base that *already* includes the version — DeepInfra's
+/// OpenAI-compatible root is `api.deepinfra.com/v1/openai`, and users
+/// sometimes paste `https://api.openai.com/v1`. Appending another `/v1`
+/// there would 404, so when the base already carries a `/v1` segment we add
+/// only `/audio/transcriptions`.
 fn transcriptions_url(base_url: &str) -> String {
     let trimmed = base_url.trim_end_matches('/');
-    format!("{}/v1/audio/transcriptions", trimmed)
+    if trimmed.ends_with("/v1") || trimmed.contains("/v1/") {
+        format!("{}/audio/transcriptions", trimmed)
+    } else {
+        format!("{}/v1/audio/transcriptions", trimmed)
+    }
 }
 
 /// One-shot transcription via OpenAI-compatible `/v1/audio/transcriptions`.
@@ -237,6 +250,21 @@ mod tests {
         assert_eq!(
             transcriptions_url("http://127.0.0.1:10097"),
             "http://127.0.0.1:10097/v1/audio/transcriptions"
+        );
+        // Groq's base carries `/openai` but no version — still needs `/v1`.
+        assert_eq!(
+            transcriptions_url("https://api.groq.com/openai"),
+            "https://api.groq.com/openai/v1/audio/transcriptions"
+        );
+        // Versioned bases (DeepInfra `/v1/openai`, or a user-pasted `.../v1`)
+        // must not get a second `/v1`.
+        assert_eq!(
+            transcriptions_url("https://api.deepinfra.com/v1/openai"),
+            "https://api.deepinfra.com/v1/openai/audio/transcriptions"
+        );
+        assert_eq!(
+            transcriptions_url("https://api.openai.com/v1"),
+            "https://api.openai.com/v1/audio/transcriptions"
         );
     }
 

--- a/crates/ha-core/src/stt/providers/xai.rs
+++ b/crates/ha-core/src/stt/providers/xai.rs
@@ -17,8 +17,8 @@ use crate::security::ssrf::{check_url, SsrfPolicy};
 
 use crate::stt::errors::{SttError, SttResult};
 use crate::stt::types::{
-    AudioPayload, SttModelConfig, SttProviderConfig, SttProviderKind, Transcript, TranscriptOptions,
-    TranscriptSegment,
+    AudioPayload, SttModelConfig, SttProviderConfig, SttProviderKind, Transcript,
+    TranscriptOptions, TranscriptSegment,
 };
 
 use super::{classify_http_status, classify_reqwest_error, load_batch_audio};

--- a/crates/ha-core/src/stt/providers/xai.rs
+++ b/crates/ha-core/src/stt/providers/xai.rs
@@ -115,15 +115,16 @@ async fn build_multipart_form(
         .mime_str(&mime_type)
         .map_err(|e| SttError::UnsupportedAudio(format!("MIME {mime_type:?} rejected: {e}")))?;
 
-    let mut form = reqwest::multipart::Form::new()
-        .part("file", part)
-        .text("model", model.id.clone());
-
+    // xAI's STT docs require the `file` part to be appended AFTER all other
+    // multipart fields, so build `model` / `language` first and add the
+    // audio part last.
+    let mut form = reqwest::multipart::Form::new().text("model", model.id.clone());
     if let Some(lang) = &options.language {
         if !lang.is_empty() {
             form = form.text("language", lang.clone());
         }
     }
+    form = form.part("file", part);
 
     Ok(form)
 }

--- a/crates/ha-core/src/stt/providers/xai.rs
+++ b/crates/ha-core/src/stt/providers/xai.rs
@@ -1,0 +1,227 @@
+//! xAI Grok STT `/v1/stt` batch engine.
+//!
+//! Reference docs:
+//! - <https://docs.x.ai/developers/model-capabilities/audio/speech-to-text>
+//!
+//! Drives `SttProviderKind::XaiStt`. xAI ships a standalone STT API (model
+//! `grok-stt`) on its own `/v1/stt` path — multipart upload with a `model`
+//! field and Bearer auth, but NOT the OpenAI `/v1/audio/transcriptions`
+//! wire (different path + response shape), so it needs a dedicated engine.
+//! Realtime streaming (`wss://api.x.ai/v1/stt`) is a future enhancement —
+//! this path is batch (record-then-transcribe) only.
+
+use std::time::Duration;
+
+use crate::provider::{apply_proxy, AuthProfile};
+use crate::security::ssrf::{check_url, SsrfPolicy};
+
+use crate::stt::errors::{SttError, SttResult};
+use crate::stt::types::{
+    AudioPayload, SttModelConfig, SttProviderConfig, SttProviderKind, Transcript, TranscriptOptions,
+    TranscriptSegment,
+};
+
+use super::{classify_http_status, classify_reqwest_error, load_batch_audio};
+
+/// Batch transcription can run long on multi-minute clips; 120s mirrors the
+/// OpenAI batch engine's headroom while still surfacing a stuck request.
+const REQUEST_TIMEOUT_SECS: u64 = 120;
+
+/// Build the `/v1/stt` URL, trimming a trailing slash so users can
+/// configure either form of the base URL.
+fn stt_url(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    format!("{}/v1/stt", trimmed)
+}
+
+/// One-shot transcription via xAI Grok STT `/v1/stt`.
+pub async fn transcribe_batch(
+    provider: &SttProviderConfig,
+    model: &SttModelConfig,
+    profile: &AuthProfile,
+    audio: AudioPayload,
+    options: &TranscriptOptions,
+) -> SttResult<Transcript> {
+    debug_assert!(matches!(provider.kind, SttProviderKind::XaiStt));
+
+    let base_url = provider.resolve_base_url(profile);
+    let url = stt_url(base_url);
+
+    let cfg = crate::config::cached_config();
+    let policy = if provider.allow_private_network {
+        SsrfPolicy::AllowPrivate
+    } else {
+        cfg.ssrf.default_policy
+    };
+    check_url(&url, policy, &cfg.ssrf.trusted_hosts)
+        .await
+        .map_err(|e| SttError::SsrfBlocked(e.to_string()))?;
+
+    // Disable auto-redirect so a 3xx on the audio upload can't silently
+    // bypass the SSRF check above (mirrors the OpenAI batch engine).
+    let client = apply_proxy(
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .user_agent("hope-agent/stt")
+            .redirect(reqwest::redirect::Policy::none()),
+    )
+    .build()
+    .map_err(|e| SttError::Network(format!("HTTP client build failed: {e}")))?;
+
+    let form = build_multipart_form(model, audio, options).await?;
+
+    let response = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {}", profile.api_key))
+        .header("Accept", "application/json")
+        .multipart(form)
+        .send()
+        .await
+        .map_err(|e| classify_reqwest_error(&e))?;
+
+    let status = response.status();
+    if status.is_redirection() {
+        let location = response
+            .headers()
+            .get(reqwest::header::LOCATION)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("<unknown>")
+            .to_string();
+        return Err(SttError::SsrfBlocked(format!(
+            "xAI redirected ({status}) to {location}; redirects are disabled to prevent SSRF bypass"
+        )));
+    }
+    let body = response
+        .text()
+        .await
+        .map_err(|e| SttError::Network(e.to_string()))?;
+
+    if !status.is_success() {
+        return Err(classify_http_status(status, &body));
+    }
+
+    parse_transcript(provider, model, &body)
+}
+
+async fn build_multipart_form(
+    model: &SttModelConfig,
+    audio: AudioPayload,
+    options: &TranscriptOptions,
+) -> SttResult<reqwest::multipart::Form> {
+    let (bytes, mime_type, filename) = load_batch_audio(audio).await?;
+
+    let part = reqwest::multipart::Part::bytes(bytes)
+        .file_name(filename)
+        .mime_str(&mime_type)
+        .map_err(|e| SttError::UnsupportedAudio(format!("MIME {mime_type:?} rejected: {e}")))?;
+
+    let mut form = reqwest::multipart::Form::new()
+        .part("file", part)
+        .text("model", model.id.clone());
+
+    if let Some(lang) = &options.language {
+        if !lang.is_empty() {
+            form = form.text("language", lang.clone());
+        }
+    }
+
+    Ok(form)
+}
+
+fn parse_transcript(
+    provider: &SttProviderConfig,
+    model: &SttModelConfig,
+    body: &str,
+) -> SttResult<Transcript> {
+    let value: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| SttError::Other(format!("Invalid JSON from provider: {e}")))?;
+
+    let text = value
+        .get("text")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| SttError::Other("Provider response missing `text` field".to_string()))?
+        .to_string();
+
+    let language = value
+        .get("language")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let duration_ms = value
+        .get("duration")
+        .and_then(|v| v.as_f64())
+        .map(|d| (d * 1000.0).round() as u64);
+
+    // Best-effort: adopt an OpenAI-style `segments` array if present. When
+    // xAI returns per-word timing instead, this stays empty.
+    let segments = value
+        .get("segments")
+        .and_then(|v| v.as_array())
+        .map(|segs| segs.iter().filter_map(parse_segment).collect::<Vec<_>>())
+        .unwrap_or_default();
+
+    Ok(Transcript {
+        text,
+        language,
+        duration_ms,
+        segments,
+        provider_id: provider.id.clone(),
+        model_id: model.id.clone(),
+    })
+}
+
+fn parse_segment(value: &serde_json::Value) -> Option<TranscriptSegment> {
+    let text = value.get("text").and_then(|v| v.as_str())?.to_string();
+    let start = value.get("start").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let end = value.get("end").and_then(|v| v.as_f64()).unwrap_or(start);
+    let speaker = value
+        .get("speaker")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    Some(TranscriptSegment {
+        text,
+        start_ms: (start * 1000.0).max(0.0) as u64,
+        end_ms: (end * 1000.0).max(0.0) as u64,
+        confidence: None,
+        speaker,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stt_url_trims_trailing_slash() {
+        assert_eq!(stt_url("https://api.x.ai/"), "https://api.x.ai/v1/stt");
+    }
+
+    #[test]
+    fn parse_transcript_extracts_text_and_segments() {
+        let provider = SttProviderConfig::new("xAI", SttProviderKind::XaiStt, "https://api.x.ai");
+        let model = SttModelConfig::new("grok-stt", "Grok STT");
+        let body = r#"{
+            "text": "hello world",
+            "language": "en",
+            "duration": 2.5,
+            "segments": [
+                {"text": "hello", "start": 0.0, "end": 1.0},
+                {"text": " world", "start": 1.0, "end": 2.5, "speaker": "A"}
+            ]
+        }"#;
+        let t = parse_transcript(&provider, &model, body).unwrap();
+        assert_eq!(t.text, "hello world");
+        assert_eq!(t.language.as_deref(), Some("en"));
+        assert_eq!(t.duration_ms, Some(2500));
+        assert_eq!(t.segments.len(), 2);
+        assert_eq!(t.segments[1].end_ms, 2500);
+        assert_eq!(t.segments[1].speaker.as_deref(), Some("A"));
+    }
+
+    #[test]
+    fn parse_transcript_rejects_response_missing_text() {
+        let provider = SttProviderConfig::new("xAI", SttProviderKind::XaiStt, "https://api.x.ai");
+        let model = SttModelConfig::new("grok-stt", "Grok STT");
+        let err = parse_transcript(&provider, &model, r#"{"error":"oops"}"#).unwrap_err();
+        assert_eq!(err.code(), "other");
+    }
+}

--- a/crates/ha-core/src/stt/session.rs
+++ b/crates/ha-core/src/stt/session.rs
@@ -124,7 +124,9 @@ impl SttSessionManager {
             }
             SttProviderKind::OpenaiTranscriptions
             | SttProviderKind::OpenaiCompatible
-            | SttProviderKind::OpenaiChatCompletionsAsr => {
+            | SttProviderKind::OpenaiChatCompletionsAsr
+            | SttProviderKind::ElevenlabsStt
+            | SttProviderKind::XaiStt => {
                 return Err(SttError::Other(format!(
                     "Streaming transcription for {:?} requires a streaming-capable provider (use the batch endpoint)",
                     provider.kind

--- a/crates/ha-core/src/stt/types.rs
+++ b/crates/ha-core/src/stt/types.rs
@@ -50,6 +50,14 @@ pub enum SttProviderKind {
     VolcengineWs,
     /// iFlytek IAT WebSocket with hmac-sha256 signed URL.
     XunfeiWs,
+    /// ElevenLabs Scribe batch transcription (`POST /v1/speech-to-text`,
+    /// multipart with a `model_id` field and `xi-api-key` auth header — not
+    /// OpenAI-shaped, so it needs its own batch provider).
+    ElevenlabsStt,
+    /// xAI Grok STT batch transcription (`POST /v1/stt`, multipart with a
+    /// `model` field and Bearer auth — a custom REST wire, not OpenAI's
+    /// `/v1/audio/transcriptions`).
+    XaiStt,
 }
 
 impl SttProviderKind {
@@ -63,6 +71,8 @@ impl SttProviderKind {
             SttProviderKind::AzureWs => "wss://westus.stt.speech.microsoft.com",
             SttProviderKind::VolcengineWs => "wss://openspeech.bytedance.com",
             SttProviderKind::XunfeiWs => "wss://iat-api.xfyun.cn",
+            SttProviderKind::ElevenlabsStt => "https://api.elevenlabs.io",
+            SttProviderKind::XaiStt => "https://api.x.ai",
         }
     }
 
@@ -74,7 +84,10 @@ impl SttProviderKind {
     pub fn supports_streaming(&self) -> bool {
         !matches!(
             self,
-            SttProviderKind::OpenaiTranscriptions | SttProviderKind::OpenaiChatCompletionsAsr
+            SttProviderKind::OpenaiTranscriptions
+                | SttProviderKind::OpenaiChatCompletionsAsr
+                | SttProviderKind::ElevenlabsStt
+                | SttProviderKind::XaiStt
         )
     }
 
@@ -85,7 +98,10 @@ impl SttProviderKind {
     pub fn uses_multipart_upload(&self) -> bool {
         matches!(
             self,
-            SttProviderKind::OpenaiTranscriptions | SttProviderKind::OpenaiCompatible
+            SttProviderKind::OpenaiTranscriptions
+                | SttProviderKind::OpenaiCompatible
+                | SttProviderKind::ElevenlabsStt
+                | SttProviderKind::XaiStt
         )
     }
 
@@ -100,6 +116,8 @@ impl SttProviderKind {
             SttProviderKind::OpenaiTranscriptions
                 | SttProviderKind::OpenaiCompatible
                 | SttProviderKind::OpenaiChatCompletionsAsr
+                | SttProviderKind::ElevenlabsStt
+                | SttProviderKind::XaiStt
         )
     }
 
@@ -113,6 +131,8 @@ impl SttProviderKind {
             SttProviderKind::AzureWs => "Azure Speech",
             SttProviderKind::VolcengineWs => "Volcengine",
             SttProviderKind::XunfeiWs => "iFlytek IAT",
+            SttProviderKind::ElevenlabsStt => "ElevenLabs Scribe",
+            SttProviderKind::XaiStt => "xAI Grok STT",
         }
     }
 }

--- a/docs/architecture/stt.md
+++ b/docs/architecture/stt.md
@@ -49,13 +49,15 @@ pub struct SttConfig {
 
 ## Provider 抽象（`SttProviderKind`）
 
-8 个 wire 协议变体，`engine` 按 kind 分发到对应 `providers/*` 实现：
+10 个 wire 协议变体，`engine` 按 kind 分发到对应 `providers/*` 实现：
 
 | 变体 | 协议 | 流式 | Batch | 典型 |
 |---|---|---|---|---|
 | `OpenaiTranscriptions` | HTTP multipart `/v1/audio/transcriptions` | ✗ | ✓ | OpenAI Whisper |
-| `OpenaiCompatible` | HTTP multipart | 视上游 | ✓ | Groq / 四个本地后端 / StepFun / SiliconFlow |
+| `OpenaiCompatible` | HTTP multipart | 视上游 | ✓ | Groq / Mistral Voxtral / DeepInfra / 四个本地后端 / StepFun / SiliconFlow |
 | `OpenaiChatCompletionsAsr` | HTTP JSON（chat/completions + input_audio） | ✗ | ✓ | DashScope Qwen3-ASR / gpt-4o-audio |
+| `ElevenlabsStt` | HTTP multipart `/v1/speech-to-text`（`model_id` + `xi-api-key`） | ✗ | ✓ | ElevenLabs Scribe v2 |
+| `XaiStt` | HTTP multipart `/v1/stt`（`model` + Bearer） | ✗ | ✓ | xAI Grok STT |
 | `DeepgramWs` | WebSocket 二进制 | ✓ | ✗ | Deepgram realtime |
 | `AssemblyaiWs` | WebSocket 二进制 | ✓ | ✗ | AssemblyAI realtime |
 | `AzureWs` | WebSocket（USP 协议） | ✓ | ✗ | Azure Speech |
@@ -165,6 +167,6 @@ STT 归「**强制留 GUI 的例外**」同类（凭据安全）：
 | [`crates/ha-core/src/stt/local.rs`](../../crates/ha-core/src/stt/local.rs) | 4 本地后端 catalog + probe + upsert |
 | [`crates/ha-core/src/stt/session.rs`](../../crates/ha-core/src/stt/session.rs) | `SttSessionManager` + `stt:*` 事件 + idle GC |
 | [`crates/ha-core/src/stt/crud.rs`](../../crates/ha-core/src/stt/crud.rs) | 唯一写入口 + `check_batch_capable` |
-| [`crates/ha-core/src/stt/providers/`](../../crates/ha-core/src/stt/providers/) | 8 协议实现 + 共享 batch / WS helper |
+| [`crates/ha-core/src/stt/providers/`](../../crates/ha-core/src/stt/providers/) | 10 协议实现 + 共享 batch / WS helper |
 | [`src-tauri/src/commands/stt.rs`](../../src-tauri/src/commands/stt.rs) | 20 Tauri 命令（unmasked） |
 | [`crates/ha-server/src/routes/stt.rs`](../../crates/ha-server/src/routes/stt.rs) | 17 HTTP 路由（masked） |

--- a/src/components/settings/voice-panel/VoicePanel.tsx
+++ b/src/components/settings/voice-panel/VoicePanel.tsx
@@ -147,6 +147,8 @@ const KIND_EXTRA_SCHEMA: Record<SttProviderKind, ExtraField[]> = {
   "openai-transcriptions": [],
   "openai-compatible": [],
   "openai-chat-completions-asr": [],
+  "elevenlabs-stt": [],
+  "xai-stt": [],
   "deepgram-ws": [],
   "assemblyai-ws": [],
   "azure-ws": [

--- a/src/components/settings/voice-panel/presets.ts
+++ b/src/components/settings/voice-panel/presets.ts
@@ -71,6 +71,74 @@ export const STT_PRESETS: SttKindPreset[] = [
     defaultModels: [],
   },
   {
+    slug: "groq",
+    kind: "openai-compatible",
+    transport: "http",
+    brand: "Groq",
+    protocol: "Whisper",
+    iconKey: "groq",
+    defaultBaseUrl: "https://api.groq.com/openai",
+    requiresBaseUrl: false,
+    // Groq's /v1/audio/transcriptions is OpenAI-compatible; turbo is the
+    // fast/cheap default, large-v3 the highest-accuracy option.
+    defaultModels: [
+      { id: "whisper-large-v3-turbo", name: "Whisper Large v3 Turbo" },
+      { id: "whisper-large-v3", name: "Whisper Large v3" },
+    ],
+  },
+  {
+    slug: "mistral-voxtral",
+    kind: "openai-compatible",
+    transport: "http",
+    brand: "Mistral Voxtral",
+    protocol: "Whisper-compatible",
+    iconKey: "mistral",
+    defaultBaseUrl: "https://api.mistral.ai",
+    requiresBaseUrl: false,
+    // Voxtral transcription via the OpenAI-compatible /v1/audio/transcriptions
+    // wire; voxtral-mini-latest is the rolling batch alias.
+    defaultModels: [{ id: "voxtral-mini-latest", name: "Voxtral Mini (latest)" }],
+  },
+  {
+    slug: "deepinfra",
+    kind: "openai-compatible",
+    transport: "http",
+    brand: "DeepInfra",
+    protocol: "Whisper",
+    iconKey: "deepinfra",
+    defaultBaseUrl: "https://api.deepinfra.com/v1/openai",
+    requiresBaseUrl: false,
+    defaultModels: [
+      { id: "openai/whisper-large-v3-turbo", name: "Whisper Large v3 Turbo" },
+      { id: "openai/whisper-large-v3", name: "Whisper Large v3" },
+    ],
+  },
+  {
+    slug: "elevenlabs-stt",
+    kind: "elevenlabs-stt",
+    transport: "http",
+    brand: "ElevenLabs Scribe",
+    iconKey: "elevenlabs",
+    defaultBaseUrl: "https://api.elevenlabs.io",
+    requiresBaseUrl: false,
+    // Scribe v2 batch transcription (POST /v1/speech-to-text): 90+
+    // languages, word timestamps, diarization. Realtime scribe_v2_realtime
+    // is streaming-only and not wired here yet.
+    defaultModels: [{ id: "scribe_v2", name: "Scribe v2" }],
+  },
+  {
+    slug: "xai-stt",
+    kind: "xai-stt",
+    transport: "http",
+    brand: "xAI Grok STT",
+    iconKey: "xai",
+    defaultBaseUrl: "https://api.x.ai",
+    requiresBaseUrl: false,
+    // grok-stt batch transcription (POST /v1/stt): ~25 languages, word
+    // timestamps, diarization. Realtime WS is not wired here yet.
+    defaultModels: [{ id: "grok-stt", name: "Grok STT" }],
+  },
+  {
     slug: "openai-chat-completions-asr",
     kind: "openai-chat-completions-asr",
     transport: "http",
@@ -120,14 +188,12 @@ export const STT_PRESETS: SttKindPreset[] = [
     iconKey: "assemblyai",
     defaultBaseUrl: "wss://streaming.assemblyai.com",
     requiresBaseUrl: false,
-    // `speech_model` enum from the v3 Universal Streaming AsyncAPI spec.
+    // `speech_model` for the v3 streaming API — u3-rt-pro (Universal-3 Pro
+    // Streaming) is the current default; universal-streaming stays as a
+    // legacy fallback for older accounts.
     defaultModels: [
-      { id: "universal-streaming-english", name: "Universal Streaming · English" },
-      {
-        id: "universal-streaming-multilingual",
-        name: "Universal Streaming · Multilingual",
-      },
-      { id: "whisper-rt", name: "Whisper-RT (99+ languages)" },
+      { id: "u3-rt-pro", name: "Universal-3 Pro Streaming" },
+      { id: "universal-streaming", name: "Universal Streaming (legacy)" },
     ],
   },
   {
@@ -205,6 +271,15 @@ export function presetSlugFromProvider(
     baseUrl.toLowerCase().includes("dashscope")
   ) {
     return "dashscope"
+  }
+  // Several branded presets share the generic `openai-compatible` kind
+  // (Groq / Mistral Voxtral / DeepInfra); disambiguate by base-URL host so
+  // a saved provider re-selects its own preset row.
+  if (kind === "openai-compatible") {
+    const host = baseUrl.toLowerCase()
+    if (host.includes("groq.com")) return "groq"
+    if (host.includes("mistral.ai")) return "mistral-voxtral"
+    if (host.includes("deepinfra.com")) return "deepinfra"
   }
   if (PRESET_BY_SLUG[kind]) return kind
   const byKind = STT_PRESETS.find((p) => p.kind === kind)

--- a/src/lib/stt.ts
+++ b/src/lib/stt.ts
@@ -20,6 +20,8 @@ export type SttProviderKind =
   | "azure-ws"
   | "volcengine-ws"
   | "xunfei-ws"
+  | "elevenlabs-stt"
+  | "xai-stt"
 
 /**
  * Mirrors `SttProviderKind::supports_batch()` in ha-core. The desktop
@@ -30,6 +32,8 @@ export const BATCH_CAPABLE_KINDS: ReadonlySet<SttProviderKind> = new Set([
   "openai-transcriptions",
   "openai-compatible",
   "openai-chat-completions-asr",
+  "elevenlabs-stt",
+  "xai-stt",
 ])
 
 /**


### PR DESCRIPTION
## 概述

调研了 2026 年中 embedding / ASR / 本地小尺寸模型的**真实最新数据**（联网核实各厂商官方文档，而非照抄第三方目录），据此刷新语音转写与本地 embedding。核心结论：embedding 云端预设、本地 LLM/embedding/ASR 目录 hope-agent 已基本领先或持平；真正的缺口在**云端 ASR 供应商**。

## 改动

### 新增云端 ASR 后端（Rust）
- **ElevenLabs Scribe**（`SttProviderKind::ElevenlabsStt`）：`POST /v1/speech-to-text`，`model_id` 字段 + `xi-api-key` 头，默认 `scribe_v2`。
- **xAI Grok STT**（`SttProviderKind::XaiStt`）：`POST /v1/stt`，`model` 字段 + Bearer，默认 `grok-stt`。
- 两者均为 batch（录音后转写）路径，复用 `load_batch_audio` / SSRF 校验 / 禁重定向 / 错误分类等既有 helper；realtime WS 留待后续。

### 新增 OpenAI 兼容 ASR 预设（前端）
- **Groq**（whisper-large-v3-turbo / -v3）、**Mistral Voxtral**（voxtral-mini-latest）、**DeepInfra**（whisper-large-v3-turbo / -v3）——均走既有 `openai-compatible` kind，纯预设行 + 按域名消歧。

### 元数据修正
- **AssemblyAI**：型号由过时的 `universal-streaming-*` 更新为 **Universal-3 Pro Streaming（`u3-rt-pro`）**。

### 本地 embedding
- Ollama 本地 embedding 目录新增 **`mxbai-embed-large:335m`**（1024 维）。

## 调研中的重要更正（真实数据 vs 参考目录）
- **SenseAudio 查无此物**：核实后确认 `senseaudio-asr` / 商汤独立 ASR 端点在 2026 年中**无法证实存在**（SenseVoice 实为阿里 FunAudioLLM，非商汤），故**不纳入**——真实的中文云端 ASR 是 DashScope `qwen3-asr-flash`，hope-agent 已有。
- **未改动**：云端 embedding（OpenAI/Gemini/Voyage/Cohere/Jina/Mistral/Qwen 均已是最新，`gemini-embedding-2` id 经核实正确）、本地 LLM（Qwen3.6/Gemma4 已最新）、本地 ASR（whisper.cpp/FunASR/sherpa-onnx 目录已全）。

## 验证
- `cargo check -p ha-core` 通过；新增 provider 解析单测 + 本地 embedding 目录序单测（9 项）通过
- `pnpm typecheck` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
