### PR TITLE
Fix Homebrew macOS dependency syntax

### DIFF
--- a/homebrew/hope-agent-arm-only.rb.tmpl
+++ b/homebrew/hope-agent-arm-only.rb.tmpl
@@ -18,7 +18,7 @@ cask "hope-agent" do
   # Intel Mac users have no installable arm64 path (Rosetta 2 translates
   # Intel → Apple Silicon, not the reverse) and should stay on the prior
   # dual-arch release until the next version that ships an x64 DMG.
-  depends_on macos: ">= :big_sur", arch: :arm64
+  depends_on macos: :big_sur, arch: :arm64
 
   app "Hope Agent.app"
 

--- a/homebrew/hope-agent.rb.tmpl
+++ b/homebrew/hope-agent.rb.tmpl
@@ -16,7 +16,7 @@ cask "hope-agent" do
   end
 
   auto_updates true
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "Hope Agent.app"
 

--- a/scripts/check-release-paths.mjs
+++ b/scripts/check-release-paths.mjs
@@ -190,6 +190,18 @@ for (const p of requiredPlatforms) {
   }
 }
 
+// ─── Check 6 ─────────────────────────────────────────────────────────
+// Homebrew deprecated string-style macOS comparisons in casks. The
+// templates should use symbols such as `depends_on macos: :big_sur`
+// so the generated public tap does not warn during `brew install`.
+for (const template of ["hope-agent.rb.tmpl", "hope-agent-arm-only.rb.tmpl"]) {
+  const templatePath = path.join("homebrew", template)
+  const cask = readFileSync(path.join(repoRoot, templatePath), "utf8")
+  if (/depends_on\s+macos:\s*["']/.test(cask)) {
+    errors.push(`${templatePath}: uses deprecated string-style depends_on macos syntax; use a symbol such as macos: :big_sur.`)
+  }
+}
+
 // ─── Report ──────────────────────────────────────────────────────────
 if (warnings.length > 0) {
   console.warn("[check-release-paths] warnings:")


### PR DESCRIPTION
```bash
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :big_sur` instead.
Please report this issue to the shiwenwen/homebrew-hope-agent tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/shiwenwen/homebrew-hope-agent/Casks/hope-agent.rb:21
```

## Summary
- update Homebrew cask templates to use the current symbolic macOS dependency syntax
- add release-path validation to reject deprecated string-style macOS dependency checks

## Verification
- npm run check:release-paths