### PR TITLE
[codex] Refine sidebar shortcuts and window minimum height

### DIFF
--- a/src-tauri/src/window_state.rs
+++ b/src-tauri/src/window_state.rs
@@ -9,7 +9,7 @@ use tauri::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 
 const MAIN_WINDOW_LABEL: &str = "main";
 const MIN_MAIN_WINDOW_WIDTH: f64 = 840.0;
-const MIN_MAIN_WINDOW_HEIGHT: f64 = 480.0;
+const MIN_MAIN_WINDOW_HEIGHT: f64 = 520.0;
 const MAX_PERSISTED_DIMENSION: f64 = 10_000.0;
 const SAVE_DEBOUNCE_MS: u64 = 300;
 const SCREEN_MARGIN: f64 = 24.0;
@@ -115,6 +115,17 @@ pub(crate) fn restore_main_window_state(app: &tauri::App) {
     let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
         return;
     };
+    if let Err(e) = window.set_min_size(Some(Size::Logical(LogicalSize::new(
+        MIN_MAIN_WINDOW_WIDTH,
+        MIN_MAIN_WINDOW_HEIGHT,
+    )))) {
+        app_warn!(
+            "window",
+            "restore_size",
+            "failed to apply window min size: {}",
+            e
+        );
+    }
     let state = match load_state() {
         Ok(Some(state)) => state,
         Ok(None) => return,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
         "height": 900,
         "center": true,
         "minWidth": 840,
-        "minHeight": 480,
+        "minHeight": 520,
         "resizable": true,
         "fullscreen": false,
         "transparent": true,

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -7,7 +7,7 @@
         "width": 1440,
         "height": 900,
         "minWidth": 840,
-        "minHeight": 480,
+        "minHeight": 520,
         "resizable": true,
         "fullscreen": false,
         "transparent": false,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback, useRef, lazy, Suspense } from "react"
 import { useTranslation } from "react-i18next"
+import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window"
 import { getTransport } from "@/lib/transport-provider"
 import { parsePayload, isTauriMode } from "@/lib/transport"
 import { logger } from "@/lib/logger"
+import { MAIN_WINDOW_MIN_HEIGHT, MAIN_WINDOW_MIN_WIDTH } from "@/lib/mainWindowSize"
 import { initLanguageFromConfig, listenLanguageConfigChange } from "@/i18n/i18n"
 import { initThemeFromConfig, listenThemeConfigChange } from "@/hooks/useTheme"
 import { initFocusTracking, listenNotificationConfigChange, notify } from "@/lib/notifications"
@@ -95,6 +97,28 @@ export default function App() {
     globalPendingUpdate.version !== ignoredVersion
 
   const completedLocalModelJobToasts = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (!isTauriMode()) return
+
+    const enforceMainWindowMinSize = async () => {
+      const win = getCurrentWindow()
+      const minSize = new LogicalSize(MAIN_WINDOW_MIN_WIDTH, MAIN_WINDOW_MIN_HEIGHT)
+      await win.setMinSize(minSize)
+
+      const [innerSize, scaleFactor] = await Promise.all([win.innerSize(), win.scaleFactor()])
+      const logicalSize = innerSize.toLogical(scaleFactor)
+      const width = Math.max(logicalSize.width, MAIN_WINDOW_MIN_WIDTH)
+      const height = Math.max(logicalSize.height, MAIN_WINDOW_MIN_HEIGHT)
+      if (width !== logicalSize.width || height !== logicalSize.height) {
+        await win.setSize(new LogicalSize(width, height))
+      }
+    }
+
+    enforceMainWindowMinSize().catch((err) => {
+      logger.warn("window", "App::enforceMainWindowMinSize", "Failed to enforce min size", err)
+    })
+  }, [])
 
   // Shared desktop-update install/restart lifecycle (also drives AboutPanel),
   // so the toast and the settings surface can't drift and the failure / staged

--- a/src/components/chat/CanvasPanel.tsx
+++ b/src/components/chat/CanvasPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react"
 import { getTransport } from "@/lib/transport-provider"
 import { parsePayload, isTauriMode } from "@/lib/transport"
+import { MAIN_WINDOW_MIN_HEIGHT, MAIN_WINDOW_MIN_WIDTH } from "@/lib/mainWindowSize"
 import { getCurrentWindow, LogicalSize } from "@tauri-apps/api/window"
 import { WebviewWindow } from "@tauri-apps/api/webviewWindow"
 import { useTranslation } from "react-i18next"
