### PR TITLE
[codex] Add project directory picker creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **输入框支持 @Agent 委派子智能体**：在对话输入框输入 `@` 时，Agent 候选会展示在文件 / 知识笔记 / 技能之后；选中后插入可视化 Agent 芯片，并在发送时把用户主动要求某个 Agent 执行任务的意图注入给模型，便于模型通过既有子智能体工具发起委派。
+- **项目工作目录选择支持新建目录**：新建 / 编辑项目时，工作目录选择提升到表单顶部，可选择已有目录或直接新建目录；未手动选择时仍沿用默认项目目录自动创建逻辑。HTTP Server 模式下远端目录选择器也支持新建目录，并继续受 `filesystem.allowRemoteWrites` 写入开关保护。
 - **内置 Provider 模板刷新**：为 Anthropic / Anthropic (Vertex AI) / OpenAI / Google Gemini / Moonshot / 智谱 / MiniMax / Kimi Coding 等补齐最新旗舰模型（Claude Fable 5、GPT-5.6 Sol/Terra/Luna、Gemini 3.5 Flash、Kimi K2.7 Code、GLM-5.2、MiniMax M3、kimi-for-coding 等，均置于各供应商列表顶部），修正 Claude Haiku 4.5、MiniMax M2.7 Highspeed 的能力与价格元数据，并新增 OpenCode Zen 旗舰网关模板。 (#412)
 - **语音转写新增供应商与模型刷新**：新增 ElevenLabs Scribe、xAI Grok STT 两个云端 ASR 后端，以及 Groq、Mistral Voxtral、DeepInfra 三个 OpenAI 兼容转写预设，可直接用于语音输入与 IM 自动转写；AssemblyAI 型号更新为 Universal-3 Pro（流式 u3-rt-pro），本地 embedding 目录新增 mxbai-embed-large。 (#413)
 

--- a/crates/ha-core/src/filesystem/mod.rs
+++ b/crates/ha-core/src/filesystem/mod.rs
@@ -6,6 +6,8 @@
 //! - `list_dir(path)` — single-level read of a directory, used by the
 //!   server-mode directory picker and the `@` chat-mention popper when the
 //!   token contains a `/`.
+//! - `create_dir(path)` — create a user-selected absolute directory for the
+//!   directory picker, then return the created directory listing.
 //! - `search_files(root, query, limit)` — fuzzy walk of `root`, respecting
 //!   `.gitignore` / hidden-file rules. Used by the chat-mention popper when
 //!   the user typed a bare `@chat`-style token.
@@ -254,6 +256,40 @@ pub fn list_dir(requested: Option<&str>) -> Result<DirListing> {
         entries,
         truncated,
     })
+}
+
+/// Create an absolute directory and return its listing.
+///
+/// This is intentionally absolute-path only because it backs owner-facing
+/// directory pickers. Workspace-relative project file operations use
+/// [`project_mkdir`] instead.
+pub fn create_dir(requested: &str) -> Result<DirListing> {
+    let trimmed = requested.trim();
+    if trimmed.is_empty() {
+        return Err(FilesystemError::bad_input("directory path is empty"));
+    }
+    let target = Path::new(trimmed);
+    if !target.is_absolute() {
+        return Err(FilesystemError::bad_input(format!(
+            "path must be absolute: {}",
+            trimmed
+        )));
+    }
+
+    std::fs::create_dir_all(target).map_err(|e| {
+        FilesystemError::bad_input(format!("cannot create directory '{}': {}", trimmed, e))
+    })?;
+    let canon = target.canonicalize().map_err(|e| {
+        FilesystemError::bad_input(format!("cannot resolve path '{}': {}", trimmed, e))
+    })?;
+    if !canon.is_dir() {
+        return Err(FilesystemError::bad_input(format!(
+            "path is not a directory: {}",
+            canon.display()
+        )));
+    }
+    let canon_str = canon.to_string_lossy().to_string();
+    list_dir(Some(&canon_str))
 }
 
 #[cfg(unix)]

