### PR TITLE
[codex] fix chat sticky anchor ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **聊天消息吸顶与耗时显示更准确**：用户消息悬浮吸顶不再只处理最后一条消息，会按当前可见回复体切换对应用户消息，并正确处理已处理折叠行、上下文压缩事件与长会话 DOM 裁剪；工具 / 思考耗时显示避免把同一轮耗时重复累加。聊天列表与输入框也收窄到更适合全屏阅读的最大宽度。
 - **MCP 配置编辑与热更新更可靠**：编辑 MCP server 时不再把界面中的 `<redacted>` 占位值写回覆盖真实 env / header / OAuth secret；服务名保持不可变，更新请求也不能改写已有 server id。禁用 / 重排 / 全局开关变更会即时同步到运行时，应用以 `mcpGlobal.enabled=false` 启动后再打开 MCP 也无需重启即可生效。
 - **MCP 工具目录与连接状态更稳定**：动态 MCP 工具名现在会处理 `foo-bar` / `foo.bar` 等清洗后重名的碰撞，避免工具互相覆盖；修改 URL / env / header / OAuth / 信任等级 / 并发上限后会重建连接，旧连接不会继续泄漏旧配置或把过期 catalog 写回工具索引；并发冷启动同一 MCP server 时也不会重复 spawn / handshake。
 - **MCP 设置面板细节修复**：切换 transport 后隐藏的 env / header 不会悄悄保存；数字字段清空会回到默认值而不是被保存成最小值；禁用 server 的测试 / 重连 / 授权按钮会置灰，避免点出无效错误。

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -2728,8 +2728,8 @@ export default function ChatScreen({
                       className={cn(
                         "absolute bottom-full mb-2 flex items-center gap-2 px-3 py-1.5 rounded-lg bg-secondary/50 text-xs text-muted-foreground animate-in fade-in slide-in-from-bottom-2 duration-300 z-10",
                         emptySessionInputHero
-                          ? "inset-x-5 mx-auto max-w-[920px] sm:inset-x-8"
-                          : "left-0 right-0 mx-4",
+                          ? "inset-x-5 mx-auto max-w-[880px] sm:inset-x-8"
+                          : "inset-x-3 mx-auto max-w-[880px]",
                       )}
                     >
                       <Brain className="h-3.5 w-3.5 shrink-0" />
@@ -2746,7 +2746,10 @@ export default function ChatScreen({
                   )}
 
                   <div
-                    className={cn(emptySessionInputHero && "flex w-full max-w-[920px] flex-col")}
+                    className={cn(
+                      "mx-auto w-full max-w-[880px]",
+                      emptySessionInputHero && "flex flex-col",
+                    )}
                   >
                     {heroComposerActive && (
                       <div className="mb-5 sm:mb-6">

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -83,6 +83,7 @@ interface MessageListProps {
 
 const AT_BOTTOM_THRESHOLD_PX = 48
 const LOAD_MORE_THRESHOLD_PX = 200
+const CHAT_CONTENT_MAX_WIDTH_CLASS = "max-w-[880px]"
 // Windowed view: cap simultaneously-rendered messages so a long-running
 // session that's been Load-More'd many times doesn't accumulate thousands of
 // markdown / shiki / katex subtrees in DOM. `messages` itself is not trimmed
@@ -90,6 +91,7 @@ const LOAD_MORE_THRESHOLD_PX = 200
 const MAX_DOM_MESSAGES = 200
 const UNLOAD_BATCH = 30
 const COMPACT_USER_ANCHOR_LEAD_PX = 32
+const COMPACT_USER_REPLY_VISIBLE_MIN_PX = 56
 const COMPACT_USER_ANCHOR_EXIT_MS = 200
 const ASK_USER_FOLLOW_FRAMES = 16
 
@@ -115,6 +117,14 @@ type MessageRenderRow =
   | { kind: "message"; item: MessageRenderItem }
   | CompletedTurnCollapseRow
 
+interface CompactUserAnchor {
+  dbId?: number
+  rowKey: string
+  bodyStartRowKey: string
+  bodyEndRowKey: string
+  text: string
+}
+
 function preferredScrollBehavior(): ScrollBehavior {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") return "smooth"
   return window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "auto" : "smooth"
@@ -136,6 +146,17 @@ function isHumanTurnStart(msg: Message): boolean {
   return msg.slashEvent?.displayAs === "user"
 }
 
+function findRenderWindowTurnStart(messages: Message[], start: number): number {
+  if (messages.length === 0) return 0
+  let i = Math.min(start, Math.max(0, messages.length - 1))
+  while (i > 0) {
+    const msg = messages[i]
+    if (msg && !msg.isMeta && isHumanTurnStart(msg)) return i
+    i -= 1
+  }
+  return 0
+}
+
 function timestampMs(msg: Message): number | null {
   if (!msg.timestamp) return null
   const ms = Date.parse(msg.timestamp)
@@ -143,17 +164,17 @@ function timestampMs(msg: Message): number | null {
 }
 
 function messageElapsedMs(msg: Message): number {
-  let total = msg.usage?.durationMs ?? 0
+  let blockTotal = 0
   const blocks = msg.contentBlocks
   if (blocks && blocks.length > 0) {
     for (const block of blocks) {
-      if (block.type === "thinking") total += block.durationMs ?? 0
-      if (block.type === "tool_call") total += block.tool.durationMs ?? 0
+      if (block.type === "thinking") blockTotal += block.durationMs ?? 0
+      if (block.type === "tool_call") blockTotal += block.tool.durationMs ?? 0
     }
   } else if (msg.toolCalls) {
-    for (const tool of msg.toolCalls) total += tool.durationMs ?? 0
+    for (const tool of msg.toolCalls) blockTotal += tool.durationMs ?? 0
   }
-  return total
+  return Math.max(msg.usage?.durationMs ?? 0, blockTotal)
 }
 
 function rowKeyForItem(item: MessageRenderItem): string {
@@ -245,6 +266,48 @@ function containsAnyHighlightTerm(text: string | null | undefined, terms: string
 
 function itemContainsAnyHighlightTerm(item: MessageRenderItem, terms: string[] | null): boolean {
   return containsAnyHighlightTerm(messageSearchText(item.msg), terms)
+}
+
+function compactAnchorTextForMessage(msg: Message): string | null {
+  const text = (msg.planComment?.comment || msg.slashEvent?.command || msg.content)
+    .replace(/\s+/g, " ")
+    .trim()
+  return text || null
+}
+
+function findActiveCompactUserAnchor(
+  container: HTMLElement,
+  anchors: CompactUserAnchor[],
+): CompactUserAnchor | null {
+  const containerRect = container.getBoundingClientRect()
+  let active: CompactUserAnchor | null = null
+
+  for (const anchor of anchors) {
+    const bodyStart = findMessageRowByKey(container, anchor.bodyStartRowKey)
+    const bodyEnd = findMessageRowByKey(container, anchor.bodyEndRowKey)
+    if (!bodyStart || !bodyEnd) continue
+    const bodyStartRect = bodyStart.getBoundingClientRect()
+    const bodyEndRect = bodyEnd.getBoundingClientRect()
+    const target = findMessageRowByKey(container, anchor.rowKey)
+    const targetHasScrolledPast = target
+      ? target.getBoundingClientRect().bottom < containerRect.top - COMPACT_USER_ANCHOR_LEAD_PX
+      : true
+
+    if (targetHasScrolledPast) {
+      const bodyTop = bodyStartRect.top
+      const bodyBottom = bodyEndRect.bottom
+      const visibleHeight =
+        Math.min(bodyBottom, containerRect.bottom) - Math.max(bodyTop, containerRect.top)
+      const bodyHeight = Math.max(0, bodyBottom - bodyTop)
+      const minVisibleHeight = Math.min(COMPACT_USER_REPLY_VISIBLE_MIN_PX, bodyHeight)
+      if (visibleHeight < minVisibleHeight) continue
+      active = anchor
+      continue
+    }
+    break
+  }
+
+  return active
 }
 
 function findMessageScrollTarget(
@@ -510,6 +573,7 @@ function CompletedTurnCollapseSummary({
   return (
     <div
       key={row.key}
+      data-message-key={row.key}
       className="grid w-full min-w-0 grid-cols-1 justify-items-stretch pb-3"
     >
       <button
@@ -568,6 +632,7 @@ export default function MessageList({
   autoCollapseCompletedTurns = true,
 }: MessageListProps) {
   const { t } = useTranslation()
+  const rootRef = useRef<HTMLDivElement | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const sessionKey = sessionId ?? "draft-session"
@@ -578,6 +643,11 @@ export default function MessageList({
   const [searchExpandedUserMessageId, setSearchExpandedUserMessageId] = useState<
     number | null
   >(null)
+  const [compactUserAnchor, setCompactUserAnchor] = useState<CompactUserAnchor | null>(null)
+  const [compactUserAnchorFrame, setCompactUserAnchorFrame] = useState<{
+    left: number
+    width: number
+  } | null>(null)
   const [compactUserAnchorVisible, setCompactUserAnchorVisible] = useState(false)
   const [compactUserAnchorMounted, setCompactUserAnchorMounted] = useState(false)
   const [expandedCompletedTurns, setExpandedCompletedTurns] = useState<Set<string>>(
@@ -697,7 +767,8 @@ export default function MessageList({
   // mounted at all.
   const items = useMemo(() => {
     const out: { msg: Message; originalIndex: number }[] = []
-    const start = Math.min(displayedStart, Math.max(0, messages.length - 1))
+    const requestedStart = Math.min(displayedStart, Math.max(0, messages.length - 1))
+    const start = findRenderWindowTurnStart(messages, requestedStart)
     for (let i = start; i < messages.length; i++) {
       const msg = messages[i]
       if (!msg.isMeta) out.push({ msg, originalIndex: i })
@@ -742,42 +813,98 @@ export default function MessageList({
   }, [])
 
   const isTimelineMode = displayMode === "timeline"
-  const compactUserAnchor = useMemo(() => {
-    if (!isTimelineMode) return null
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-      const msg = messages[i]
-      if (msg.isMeta || msg.fromAgentId || isCenteredSystemMessage(msg)) continue
-      if (!isUserAlignedMessage(msg)) continue
-      const text = (msg.planComment?.comment || msg.slashEvent?.command || msg.content)
-        .replace(/\s+/g, " ")
-        .trim()
-      if (!text) return null
-      return {
-        dbId: msg.dbId,
-        rowKey: getMessageRowKey(msg, i),
-        text,
+  const compactUserAnchors = useMemo(() => {
+    if (!isTimelineMode) return []
+    const anchors: CompactUserAnchor[] = []
+    let pendingAnchor: Omit<CompactUserAnchor, "bodyStartRowKey" | "bodyEndRowKey"> | null = null
+    let pendingBodyStartRowKey: string | null = null
+    let pendingBodyEndRowKey: string | null = null
+
+    const finishPendingAnchor = () => {
+      if (pendingAnchor && pendingBodyStartRowKey && pendingBodyEndRowKey) {
+        anchors.push({
+          ...pendingAnchor,
+          bodyStartRowKey: pendingBodyStartRowKey,
+          bodyEndRowKey: pendingBodyEndRowKey,
+        })
+      }
+      pendingAnchor = null
+      pendingBodyStartRowKey = null
+      pendingBodyEndRowKey = null
+    }
+
+    for (const row of renderRows) {
+      const rowKey = row.kind === "message" ? rowKeyForItem(row.item) : row.key
+      if (row.kind !== "message") {
+        if (pendingAnchor) {
+          pendingBodyStartRowKey = pendingBodyStartRowKey ?? rowKey
+          pendingBodyEndRowKey = rowKey
+        }
+        continue
+      }
+
+      const { msg } = row.item
+      if (!msg.fromAgentId && !isCenteredSystemMessage(msg) && isUserAlignedMessage(msg)) {
+        finishPendingAnchor()
+        const text = compactAnchorTextForMessage(msg)
+        if (text) {
+          pendingAnchor = {
+            dbId: msg.dbId,
+            rowKey,
+            text,
+          }
+        }
+      } else if (pendingAnchor) {
+        pendingBodyStartRowKey = pendingBodyStartRowKey ?? rowKey
+        pendingBodyEndRowKey = rowKey
       }
     }
-    return null
-  }, [isTimelineMode, messages])
+
+    finishPendingAnchor()
+    return anchors
+  }, [isTimelineMode, renderRows])
 
   const updateCompactUserAnchor = useCallback(() => {
+    const root = rootRef.current
     const el = containerRef.current
-    const rowKey = compactUserAnchor?.rowKey
-    if (!el || !rowKey) {
+    const content = contentRef.current
+    if (root && content) {
+      const rootRect = root.getBoundingClientRect()
+      const contentRect = content.getBoundingClientRect()
+      const nextFrame = {
+        left: contentRect.left - rootRect.left,
+        width: contentRect.width,
+      }
+      setCompactUserAnchorFrame((prev) =>
+        prev &&
+        Math.abs(prev.left - nextFrame.left) < 0.5 &&
+        Math.abs(prev.width - nextFrame.width) < 0.5
+          ? prev
+          : nextFrame,
+      )
+    } else {
+      setCompactUserAnchorFrame(null)
+    }
+
+    if (!el || compactUserAnchors.length === 0) {
       setCompactUserAnchorVisible(false)
       return
     }
-    const target = findMessageRowByKey(el, rowKey)
-    if (!target) {
-      setCompactUserAnchorVisible(false)
-      return
+    const active = findActiveCompactUserAnchor(el, compactUserAnchors)
+    if (active) {
+      setCompactUserAnchor((prev) =>
+        prev?.rowKey === active.rowKey && prev.text === active.text ? prev : active,
+      )
     }
-    const containerTop = el.getBoundingClientRect().top
-    const targetBottom = target.getBoundingClientRect().bottom
-    const visible = targetBottom < containerTop - COMPACT_USER_ANCHOR_LEAD_PX
+    const visible = active != null
     setCompactUserAnchorVisible((prev) => (prev === visible ? prev : visible))
-  }, [compactUserAnchor?.rowKey])
+  }, [compactUserAnchors])
+
+  useLayoutEffect(() => {
+    setCompactUserAnchor(null)
+    setCompactUserAnchorVisible(false)
+    setCompactUserAnchorMounted(false)
+  }, [sessionKey, isTimelineMode])
 
   useLayoutEffect(() => {
     updateCompactUserAnchor()
@@ -1295,7 +1422,7 @@ export default function MessageList({
   const showJumpToLatest = Boolean((!atBottom && items.length > 0) || hasMoreAfter)
 
   return (
-    <div className="relative flex-1 min-h-0 min-w-0 overflow-hidden">
+    <div ref={rootRef} className="relative flex-1 min-h-0 min-w-0 overflow-hidden">
       <div
         ref={containerRef}
         key={sessionKey}
@@ -1316,7 +1443,7 @@ export default function MessageList({
           isTimelineMode && "px-5 sm:px-6",
         )}
       >
-        <div ref={contentRef}>
+        <div ref={contentRef} className={cn("mx-auto w-full", CHAT_CONTENT_MAX_WIDTH_CLASS)}>
           {hasMore && displayedStart === 0 && (
             <div className="pt-6">
               <LoadMoreRow loadingMore={loadingMore} onLoadMore={onLoadMore} />
@@ -1469,8 +1596,17 @@ export default function MessageList({
 
       {compactUserAnchor && (compactUserAnchorVisible || compactUserAnchorMounted) && (
         <div
+          style={
+            compactUserAnchorFrame
+              ? {
+                  left: compactUserAnchorFrame.left,
+                  width: compactUserAnchorFrame.width,
+                }
+              : undefined
+          }
           className={cn(
-            "pointer-events-none absolute inset-x-0 top-2 z-30 flex justify-end px-5 transition-all duration-200 ease-out sm:px-6",
+            "pointer-events-none absolute top-2 z-30 flex justify-end transition-all duration-200 ease-out",
+            !compactUserAnchorFrame && "inset-x-0 px-4 sm:px-6",
             compactUserAnchorVisible
               ? "translate-y-0 opacity-100 animate-in fade-in-0 slide-in-from-top-1"
               : "-translate-y-1 opacity-0",

--- a/src/components/chat/message/executionStatus.ts
+++ b/src/components/chat/message/executionStatus.ts
@@ -114,9 +114,10 @@ export function toolHasMedia(tool: ToolCall): boolean {
 /**
  * Wall-clock elapsed across a set of tools: the span from the earliest start to
  * the latest end. Tools that ran in parallel within a round therefore count
- * once instead of being summed (summing overstates the real elapsed). Falls
- * back to summed durations when no usable timestamps exist. `now` lets a still
- * running tool (no `durationMs` yet) contribute its in-progress elapsed.
+ * once instead of being summed, while the visible wait between sequential tools
+ * still counts as elapsed time. Falls back to summed durations when no usable
+ * timestamps exist. `now` lets a still-running tool (no `durationMs` yet)
+ * contribute its in-progress elapsed.
  */
 export function getToolsWallClockMs(tools: ToolCall[], now?: number): number | undefined {
   const elapsed = (tool: ToolCall): number | undefined => {


### PR DESCRIPTION
## Summary

- Improve chat user-message sticky anchors so each user turn can become the floating anchor while its reply body is still visible.
- Keep sticky anchor bounds aligned with the constrained chat content width, and cap the chat list/input width for full-screen layouts.
- Fix displayed elapsed time so turn/tool timing does not double-count overlapping usage and step durations.
- Add an Unreleased changelog entry.

## Root Cause

The previous sticky anchor logic only tracked the latest user message and used the user row alone as the trigger. In long timeline sessions, folded completed-turn rows, context compaction events, and DOM windowing could leave the active turn without a usable reply-body boundary, so the anchor either did not appear or stayed too long.

## Validation

- `pnpm typecheck`
- `git diff --check`
- pre-push hook passed:
  - `cargo fmt --all --check`
  - `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
  - `pnpm typecheck`
  - `pnpm lint` (1 existing warning in `src/components/chat/hooks/useChatStream.ts`)
  - `node scripts/verify-updater-pubkey.mjs`
  - `pnpm test`
  - `cargo test -p ha-core -p ha-server --locked`