@@ -124,9 +125,9 @@ export default function CanvasPanel({
     if (!isTauriMode()) return
     const win = getCurrentWindow()
     if (canvas && !detached) {
-      win.setMinSize(new LogicalSize(1280, 480))
+      win.setMinSize(new LogicalSize(1280, MAIN_WINDOW_MIN_HEIGHT))
     } else {
-      win.setMinSize(new LogicalSize(840, 480))
+      win.setMinSize(new LogicalSize(MAIN_WINDOW_MIN_WIDTH, MAIN_WINDOW_MIN_HEIGHT))
     }
   }, [canvas, detached])
 

--- a/src/components/chat/plan-mode/PlanPanel.tsx
+++ b/src/components/chat/plan-mode/PlanPanel.tsx
@@ -4,6 +4,7 @@ import { WebviewWindow } from "@tauri-apps/api/webviewWindow"
 import { getTransport } from "@/lib/transport-provider"
 import { isTauriMode } from "@/lib/transport"
 import { logger } from "@/lib/logger"
+import { MAIN_WINDOW_MIN_HEIGHT, MAIN_WINDOW_MIN_WIDTH } from "@/lib/mainWindowSize"
 import {
   ClipboardList,
   X,
@@ -77,12 +78,12 @@ export function PlanPanel({
     if (!desktopMode) return
     const win = getCurrentWindow()
     if (!detached) {
-      win.setMinSize(new LogicalSize(1240, 480))
+      win.setMinSize(new LogicalSize(1240, MAIN_WINDOW_MIN_HEIGHT))
     } else {
-      win.setMinSize(new LogicalSize(840, 480))
+      win.setMinSize(new LogicalSize(MAIN_WINDOW_MIN_WIDTH, MAIN_WINDOW_MIN_HEIGHT))
     }
     return () => {
-      win.setMinSize(new LogicalSize(840, 480))
+      win.setMinSize(new LogicalSize(MAIN_WINDOW_MIN_WIDTH, MAIN_WINDOW_MIN_HEIGHT))
     }
   }, [detached, desktopMode])
 

--- a/src/components/common/IconSidebar.tsx
+++ b/src/components/common/IconSidebar.tsx
@@ -237,106 +237,116 @@ export default function IconSidebar({
 
         <div className="my-1 h-px w-6 bg-border-soft/80" />
 
-        {/* Agents entry */}
-        <div className="w-full flex justify-center mt-1">
-          <IconTip label={t("settings.agents")} side="right">
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "rounded-xl h-8 w-8",
-                view === "agents"
-                  ? "bg-primary/10 text-primary hover:bg-primary/20"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={onOpenAgents}
-            >
-              <Bot className="h-4 w-4" />
-            </Button>
-          </IconTip>
-        </div>
-
-        {/* Model configuration entry */}
-        <div className="w-full flex justify-center mt-1">
-          <IconTip label={t("settings.modelConfig")} side="right">
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "rounded-xl h-8 w-8",
-                view === "modelConfig"
-                  ? "bg-primary/10 text-primary hover:bg-primary/20"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={onOpenModelConfig}
-            >
-              <Server className="h-4 w-4" />
-            </Button>
-          </IconTip>
-        </div>
-
-        {/* Channels entry */}
-        <div className="w-full flex justify-center mt-1">
-          <IconTip label={t("settings.channels")} side="right">
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "rounded-xl h-8 w-8",
-                view === "channels"
-                  ? "bg-primary/10 text-primary hover:bg-primary/20"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={onOpenChannels}
-            >
-              <MessageCircle className="h-4 w-4" />
-            </Button>
-          </IconTip>
-        </div>
-
-        {/* Skills entry */}
-        <div className="w-full flex justify-center mt-1">
-          <div className="relative">
-            <IconTip label={t("settings.skills")} side="right">
+        <div className="icon-sidebar-settings-shortcuts flex w-full flex-col items-center">
+          {/* Agents entry */}
+          <div className="w-full flex justify-center mt-1">
+            <IconTip label={t("settings.agents")} side="right">
               <Button
                 variant="ghost"
                 size="icon"
                 className={cn(
                   "rounded-xl h-8 w-8",
-                  view === "skills"
+                  view === "agents"
                     ? "bg-primary/10 text-primary hover:bg-primary/20"
                     : "text-muted-foreground hover:text-foreground",
                 )}
-                onClick={onOpenSkills}
+                onClick={onOpenAgents}
               >
-                <Puzzle className="h-4 w-4" />
+                <Bot className="h-4 w-4" />
               </Button>
             </IconTip>
-            {skillDraftCount > 0 && (
-              <span className="pointer-events-none absolute -right-1.5 -top-1 z-10 inline-flex h-[15px] min-w-[15px] items-center justify-center rounded-full border border-background bg-amber-500 px-1 text-[9px] font-bold leading-none text-white tabular-nums animate-in zoom-in-0 duration-200">
-                {skillDraftBadgeLabel}
-              </span>
-            )}
+          </div>
+
+          {/* Model configuration entry */}
+          <div className="w-full flex justify-center mt-1">
+            <IconTip label={t("settings.modelConfig")} side="right">
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "rounded-xl h-8 w-8",
+                  view === "modelConfig"
+                    ? "bg-primary/10 text-primary hover:bg-primary/20"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={onOpenModelConfig}
+              >
+                <Server className="h-4 w-4" />
+              </Button>
+            </IconTip>
+          </div>
+
+          {/* Channels entry */}
+          <div className="w-full flex justify-center mt-1">
+            <IconTip label={t("settings.channels")} side="right">
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "rounded-xl h-8 w-8",
+                  view === "channels"
+                    ? "bg-primary/10 text-primary hover:bg-primary/20"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={onOpenChannels}
+              >
+                <MessageCircle className="h-4 w-4" />
+              </Button>
+            </IconTip>
+          </div>
+
+          {/* Skills entry */}
+          <div className="w-full flex justify-center mt-1">
+            <div className="relative">
+              <IconTip label={t("settings.skills")} side="right">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className={cn(
+                    "rounded-xl h-8 w-8",
+                    view === "skills"
+                      ? "bg-primary/10 text-primary hover:bg-primary/20"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                  onClick={onOpenSkills}
+                >
+                  <Puzzle className="h-4 w-4" />
+                </Button>
+              </IconTip>
+              {skillDraftCount > 0 && (
+                <span className="pointer-events-none absolute -right-1.5 -top-1 z-10 inline-flex h-[15px] min-w-[15px] items-center justify-center rounded-full border border-background bg-amber-500 px-1 text-[9px] font-bold leading-none text-white tabular-nums animate-in zoom-in-0 duration-200">
+                  {skillDraftBadgeLabel}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* Memory entry */}
+          <div className="w-full flex justify-center mt-1">
+            <IconTip label={t("settings.memory")} side="right">
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "rounded-xl h-8 w-8",
+                  view === "memory"
+                    ? "bg-primary/10 text-primary hover:bg-primary/20"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={onOpenMemory}
+              >
+                <Brain className="h-4 w-4" />
+              </Button>
+            </IconTip>
           </div>
         </div>
 
-        {/* Memory entry */}
+        <div className="icon-sidebar-settings-shortcuts-trailing-divider my-1 h-px w-6 bg-border-soft/60" />
+
+        {/* Browser backend — status indicator + entry to Settings → Browser.
+            Green dot when a backend is live; hover shows details. */}
         <div className="w-full flex justify-center mt-1">
-          <IconTip label={t("settings.memory")} side="right">
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "rounded-xl h-8 w-8",
-                view === "memory"
-                  ? "bg-primary/10 text-primary hover:bg-primary/20"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={onOpenMemory}
-            >
-              <Brain className="h-4 w-4" />
-            </Button>
-          </IconTip>
+          <BrowserStatusIndicator onOpen={() => onOpenSettings("browser")} />
         </div>
 
         {/* Plans (read-only history viewer) entry */}
@@ -356,14 +366,6 @@ export default function IconSidebar({
               <ClipboardList className="h-4 w-4" />
             </Button>
           </IconTip>
-        </div>
-
-        <div className="my-1 h-px w-6 bg-border-soft/60" />
-
-        {/* Browser backend — status indicator + entry to Settings → Browser.
-            Green dot when a backend is live; hover shows details. */}
-        <div className="w-full flex justify-center mt-1">
-          <BrowserStatusIndicator onOpen={() => onOpenSettings("browser")} />
         </div>
 
         {/* Logs entry, quick jump to Settings -> Logs near runtime status. */}
@@ -386,101 +388,103 @@ export default function IconSidebar({
           {/* Server runtime health — always visible so users can catch port
               conflicts, high WS load, etc. without opening Settings. */}
           <ServerStatusIndicator onOpen={() => onOpenSettings("server")} />
-          {/* Profile */}
-          <IconTip label={t("settings.profileSettings")} side="right">
-            <Button
-              variant="ghost"
-              size="icon"
-              className={cn(
-                "rounded-xl h-8 w-8",
-                view === "profile"
-                  ? "bg-primary/10 text-primary hover:bg-primary/20"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-              onClick={onOpenProfile}
-            >
-              <User className="h-4 w-4" />
-            </Button>
-          </IconTip>
+          <div className="icon-sidebar-preference-shortcuts flex flex-col items-center gap-2">
+            {/* Profile */}
+            <IconTip label={t("settings.profileSettings")} side="right">
+              <Button
+                variant="ghost"
+                size="icon"
+                className={cn(
+                  "rounded-xl h-8 w-8",
+                  view === "profile"
+                    ? "bg-primary/10 text-primary hover:bg-primary/20"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={onOpenProfile}
+              >
+                <User className="h-4 w-4" />
+              </Button>
+            </IconTip>
 
-          {/* Theme Toggle */}
-          <IconTip label={`${t("theme.title")}: ${t(`theme.${theme}`)}`} side="right">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="rounded-xl text-muted-foreground hover:text-foreground h-8 w-8"
-              onClick={cycleTheme}
-            >
-              {theme === "auto" ? (
-                <SunMoon className="h-4 w-4" />
-              ) : theme === "light" ? (
-                <Sun className="h-4 w-4" />
-              ) : (
-                <Moon className="h-4 w-4" />
-              )}
-            </Button>
-          </IconTip>
-
-          {/* Language Selector */}
-          <div className="relative">
-            <IconTip label={t("language.title")} side="right">
+            {/* Theme Toggle */}
+            <IconTip label={`${t("theme.title")}: ${t(`theme.${theme}`)}`} side="right">
               <Button
                 variant="ghost"
                 size="icon"
                 className="rounded-xl text-muted-foreground hover:text-foreground h-8 w-8"
-                onClick={() => setShowLangMenu(!showLangMenu)}
+                onClick={cycleTheme}
               >
-                <Languages className="h-4 w-4" />
+                {theme === "auto" ? (
+                  <SunMoon className="h-4 w-4" />
+                ) : theme === "light" ? (
+                  <Sun className="h-4 w-4" />
+                ) : (
+                  <Moon className="h-4 w-4" />
+                )}
               </Button>
             </IconTip>
-            {showLangMenu && (
-              <>
-                <div className="fixed inset-0 z-40" onClick={() => setShowLangMenu(false)} />
-                <div className="absolute left-14 bottom-0 z-50 bg-surface-floating border border-border-soft rounded-floating shadow-floating py-1 min-w-[160px] max-h-[400px] overflow-y-auto animate-in fade-in-0 zoom-in-95 slide-in-from-left-1 duration-150">
-                  {/* Follow System option */}
-                  <button
-                    className={`flex items-center gap-2.5 w-full px-3 py-1.5 text-xs transition-colors hover:bg-secondary ${
-                      isFollowingSystem() ? "text-primary font-medium" : "text-foreground"
-                    }`}
-                    onClick={() => {
-                      setFollowSystemLanguage()
-                      setShowLangMenu(false)
-                    }}
-                  >
-                    <Monitor className="h-3.5 w-3.5 text-primary/70" />
-                    <span>{t("language.system")}</span>
-                    {isFollowingSystem() && <span className="ml-auto text-primary">●</span>}
-                  </button>
-                  <div className="border-t border-border/50 my-0.5" />
-                  {SUPPORTED_LANGUAGES.map((lang) => (
+
+            {/* Language Selector */}
+            <div className="relative">
+              <IconTip label={t("language.title")} side="right">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="rounded-xl text-muted-foreground hover:text-foreground h-8 w-8"
+                  onClick={() => setShowLangMenu(!showLangMenu)}
+                >
+                  <Languages className="h-4 w-4" />
+                </Button>
+              </IconTip>
+              {showLangMenu && (
+                <>
+                  <div className="fixed inset-0 z-40" onClick={() => setShowLangMenu(false)} />
+                  <div className="absolute left-14 bottom-0 z-50 bg-surface-floating border border-border-soft rounded-floating shadow-floating py-1 min-w-[160px] max-h-[400px] overflow-y-auto animate-in fade-in-0 zoom-in-95 slide-in-from-left-1 duration-150">
+                    {/* Follow System option */}
                     <button
-                      key={lang.code}
                       className={`flex items-center gap-2.5 w-full px-3 py-1.5 text-xs transition-colors hover:bg-secondary ${
-                        !isFollowingSystem() &&
-                        (i18n.language === lang.code ||
-                          (i18n.language.startsWith(lang.code + "-") && lang.code !== "zh"))
-                          ? "text-primary font-medium"
-                          : "text-foreground"
+                        isFollowingSystem() ? "text-primary font-medium" : "text-foreground"
                       }`}
                       onClick={() => {
-                        setLanguage(lang.code)
+                        setFollowSystemLanguage()
                         setShowLangMenu(false)
                       }}
                     >
-                      <span className="text-[10px] font-bold w-5 text-primary/70">
-                        {lang.shortLabel}
-                      </span>
-                      <span>{lang.label}</span>
-                      {!isFollowingSystem() &&
-                        (i18n.language === lang.code ||
-                          (i18n.language.startsWith(lang.code + "-") && lang.code !== "zh")) && (
-                          <span className="ml-auto text-primary">●</span>
-                        )}
+                      <Monitor className="h-3.5 w-3.5 text-primary/70" />
+                      <span>{t("language.system")}</span>
+                      {isFollowingSystem() && <span className="ml-auto text-primary">●</span>}
                     </button>
-                  ))}
-                </div>
-              </>
-            )}
+                    <div className="border-t border-border/50 my-0.5" />
+                    {SUPPORTED_LANGUAGES.map((lang) => (
+                      <button
+                        key={lang.code}
+                        className={`flex items-center gap-2.5 w-full px-3 py-1.5 text-xs transition-colors hover:bg-secondary ${
+                          !isFollowingSystem() &&
+                          (i18n.language === lang.code ||
+                            (i18n.language.startsWith(lang.code + "-") && lang.code !== "zh"))
+                            ? "text-primary font-medium"
+                            : "text-foreground"
+                        }`}
+                        onClick={() => {
+                          setLanguage(lang.code)
+                          setShowLangMenu(false)
+                        }}
+                      >
+                        <span className="text-[10px] font-bold w-5 text-primary/70">
+                          {lang.shortLabel}
+                        </span>
+                        <span>{lang.label}</span>
+                        {!isFollowingSystem() &&
+                          (i18n.language === lang.code ||
+                            (i18n.language.startsWith(lang.code + "-") && lang.code !== "zh")) && (
+                            <span className="ml-auto text-primary">●</span>
+                          )}
+                      </button>
+                    ))}
+                  </div>
+                </>
+              )}
+            </div>
           </div>
           {/* Settings */}
           <div className="relative flex justify-center mt-1">

--- a/src/index.css
+++ b/src/index.css
@@ -161,6 +161,14 @@
   }
 }
 
+@media (max-height: 800px) {
+  .icon-sidebar-settings-shortcuts,
+  .icon-sidebar-settings-shortcuts-trailing-divider,
+  .icon-sidebar-preference-shortcuts {
+    display: none;
+  }
+}
+
 /* Streaming bubble floor.
  * `min-width` / `min-height` lock the bubble to a one-line-of-text floor
  * so the dots → first-token transition doesn't shrink the box during the

--- a/src/lib/mainWindowSize.ts
+++ b/src/lib/mainWindowSize.ts
@@ -1,0 +1,2 @@
+export const MAIN_WINDOW_MIN_WIDTH = 840
+export const MAIN_WINDOW_MIN_HEIGHT = 520


### PR DESCRIPTION
## Summary
- Hide the settings shortcut groups when the sidebar is too short, while keeping the divider between the top function area and bottom status/log area.
- Move the Plan history icon directly above Logs.
- Unify the main-window minimum height to 520 across Tauri configs, Rust window restore, App runtime setup, and Canvas/Plan panel min-size updates.

## Notes
- Root cause for the height staying at 480: CanvasPanel and PlanPanel were resetting the window min size with a hardcoded 480 height, and the Windows Tauri overlay config still had minHeight 480.
- Per request, resize clamping was removed; the code only sets the actual window min size and grows the window if it is already below the minimum on startup.

## Validation
- pnpm typecheck
- cargo check -p hope-agent
- pre-push hook: cargo fmt --all --check, cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings, pnpm typecheck, pnpm lint, pnpm test, cargo test -p ha-core -p ha-server --locked

Lint note: ESLint completed with the existing warning in src/components/chat/hooks/useChatStream.ts about setAttachedFiles.