--- a/crates/ha-server/src/lib.rs
+++ b/crates/ha-server/src/lib.rs
@@ -1822,6 +1822,10 @@ fn build_router_with_cors(
         // and the chat-input `@` mention popper)
         .route("/filesystem/list-dir", get(routes::filesystem::list_dir))
         .route(
+            "/filesystem/create-dir",
+            post(routes::filesystem::create_dir),
+        )
+        .route(
             "/filesystem/search-files",
             get(routes::filesystem::search_files),
         )

--- a/crates/ha-server/src/routes/filesystem.rs
+++ b/crates/ha-server/src/routes/filesystem.rs
@@ -2,7 +2,8 @@
 //!
 //! Desktop clients use the native directory dialog for the working-dir
 //! picker; HTTP/WS clients have no such affordance (browsers sandbox
-//! filesystem access), so the server exposes a minimal read-only listing API.
+//! filesystem access), so the server exposes minimal listing/search APIs plus
+//! an opt-in mkdir API for directory-picker flows.
 //! Auth is handled by the existing `Authorization: Bearer` middleware —
 //! anyone who can hit this endpoint already has full agent-level access to
 //! the host.
@@ -25,6 +26,19 @@ fn map_err(e: FilesystemError) -> AppError {
     }
 }
 
+fn ensure_writes_allowed() -> Result<(), AppError> {
+    if ha_core::config::cached_config()
+        .filesystem
+        .allow_remote_writes
+    {
+        Ok(())
+    } else {
+        Err(AppError::forbidden(
+            "remote file writes are disabled; enable filesystem.allowRemoteWrites to allow them",
+        ))
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ListDirQuery {
     /// Absolute path to list. When omitted, the handler returns a platform
@@ -38,6 +52,24 @@ pub async fn list_dir(Query(q): Query<ListDirQuery>) -> Result<Json<Value>, AppE
     let result = tokio::task::spawn_blocking(move || filesystem::list_dir(requested.as_deref()))
         .await
         .map_err(|e| AppError::internal(format!("list-dir task failed: {}", e)))?
+        .map_err(map_err)?;
+    Ok(Json(serde_json::to_value(result)?))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateDirBody {
+    /// Absolute path to create.
+    pub path: String,
+}
+
+/// `POST /api/filesystem/create-dir` — create an absolute directory and return
+/// the created directory listing.
+pub async fn create_dir(Json(body): Json<CreateDirBody>) -> Result<Json<Value>, AppError> {
+    ensure_writes_allowed()?;
+    let path = body.path;
+    let result = tokio::task::spawn_blocking(move || filesystem::create_dir(&path))
+        .await
+        .map_err(|e| AppError::internal(format!("create-dir task failed: {}", e)))?
         .map_err(map_err)?;
     Ok(Json(serde_json::to_value(result)?))
 }

--- a/src-tauri/src/commands/filesystem.rs
+++ b/src-tauri/src/commands/filesystem.rs
@@ -22,6 +22,15 @@ pub async fn fs_list_dir(path: Option<String>) -> Result<DirListing, CmdError> {
 }
 
 #[tauri::command]
+pub async fn fs_create_dir(path: String) -> Result<DirListing, CmdError> {
+    Ok(
+        tokio::task::spawn_blocking(move || filesystem::create_dir(&path))
+            .await
+            .context("fs_create_dir task failed")??,
+    )
+}
+
+#[tauri::command]
 pub async fn fs_search_files(
     root: String,
     q: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,6 +252,7 @@ pub fn run() {
             commands::misc::set_dock_badge_cmd,
             // Filesystem listing & search (chat-input @ mention popper, working-dir picker)
             commands::filesystem::fs_list_dir,
+            commands::filesystem::fs_create_dir,
             commands::filesystem::fs_search_files,
             // Agent management
             commands::agent_mgmt::list_agents,

--- a/src/components/chat/input/ServerDirectoryBrowser.tsx
+++ b/src/components/chat/input/ServerDirectoryBrowser.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
-import { ChevronUp, Folder, FolderOpen, Loader2, RefreshCw } from "lucide-react"
+import { ChevronUp, Folder, FolderOpen, FolderPlus, Loader2, RefreshCw } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import {
   Dialog,
@@ -21,6 +21,7 @@ interface ServerDirectoryBrowserProps {
   onOpenChange: (open: boolean) => void
   initialPath?: string | null
   onSelect: (path: string) => void
+  allowCreate?: boolean
 }
 
 export default function ServerDirectoryBrowser({
@@ -28,16 +29,21 @@ export default function ServerDirectoryBrowser({
   onOpenChange,
   initialPath,
   onSelect,
+  allowCreate = false,
 }: ServerDirectoryBrowserProps) {
   const { t } = useTranslation()
   const [listing, setListing] = useState<DirListing | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [manualPath, setManualPath] = useState("")
+  const [newFolderName, setNewFolderName] = useState("")
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
 
   const load = useCallback(async (path?: string) => {
     setLoading(true)
     setError(null)
+    setCreateError(null)
     try {
       const result = await getTransport().listServerDirectory(path)
       setListing(result)
@@ -72,6 +78,39 @@ export default function ServerDirectoryBrowser({
     const trimmed = manualPath.trim()
     if (!trimmed) return
     load(trimmed)
+  }
+
+  const handleCreateSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!allowCreate || !listing || loading || creating) return
+
+    const name = newFolderName.trim()
+    if (!name) return
+    if (name === "." || name === ".." || /[\\/]/.test(name)) {
+      setCreateError(t("chat.workingDir.invalid"))
+      return
+    }
+
+    setCreating(true)
+    setCreateError(null)
+    try {
+      const created = await getTransport().createDirectory(joinDirectoryPath(listing.path, name))
+      setListing(created)
+      setManualPath(created.path)
+      setNewFolderName("")
+      onSelect(created.path)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      logger.error(
+        "chat",
+        "ServerDirectoryBrowser::createDirectory",
+        "Failed to create directory",
+        e,
+      )
+      setCreateError(message)
+    } finally {
+      setCreating(false)
+    }
   }
 
   const handleSelectCurrent = () => {
@@ -114,6 +153,43 @@ export default function ServerDirectoryBrowser({
             )}
           </Button>
         </form>
+
+        {allowCreate && (
+          <form
+            onSubmit={handleCreateSubmit}
+            className="rounded-md border border-border bg-muted/20 p-3"
+          >
+            <div className="mb-2 flex items-center gap-2 text-xs font-medium">
+              <FolderPlus className="h-3.5 w-3.5 text-primary" />
+              {t("fileBrowser.newFolder", { defaultValue: "New folder" })}
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                value={newFolderName}
+                onChange={(e) => setNewFolderName(e.target.value)}
+                placeholder={t("knowledge.folderNamePlaceholder", {
+                  defaultValue: "Folder name",
+                })}
+                disabled={!listing || loading || creating}
+                className="h-9 flex-1 text-sm"
+              />
+              <Button
+                type="submit"
+                size="sm"
+                disabled={!listing || loading || creating || !newFolderName.trim()}
+              >
+                {creating ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  t("common.create")
+                )}
+              </Button>
+            </div>
+            {createError && (
+              <p className="mt-2 break-all text-xs text-destructive">{createError}</p>
+            )}
+          </form>
+        )}
 
         <div className="rounded border border-border bg-muted/20 h-[360px] overflow-y-auto">
           {loading && (
@@ -180,4 +256,11 @@ export default function ServerDirectoryBrowser({
       </DialogContent>
     </Dialog>
   )
+}
+
+function joinDirectoryPath(base: string, name: string): string {
+  const separator = base.includes("\\") && !base.includes("/") ? "\\" : "/"
+  const normalizedBase = base.replace(/[\\/]+$/, "")
+  if (!normalizedBase) return `${separator}${name}`
+  return `${normalizedBase}${separator}${name}`
 }

--- a/src/components/chat/project/ProjectDialog.tsx
+++ b/src/components/chat/project/ProjectDialog.tsx
@@ -6,7 +6,7 @@
  *  - `mode="edit"` + `initialProject=<Project>` → prefilled form, calls onUpdate
  */
 
-import { useEffect, useRef, useState, type ChangeEvent } from "react"
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "react"
 import { useTranslation } from "react-i18next"
 import {
   Bot,
@@ -16,6 +16,7 @@ import {
   FileText,
   FolderKanban,
   FolderOpen,
+  FolderPlus,
   ImagePlus,
   Loader2,
   Palette,
@@ -46,7 +47,6 @@ import {
 } from "@/components/common/AgentSelectDisplay"
 import { cn } from "@/lib/utils"
 import { formatBytes } from "@/lib/format"
-import { isTauriMode } from "@/lib/transport"
 import ServerDirectoryBrowser from "@/components/chat/input/ServerDirectoryBrowser"
 import { useDirectoryPicker } from "@/components/chat/input/useDirectoryPicker"
 import ProjectKnowledgeSection from "./ProjectKnowledgeSection"
@@ -127,7 +127,6 @@ export default function ProjectDialog({
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [instructions, setInstructions] = useState("")
-  const [emoji, setEmoji] = useState("")
   const [logo, setLogo] = useState<string>("")
   const [color, setColor] = useState<string>("")
   const [defaultAgentId, setDefaultAgentId] = useState<string>("")
@@ -151,7 +150,6 @@ export default function ProjectDialog({
       setName(initialProject.name ?? "")
       setDescription(initialProject.description ?? "")
       setInstructions(initialProject.instructions ?? "")
-      setEmoji(initialProject.emoji ?? "")
       setLogo(initialProject.logo ?? "")
       setColor(initialProject.color ?? "")
       setDefaultAgentId(initialProject.defaultAgentId ?? "")
@@ -160,7 +158,6 @@ export default function ProjectDialog({
       setName("")
       setDescription("")
       setInstructions("")
-      setEmoji("")
       setLogo("")
       setColor("")
       setDefaultAgentId("")
@@ -189,13 +186,26 @@ export default function ProjectDialog({
     setLogoError("")
   }
 
+  const handleWorkingDirPicked = useCallback(
+    (path: string) => {
+      setWorkingDir(path)
+      if (mode !== "create") return
+
+      const inferredName = getDirectoryName(path)
+      if (!inferredName) return
+
+      setName((currentName) => (currentName.trim() ? currentName : inferredName))
+    },
+    [mode],
+  )
+
   const {
     pick: pickWorkingDir,
     browserOpen: dirBrowserOpen,
     setBrowserOpen: setDirBrowserOpen,
     handleBrowserSelect: handleWorkingDirSelect,
   } = useDirectoryPicker({
-    onPicked: setWorkingDir,
+    onPicked: handleWorkingDirPicked,
     errorTitle: t("project.workingDir.invalid"),
     loggerSource: "ProjectDialog::pickWorkingDir",
   })
@@ -203,6 +213,11 @@ export default function ProjectDialog({
   function handlePickWorkingDir() {
     if (saving) return
     void pickWorkingDir()
+  }
+
+  function handleCreateWorkingDir() {
+    if (saving) return
+    setDirBrowserOpen(true)
   }
 
   function clearWorkingDir() {
@@ -222,7 +237,6 @@ export default function ProjectDialog({
           name: name.trim(),
           description: description.trim() || null,
           instructions: instructions.trim() || null,
-          emoji: emoji.trim() || null,
           logo: logo || null,
           color: color || null,
           defaultAgentId: defaultAgentId || null,
@@ -239,7 +253,6 @@ export default function ProjectDialog({
           name: name.trim(),
           description: description.trim(),
           instructions: instructions.trim(),
-          emoji: emoji.trim(),
           logo: logo,
           color: color,
           defaultAgentId: defaultAgentId,
@@ -277,8 +290,6 @@ export default function ProjectDialog({
               >
                 {logo ? (
                   <img src={logo} alt="" className="h-full w-full object-cover" />
-                ) : emoji ? (
-                  <span>{emoji}</span>
                 ) : (
                   <FolderKanban className="h-5 w-5" />
                 )}
@@ -289,6 +300,66 @@ export default function ProjectDialog({
         </div>
 
         <div className="max-h-[calc(88vh-9.5rem)] overflow-y-auto px-6 py-5">
+          <div className="mb-5 border-b border-border/70 pb-5">
+            <div className="mb-3 flex items-start gap-3">
+              <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border/70 bg-muted/30 text-muted-foreground">
+                <FolderOpen className="h-4 w-4" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <Label className="text-sm font-semibold">
+                  {t("project.workingDir.label")}
+                </Label>
+                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                  {t("project.workingDir.hint")}
+                </p>
+              </div>
+            </div>
+            <div className="grid gap-2 lg:grid-cols-[minmax(0,1fr)_auto]">
+              <Input
+                id="project-working-dir"
+                value={workingDir}
+                readOnly
+                placeholder={t("project.workingDir.placeholder")}
+                className="h-10 bg-background font-mono text-xs shadow-none"
+              />
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handlePickWorkingDir}
+                  disabled={saving}
+                  className="h-10 shadow-none"
+                >
+                  <FolderOpen className="mr-1.5 h-4 w-4" />
+                  {t("project.workingDir.pick")}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleCreateWorkingDir}
+                  disabled={saving}
+                  className="h-10 shadow-none"
+                >
+                  <FolderPlus className="mr-1.5 h-4 w-4" />
+                  {t("fileBrowser.newFolder", { defaultValue: "New folder" })}
+                </Button>
+                {workingDir && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={clearWorkingDir}
+                    disabled={saving}
+                    aria-label={t("project.workingDir.clear")}
+                    className="h-9 w-9"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </div>
+          </div>
+
           <div className="grid gap-5 lg:grid-cols-[13rem_minmax(0,1fr)]">
             <div className="space-y-4">
               <div className="space-y-2">
@@ -315,11 +386,7 @@ export default function ProjectDialog({
                             : "bg-background text-primary",
                         )}
                       >
-                        {emoji ? (
-                          <span>{emoji}</span>
-                        ) : (
-                          <ImagePlus className="h-7 w-7 text-muted-foreground" />
-                        )}
+                        <ImagePlus className="h-7 w-7 text-muted-foreground" />
                       </div>
                       <span className="text-xs font-medium text-muted-foreground">
                         {t("project.uploadLogo")}
@@ -400,29 +467,15 @@ export default function ProjectDialog({
             </div>
 
             <div className="space-y-5">
-              <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_5rem]">
-                <div className="space-y-1.5">
-                  <Label htmlFor="project-name">{t("project.projectName")}</Label>
-                  <Input
-                    id="project-name"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    placeholder={t("project.projectNamePlaceholder")}
-                    autoFocus
-                    className="h-10"
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="project-emoji">{t("project.projectEmoji")}</Label>
-                  <Input
-                    id="project-emoji"
-                    value={emoji}
-                    onChange={(e) => setEmoji(e.target.value)}
-                    placeholder={t("project.projectEmojiPlaceholder", "可选")}
-                    maxLength={4}
-                    className="h-10 text-center text-lg"
-                  />
-                </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="project-name">{t("project.projectName")}</Label>
+                <Input
+                  id="project-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder={t("project.projectNamePlaceholder")}
+                  className="h-10"
+                />
               </div>
 
               <div className="space-y-1.5">
@@ -473,46 +526,6 @@ export default function ProjectDialog({
                 </Select>
               </div>
 
-              <div className="space-y-1.5">
-                <Label className="flex items-center gap-2">
-                  <FolderOpen className="h-4 w-4 text-muted-foreground" />
-                  {t("project.workingDir.label")}
-                </Label>
-                <p className="text-xs text-muted-foreground">
-                  {t("project.workingDir.hint")}
-                </p>
-                <div className="flex items-center gap-2">
-                  <Input
-                    id="project-working-dir"
-                    value={workingDir}
-                    readOnly
-                    placeholder={t("project.workingDir.placeholder")}
-                    className="h-10 flex-1 font-mono text-xs"
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={handlePickWorkingDir}
-                    disabled={saving}
-                  >
-                    {t("project.workingDir.pick")}
-                  </Button>
-                  {workingDir && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={clearWorkingDir}
-                      disabled={saving}
-                      aria-label={t("project.workingDir.clear")}
-                      className="h-9 w-9"
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  )}
-                </div>
-              </div>
-
               {mode === "edit" && initialProject?.id && (
                 <ProjectKnowledgeSection projectId={initialProject.id} />
               )}
@@ -544,14 +557,13 @@ export default function ProjectDialog({
           </div>
         </div>
 
-        {!isTauriMode() && (
-          <ServerDirectoryBrowser
-            open={dirBrowserOpen}
-            initialPath={workingDir || null}
-            onOpenChange={setDirBrowserOpen}
-            onSelect={handleWorkingDirSelect}
-          />
-        )}
+        <ServerDirectoryBrowser
+          open={dirBrowserOpen}
+          initialPath={workingDir || null}
+          onOpenChange={setDirBrowserOpen}
+          onSelect={handleWorkingDirSelect}
+          allowCreate
+        />
 
         <DialogFooter className="border-t border-border/70 bg-background px-6 py-4">
           <Button
@@ -589,6 +601,13 @@ export default function ProjectDialog({
 /** Hard cap on raw upload size before decoding — guards against oversized
  * images crashing the canvas decoder. 8 MB is comfortable for any real logo. */
 const MAX_LOGO_SOURCE_BYTES = 8 * 1024 * 1024
+
+function getDirectoryName(path: string): string {
+  const trimmed = path.trim().replace(/[\\/]+$/, "")
+  if (!trimmed) return ""
+  const segments = trimmed.split(/[\\/]+/)
+  return segments[segments.length - 1] ?? ""
+}
 
 async function resizeImageToDataUrl(
   file: File,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -599,8 +599,8 @@
     "viewSystemPrompt": "View System Prompt",
     "weeksAgo": "{{count}}w ago",
     "workingDir": {
-      "browserDescription": "Paths are resolved on the server machine where the agent runs.",
-      "browserTitle": "Select a directory on the server",
+      "browserDescription": "Paths are resolved on the machine where the agent runs.",
+      "browserTitle": "Select a directory",
       "change": "Change directory",
       "clear": "Clear directory",
       "current": "Working directory",
@@ -2217,7 +2217,7 @@
     "projectInstructionsHint": "These instructions are automatically added to the system prompt of every session in this project.",
     "projectInstructionsPlaceholder": "e.g. Always reply in English; keep the tone clear and friendly; start with the conclusion",
     "projectLogo": "Logo",
-    "projectLogoHint": "Optional. When set, replaces the emoji icon in the sidebar. Images are auto-resized to 256×256.",
+    "projectLogoHint": "Optional. Images are auto-resized to 256×256.",
     "projectName": "Project Name",
     "projectNamePlaceholder": "e.g. Hope Agent Development",
     "projects": "Projects",
@@ -2237,11 +2237,11 @@
     "uploadLogo": "Upload logo",
     "workingDir": {
       "clear": "Clear",
-      "hint": "Sessions in this project default to this directory; session-level setting overrides it.",
+      "hint": "Choose an existing directory or create a new one. Leave empty to auto-create the default project directory.",
       "invalid": "Invalid working directory",
       "label": "Working Directory",
       "pick": "Pick directory",
-      "placeholder": "Not set (sessions can override)"
+      "placeholder": "Not set (default project directory will be created)"
     },
     "knowledge": {
       "label": "Knowledge spaces",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -599,8 +599,8 @@
     "viewSystemPrompt": "查看系统提示词",
     "weeksAgo": "{{count}}周前",
     "workingDir": {
-      "browserDescription": "路径将在运行 Agent 的服务器上解析。",
-      "browserTitle": "选择服务器上的目录",
+      "browserDescription": "路径将在运行 Agent 的机器上解析。",
+      "browserTitle": "选择目录",
       "change": "更换目录",
       "clear": "清除目录",
       "current": "工作目录",
@@ -2217,7 +2217,7 @@
     "projectInstructionsHint": "这些指令会自动加入该项目所有会话的系统提示词",
     "projectInstructionsPlaceholder": "例如：始终用中文回复；语气清楚亲切；先给结论再补充细节",
     "projectLogo": "Logo",
-    "projectLogoHint": "可选。设置后会替代侧边栏的 Emoji 图标显示。图片会自动压缩到 256×256。",
+    "projectLogoHint": "可选。图片会自动压缩到 256×256。",
     "projectName": "项目名称",
     "projectNamePlaceholder": "例如：Hope Agent 开发",
     "projects": "项目",
@@ -2237,11 +2237,11 @@
     "uploadLogo": "上传 Logo",
     "workingDir": {
       "clear": "清除",
-      "hint": "项目下的会话默认使用该目录；会话级设置会覆盖此项。",
+      "hint": "可选择已有目录，也可新建目录。留空则自动创建默认项目目录。",
       "invalid": "无效的工作目录",
       "label": "项目工作目录",
       "pick": "选择目录",
-      "placeholder": "未设置（会话可单独覆盖）"
+      "placeholder": "未设置（将自动创建默认项目目录）"
     },
     "knowledge": {
       "label": "知识空间",

--- a/src/lib/transport-http.ts
+++ b/src/lib/transport-http.ts
@@ -1452,6 +1452,29 @@ export class HttpTransport implements Transport {
     return (await res.json()) as DirListing;
   }
 
+  async createDirectory(path: string): Promise<DirListing> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) headers["Authorization"] = `Bearer ${this.apiKey}`;
+    const res = await fetch(`${this.baseUrl}/api/filesystem/create-dir`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ path }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      this.handleAuthFailure(res.status);
+      let message = text || `create-dir failed: ${res.status}`;
+      try {
+        const parsed = JSON.parse(text) as { error?: string };
+        if (parsed?.error) message = parsed.error;
+      } catch {
+        /* text was not JSON */
+      }
+      throw new Error(message);
+    }
+    return (await res.json()) as DirListing;
+  }
+
   async exportSession(args: ExportSessionArgs): Promise<ExportSessionResult | null> {
     const url = new URL(
       `${this.baseUrl}/api/sessions/${encodeURIComponent(args.sessionId)}/export`,

--- a/src/lib/transport-tauri.ts
+++ b/src/lib/transport-tauri.ts
@@ -134,6 +134,10 @@ export class TauriTransport implements Transport {
     return invoke<DirListing>("fs_list_dir", { path: path ?? null });
   }
 
+  async createDirectory(path: string): Promise<DirListing> {
+    return invoke<DirListing>("fs_create_dir", { path });
+  }
+
   async projectFsRawUrl(
     args: ProjectFsScope & { path: string; download?: boolean },
   ): Promise<string | null> {

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -214,6 +214,13 @@ export interface Transport {
   listServerDirectory(path?: string): Promise<DirListing>;
 
   /**
+   * Create an absolute directory on the runtime machine and return its listing.
+   * In Tauri mode this is the user's local filesystem; in HTTP mode it is the
+   * server host filesystem.
+   */
+  createDirectory(path: string): Promise<DirListing>;
+
+  /**
    * Fuzzy-search files & directories under `root`. Used by the chat-input
    * `@` mention popper for tokens that don't contain a `/` (e.g. `@chat`).
    *


### PR DESCRIPTION
## Summary

- Move the project working directory selector to the top of the project dialog and remove the emoji field from the form.
- Add create-directory support to the shared directory browser, including HTTP/server mode and Tauri mode.
- Keep project default-directory auto-creation unchanged when no working directory is selected, and document the behavior in the changelog.

## Notes

HTTP directory creation is gated by the existing `filesystem.allowRemoteWrites` setting, matching the remote file-write policy.

## Validation

- `pnpm typecheck`
- `cargo check -p ha-core -p ha-server`
- pre-push hook: `cargo fmt --all --check`, `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`, `pnpm typecheck`, `pnpm lint`, `pnpm test`, `cargo test -p ha-core -p ha-server --locked`
