### PR TITLE
🦭 fix: MCP SSE 握手 / embedding 设置读取 / 消息选区复制 (#421 #423 #424)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,11 +423,11 @@ ha-core 主要领域：`agent/` `chat_engine/` `context_compact/` `memory/` `kno
 
 - **LOW**：UI 偏好、显示配额（theme / language / notification / canvas 等）
 - **MEDIUM**：行为调整，影响上下文 / 成本 / 输出质量（compact / memory_* / web_search / approval / multimodal / dreaming 等）
-- **HIGH**：安全 / 网络暴露 / 全局键位 / 凭据 / 需要重启 / 权限规则 / 审批策略 / MCP 子系统级开关（proxy / embedding / shortcuts / server / skill_env / acp_control / `permission.global_yolo` / `smart_mode` / `mcp_global` / `protected_paths` / `dangerous_commands` / `unattended_approval` / `auto_update` 等）——技能在 `update_settings` 前**必须二次确认**
+- **HIGH**：安全 / 网络暴露 / 全局键位 / 凭据 / 需要重启 / 权限规则 / 审批策略 / MCP 子系统级开关（proxy / shortcuts / server / skill_env / acp_control / `permission.global_yolo` / `smart_mode` / `mcp_global` / `protected_paths` / `dangerous_commands` / `unattended_approval` / `auto_update` 等）——技能在 `update_settings` 前**必须二次确认**（注：`embedding` 已改为只读，见下节「强制留 GUI 的例外」）
 
 ### 强制留 GUI 的例外（read-only via skill）
 
-四类不进 `update_settings`（凭据安全 + 运行时稳定性）：**Provider 列表与 API Key**、**IM Channel 账号（`channels`）**、**MCP 服务器配置（`mcp_servers`）**、**`active_model` / `fallback_models` 写入**。`get_settings` 仍可读但敏感字段 redact（`channels.accounts[*].credentials/settings`、`mcp_servers.env/headers/oauth`）。
+五类不进 `update_settings`（凭据安全 + 运行时稳定性）：**Provider 列表与 API Key**、**IM Channel 账号（`channels`）**、**MCP 服务器配置（`mcp_servers`）**、**`active_model` / `fallback_models` 写入**、**embedding 模型选择（`embedding`）——携 API Key + 重 reembed 副作用，写入走 Settings → Memory（`embedding_models` + `memory_embedding` owner 命令）**。`get_settings` 仍可读但敏感字段 redact（`channels.accounts[*].credentials/settings`、`mcp_servers.env/headers/oauth`、`embedding.apiKey`；embedding 读经 `resolve_memory_embedding_config` 解析真实启用模型）。
 
 ### 含凭据 category 的 read 脱敏（write 仍允许）
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **聊天消息可只复制选中内容**：在 AI 回复中拖拽选中部分文字后，右键复制与 `Ctrl/Cmd+C` 现在只复制所选文本而非整条消息；未选中时右键菜单仍可一键复制整条消息。 (#424)
+- **MCP SSE 传输恢复可用**：`kind: sse` 的 MCP 服务器不再被错误地按 Streamable HTTP 直连（导致 `400 session_id is required`），改为正确完成 SSE 握手（建立连接 → 取回 endpoint → 按 session 收发），并对服务器返回的 endpoint 地址二次做 SSRF 校验。此外，SSE 连接本地地址（`localhost` / 私网）时会自动绕过系统代理，避免「开代理连云端模型」时本地 MCP 被代理劫持。 (#421)
+- **技能可读取到已配置的 embedding**：`ha-settings` 技能的 `get_settings("embedding")` 不再返回全 null，改为反映设置中实际启用的 embedding 模型（API 密钥脱敏显示）；embedding 的写入统一改由设置界面管理。 (#423)
 - **聊天消息吸顶与耗时显示更准确**：用户消息悬浮吸顶不再只处理最后一条消息，会按当前可见回复体切换对应用户消息，并正确处理已处理折叠行、上下文压缩事件与长会话 DOM 裁剪；工具 / 思考耗时显示避免把同一轮耗时重复累加。聊天列表与输入框也收窄到更适合全屏阅读的最大宽度。
 - **MCP 配置编辑与热更新更可靠**：编辑 MCP server 时不再把界面中的 `<redacted>` 占位值写回覆盖真实 env / header / OAuth secret；服务名保持不可变，更新请求也不能改写已有 server id。禁用 / 重排 / 全局开关变更会即时同步到运行时，应用以 `mcpGlobal.enabled=false` 启动后再打开 MCP 也无需重启即可生效。
 - **MCP 工具目录与连接状态更稳定**：动态 MCP 工具名现在会处理 `foo-bar` / `foo.bar` 等清洗后重名的碰撞，避免工具互相覆盖；修改 URL / env / header / OAuth / 信任等级 / 并发上限后会重建连接，旧连接不会继续泄漏旧配置或把过期 catalog 写回工具索引；并发冷启动同一 MCP server 时也不会重复 spawn / handshake。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,6 +3102,7 @@ dependencies = [
  "signal-hook",
  "similar",
  "sqlite-vec",
+ "sse-stream",
  "sysinfo",
  "tar",
  "teloxide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,10 @@ uuid = { version = "1", features = ["v4"] }
 rusqlite = { version = "0.39", features = ["bundled"] }
 reqwest = { version = "0.12", features = ["json", "blocking", "stream", "native-tls", "multipart"] }
 futures-util = "0.3"
+# SSE frame parser (same crate rmcp pulls in via `client-side-sse`). Powers the
+# hand-rolled legacy MCP HTTP+SSE client transport — rmcp 1.5 dropped its own
+# standalone SSE client, so ha-core owns the handshake.
+sse-stream = "0.2"
 sha2 = "0.10"
 base64 = "0.22"
 dirs = "6"

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -24,6 +24,7 @@ uuid = { workspace = true }
 rusqlite = { workspace = true }
 reqwest = { workspace = true }
 futures-util = { workspace = true }
+sse-stream = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 # Used by the macOS desktop-updater EXDEV guard (platform::redirect_updater_tmpdir_*)

--- a/crates/ha-core/src/mcp/transport.rs
+++ b/crates/ha-core/src/mcp/transport.rs
@@ -239,6 +239,58 @@ async fn authorized_headers(cfg: &McpServerConfig) -> McpResult<HashMap<HeaderNa
     Ok(headers)
 }
 
+/// True when `host` is loopback / private / link-local, i.e. a proxy must be
+/// bypassed to reach it. Remote hosts return `false` (the proxy still applies).
+///
+/// Why: a user who runs a system / env HTTP proxy to reach remote LLM APIs will
+/// otherwise have that proxy hijack a local MCP server — `http://localhost:PORT`
+/// gets routed through the proxy, which can't dial loopback and returns a 503 /
+/// hangs. reqwest picks up the OS proxy but does NOT honor its bypass list
+/// (macOS `ExceptionsList` / `ExcludeSimpleHostnames`), so we decide the bypass
+/// ourselves from the target host. Applied on the SSE path (ha-core's own
+/// reqwest); the Streamable HTTP path is on rmcp's reqwest and can't share it.
+fn host_bypasses_proxy(host: &str) -> bool {
+    use std::net::IpAddr;
+    // `url::Host` never yields brackets, but strip them defensively.
+    let bare = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    let lower = bare.to_ascii_lowercase();
+    if lower == "localhost" || lower.ends_with(".localhost") {
+        return true;
+    }
+    match bare.parse::<IpAddr>() {
+        Ok(IpAddr::V4(v4)) => v4.is_loopback() || v4.is_private() || v4.is_link_local(),
+        Ok(IpAddr::V6(v6)) => {
+            v6.is_loopback() || v6.is_unique_local() || v6.is_unicast_link_local()
+        }
+        // A resolvable remote hostname — keep the proxy (it may be how the user
+        // reaches the outside world). SSRF classification stays the security
+        // boundary; this only decides proxy routing.
+        Err(_) => false,
+    }
+}
+
+/// Build the reqwest client for the hand-rolled SSE transport. Mirrors rmcp's
+/// default client (`pool_max_idle_per_host(0)` to dodge TCP Delayed-ACK stalls)
+/// and additionally bypasses the system / env proxy when the target host is
+/// loopback / private (see [`host_bypasses_proxy`]).
+fn build_mcp_http_client(target_url: &str, server_name: &str) -> McpResult<reqwest::Client> {
+    let mut builder = reqwest::Client::builder().pool_max_idle_per_host(0);
+    let bypass_proxy = url::Url::parse(target_url)
+        .ok()
+        .and_then(|u| u.host_str().map(host_bypasses_proxy))
+        .unwrap_or(false);
+    if bypass_proxy {
+        builder = builder.no_proxy();
+    }
+    builder.build().map_err(|e| McpError::Transport {
+        server: server_name.to_string(),
+        source: format!("failed to build MCP HTTP client: {e}"),
+    })
+}
+
 /// Classify a networked-transport error as `Auth` vs `Transport` using
 /// [`is_auth_challenge`]. The `verb` is the user-visible slice of the
 /// error message that names the phase that failed (e.g. `"handshake"`
@@ -269,6 +321,13 @@ pub async fn build_http_client(cfg: &McpServerConfig, url: &str) -> McpResult<Co
     ssrf_gate_url(cfg, &expanded_url).await?;
     let headers = authorized_headers(cfg).await?;
 
+    // NOTE: this path uses rmcp's own reqwest (0.13) client via `from_config`.
+    // We can't inject a proxy-bypassing client here the way `build_sse_client`
+    // does (ha-core is on reqwest 0.12; rmcp's `StreamableHttpClient` is impl'd
+    // only for its 0.13 `reqwest::Client`, and rmcp exposes no proxy knob), so a
+    // system proxy set for remote APIs can still hijack a *local* Streamable HTTP
+    // MCP server. Local MCP is overwhelmingly stdio / SSE, so this is left as a
+    // known limitation rather than pulling a second reqwest major into ha-core.
     let http_cfg =
         StreamableHttpClientTransportConfig::with_uri(expanded_url).custom_headers(headers);
     let transport = StreamableHttpClientTransport::from_config(http_cfg);
@@ -501,6 +560,188 @@ fn ws_to_http_equiv(url: &str) -> McpResult<String> {
     Ok(parsed.to_string())
 }
 
+/// Resolve the server-provided SSE `endpoint` value against the SSE base URL.
+/// The endpoint is usually a relative path carrying `?session_id=…`; absolute
+/// URLs are honored as-is. Extracted as a pure function so the resolution +
+/// same-origin behavior is unit-testable without real sockets.
+fn resolve_sse_endpoint(base_url: &str, endpoint: &str, server_name: &str) -> McpResult<url::Url> {
+    let base = url::Url::parse(base_url).map_err(|e| {
+        McpError::Config(format!("invalid SSE URL for server '{server_name}': {e}"))
+    })?;
+    base.join(endpoint.trim()).map_err(|e| McpError::Transport {
+        server: server_name.to_string(),
+        source: format!("SSE server returned an unresolvable endpoint '{endpoint}': {e}"),
+    })
+}
+
+/// Build a legacy MCP HTTP+SSE (2024-11-05 spec) client and complete the
+/// handshake. This is a DIFFERENT wire protocol from Streamable HTTP: the
+/// client GETs the SSE URL, the server replies with an `endpoint` event whose
+/// data is a session-scoped POST URL, and JSON-RPC then flows client→server via
+/// POST to that URL and server→client over the open SSE `message` stream.
+///
+/// rmcp 1.5 retired its standalone SSE client (only the `client-side-sse` frame
+/// parser remains), and routing `Sse` through the Streamable HTTP client fails
+/// because that client POSTs `initialize` directly and the legacy server rejects
+/// it with `400 session_id is required`. So we hand-roll the handshake and
+/// bridge it into rmcp's generic `(Sink, Stream)` serve path — exactly like
+/// `build_ws_client`.
+///
+/// SSRF is enforced twice: on the GET URL, and again on the server-provided
+/// `endpoint` URL before the first POST (server-controlled data is a fresh
+/// outbound surface the GET gate never saw).
+pub async fn build_sse_client(cfg: &McpServerConfig, url: &str) -> McpResult<ConnectedClient> {
+    use futures_util::StreamExt;
+    use sse_stream::SseStream;
+
+    let expanded_url = expand_placeholders(url, |name| std::env::var(name).ok());
+    // SSRF gate #1: the GET URL, before any dial.
+    ssrf_gate_url(cfg, &expanded_url).await?;
+
+    // One reqwest client shared by the long-lived GET stream and the outbound
+    // POSTs. Auth headers (OAuth Bearer / user-pinned) are shared by both.
+    // `build_mcp_http_client` bypasses the system proxy for loopback / private
+    // targets so a proxy set for remote APIs can't hijack a local SSE server.
+    let auth_headers = authorized_headers(cfg).await?;
+    let mut header_map = reqwest::header::HeaderMap::with_capacity(auth_headers.len() + 1);
+    for (name, value) in auth_headers {
+        header_map.insert(name, value);
+    }
+    let client = build_mcp_http_client(&expanded_url, &cfg.name)?;
+
+    // 1) Open the SSE stream.
+    let response = client
+        .get(&expanded_url)
+        .headers(header_map.clone())
+        .header(reqwest::header::ACCEPT, "text/event-stream")
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(|e| classify_network_error(&cfg.name, "SSE handshake", e))?;
+
+    // Box-pin the `!Unpin` parser so it can be driven by `.next()` here and then
+    // handed to `filter_map` without pin plumbing leaking into the Stream half.
+    let mut sse = Box::pin(SseStream::from_byte_stream(response.bytes_stream()));
+
+    // 2) Read up to the `endpoint` event to learn the session-scoped POST URL.
+    //    The whole handshake runs under `do_connect`'s connect_timeout, so a
+    //    server that never sends `endpoint` surfaces as a Timeout, not a hang.
+    let endpoint_data = loop {
+        match sse.next().await {
+            Some(Ok(frame)) if frame.event.as_deref() == Some("endpoint") => {
+                break frame.data.unwrap_or_default();
+            }
+            // Keep-alive comments / other pre-handshake frames: ignore and wait.
+            Some(Ok(_)) => continue,
+            Some(Err(e)) => {
+                return Err(McpError::Transport {
+                    server: cfg.name.clone(),
+                    source: format!("SSE handshake failed reading endpoint event: {e}"),
+                })
+            }
+            None => {
+                return Err(McpError::Transport {
+                    server: cfg.name.clone(),
+                    source: "SSE stream closed before sending an endpoint event".into(),
+                })
+            }
+        }
+    };
+
+    // 3) Resolve the endpoint (usually relative) against the SSE base, then SSRF
+    //    gate #2 — the endpoint is server-controlled and could point at an
+    //    internal host the GET gate never vetted.
+    let endpoint = resolve_sse_endpoint(&expanded_url, &endpoint_data, &cfg.name)?;
+    ssrf_gate_url(cfg, endpoint.as_str()).await?;
+    let endpoint = endpoint.to_string();
+
+    // 4) Stream half (server→client): remaining SSE `message` frames parsed as
+    //    JSON-RPC. Non-message frames (later endpoint pings, comments) are dropped.
+    let stream_server = cfg.name.clone();
+    let stream = sse.filter_map(move |frame| {
+        let server = stream_server.clone();
+        async move {
+            let frame = frame.ok()?;
+            // Per the SSE spec a missing / empty `event:` field defaults to "message".
+            if !matches!(frame.event.as_deref(), None | Some("") | Some("message")) {
+                return None;
+            }
+            let data = frame.data?;
+            match serde_json::from_str::<rmcp::service::RxJsonRpcMessage<RoleClient>>(&data) {
+                Ok(message) => Some(message),
+                Err(e) => {
+                    crate::app_warn!(
+                        "mcp",
+                        &format!("{server}:sse"),
+                        "dropping unparseable SSE message frame: {e}"
+                    );
+                    None
+                }
+            }
+        }
+    });
+    let stream: std::pin::Pin<
+        Box<dyn futures_util::Stream<Item = rmcp::service::RxJsonRpcMessage<RoleClient>> + Send>,
+    > = Box::pin(stream);
+
+    // 5) Sink half (client→server): each JSON-RPC message is POSTed to the
+    //    session endpoint. `Sink::start_send` is sync but the POST is async, so
+    //    route through a bounded channel drained by a background task and expose
+    //    the sender as a `Sink` via `PollSender` (natural backpressure). The task
+    //    exits when the sink is dropped (rmcp closing the transport).
+    let (tx, mut rx) =
+        tokio::sync::mpsc::channel::<rmcp::service::TxJsonRpcMessage<RoleClient>>(64);
+    let post_client = client;
+    let post_headers = header_map;
+    let post_server = cfg.name.clone();
+    tokio::spawn(async move {
+        while let Some(message) = rx.recv().await {
+            let body = match serde_json::to_vec(&message) {
+                Ok(body) => body,
+                Err(e) => {
+                    crate::app_warn!(
+                        "mcp",
+                        &format!("{post_server}:sse"),
+                        "failed to serialize outbound SSE message: {e}"
+                    );
+                    continue;
+                }
+            };
+            let result = post_client
+                .post(&endpoint)
+                .headers(post_headers.clone())
+                .header(reqwest::header::CONTENT_TYPE, "application/json")
+                .body(body)
+                .send()
+                .await;
+            match result {
+                Ok(response) if response.status().is_success() => {}
+                Ok(response) => crate::app_warn!(
+                    "mcp",
+                    &format!("{post_server}:sse"),
+                    "SSE message POST rejected with HTTP {}",
+                    response.status()
+                ),
+                Err(e) => crate::app_warn!(
+                    "mcp",
+                    &format!("{post_server}:sse"),
+                    "SSE message POST failed: {e}"
+                ),
+            }
+        }
+    });
+    let sink = tokio_util::sync::PollSender::new(tx);
+
+    let running = ()
+        .serve((sink, stream))
+        .await
+        .map_err(|e| classify_network_error(&cfg.name, "SSE handshake", e))?;
+    Ok(ConnectedClient {
+        running,
+        stderr: None,
+    })
+}
+
 /// Entry point used by `client::do_connect`. Dispatches on the transport
 /// kind, runs any gating policy (SSRF), constructs the appropriate
 /// rmcp transport, and returns a connected client ready for
@@ -509,20 +750,7 @@ pub async fn build_transport_for(cfg: &McpServerConfig) -> McpResult<ConnectedCl
     match &cfg.transport {
         McpTransportSpec::Stdio { .. } => build_stdio_client(cfg).await,
         McpTransportSpec::StreamableHttp { url } => build_http_client(cfg, url).await,
-        McpTransportSpec::Sse { url } => {
-            // rmcp 1.5 retired the standalone SSE client; Streamable HTTP
-            // speaks the same SSE sub-protocol on its GET channel, so we
-            // route legacy `Sse` entries through that. Servers that
-            // strictly require the old SSE-only transport need a rebuild
-            // or a newer server version.
-            crate::app_warn!(
-                "mcp",
-                &format!("{}:transport", cfg.name),
-                "Legacy SSE transport routed through Streamable HTTP; \
-                 update the server to the 2025-03-26 spec if behavior differs"
-            );
-            build_http_client(cfg, url).await
-        }
+        McpTransportSpec::Sse { url } => build_sse_client(cfg, url).await,
         McpTransportSpec::WebSocket { url } => build_ws_client(cfg, url).await,
     }
 }
@@ -644,6 +872,97 @@ mod tests {
             Err(McpError::Blocked { .. }) => {}
             Err(other) => panic!("expected Blocked, got: {other:?}"),
             Ok(_) => panic!("expected Blocked for private URL under Strict policy"),
+        }
+    }
+
+    #[tokio::test]
+    async fn sse_transport_honors_ssrf_policy() {
+        // Untrusted + private-network SSE GET URL → Blocked, before any dial.
+        // The server-provided endpoint is re-gated separately (integration),
+        // but the GET URL must be gated up front like HTTP/WS.
+        let mut cfg = stdio_cfg("echo");
+        cfg.transport = McpTransportSpec::Sse {
+            url: "http://127.0.0.1:9999/sse".into(),
+        };
+        cfg.trust_level = McpTrustLevel::Untrusted;
+        match build_transport_for(&cfg).await {
+            Err(McpError::Blocked { .. }) => {}
+            Err(other) => panic!("expected Blocked, got: {other:?}"),
+            Ok(_) => panic!("expected Blocked for private SSE URL under Strict policy"),
+        }
+    }
+
+    #[test]
+    fn resolve_sse_endpoint_relative_and_absolute() {
+        // Relative endpoint (the common shape) keeps the base origin + carries
+        // the session_id query the legacy handshake mints.
+        let resolved =
+            resolve_sse_endpoint("https://host.example/sse", "/messages?session_id=abc", "t")
+                .unwrap();
+        assert_eq!(
+            resolved.as_str(),
+            "https://host.example/messages?session_id=abc"
+        );
+
+        // Relative without a leading slash resolves against the base path dir.
+        let resolved =
+            resolve_sse_endpoint("https://host.example/mcp/sse", "message?session_id=x", "t")
+                .unwrap();
+        assert_eq!(
+            resolved.as_str(),
+            "https://host.example/mcp/message?session_id=x"
+        );
+
+        // An absolute endpoint is honored verbatim (it is still SSRF re-gated
+        // by the caller before any POST).
+        let resolved = resolve_sse_endpoint(
+            "https://host.example/sse",
+            "https://other.example/inbox?session_id=z",
+            "t",
+        )
+        .unwrap();
+        assert_eq!(
+            resolved.as_str(),
+            "https://other.example/inbox?session_id=z"
+        );
+    }
+
+    #[test]
+    fn host_bypasses_proxy_covers_loopback_and_private() {
+        // Loopback / localhost → bypass the proxy (local MCP servers).
+        for host in [
+            "localhost",
+            "app.localhost",
+            "LOCALHOST",
+            "127.0.0.1",
+            "127.1.2.3",
+            "::1",
+            "[::1]",
+        ] {
+            assert!(host_bypasses_proxy(host), "{host} should bypass proxy");
+        }
+        // Private / link-local ranges (LAN MCP servers) → bypass.
+        for host in [
+            "10.0.0.5",
+            "192.168.1.20",
+            "172.16.0.1",
+            "172.31.255.254",
+            "169.254.1.1",
+            "fd00::1", // unique-local IPv6
+            "fe80::1", // link-local IPv6
+        ] {
+            assert!(host_bypasses_proxy(host), "{host} should bypass proxy");
+        }
+        // Public hosts → keep the proxy (it may be how the user reaches them).
+        for host in [
+            "example.com",
+            "api.openai.com",
+            "8.8.8.8",
+            "1.1.1.1",
+            "172.32.0.1",   // just outside 172.16/12
+            "2606:4700::1", // public IPv6
+        ] {
+            assert!(!host_bypasses_proxy(host), "{host} should keep proxy");
         }
     }
 }

--- a/crates/ha-core/src/mcp/transport.rs
+++ b/crates/ha-core/src/mcp/transport.rs
@@ -277,7 +277,17 @@ fn host_bypasses_proxy(host: &str) -> bool {
 /// and additionally bypasses the system / env proxy when the target host is
 /// loopback / private (see [`host_bypasses_proxy`]).
 fn build_mcp_http_client(target_url: &str, server_name: &str) -> McpResult<reqwest::Client> {
-    let mut builder = reqwest::Client::builder().pool_max_idle_per_host(0);
+    let mut builder = reqwest::Client::builder()
+        .pool_max_idle_per_host(0)
+        // Do NOT follow redirects. The SSRF gate only validates the pre-redirect
+        // URL (the GET target and the server-provided POST endpoint), so a 30x
+        // would let an untrusted server bounce the handshake / POST to a
+        // loopback / link-local / metadata host the gate never saw. reqwest's
+        // redirect callback is sync and can't re-run the async DNS-resolving
+        // `check_url`, so the safe move is to not follow at all — a redirect is
+        // surfaced as an error instead (mirrors the WebSocket transport, which
+        // also never follows redirects).
+        .redirect(reqwest::redirect::Policy::none());
     let bypass_proxy = url::Url::parse(target_url)
         .ok()
         .and_then(|u| u.host_str().map(host_bypasses_proxy))
@@ -618,6 +628,19 @@ pub async fn build_sse_client(cfg: &McpServerConfig, url: &str) -> McpResult<Con
         .await
         .and_then(reqwest::Response::error_for_status)
         .map_err(|e| classify_network_error(&cfg.name, "SSE handshake", e))?;
+
+    // Redirects are disabled on the client (SSRF: a 30x could bounce to an
+    // internal host the gate never validated). `error_for_status` ignores 3xx,
+    // so reject it explicitly rather than parsing an empty redirect body.
+    if response.status().is_redirection() {
+        return Err(McpError::Transport {
+            server: cfg.name.clone(),
+            source: format!(
+                "SSE endpoint returned a redirect ({}); redirects are not followed",
+                response.status()
+            ),
+        });
+    }
 
     // Box-pin the `!Unpin` parser so it can be driven by `.next()` here and then
     // handed to `filter_map` without pin plumbing leaking into the Stream half.

--- a/crates/ha-core/src/tools/definitions/core_tools.rs
+++ b/crates/ha-core/src/tools/definitions/core_tools.rs
@@ -1616,14 +1616,14 @@ pub fn get_available_tools() -> Vec<ToolDefinition> {
                 "properties": {
                     "category": {
                         "type": "string",
-                        "description": "Update application settings for a category. HIGH-risk: proxy, embedding, shortcuts, skills, server, acp_control, skill_env, security, security.ssrf, smart_mode, mcp_global, knowledge_maintenance, knowledge_media_retention, unattended_approval, auto_update, browser — require explicit user confirmation first. `browser` gates whether the agent drives the user's real logged-in Chrome (extension backend) and toggles the raw-CDP escape hatch (extension.allowRawCdp). `knowledge_media_retention` can persist private original audio/video/image files on disk. `security` toggles the global dangerous-mode switch that skips ALL tool approvals; `smart_mode` reshapes which tool calls auto-approve; `mcp_global` is the MCP subsystem kill switch; `unattended_approval` decides whether approvals with no human surface (cron / headless / ACP / subagent) auto-deny or auto-proceed.",
+                        "description": "Update application settings for a category. HIGH-risk: proxy, shortcuts, skills, server, acp_control, skill_env, security, security.ssrf, smart_mode, mcp_global, knowledge_maintenance, knowledge_media_retention, unattended_approval, auto_update, browser — require explicit user confirmation first. `browser` gates whether the agent drives the user's real logged-in Chrome (extension backend) and toggles the raw-CDP escape hatch (extension.allowRawCdp). `knowledge_media_retention` can persist private original audio/video/image files on disk. `security` toggles the global dangerous-mode switch that skips ALL tool approvals; `smart_mode` reshapes which tool calls auto-approve; `mcp_global` is the MCP subsystem kill switch; `unattended_approval` decides whether approvals with no human surface (cron / headless / ACP / subagent) auto-deny or auto-proceed.",
                         "enum": [
                             "user", "theme", "language", "ui_effects", "prevent_sleep", "sidebar_ui", "proxy",
                             "web_search", "web_fetch", "browser", "compact", "session_title", "notification", "startup_notification",
                             "temperature", "tool_timeout", "timeout_policy", "approval", "unattended_approval",
                             "image_generate", "canvas", "image", "pdf",
                             "async_tools", "cron", "deferred_tools",
-                            "memory_extract", "memory_selection", "memory_budget", "embedding",
+                            "memory_extract", "memory_selection", "memory_budget",
                             "embedding_cache", "dedup", "hybrid_search",
                             "temporal_decay", "mmr", "multimodal", "dreaming", "knowledge_maintenance",
                             "knowledge_media_retention", "knowledge_passive_recall", "knowledge_search", "sprite",

--- a/crates/ha-core/src/tools/settings.rs
+++ b/crates/ha-core/src/tools/settings.rs
@@ -31,6 +31,13 @@ const BLOCKED_UPDATE_CATEGORIES: &[&str] = &[
     "stt_providers",
     "active_stt_model",
     "stt_fallback_models",
+    // Embedding — the active model selection carries an API key and a heavy
+    // background reembed side effect (same class as `active_model` /
+    // `memory_embedding` / `knowledge_embedding`, which are already GUI-only).
+    // The real config lives in `embedding_models` + `memory_embedding`; the
+    // legacy `cfg.embedding` write sink was a silent no-op. Read is repointed at
+    // the resolved config (redacted); writes go through Settings → Memory.
+    "embedding",
 ];
 
 /// Risk classification for a settings category.
@@ -94,7 +101,7 @@ fn risk_level(category: &str) -> &'static str {
         | "sprite" => "medium",
 
         // ── HIGH ───────────────────────────────────────────────
-        "proxy" | "embedding" | "shortcuts" | "skills" | "server" | "acp_control" | "skill_env"
+        "proxy" | "shortcuts" | "skills" | "server" | "acp_control" | "skill_env"
         | "security" | "security.ssrf" | "smart_mode" | "mcp_global" | "filesystem"
         // Browser backend: extension.enabled / backendPreference gate whether the
         // agent can drive the user's real logged-in Chrome; allowRawCdp toggles
@@ -113,12 +120,13 @@ fn risk_level(category: &str) -> &'static str {
         | "auto_update" => "high",
 
         // Read-only categories — no risk since they can't be mutated here.
-        // `channels` and `mcp_servers` are categorized "low" for read because
-        // the response is redacted before it reaches the model.
+        // `channels` / `mcp_servers` / `embedding` are categorized "low" for
+        // read because the response is redacted before it reaches the model.
         "active_model"
         | "fallback_models"
         | "channels"
         | "mcp_servers"
+        | "embedding"
         | "hooks"
         | "stt_providers"
         | "active_stt_model"
@@ -402,6 +410,35 @@ fn redact_server_value(mut value: Value) -> Value {
     value
 }
 
+/// Redact the API keys from a resolved `EmbeddingConfig` JSON tree. The
+/// provider / base URL / model / dimensions stay visible so the model can
+/// describe which embedding backend is active, but the credentials never enter
+/// conversation history. `fallbackApiKey` is masked defensively even though the
+/// resolved memory config currently leaves the fallback fields unset.
+fn redact_embedding_value(mut value: Value) -> Value {
+    if let Some(obj) = value.as_object_mut() {
+        redact_string_field(obj, "apiKey");
+        redact_string_field(obj, "fallbackApiKey");
+    }
+    value
+}
+
+/// Resolve the `embedding` read category from the single source of truth
+/// (`embedding_models` + `memory_embedding` selection) the GUI actually writes
+/// and runtime provider init reads — NOT the deprecated `cfg.embedding` sink,
+/// which is `skip_serializing` and never populated (the cause of #423). Mirrors
+/// the Tauri `get_embedding_config` command, then redacts the API key. A
+/// disabled / unresolved selection resolves to a clean default (enabled=false)
+/// so the skill reads cleanly when embedding is off.
+fn read_embedding_from(
+    selection: &crate::memory::EmbeddingSelection,
+    models: &[crate::memory::EmbeddingModelConfig],
+) -> Result<Value> {
+    let resolved = crate::memory::resolve_memory_embedding_config(selection, models)?;
+    let config = resolved.map(|(_, c, _)| c).unwrap_or_default();
+    Ok(redact_embedding_value(serde_json::to_value(&config)?))
+}
+
 /// Redact `backends[*].env` from an `AcpControlConfig` JSON tree — env vars
 /// frequently contain `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / similar.
 fn redact_acp_control_value(mut value: Value) -> Value {
@@ -499,7 +536,7 @@ fn read_category(category: &str) -> Result<Value> {
         "memory_extract" => Ok(serde_json::to_value(&cfg.memory_extract)?),
         "memory_selection" => Ok(serde_json::to_value(&cfg.memory_selection)?),
         "memory_budget" => Ok(serde_json::to_value(&cfg.memory_budget)?),
-        "embedding" => Ok(serde_json::to_value(&cfg.embedding)?),
+        "embedding" => read_embedding_from(&cfg.memory_embedding, &cfg.embedding_models),
         "embedding_cache" => Ok(serde_json::to_value(&cfg.embedding_cache)?),
         "dedup" => Ok(serde_json::to_value(&cfg.dedup)?),
         "hybrid_search" => Ok(serde_json::to_value(&cfg.hybrid_search)?),
@@ -714,13 +751,13 @@ fn get_all_overview() -> Result<String> {
             "teams", "im_auto_transcribe", "knowledge_passive_recall", "knowledge_search", "sprite"
         ],
         "high": [
-            "proxy", "embedding", "shortcuts", "skills", "server",
+            "proxy", "shortcuts", "skills", "server",
             "acp_control", "skill_env", "security", "security.ssrf",
             "smart_mode", "mcp_global", "knowledge_maintenance", "knowledge_media_retention", "unattended_approval", "auto_update",
             "browser"
         ],
         "read_only": [
-            "active_model", "fallback_models", "channels", "mcp_servers",
+            "active_model", "fallback_models", "channels", "mcp_servers", "embedding",
             "stt_providers", "active_stt_model", "stt_fallback_models"
         ],
     });
@@ -965,7 +1002,9 @@ async fn update_app_config(category: &str, values: &Value) -> Result<String> {
         "memory_extract" => merge_field(&mut store.memory_extract, values)?,
         "memory_selection" => merge_field(&mut store.memory_selection, values)?,
         "memory_budget" => merge_field(&mut store.memory_budget, values)?,
-        "embedding" => merge_field(&mut store.embedding, values)?,
+        // `embedding` is read-only (BLOCKED_UPDATE_CATEGORIES): the real config
+        // lives in `embedding_models` + `memory_embedding`, and this legacy sink
+        // is `skip_serializing`, so a write here never persisted. Reject earlier.
         "embedding_cache" => merge_field(&mut store.embedding_cache, values)?,
         "dedup" => merge_field(&mut store.dedup, values)?,
         "hybrid_search" => merge_field(&mut store.hybrid_search, values)?,
@@ -1134,7 +1173,7 @@ async fn update_app_config(category: &str, values: &Value) -> Result<String> {
     }
 
     // Backend hot-reload: trigger side-effects for categories that cache state
-    trigger_backend_hot_reload(category, &store).await?;
+    trigger_backend_hot_reload(category).await?;
 
     // Return the saved value directly from the mutated store (avoids re-reading cache)
     let updated_value = read_category(category)?;
@@ -1203,40 +1242,11 @@ fn update_team_templates(values: &Value) -> Result<String> {
 }
 
 /// Trigger backend hot-reload side-effects for categories that cache state in memory.
-async fn trigger_backend_hot_reload(category: &str, store: &config::AppConfig) -> Result<()> {
+async fn trigger_backend_hot_reload(category: &str) -> Result<()> {
     match category {
-        "embedding" => {
-            // Re-initialize embedding provider when config changes
-            if let Some(backend) = crate::get_memory_backend() {
-                if store.embedding.enabled {
-                    match crate::memory::create_embedding_provider(&store.embedding) {
-                        Ok(provider) => {
-                            backend.set_embedder(provider);
-                            app_info!(
-                                "settings",
-                                "hot_reload",
-                                "Embedding provider re-initialized after config change"
-                            );
-                        }
-                        Err(e) => {
-                            app_warn!(
-                                "settings",
-                                "hot_reload",
-                                "Failed to re-initialize embedding provider: {}",
-                                e
-                            );
-                        }
-                    }
-                } else {
-                    backend.clear_embedder();
-                    app_info!(
-                        "settings",
-                        "hot_reload",
-                        "Embedding provider cleared (disabled)"
-                    );
-                }
-            }
-        }
+        // `embedding` writes are blocked here; its provider hot-reload is owned
+        // by the GUI-only owner commands (`memory_embedding_set_default`), so no
+        // reload branch is needed on this path.
         "web_search" => {
             // SearXNG config may affect Docker container — no cached state to invalidate,
             // but weather system may use web search indirectly. No action needed.
@@ -1357,7 +1367,6 @@ mod tests {
     fn risk_level_high_categories() {
         for cat in [
             "proxy",
-            "embedding",
             "shortcuts",
             "skills",
             "server",
@@ -1386,19 +1395,78 @@ mod tests {
         // Read-only categories report `low` because the model cannot mutate them
         // through this tool — the BLOCKED_UPDATE_CATEGORIES check rejects writes
         // before risk_level is even consulted.
-        for cat in ["active_model", "fallback_models", "channels", "mcp_servers"] {
+        for cat in [
+            "active_model",
+            "fallback_models",
+            "channels",
+            "mcp_servers",
+            "embedding",
+        ] {
             assert_eq!(risk_level(cat), "low", "{cat} should be low (read-only)");
         }
     }
 
     #[test]
     fn blocked_update_includes_channels_and_mcp_servers() {
-        for cat in ["active_model", "fallback_models", "channels", "mcp_servers"] {
+        for cat in [
+            "active_model",
+            "fallback_models",
+            "channels",
+            "mcp_servers",
+            "embedding",
+        ] {
             assert!(
                 BLOCKED_UPDATE_CATEGORIES.contains(&cat),
                 "{cat} must be in BLOCKED_UPDATE_CATEGORIES"
             );
         }
+    }
+
+    #[test]
+    fn read_embedding_resolves_configured_model_and_redacts_key() {
+        use crate::memory::{EmbeddingModelConfig, EmbeddingProviderType, EmbeddingSelection};
+
+        // Reproduces #423: the GUI configures embedding through
+        // `embedding_models` + `memory_embedding`, not the deprecated
+        // `cfg.embedding` sink. The read arm must resolve the real config and
+        // redact the key. This tests `read_embedding_from` directly so it does
+        // not depend on global `cached_config()` state.
+        let models = vec![EmbeddingModelConfig {
+            id: "m1".into(),
+            name: "OpenAI small".into(),
+            provider_type: EmbeddingProviderType::OpenaiCompatible,
+            api_base_url: Some("https://api.openai.com".into()),
+            api_key: Some("sk-secret".into()),
+            api_model: Some("text-embedding-3-small".into()),
+            api_dimensions: Some(1536),
+            source: None,
+        }];
+        let selection = EmbeddingSelection {
+            enabled: true,
+            model_config_id: Some("m1".into()),
+            active_signature: None,
+            last_reembedded_signature: None,
+        };
+
+        let value = read_embedding_from(&selection, &models).expect("resolve embedding");
+        assert_eq!(value["enabled"], serde_json::json!(true));
+        assert_eq!(
+            value["apiBaseUrl"],
+            serde_json::json!("https://api.openai.com")
+        );
+        assert_eq!(
+            value["apiModel"],
+            serde_json::json!("text-embedding-3-small")
+        );
+        assert_eq!(value["apiDimensions"], serde_json::json!(1536));
+        // The key is masked, never echoed raw, and never null when configured.
+        assert_eq!(value["apiKey"], serde_json::json!("[REDACTED]"));
+
+        // Disabled selection resolves to a clean default (enabled=false), no error.
+        let off = EmbeddingSelection::default();
+        let value = read_embedding_from(&off, &models).expect("resolve disabled embedding");
+        assert_eq!(value["enabled"], serde_json::json!(false));
+        assert_eq!(value["apiKey"], Value::Null);
     }
 
     #[test]

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -372,7 +372,8 @@ stdio server 是任意 binary，潜在命令执行入口：
 
 ### redirect 处理
 
-- **HTTP / SSE**：reqwest `redirect::limited(5)`；每跳不重跑 SSRF（已知 gap，和其它 HTTP 客户端路径一致）
+- **SSE**：`build_mcp_http_client` 用 `redirect::Policy::none()` **不跟 redirect**——SSRF 只校验了 pre-redirect 的 GET URL 与 server 返回的 endpoint，30x 可绕过 gate 弹到内网；reqwest 的 redirect 回调是同步的、跑不了异步 DNS 解析的 `check_url`，故直接不跟（GET 拿到 3xx 显式报错）。与 WebSocket 一致
+- **Streamable HTTP**：走 rmcp 自带 reqwest client（default redirect），每跳不重跑 SSRF（**已知 gap**——ha-core 无法配置 rmcp 内部 client 的 redirect policy，见上文「代理绕行」同源的 0.12/0.13 版本墙）
 - **WebSocket**：`connect_async` **不**跟 HTTP redirect — RFC 6455 要求 101 Switching Protocols，3xx 直接算 handshake 失败，所以单次 SSRF 覆盖了全部 dial-out
 
 ---

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -31,7 +31,7 @@ MCP 客户端把 hope-agent 变成一个 **MCP Host**——就像 Claude Desktop
 
 设计范围覆盖：
 
-- **四种 transport**：stdio、Streamable HTTP、SSE（走 Streamable HTTP 的 SSE 子协议）、WebSocket
+- **四种 transport**：stdio、Streamable HTTP、SSE（legacy HTTP+SSE handshake，`build_sse_client` 手写）、WebSocket
 - **完整 OAuth 2.1 + PKCE**：discovery（RFC 8414）、Dynamic Client Registration（RFC 7591）、loopback callback（RFC 8252）、refresh 自动执行
 - **凭据安全**：0600 原子写 + ErrorKind::NotFound 无 TOCTOU；删除 server 自动清理
 - **三种使用形态**：MCP 工具通过 `mcp__<server>__<tool>` 命名空间调度；`mcp_resource(action=list|read)` / `mcp_prompt(action=list|get)` 作为独立 internal tool 访问被动数据
@@ -132,10 +132,19 @@ stateDiagram-v2
 
 ### Streamable HTTP
 
-- rmcp 1.5 首选的远程协议；SSE 从 rmcp 1.5 起退役，`McpTransportSpec::Sse` 路由到同一 client（带一次 warn 日志）
+- rmcp 1.5 首选的远程协议（2025-03-26 spec）：直接 POST `initialize`，session 走 `Mcp-Session-Id` 响应头
 - 出站前 `ssrf_gate_url` — `Trusted` 用 `default_policy`，`Untrusted` 用 `Strict`
 - `authorized_headers` 注入 user headers + OAuth Bearer（若 `cfg.oauth.is_some()` 且磁盘有凭据且用户未显式设 `Authorization`）
 - handshake 401/403/unauthorized/invalid_token → `McpError::Auth` → `ServerState::NeedsAuth`
+
+### SSE（legacy HTTP+SSE，2024-11-05 spec）
+
+- **与 Streamable HTTP 是两套 wire 协议**：rmcp 1.5 退役了独立 SSE client（只留 `client-side-sse` 帧解析器），但 `Sse` **不能**路由到 Streamable HTTP client——后者直接 POST `initialize`，legacy SSE server 无 session 会回 `400 session_id is required`
+- `build_sse_client` 手写握手：GET SSE URL → 读到 `endpoint` 事件拿 session-scoped POST URL → 之后 client→server 走 POST 到该 URL、server→client 走 SSE `message` 帧；用 `sse-stream` 解析帧，桥接到 rmcp 的 `IntoTransport for (Si, St)`（Stream 半 = `message` 帧 → `RxJsonRpcMessage`；Sink 半 = `PollSender` + 后台 POST 任务，`start_send` 同步 / POST 异步）
+- **SSRF 两道门（红线）**：① GET URL 出站前 `ssrf_gate_url`；② server 返回的 `endpoint` URL 是 server-controlled、首次 POST 前经 `resolve_sse_endpoint`（相对路径按 base 解析）后**再过一次** `ssrf_gate_url`——防恶意 server 把 POST 引到内网
+- handshake 错误经 `classify_network_error(cfg_name, "SSE handshake", e)`，401/403 → `Auth` → `NeedsAuth`
+- 整个握手在 `do_connect` 的 `connect_timeout_secs` 内：server 不发 `endpoint` 就超时（`Timeout`），不会挂死
+- **代理绕行（loopback/私网）**：reqwest 会抓系统/环境代理但**不遵守 OS bypass 列表**（macOS `ExceptionsList` / `ExcludeSimpleHostnames`），导致「开代理连云端 LLM」时本地 MCP（`http://localhost:PORT`）被代理劫持 → 503。`build_mcp_http_client` 按 `host_bypasses_proxy(host)`（`localhost`/`*.localhost` + IPv4 loopback/private/link-local + IPv6 loopback/ULA/link-local）对本地目标 `.no_proxy()`，远程目标仍走代理。**仅 SSE 路径**——Streamable HTTP 走 rmcp 自带 reqwest（0.13，ha-core 是 0.12），无注入点，本地 Streamable HTTP + 代理仍会被劫持（已知限制，本地 MCP 绝大多数是 stdio / SSE，不为此引入第二个 reqwest 大版本）
 
 ### WebSocket
 
@@ -338,6 +347,7 @@ struct McpCredentials {
 | 出站点 | Policy | 备注 |
 |---|---|---|
 | HTTP / SSE transport handshake | `Trusted` → `default_policy`; `Untrusted` → `Strict` | `check_url` 失败 → `McpError::Blocked` |
+| SSE server-provided `endpoint` URL | 同上 | server-controlled，首次 POST 前 `resolve_sse_endpoint` + **再过一次** `check_url`（红线） |
 | WebSocket handshake | 同上 | ws→http / wss→https 重写给 `check_url` 理解 |
 | OAuth discovery / DCR / token / refresh | **固定 `Default`** | OAuth server 必然是公网，`Strict` 会误伤；metadata IP 仍拒 |
 | stdio transport | 不涉网络 | 跳过 SSRF |

--- a/skills/ha-settings/SKILL.md
+++ b/skills/ha-settings/SKILL.md
@@ -111,7 +111,6 @@ If the response includes `sideEffect`, surface it to the user (e.g. "this requir
 | Category | Fields | Why high risk |
 |----------|--------|---------------|
 | `proxy` | `mode`, `url` | Affects ALL outgoing HTTP |
-| `embedding` | `provider`, `model`, `dimensions` | May invalidate existing vector indexes |
 | `shortcuts` | `bindings` (array) | Global OS keybindings, can collide |
 | `skills` | `extraSkillsDirs`, `disabledSkills`, `skillEnvCheck`, `allowRemoteInstall` | Disabling skills removes tools; `allowRemoteInstall` opens the HTTP `/api/skills/{name}/install` route that spawns `brew`/`npm -g`/`go install`/`uv tool install` — effectively RCE over the API Key |
 | `server` | `bindAddr` (e.g. `127.0.0.1:8420` vs `0.0.0.0:8420`), `apiKey`, `publicBaseUrl`. **Read responses redact `apiKey` to `"[REDACTED]"`** so the bearer token isn't echoed back on every overview; writes still flow through. | Network exposure, requires app restart |
@@ -135,6 +134,7 @@ If the response includes `sideEffect`, surface it to the user (e.g. "this requir
 |----------|-------------|
 | `active_model` | Current primary model — use Settings UI |
 | `fallback_models` | Fallback chain — use Settings UI |
+| `embedding` | Active memory-embedding config. Read resolves the currently-selected model from the shared `embedding_models` library + `memory_embedding` selection (the same source the GUI and runtime use) and returns `enabled` / `providerType` / `apiBaseUrl` / `apiModel` / `apiDimensions` with **`apiKey` redacted** (`"[REDACTED]"`); a disabled selection reads as `enabled:false`. Writes are GUI-only (Settings → Memory) — the model choice carries an API key and a heavy background reembed side effect, same class as `active_model` / `memory_embedding` / `knowledge_embedding`. |
 | `channels` | IM Channel accounts (Telegram / WeChat / Feishu / QQ / Discord). Read returns the account list with **`credentials` and `settings` fields redacted** (`"[REDACTED]"`); structural metadata (`id`, `channelId`, `label`, `enabled`, `agentId`, `autoApproveTools`, `security`) is exposed so the model can reference accounts without seeing bot tokens. Writes must go through Settings → Channels so the registry can drop/re-establish listeners under user supervision and credentials stay out of conversation logs. |
 | `mcp_servers` | MCP server configs. Read returns the server list with **`env`, `headers`, `oauth` fields redacted**. Writes must go through Settings → MCP Servers UI which enforces "trust acknowledgement" for stdio servers and routes credentials through `platform::write_secure_file` (0600). |
 | `hooks` | Hooks system (Claude Code compatible). Read returns `{ disableAllHooks, hooks }` with **http handler `headers` values redacted**. **Read-only here on purpose** — hooks run arbitrary commands / HTTP / LLM prompts / sub-agents on lifecycle events, so a writable category would let the model persist its own command execution (privilege escalation). Edit in Settings → Hooks or the scope files (user: `config.json`; project: `<working_dir>/.hope-agent/hooks.json`, repo-shared; local: `hooks.local.json`, git-ignored; managed: `/etc/hope-agent/hooks.json`). All scopes are UNIONed. |
@@ -238,5 +238,5 @@ Returns `{id, timestamp, kind, category, source}` newest first.
 - **Field names are camelCase** (e.g. `softRatio`, `toolTimeout`, `approvalTimeoutEnabled`, `askUserQuestionTimeoutEnabled`, `askUserQuestionTimeoutSecs`).
 - **Security restrictions** — cannot modify Providers or API Keys through this tool; guide the user to the Settings UI.
 - **Surface side effects** — if the response has `sideEffect` (e.g. "requires restart"), tell the user.
-- **Secrets in logs** — never echo `apiKey`, `remoteApiKey`, or `skill_env` values back in chat unless the user explicitly asks. Note that `get_settings` for `server` / `web_search` / `image_generate` / `acp_control` already redacts the credential fields to `"[REDACTED]"` — if you see that marker, the field is set but the value is hidden from the model intentionally.
+- **Secrets in logs** — never echo `apiKey`, `remoteApiKey`, or `skill_env` values back in chat unless the user explicitly asks. Note that `get_settings` for `server` / `web_search` / `image_generate` / `acp_control` / `embedding` already redacts the credential fields to `"[REDACTED]"` — if you see that marker, the field is set but the value is hidden from the model intentionally.
 - **Rollback is built-in** — if a change goes wrong, offer `restore_settings_backup` instead of trying to reconstruct the old values manually.

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -12,6 +12,7 @@ import { ArrowDown, ChevronRight } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { logger } from "@/lib/logger"
 import { applyInlineHighlight, clearInlineHighlight } from "@/lib/inlineHighlight"
+import { hasActiveTextSelection } from "@/lib/contextMenuGuard"
 import { AnimatedCollapse, AnimatedPresenceBox } from "@/components/ui/animated-presence"
 import {
   extractMessageFileAttachments,
@@ -1402,6 +1403,12 @@ export default function MessageList({
   const handleContextMenu = useCallback((e: React.MouseEvent, index: number) => {
     const msg = messagesRef.current[index]
     if (msg.role !== "assistant" || !msg.content) return
+    // Respect standard browser copy: when the user has highlighted part of the
+    // message and right-clicks inside that selection, don't hijack with our
+    // whole-message menu — let the native context menu (whose "Copy" honours
+    // the exact selection) through. The desktop guard defers for the same
+    // reason, so this is consistent in both Tauri and the web client.
+    if (hasActiveTextSelection(e.target)) return
     e.preventDefault()
     setContextMenu({ x: e.clientX, y: e.clientY, index })
   }, [])

--- a/src/lib/contextMenuGuard.ts
+++ b/src/lib/contextMenuGuard.ts
@@ -14,7 +14,34 @@ export function shouldSuppressNativeContextMenu(
   event: Pick<MouseEvent, "defaultPrevented" | "target">,
 ): boolean {
   if (event.defaultPrevented) return false
+  // A live text selection is precisely the case where the user wants the
+  // native "Copy" (respecting exactly what they highlighted). Suppressing it
+  // here would strand them with no selection-aware copy, so let the native
+  // menu through — same rationale as the input/contenteditable exception.
+  if (hasActiveTextSelection(event.target)) return false
   return !isNativeContextMenuAllowedTarget(event.target)
+}
+
+/** True when there is a non-collapsed text selection and the right-click
+ *  landed inside it — the standard-browser precondition for a selection-aware
+ *  "Copy". Shared by the desktop context-menu guard and the chat message
+ *  context menu so both defer to native copy instead of overriding the
+ *  clipboard with whole-element text. Pure DOM/selection logic, so it behaves
+ *  identically in the Tauri webview and the web (HTTP) client. */
+export function hasActiveTextSelection(target: EventTarget | null): boolean {
+  if (typeof window === "undefined" || typeof window.getSelection !== "function") {
+    return false
+  }
+  const selection = window.getSelection()
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return false
+  if (!selection.toString().trim()) return false
+
+  const node = target instanceof Node ? target : null
+  if (!node) return true
+  for (let i = 0; i < selection.rangeCount; i++) {
+    if (selection.getRangeAt(i).intersectsNode(node)) return true
+  }
+  return false
 }
 
 export function isNativeContextMenuAllowedTarget(target: EventTarget | null): boolean {


### PR DESCRIPTION
## 概述

系统性修复三个 issue（均从根因层处理，非临时打补丁）。

### #421 MCP SSE 传输握手未实现，始终 400

`kind: sse` 的 MCP server 之前被错误地用 Streamable HTTP client 直连——两者是**不同的线协议**：legacy HTTP+SSE（2024-11-05）要求先握手拿 session，直接 POST 会 `400 session_id is required`。核实 rmcp 确实退役了独立 SSE client（`transport-sse-client` 在 0.11 移除，最新 2.0 仍无），故新写 `build_sse_client` **手写 2024-11-05 HTTP+SSE 握手**，桥接进 rmcp 的 `(Sink, Stream)` serve 路径（对标已有 WebSocket transport）：

- GET 打开 SSE 流 → 读 `endpoint` 事件拿 session-scoped POST URL → client→server 走 POST、server→client 走 SSE `message` 帧
- **SSRF 两道门**：GET URL + server 返回的 `endpoint` 首次 POST 前各校验一次（endpoint 是 server-controlled 数据，属新出站面）
- 本地 loopback/私网目标自动 `.no_proxy()` 绕过系统代理（修复「开代理连云端模型时本地 SSE MCP 被代理劫持 → 503」），远程目标仍走代理

### #423 `get_settings("embedding")` 返回全 null

读路径指向已废弃的 `cfg.embedding`（`#[serde(skip_serializing)]`，GUI 早已改用 `embedding_models` + `memory_embedding` selection）。改为经 `resolve_memory_embedding_config` 解析真实启用配置（与 Tauri `get_embedding_config`、运行时 init 同一真相源）并脱敏 `apiKey`；写入改**只读**（加入 `BLOCKED_UPDATE_CATEGORIES`，与 active_model/channels/mcp_servers 同类，走设置界面），删除永不持久化的写入死代码。同步更新 core_tools 枚举、SKILL.md、AGENTS.md 契约面。

### #424 选中部分文本但复制整条消息

排查确认无任何 copy 事件拦截器（`Ctrl/Cmd+C` 本就正常）；根因是右键自定义菜单无条件 `preventDefault` 且只复制整条。改为：有文本选区且右键落在选区内时**让位原生复制、仅复制选中**；无选区时右键菜单仍整条复制。判定逻辑与桌面 `contextMenuGuard` 共用，Tauri / web 表现一致。

## 验证

- `cargo test -p ha-core -p ha-server` 全绿（ha-core 2570 lib 测试 + mcp/settings 新单测）；`cargo clippy` 零告警；`pnpm typecheck` 通过
- #421 用官方 `@modelcontextprotocol/server-everything sse` 本机端到端验证握手通过（不再 400/503，工具正常往返）

## 已知限制

本地 **Streamable HTTP** MCP + 系统代理仍会被劫持：ha-core 用 reqwest 0.12、rmcp 用 0.13，无法向 rmcp 的 Streamable HTTP transport 注入绕代理 client，且不为此引入第二个 reqwest 大版本（破坏 reqwest 隔离红线）。本地 MCP 绝大多数是 stdio / SSE，故记为已知限制并在 `mcp.md` 标注。

## 相关 issue

处理 #421 #423 #424（按要求保持 open，不自动关闭）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
