### PR TITLE
Fix session switch loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Markdown 文件链接复用统一文件类型图标**：本地文件超链接现在使用与下挂文件一致的彩色文件类型图标，可按 CSS / TSX / Rust / Markdown 等后缀显示对应图标，而不是统一显示通用代码图标。
 - **插件浏览器控制会唤出实时 BrowserPanel**：通过 Chrome 扩展接管真实浏览器标签页时，BrowserPanel 截帧不再只查全局 CDP 缓存；`browser:frame` 与 `browser_capture_frame` 现在按会话优先捕获 extension claimed tab，并在前端按 `sessionId` 过滤，避免其它会话的浏览器动作误打开当前右侧面板。
+- **切换长会话与重载侧边栏更顺滑**：切换未缓存会话时先立即切换会话 shell、异步加载历史消息，并用非布局占位避免历史加载动画推挤内容；启动 / reload 期间侧边栏会等会话、项目与显示模式首屏数据稳定后再渲染列表，且仅在用户首次交互后恢复展开动画，减少长会话和会话列表的卡顿与重影。
 
 ## [0.16.0] - 2026-07-06
 

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -2952,6 +2952,7 @@ export default function ChatScreen({
                       inputHistory={inputHistory}
                       quickPrompts={quickPrompts}
                       onSend={() => stream.handleSend()}
+                      sendDisabled={session.historyLoading}
                       loading={session.loading}
                       availableModels={availableModels}
                       activeModel={activeModel}

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -643,6 +643,7 @@ export default function ChatScreen({
     reorderProjects,
     moveSessionToProject,
     reloadProjects,
+    initialLoading: projectsInitialLoading,
   } = useProjects({
     includeArchived: true,
     activeSessionIdRef: activeSessionIdForProjectsRef,
@@ -2570,6 +2571,7 @@ export default function ChatScreen({
 
   const emptySessionInputHero =
     session.messages.length === 0 &&
+    !session.historyLoading &&
     !session.loading &&
     !planMode.pendingQuestionGroup &&
     !planMode.planCardInfo &&
@@ -2588,8 +2590,10 @@ export default function ChatScreen({
         sessions={session.sessions}
         agents={session.agents}
         projects={projects}
+        projectsLoading={projectsInitialLoading}
         currentSessionId={session.currentSessionId}
         loadingSessionIds={session.loadingSessionIds}
+        sessionsLoading={session.sessionsLoading}
         panelWidth={panelWidth}
         sidebarCollapsed={sidebarCollapsed}
         onPanelWidthChange={setPanelWidth}
@@ -2853,6 +2857,7 @@ export default function ChatScreen({
             <FileActionsContext.Provider value={fileActionsValue}>
               <MessageList
                 messages={session.messages}
+                historyLoading={session.historyLoading}
                 loading={session.loading}
                 executionState={
                   session.currentSessionId

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -37,6 +37,7 @@ import type { PlanModeState } from "./plan-mode/usePlanMode"
 
 interface MessageListProps {
   messages: Message[]
+  historyLoading?: boolean
   loading: boolean
   executionState?: ChatTurnStatus | null
   agents: AgentSummaryForSidebar[]
@@ -606,6 +607,7 @@ function CompletedTurnCollapseSummary({
 
 export default function MessageList({
   messages,
+  historyLoading = false,
   loading,
   executionState,
   agents,
@@ -934,11 +936,14 @@ export default function MessageList({
   // Baseline for entrance animation: only messages appended *after* this
   // session was opened animate in. The initial set renders statically — no
   // distracting cascade when entering an existing conversation. Render-time
-  // prop-derived state per React docs: rebase on session swap.
+  // prop-derived state per React docs: rebase on session swap and after async
+  // history hydration completes.
   const [animationBaseline, setAnimationBaseline] = useState(messages.length)
   const [animationBaselineSession, setAnimationBaselineSession] = useState(sessionKey)
-  if (animationBaselineSession !== sessionKey) {
+  const [animationBaselineHistoryLoading, setAnimationBaselineHistoryLoading] = useState(historyLoading)
+  if (animationBaselineSession !== sessionKey || animationBaselineHistoryLoading !== historyLoading) {
     setAnimationBaselineSession(sessionKey)
+    setAnimationBaselineHistoryLoading(historyLoading)
     setAnimationBaseline(messages.length)
   }
 
@@ -1428,8 +1433,9 @@ export default function MessageList({
     planCardData && planState && planState !== "off" && planState !== "planning",
   )
   const showEmpty = items.length === 0
+  const showHistoryLoading = showEmpty && historyLoading
   const hasFooterContent = Boolean(
-    pendingQuestionGroup || planCardVisible || planSubagentRunning || showEmpty,
+    pendingQuestionGroup || planCardVisible || planSubagentRunning || (showEmpty && !historyLoading),
   )
   // Show whenever user is scrolled away from bottom — independent of loading
   // state. Lets the user always have a one-click way back to latest.
@@ -1602,7 +1608,7 @@ export default function MessageList({
                   <span>{t("planMode.planningInProgress")}</span>
                 </div>
               )}
-              {showEmpty && !heroComposer && (
+              {showEmpty && !historyLoading && !heroComposer && (
                 <div className="flex min-h-[50vh] items-center justify-center animate-in fade-in-0 duration-300">
                   <ChatWelcomeHero incognito={incognito} />
                 </div>
@@ -1611,6 +1617,15 @@ export default function MessageList({
           </AnimatedCollapse>
         </div>
       </div>
+
+      {showHistoryLoading && (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center px-4">
+          <div className="flex items-center gap-2 rounded-lg border border-border/70 bg-surface-floating px-3 py-2 text-sm text-muted-foreground shadow-sm">
+            <span className="h-3.5 w-3.5 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            <span>{t("chat.loadingSession", "正在加载会话…")}</span>
+          </div>
+        </div>
+      )}
 
       {compactUserAnchor && (compactUserAnchorVisible || compactUserAnchorMounted) && (
         <div

--- a/src/components/chat/hooks/useChatSession.ts
+++ b/src/components/chat/hooks/useChatSession.ts
@@ -40,6 +40,7 @@ export interface UseChatSessionReturn {
   setCurrentAgentId: React.Dispatch<React.SetStateAction<string>>
   agentName: string
   setAgentName: React.Dispatch<React.SetStateAction<string>>
+  historyLoading: boolean
   loading: boolean
   setLoading: React.Dispatch<React.SetStateAction<boolean>>
   loadingSessionIds: Set<string>
@@ -49,6 +50,7 @@ export interface UseChatSessionReturn {
   hasMoreAfter: boolean
   loadingMoreAfter: boolean
   hasMoreSessions: boolean
+  sessionsLoading: boolean
   loadingMoreSessions: boolean
   /**
    * Search-jump intent for MessageList: which message to scroll to + which
@@ -139,6 +141,7 @@ export function useChatSession({
   const [agents, setAgents] = useState<AgentSummaryForSidebar[]>([])
   const [currentAgentId, setCurrentAgentId] = useState<string>(DEFAULT_AGENT_ID)
   const [agentName, setAgentName] = useState("")
+  const [historyLoading, setHistoryLoading] = useState(false)
   const [loading, setLoading] = useState(false)
   const [loadingSessionIds, setLoadingSessionIds] = useState<Set<string>>(new Set())
   const [pendingScrollIntent, setPendingScrollIntent] = useState<
@@ -165,6 +168,7 @@ export function useChatSession({
   // list `sessions` in their deps (which would invalidate them on every
   // streaming meta tick and cascade re-renders into the sidebar tree).
   const sessionsRef = useRef<SessionMeta[]>([])
+  const agentsRef = useRef<AgentSummaryForSidebar[]>([])
   // Tracks the previous `currentSessionId` so the effect below can fire
   // `purge_session_if_incognito` exactly once per swap.
   const previousSessionIdRef = useRef<string | null>(null)
@@ -182,6 +186,10 @@ export function useChatSession({
     sessionsRef.current = sessions
   }, [sessions])
 
+  useEffect(() => {
+    agentsRef.current = agents
+  }, [agents])
+
   // --- Session pagination sub-hook ---
   const {
     hasMore,
@@ -192,6 +200,7 @@ export function useChatSession({
     loadingMoreAfter,
     hasMoreSessions,
     // setHasMoreSessions not needed at this level
+    sessionsLoading,
     loadingMoreSessions,
     handleLoadMore,
     handleLoadMoreAfter,
@@ -280,6 +289,28 @@ export function useChatSession({
       })
     },
     [],
+  )
+
+  const activateSessionShell = useCallback(
+    (sessionId: string, opts: { clearMessages: boolean; hasMoreAfter?: boolean }) => {
+      currentSessionIdRef.current = sessionId
+      if (opts.clearMessages) {
+        setMessages([])
+        setPendingScrollIntent(null)
+      }
+      setHasMore(false)
+      setHasMoreAfter(opts.hasMoreAfter ?? false)
+      setLoading(loadingSessionsRef.current.has(sessionId))
+      setCurrentSessionId(sessionId)
+
+      const meta = sessionsRef.current.find((s) => s.id === sessionId)
+      if (meta) {
+        setCurrentAgentId(meta.agentId)
+        const agent = agentsRef.current.find((a) => a.id === meta.agentId)
+        if (agent) setAgentName(agent.name)
+      }
+    },
+    [setHasMore, setHasMoreAfter],
   )
 
   // Per-session ref cleanup shared by explicit-delete / incognito purge /
@@ -640,6 +671,8 @@ export function useChatSession({
       // were away converge into the cached view within ~1 RTT.
       const cached = sessionCacheRef.current.get(sessionId)
       if (targetMessageId === undefined && cached) {
+        setHistoryLoading(false)
+        currentSessionIdRef.current = sessionId
         setMessages(cached)
         setHasMore(hasMoreRef.current.get(sessionId) ?? false)
         setHasMoreAfter(hasMoreAfterRef.current.get(sessionId) ?? false)
@@ -671,6 +704,13 @@ export function useChatSession({
           })
         }
       } else {
+        const alreadyCurrent = sessionId === currentSessionIdRef.current
+        setHistoryLoading(true)
+        if (!alreadyCurrent) {
+          // Make the navigation visible immediately. The message window is filled
+          // below when the DB/transport round-trip finishes.
+          activateSessionShell(sessionId, { clearMessages: true })
+        }
         try {
           let msgs: SessionMessage[]
           let hasMoreBefore: boolean
@@ -701,6 +741,7 @@ export function useChatSession({
           }
           const displayMessages = await materializeMessages(sessionId, msgs, sessionsRef)
           if (switchVersionRef.current !== version) return // stale switch
+          setHistoryLoading(false)
           sessionCacheRef.current.set(sessionId, displayMessages)
           hasMoreRef.current.set(sessionId, hasMoreBefore)
           hasMoreAfterRef.current.set(sessionId, hasMoreAfterFlag)
@@ -714,9 +755,13 @@ export function useChatSession({
           setHasMore(hasMoreBefore)
           setHasMoreAfter(hasMoreAfterFlag)
           setLoading(loadingSessionsRef.current.has(sessionId))
+          currentSessionIdRef.current = sessionId
           setCurrentSessionId(sessionId)
           touchSessionCacheLru(sessionId)
         } catch (e) {
+          if (switchVersionRef.current === version && currentSessionIdRef.current === sessionId) {
+            setHistoryLoading(false)
+          }
           logger.error("session", "ChatScreen::switchSession", "Failed to load session", {
             sessionId,
             error: e,
@@ -734,24 +779,18 @@ export function useChatSession({
 
       if (switchVersionRef.current !== version) return // stale switch
 
-      // Use fresh sessions list for session lookup
-      const [currentSessions] = await getTransport()
-        .call<[SessionMeta[], number]>("list_sessions_cmd", {})
-        .catch(() => [[] as SessionMeta[], 0] as [SessionMeta[], number])
-      const currentAgents = await getTransport()
-        .call<AgentSummaryForSidebar[]>("list_agents")
-        .catch(() => [] as AgentSummaryForSidebar[])
-      let session = currentSessions.find((s) => s.id === sessionId)
+      let session = sessionsRef.current.find((s) => s.id === sessionId)
       if (!session) {
         const fetchedSession = await getTransport()
           .call<SessionMeta | null>("get_session_cmd", { sessionId })
           .catch(() => null)
+        if (switchVersionRef.current !== version) return // stale switch
         session = fetchedSession ?? undefined
       }
       if (session) {
         upsertSessionMeta(session)
         setCurrentAgentId(session.agentId)
-        const agent = currentAgents.find((a) => a.id === session.agentId)
+        const agent = agentsRef.current.find((a) => a.id === session.agentId)
         if (agent) setAgentName(agent.name)
 
         // Restore the model used in this session (if still available)
@@ -768,6 +807,7 @@ export function useChatSession({
             const agentConfig = await getTransport().call<AgentConfig>("get_agent_config", {
               id: session.agentId,
             })
+            if (switchVersionRef.current !== version) return // stale switch
             if (agentConfig.model.primary) {
               const modelExists = availableModels.some(
                 (m) => `${m.providerId}::${m.modelId}` === agentConfig.model.primary,
@@ -777,6 +817,12 @@ export function useChatSession({
                 // Mark session as read and refresh (await + log; see #6 below).
                 try {
                   await getTransport().call("mark_session_read_cmd", { sessionId })
+                  if (switchVersionRef.current !== version) return // stale switch
+                  updateSessionMeta(sessionId, (prev) =>
+                    prev.unreadCount === 0 && prev.channelUnreadCount === 0
+                      ? prev
+                      : { ...prev, unreadCount: 0, channelUnreadCount: 0 },
+                  )
                 } catch (e) {
                   logger.warn(
                     "session",
@@ -805,6 +851,12 @@ export function useChatSession({
       // error instead of swallowing it (#6 — was fire-and-forget + silent).
       try {
         await getTransport().call("mark_session_read_cmd", { sessionId })
+        if (switchVersionRef.current !== version) return // stale switch
+        updateSessionMeta(sessionId, (prev) =>
+          prev.unreadCount === 0 && prev.channelUnreadCount === 0
+            ? prev
+            : { ...prev, unreadCount: 0, channelUnreadCount: 0 },
+        )
       } catch (e) {
         logger.warn(
           "session",
@@ -824,10 +876,12 @@ export function useChatSession({
       setActiveModel,
       reloadSessions,
       onSidebarAggregatesChanged,
+      activateSessionShell,
       setHasMore,
       setHasMoreAfter,
       touchSessionCacheLru,
       upsertSessionMeta,
+      updateSessionMeta,
     ],
   )
 
@@ -866,6 +920,7 @@ export function useChatSession({
       // Save current session to cache
       // (cache is already maintained by updateSessionMessages)
       const cachedAgent = agents.find((a) => a.id === agentId)
+      setHistoryLoading(false)
       setMessages([])
       setCurrentSessionId(null)
       setLoading(false)
@@ -932,6 +987,7 @@ export function useChatSession({
         if (currentSessionIdRef.current === sessionId) {
           setMessages([])
           setCurrentSessionId(null)
+          setHistoryLoading(false)
           setLoading(false)
           setHasMore(false)
           setHasMoreAfter(false)
@@ -971,6 +1027,7 @@ export function useChatSession({
     setCurrentAgentId,
     agentName,
     setAgentName,
+    historyLoading,
     loading,
     setLoading,
     loadingSessionIds,
@@ -980,6 +1037,7 @@ export function useChatSession({
     hasMoreAfter,
     loadingMoreAfter,
     hasMoreSessions,
+    sessionsLoading,
     loadingMoreSessions,
     pendingScrollIntent,
     clearPendingScrollIntent,

--- a/src/components/chat/hooks/useSessionPagination.ts
+++ b/src/components/chat/hooks/useSessionPagination.ts
@@ -32,6 +32,7 @@ export interface UseSessionPaginationReturn {
   loadingMoreAfter: boolean
   hasMoreSessions: boolean
   setHasMoreSessions: React.Dispatch<React.SetStateAction<boolean>>
+  sessionsLoading: boolean
   loadingMoreSessions: boolean
   handleLoadMore: () => Promise<void>
   handleLoadMoreAfter: () => Promise<void>
@@ -63,10 +64,14 @@ export function useSessionPagination({
   const [hasMoreAfter, setHasMoreAfter] = useState(false)
   const [loadingMoreAfter, setLoadingMoreAfter] = useState(false)
   const [hasMoreSessions, setHasMoreSessions] = useState(false)
+  const [sessionsLoading, setSessionsLoading] = useState(true)
   const [loadingMoreSessions, setLoadingMoreSessions] = useState(false)
   const loadedSessionRowsRef = useRef(0)
+  const sessionsLoadedOnceRef = useRef(false)
 
   const reloadSessions = useCallback(async () => {
+    const isInitialLoad = !sessionsLoadedOnceRef.current
+    if (isInitialLoad) setSessionsLoading(true)
     try {
       const [list, total] = await getTransport().call<[SessionMeta[], number]>("list_sessions_cmd", {
         limit: SESSION_PAGE_SIZE,
@@ -88,6 +93,11 @@ export function useSessionPagination({
       setHasMoreSessions(list.length + (hasActiveExtra ? 1 : 0) < total)
     } catch (e) {
       logger.error("ui", "ChatScreen::loadSessions", "Failed to load sessions", e)
+    } finally {
+      if (isInitialLoad) {
+        sessionsLoadedOnceRef.current = true
+        setSessionsLoading(false)
+      }
     }
   }, [setSessions, currentSessionIdRef, sessionsRef])
 
@@ -301,6 +311,7 @@ export function useSessionPagination({
     loadingMoreAfter,
     hasMoreSessions,
     setHasMoreSessions,
+    sessionsLoading,
     loadingMoreSessions,
     handleLoadMore,
     handleLoadMoreAfter,

--- a/src/components/chat/input/ChatInput.test.tsx
+++ b/src/components/chat/input/ChatInput.test.tsx
@@ -246,6 +246,18 @@ describe("ChatInput", () => {
     expect(onSend).toHaveBeenCalledTimes(1)
   })
 
+  test("blocks mouse and keyboard sends while send is disabled", () => {
+    const onSend = vi.fn()
+    renderChatInput({ input: "hello", onSend, sendDisabled: true })
+
+    const sendButton = screen.getByRole("button", { name: "chat.send" }) as HTMLButtonElement
+    expect(sendButton.disabled).toBe(true)
+    fireEvent.click(sendButton)
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter" })
+
+    expect(onSend).not.toHaveBeenCalled()
+  })
+
   test("allows sending when only attachments are present", () => {
     const onSend = vi.fn()
     const file = new File(["image"], "photo.png", { type: "image/png" })

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -92,6 +92,7 @@ interface ChatInputProps {
   inputHistory?: string[]
   quickPrompts?: QuickPromptItem[]
   onSend: () => void
+  sendDisabled?: boolean
   loading: boolean
   availableModels: AvailableModel[]
   activeModel: ActiveModel | null
@@ -209,6 +210,7 @@ export default function ChatInput({
   inputHistory = [],
   quickPrompts = [],
   onSend,
+  sendDisabled = false,
   loading,
   availableModels,
   activeModel,
@@ -717,10 +719,13 @@ export default function ChatInput({
     [historyIndex, input, inputHandleRef, inputHistory, onInputChange],
   )
 
+  const sendUnavailable = sendDisabled || !hasSendableContent
+
   const handleSend = useCallback(() => {
+    if (sendUnavailable) return
     resetHistoryBrowsing()
     onSend()
-  }, [onSend, resetHistoryBrowsing])
+  }, [onSend, resetHistoryBrowsing, sendUnavailable])
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLElement>) {
     if (e.nativeEvent.isComposing || e.keyCode === 229) return
@@ -1450,15 +1455,21 @@ export default function ChatInput({
                 )}
 
                 <IconTip
-                  label={loading && hasSendableContent ? t("chat.queueMessage") : t("chat.send")}
+                  label={
+                    loading && hasSendableContent && !sendDisabled
+                      ? t("chat.queueMessage")
+                      : t("chat.send")
+                  }
                 >
                   <Button
                     size="icon"
                     className="h-8 w-8 rounded-full shrink-0"
                     onClick={handleSend}
-                    disabled={!hasSendableContent}
+                    disabled={sendUnavailable}
                     aria-label={
-                      loading && hasSendableContent ? t("chat.queueMessage") : t("chat.send")
+                      loading && hasSendableContent && !sendDisabled
+                        ? t("chat.queueMessage")
+                        : t("chat.send")
                     }
                   >
                     <Send className="h-4 w-4" />

--- a/src/components/chat/project/ProjectSection.tsx
+++ b/src/components/chat/project/ProjectSection.tsx
@@ -111,6 +111,7 @@ interface ProjectSectionProps {
   getAgentInfo: (agentId: string) => AgentSummaryForSidebar | undefined
   formatRelativeTime: (dateStr: string) => string
   displayMode: SidebarDisplayMode
+  motionDisabled?: boolean
 }
 
 const EXPANDED_STORAGE_KEY = "ha:project-expanded"
@@ -144,6 +145,7 @@ export default function ProjectSection(props: ProjectSectionProps) {
     setExpanded,
     onAddProject,
     onReorderProjects,
+    motionDisabled = false,
   } = props
   const visibleProjects = useMemo(() => projects.filter((p) => !p.archived), [projects])
   const archivedProjects = useMemo(() => projects.filter((p) => p.archived), [projects])
@@ -271,7 +273,7 @@ export default function ProjectSection(props: ProjectSectionProps) {
         }
       />
 
-      <AnimatedCollapse open={expanded}>
+      <AnimatedCollapse open={expanded} durationMs={motionDisabled ? 0 : undefined}>
         <div className="space-y-0.5 px-3 pb-1 pt-1">
           {visibleProjects.length === 0 && (
             <button
@@ -337,7 +339,7 @@ export default function ProjectSection(props: ProjectSectionProps) {
                   {archivedProjects.length}
                 </span>
               </button>
-              <AnimatedCollapse open={archivedExpanded}>
+              <AnimatedCollapse open={archivedExpanded} durationMs={motionDisabled ? 0 : undefined}>
                 <div className="mt-0.5 space-y-0.5">
                   {archivedProjects.map((project) => (
                     <ProjectGroup
@@ -438,6 +440,7 @@ function ProjectGroup({
   isDragging = false,
   suppressChildren = false,
   onPrepareReorder,
+  motionDisabled = false,
 }: ProjectGroupProps) {
   const { t } = useTranslation()
   // The active session is already excluded from `project.unreadCount` by the
@@ -669,7 +672,7 @@ function ProjectGroup({
       </div>
 
       {!suppressChildren && (
-        <AnimatedCollapse open={groupExpanded}>
+        <AnimatedCollapse open={groupExpanded} durationMs={motionDisabled ? 0 : undefined}>
           <div
             className={cn(
               "pl-4 pr-1 mt-0.5",

--- a/src/components/chat/project/hooks/useProjects.ts
+++ b/src/components/chat/project/hooks/useProjects.ts
@@ -22,6 +22,7 @@ import type {
 export interface UseProjectsReturn {
   projects: ProjectMeta[]
   loading: boolean
+  initialLoading: boolean
   error: string | null
   reloadProjects: () => Promise<void>
   createProject: (input: CreateProjectInput) => Promise<Project | null>
@@ -45,7 +46,8 @@ export function useProjects(
   const { includeArchived = false, activeSessionIdRef } = options
 
   const [projects, setProjects] = useState<ProjectMeta[]>([])
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [initialLoading, setInitialLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   // Keep the latest args in a ref so the EventBus handler always reloads
@@ -77,7 +79,10 @@ export function useProjects(
       logger.warn("chat", "useProjects", "reloadProjects failed", msg)
       setError(msg)
     } finally {
-      if (seq === reloadSeqRef.current) setLoading(false)
+      if (seq === reloadSeqRef.current) {
+        setInitialLoading(false)
+        setLoading(false)
+      }
     }
   }, [activeSessionIdRef])
 
@@ -215,6 +220,7 @@ export function useProjects(
   return {
     projects,
     loading,
+    initialLoading,
     error,
     reloadProjects,
     createProject,

--- a/src/components/chat/sidebar/AgentSection.tsx
+++ b/src/components/chat/sidebar/AgentSection.tsx
@@ -36,6 +36,7 @@ interface AgentSectionProps {
   onReorderAgents?: (agentIds: string[]) => void
   panelWidth: number
   displayMode: SidebarDisplayMode
+  motionDisabled?: boolean
 }
 
 const AGENT_CARD_MIN_WIDTH_PX = 156
@@ -224,6 +225,7 @@ export default function AgentSection({
   onReorderAgents,
   panelWidth,
   displayMode,
+  motionDisabled = false,
 }: AgentSectionProps) {
   const { t } = useTranslation()
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -264,7 +266,11 @@ export default function AgentSection({
         onToggle={() => setAgentsExpanded(!agentsExpanded)}
         className="sticky top-0 z-20 mb-0 flex h-8 items-center border-b border-border/50 bg-surface-panel px-3"
       />
-      <AnimatedCollapse open={agentsExpanded} unmountOnExit={false}>
+      <AnimatedCollapse
+        open={agentsExpanded}
+        unmountOnExit={false}
+        durationMs={motionDisabled ? 0 : undefined}
+      >
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext items={agents.map((agent) => agent.id)} strategy={rectSortingStrategy}>
             <div

--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from "react"
+import { flushSync } from "react-dom"
 import { useTranslation } from "react-i18next"
 import {
   AlertDialog,
@@ -14,7 +15,7 @@ import { IconTip } from "@/components/ui/tooltip"
 import { FloatingMenu } from "@/components/ui/floating-menu"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
-import { Bot, ListCollapse, MessageSquarePlus, PanelLeft, Rows3, Search, X } from "lucide-react"
+import { Bot, ListCollapse, Loader2, MessageSquarePlus, PanelLeft, Rows3, Search, X } from "lucide-react"
 import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import type { SessionSearchResult } from "@/types/chat"
@@ -59,8 +60,10 @@ export default function ChatSidebar({
   sessions,
   agents,
   projects = [],
+  projectsLoading = false,
   currentSessionId,
   loadingSessionIds,
+  sessionsLoading = false,
   panelWidth,
   sidebarCollapsed,
   onPanelWidthChange,
@@ -97,6 +100,7 @@ export default function ChatSidebar({
   const [sidebarDisplayMode, setSidebarDisplayMode] = useState<SidebarDisplayMode>(
     DEFAULT_SIDEBAR_DISPLAY_MODE,
   )
+  const [sidebarDisplayModeReady, setSidebarDisplayModeReady] = useState(false)
 
   const setAgentsExpanded = useCallback((expanded: boolean) => {
     setAgentsExpandedState(expanded)
@@ -168,15 +172,20 @@ export default function ChatSidebar({
     getTransport()
       .call<string>("get_sidebar_display_mode")
       .then((mode) => {
-        if (!cancelled) setSidebarDisplayMode(normalizeSidebarDisplayMode(mode))
+        if (!cancelled) {
+          setSidebarDisplayMode(normalizeSidebarDisplayMode(mode))
+          setSidebarDisplayModeReady(true)
+        }
       })
       .catch((err) => {
         logger.error("chat", "ChatSidebar::loadDisplayMode", "failed to load sidebar mode", err)
+        if (!cancelled) setSidebarDisplayModeReady(true)
       })
 
     const handleModeChanged = (event: Event) => {
       const detail = (event as CustomEvent<{ mode?: unknown }>).detail
       setSidebarDisplayMode(normalizeSidebarDisplayMode(detail?.mode))
+      setSidebarDisplayModeReady(true)
     }
     window.addEventListener("sidebar-display-mode-changed", handleModeChanged)
     return () => {
@@ -366,6 +375,22 @@ export default function ChatSidebar({
     searchInputRef.current?.focus({ preventScroll: true })
   }, [])
 
+  const sidebarContentReady = sidebarDisplayModeReady && !sessionsLoading && !projectsLoading
+  const [sidebarMotionEnabled, setSidebarMotionEnabled] = useState(false)
+
+  useEffect(() => {
+    if (!sidebarContentReady) {
+      setSidebarMotionEnabled(false)
+    }
+  }, [sidebarContentReady])
+
+  const enableSidebarMotion = useCallback(() => {
+    if (!sidebarContentReady || sidebarMotionEnabled) return
+    flushSync(() => setSidebarMotionEnabled(true))
+  }, [sidebarContentReady, sidebarMotionEnabled])
+
+  const sidebarMotionDisabled = !sidebarMotionEnabled
+
   const handleSearchSurfaceMouseDown = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const target = e.target as HTMLElement | null
@@ -400,6 +425,7 @@ export default function ChatSidebar({
       selectedAgentId={selectedAgentId}
       currentSessionId={currentSessionId}
       loadingSessionIds={loadingSessionIds}
+      sessionsLoading={sessionsLoading}
       loadingMoreSessions={loadingMoreSessions}
       onSwitchSession={onSwitchSession}
       onDeleteClick={handleDeleteClick}
@@ -432,6 +458,7 @@ export default function ChatSidebar({
         className={cn(
           "relative h-full shrink-0",
           !isResizing &&
+            !sidebarMotionDisabled &&
             "transition-[width] duration-[250ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none",
         )}
       >
@@ -440,8 +467,12 @@ export default function ChatSidebar({
             style={{ width: panelWidth }}
             aria-hidden={sidebarCollapsed}
             inert={sidebarCollapsed ? true : undefined}
+            onPointerDownCapture={enableSidebarMotion}
+            onKeyDownCapture={enableSidebarMotion}
             className={cn(
-              "h-full border-r border-border-soft bg-surface-panel shadow-panel flex flex-col transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[opacity,transform] [contain:layout_paint] motion-reduce:transition-none",
+              "h-full border-r border-border-soft bg-surface-panel shadow-panel flex flex-col [contain:layout_paint]",
+              !sidebarMotionDisabled &&
+                "transition-[opacity,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[opacity,transform] motion-reduce:transition-none",
               sidebarCollapsed
                 ? "pointer-events-none -translate-x-4 opacity-0"
                 : "translate-x-0 opacity-100",
@@ -572,7 +603,10 @@ export default function ChatSidebar({
             </div>
 
             <div
-              className="flex-1 overflow-y-auto overflow-x-hidden [overscroll-behavior-y:none]"
+              className={cn(
+                "flex-1 overflow-y-auto overflow-x-hidden [overscroll-behavior-y:none]",
+                sidebarMotionDisabled && "[&_*]:!animate-none [&_*]:!transition-none",
+              )}
               onScroll={(e) => {
                 if (isHistorySearching) return
                 if (!hasMoreSessions || loadingMoreSessions || !onLoadMoreSessions) return
@@ -583,7 +617,11 @@ export default function ChatSidebar({
                 }
               }}
             >
-              {isHistorySearching ? (
+              {!sidebarContentReady ? (
+                <div className="flex justify-center py-8">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                </div>
+              ) : isHistorySearching ? (
                 sessionListNode
               ) : (
                 <>
@@ -600,6 +638,7 @@ export default function ChatSidebar({
                       onReorderAgents={onReorderAgents}
                       panelWidth={panelWidth}
                       displayMode={sidebarDisplayMode}
+                      motionDisabled={sidebarMotionDisabled}
                     />
                   )}
 
@@ -634,6 +673,7 @@ export default function ChatSidebar({
                       getAgentInfo={getAgentInfo}
                       formatRelativeTime={formatRelativeTime}
                       displayMode={sidebarDisplayMode}
+                      motionDisabled={sidebarMotionDisabled}
                     />
                   )}
 
@@ -648,7 +688,9 @@ export default function ChatSidebar({
             color does not occupy a strip of the conversation canvas. */}
         <div
           className={cn(
-            "absolute inset-y-0 right-0 z-20 cursor-col-resize transition-[width,opacity,background-color] duration-200 ease-out hover:bg-primary/30 active:bg-primary/50",
+            "absolute inset-y-0 right-0 z-20 cursor-col-resize hover:bg-primary/30 active:bg-primary/50",
+            !sidebarMotionDisabled &&
+              "transition-[width,opacity,background-color] duration-200 ease-out",
             sidebarCollapsed ? "w-0 pointer-events-none opacity-0" : "w-1 opacity-100",
           )}
           onMouseDown={handleDragStart}

--- a/src/components/chat/sidebar/SearchResultItem.tsx
+++ b/src/components/chat/sidebar/SearchResultItem.tsx
@@ -92,7 +92,7 @@ export default function SearchResultItem({
       role="button"
       tabIndex={0}
       className={cn(
-        "flex items-start gap-2.5 w-full px-2.5 py-2 rounded-lg text-left transition-colors group cursor-pointer",
+        "flex items-start gap-2.5 w-full px-2.5 py-2 rounded-lg text-left group cursor-pointer",
         displayMode === "compact" && "gap-1.5 px-2 py-1.5 rounded-md",
         isActive
           ? "bg-secondary/70 border border-border/50"

--- a/src/components/chat/sidebar/SessionItem.tsx
+++ b/src/components/chat/sidebar/SessionItem.tsx
@@ -137,7 +137,7 @@ export default function SessionItem({
           role="button"
           tabIndex={0}
           className={cn(
-            "relative flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-left transition-colors group cursor-pointer",
+            "relative flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-left group cursor-pointer",
             isCompact && "gap-1.5 px-2 py-[7px] rounded-md",
             isActive
               ? "bg-secondary/70 border border-border/50"
@@ -327,7 +327,7 @@ export default function SessionItem({
                         </IconTip>
                       )}
                       {/* hover 时在原行右侧就地显示 agent 头像 + 名称（替换时间），不弹浮层 */}
-                      <span className="hidden min-w-0 items-center gap-1 group-hover:flex animate-in fade-in-0 slide-in-from-right-1 duration-200">
+                      <span className="hidden min-w-0 items-center gap-1 group-hover:flex">
                         <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 text-[8px] text-primary">
                           {agent?.avatar ? (
                             <img

--- a/src/components/chat/sidebar/SessionList.tsx
+++ b/src/components/chat/sidebar/SessionList.tsx
@@ -44,6 +44,7 @@ interface SessionListProps {
   selectedAgentId: string | null
   currentSessionId: string | null
   loadingSessionIds: Set<string>
+  sessionsLoading?: boolean
   loadingMoreSessions?: boolean
   onSwitchSession: (
     sessionId: string,
@@ -85,6 +86,7 @@ export default function SessionList({
   selectedAgentId,
   currentSessionId,
   loadingSessionIds,
+  sessionsLoading = false,
   loadingMoreSessions,
   onSwitchSession,
   onDeleteClick,
@@ -111,6 +113,8 @@ export default function SessionList({
   const { t } = useTranslation()
 
   const isSearching = searchQuery.trim().length > 0
+  const showInitialSessionLoading =
+    !isSearching && sessionsLoading && sessions.length === 0 && filteredSessions.length === 0
 
   // Cron sessions live in the cron panel's "conversations" timeline now, never
   // the main sidebar — drop them from search results entirely. This is the base
@@ -199,7 +203,7 @@ export default function SessionList({
               <ContextMenuTrigger asChild>
                 <button
                   className={cn(
-                    "relative px-2 py-1 text-[11px] rounded-md transition-colors whitespace-nowrap",
+                    "relative px-2 py-1 text-[11px] rounded-md whitespace-nowrap",
                     isActive
                       ? "text-foreground font-semibold"
                       : "text-muted-foreground hover:text-foreground/70",
@@ -230,9 +234,9 @@ export default function SessionList({
       {/* Search results or session list */}
       {isSearching ? (
         <div
-          key={`search-${sessionFilter}-${displayMode}`}
+          key={`search-${sessionFilter}`}
           className={cn(
-            "p-2 animate-in fade-in-0 slide-in-from-bottom-1 duration-150",
+            "p-2",
             displayMode === "compact" ? "space-y-1" : "space-y-0.5",
           )}
         >
@@ -287,13 +291,17 @@ export default function SessionList({
         </div>
       ) : (
         <div
-          key={`sessions-${sessionFilter}-${selectedAgentId ?? "all"}-${displayMode}`}
+          key={`sessions-${sessionFilter}-${selectedAgentId ?? "all"}`}
           className={cn(
-            "p-2 animate-in fade-in-0 slide-in-from-bottom-1 duration-150",
+            "p-2",
             displayMode === "compact" ? "space-y-1" : "space-y-0.5",
           )}
         >
-          {filteredSessions.length === 0 ? (
+          {showInitialSessionLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            </div>
+          ) : filteredSessions.length === 0 ? (
             <div className="text-center py-8">
               <MessageSquare className="h-8 w-8 text-muted-foreground/20 mx-auto mb-2" />
               <p className="text-xs text-muted-foreground/60">

--- a/src/components/chat/sidebar/types.ts
+++ b/src/components/chat/sidebar/types.ts
@@ -21,8 +21,10 @@ export interface ChatSidebarProps {
   agents: AgentSummaryForSidebar[]
   /** Projects visible in the sidebar. Empty array when none exist. */
   projects?: ProjectMeta[]
+  projectsLoading?: boolean
   currentSessionId: string | null
   loadingSessionIds: Set<string>
+  sessionsLoading?: boolean
   panelWidth: number
   sidebarCollapsed: boolean
   onPanelWidthChange: (width: number) => void


### PR DESCRIPTION
## Summary
- Switch uncached sessions immediately while history loads asynchronously.
- Render history-loading as an overlay and rebase message mount animations during history hydration.
- Gate sidebar initial rendering/motion until sessions, projects, and display-mode state are ready, then restore expand/collapse animation on first user interaction.
- Update CHANGELOG.md under Unreleased.

## Validation
- pnpm typecheck
- git push pre-push hook: cargo fmt --all --check; cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings; pnpm typecheck; pnpm lint; pnpm test; cargo test -p ha-core -p ha-server --locked

## Notes
- ESLint reported one existing warning in src/components/chat/hooks/useChatStream.ts about setAttachedFiles dependency.