### PR TITLE
fix: 修复长文本附件预览和编辑

### DIFF
--- a/src/QuickChatWindow.tsx
+++ b/src/QuickChatWindow.tsx
@@ -220,6 +220,11 @@ export default function QuickChatWindow() {
             onRemoveFile={(i) =>
               stream.setAttachedFiles((prev) => prev.filter((_, idx) => idx !== i))
             }
+            onUpdateFile={(index, file) =>
+              stream.setAttachedFiles((prev) =>
+                prev.map((existing, idx) => (idx === index ? file : existing)),
+              )
+            }
             pendingMessage={stream.pendingMessage}
             onCancelPending={() => stream.setPendingMessage(null)}
             onStop={stream.handleStop}

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -2966,6 +2966,11 @@ export default function ChatScreen({
                       onRemoveFile={(index) =>
                         stream.setAttachedFiles((prev) => prev.filter((_, i) => i !== index))
                       }
+                      onUpdateFile={(index, file) =>
+                        stream.setAttachedFiles((prev) =>
+                          prev.map((existing, i) => (i === index ? file : existing)),
+                        )
+                      }
                       pendingQuotes={stream.pendingQuotes}
                       onRemoveQuote={(index) => {
                         stream.setPendingQuotes((prev) => prev.filter((_, i) => i !== index))

--- a/src/components/chat/QuickChatDialog.tsx
+++ b/src/components/chat/QuickChatDialog.tsx
@@ -290,6 +290,11 @@ export default function QuickChatDialog({
             onRemoveFile={(i) =>
               stream.setAttachedFiles((prev) => prev.filter((_, idx) => idx !== i))
             }
+            onUpdateFile={(index, file) =>
+              stream.setAttachedFiles((prev) =>
+                prev.map((existing, idx) => (idx === index ? file : existing)),
+              )
+            }
             pendingMessage={stream.pendingMessage}
             onCancelPending={() => stream.setPendingMessage(null)}
             onStop={stream.handleStop}

--- a/src/components/chat/input/AttachmentBar.test.tsx
+++ b/src/components/chat/input/AttachmentBar.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { AttachmentPreview } from "./AttachmentBar"
+import { createPastedTextAttachment, getPastedTextFileMeta } from "./pastedTextAttachment"
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string }) => options?.defaultValue ?? key,
+  }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+  },
+}))
+
+vi.mock("@/components/common/ImageLightbox", () => ({
+  useLightbox: () => ({ openLightbox: vi.fn() }),
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe("AttachmentPreview", () => {
+  test("edits a pasted text attachment and replaces the staged file", async () => {
+    const onUpdateFile = vi.fn()
+    const file = createPastedTextAttachment("title\n" + "body\n".repeat(35))
+
+    render(
+      <TooltipProvider>
+        <AttachmentPreview
+          attachedFiles={[file]}
+          onRemoveFile={vi.fn()}
+          onUpdateFile={onUpdateFile}
+        />
+      </TooltipProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "chat.pastedTextPreviewOpen" }))
+
+    const editor = await screen.findByRole("textbox", { name: "chat.pastedTextPreviewTitle" })
+    fireEvent.change(editor, { target: { value: "edited\ncontent" } })
+    fireEvent.click(screen.getByRole("button", { name: "common.save" }))
+
+    expect(onUpdateFile).toHaveBeenCalledTimes(1)
+    expect(onUpdateFile).toHaveBeenCalledWith(0, expect.any(File))
+    const updatedFile = onUpdateFile.mock.calls[0]?.[1] as File
+    expect(updatedFile.name).toBe(file.name)
+    expect(await updatedFile.text()).toBe("edited\ncontent")
+    expect(getPastedTextFileMeta(updatedFile)?.lineCount).toBe(2)
+  })
+})

--- a/src/components/chat/input/AttachmentBar.tsx
+++ b/src/components/chat/input/AttachmentBar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useRef, useMemo, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
 import {
   Dialog,
   DialogClose,
@@ -15,21 +16,25 @@ import { AnimatedCollapse } from "@/components/ui/animated-presence"
 import { IconTip } from "@/components/ui/tooltip"
 import { Copy, FileText, Paperclip, X } from "lucide-react"
 import { useLightbox } from "@/components/common/ImageLightbox"
-import { getPastedTextFileMeta } from "./pastedTextAttachment"
+import { getPastedTextFileMeta, updatePastedTextAttachment } from "./pastedTextAttachment"
 
 interface AttachmentPreviewProps {
   attachedFiles: File[]
   onRemoveFile: (index: number) => void
+  onUpdateFile: (index: number, file: File) => void
 }
 
-export function AttachmentPreview({ attachedFiles, onRemoveFile }: AttachmentPreviewProps) {
+export function AttachmentPreview({
+  attachedFiles,
+  onRemoveFile,
+  onUpdateFile,
+}: AttachmentPreviewProps) {
   const { t } = useTranslation()
   const { openLightbox } = useLightbox()
   const [pastedTextPreview, setPastedTextPreview] = useState<{
+    index: number
     fileName: string
     text: string
-    chars: number
-    lines: number
   } | null>(null)
 
   // Stable blob URLs with cleanup to prevent memory leaks
@@ -46,22 +51,36 @@ export function AttachmentPreview({ attachedFiles, onRemoveFile }: AttachmentPre
     [blobUrls],
   )
 
-  const openPastedTextPreview = useCallback(async (file: File) => {
+  const openPastedTextPreview = useCallback(async (file: File, index: number) => {
     const text = await file.text()
-    const meta = getPastedTextFileMeta(file)
     setPastedTextPreview({
+      index,
       fileName: file.name,
       text,
-      chars: meta?.charCount ?? text.length,
-      lines: meta?.lineCount ?? countLines(text),
     })
   }, [])
+
+  const previewStats = pastedTextPreview
+    ? {
+        chars: pastedTextPreview.text.length,
+        lines: countLines(pastedTextPreview.text),
+      }
+    : null
 
   const copyPreviewText = useCallback(async () => {
     if (!pastedTextPreview) return
     await navigator.clipboard.writeText(pastedTextPreview.text)
     toast.success(t("chat.copied"))
   }, [pastedTextPreview, t])
+
+  const savePreviewText = useCallback(() => {
+    if (!pastedTextPreview) return
+    const file = attachedFiles[pastedTextPreview.index]
+    if (!file) return
+    onUpdateFile(pastedTextPreview.index, updatePastedTextAttachment(file, pastedTextPreview.text))
+    setPastedTextPreview(null)
+    toast.success(t("common.saved"))
+  }, [attachedFiles, onUpdateFile, pastedTextPreview, t])
 
   return (
     <>
@@ -86,24 +105,34 @@ export function AttachmentPreview({ attachedFiles, onRemoveFile }: AttachmentPre
           if (!open) setPastedTextPreview(null)
         }}
       >
-        <DialogContent className="max-h-[86vh] max-w-3xl grid-rows-[auto_minmax(0,1fr)_auto]">
-          <DialogHeader>
-            <DialogTitle className="truncate">
+        <DialogContent className="flex h-[min(86vh,42rem)] max-h-[86vh] w-[calc(100vw-2rem)] max-w-4xl flex-col gap-0 overflow-hidden p-0 sm:w-[calc(100vw-4rem)]">
+          <DialogHeader className="shrink-0 px-6 pt-6 pr-12">
+            <DialogTitle className="truncate text-left">
               {pastedTextPreview?.fileName || t("chat.pastedTextPreviewTitle")}
             </DialogTitle>
-            <DialogDescription>
-              {pastedTextPreview
+            <DialogDescription className="text-left">
+              {previewStats
                 ? t("chat.pastedTextPreviewMeta", {
-                    chars: pastedTextPreview.chars.toLocaleString(),
-                    lines: pastedTextPreview.lines.toLocaleString(),
+                    chars: previewStats.chars.toLocaleString(),
+                    lines: previewStats.lines.toLocaleString(),
                   })
                 : null}
             </DialogDescription>
           </DialogHeader>
-          <pre className="min-h-0 overflow-auto rounded-md border border-border/70 bg-secondary/35 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap text-foreground">
-            {pastedTextPreview?.text}
-          </pre>
-          <DialogFooter className="gap-2 sm:gap-2">
+          <div className="min-h-0 flex-1 px-6 py-4">
+            <Textarea
+              aria-label={t("chat.pastedTextPreviewTitle")}
+              spellCheck={false}
+              value={pastedTextPreview?.text ?? ""}
+              onChange={(event) =>
+                setPastedTextPreview((preview) =>
+                  preview ? { ...preview, text: event.target.value } : preview,
+                )
+              }
+              className="h-full min-h-0 resize-none overflow-auto whitespace-pre-wrap border-border/70 bg-secondary/35 font-mono text-xs leading-relaxed shadow-none"
+            />
+          </div>
+          <DialogFooter className="shrink-0 gap-2 border-t border-border/70 px-6 py-4 sm:gap-2">
             <Button
               type="button"
               variant="outline"
@@ -114,8 +143,13 @@ export function AttachmentPreview({ attachedFiles, onRemoveFile }: AttachmentPre
               {t("chat.copy")}
             </Button>
             <DialogClose asChild>
-              <Button type="button">{t("common.close")}</Button>
+              <Button type="button" variant="outline">
+                {t("common.cancel")}
+              </Button>
             </DialogClose>
+            <Button type="button" onClick={savePreviewText} disabled={!pastedTextPreview}>
+              {t("common.save")}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -140,7 +174,7 @@ function AttachmentPreviewItem({
   blobUrl: string
   onRemoveFile: (index: number) => void
   openLightbox: (src: string, alt?: string) => void
-  onOpenPastedText: (file: File) => void
+  onOpenPastedText: (file: File, index: number) => void
 }) {
   const { t } = useTranslation()
   const pastedTextMeta = getPastedTextFileMeta(file)
@@ -159,7 +193,7 @@ function AttachmentPreviewItem({
           if (blobUrl) {
             openLightbox(blobUrl, file.name)
           } else if (canPreviewPastedText) {
-            void onOpenPastedText(file)
+            void onOpenPastedText(file, index)
           }
         }}
       >

--- a/src/components/chat/input/ChatInput.test.tsx
+++ b/src/components/chat/input/ChatInput.test.tsx
@@ -172,6 +172,7 @@ function renderChatInput(overrides: Partial<Parameters<typeof ChatInput>[0]> = {
     attachedFiles: [],
     onAttachFiles: vi.fn(),
     onRemoveFile: vi.fn(),
+    onUpdateFile: vi.fn(),
     permissionMode: "default",
     onPermissionModeChange: vi.fn(),
     sandboxMode: "off",

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -102,6 +102,7 @@ interface ChatInputProps {
   attachedFiles: File[]
   onAttachFiles: (files: File[]) => void
   onRemoveFile: (index: number) => void
+  onUpdateFile: (index: number, file: File) => void
   pendingQuotes?: PendingFileQuote[]
   onRemoveQuote?: (index: number) => void
   /** Click a staged quote chip to reveal that file in the file browser. */
@@ -220,6 +221,7 @@ export default function ChatInput({
   attachedFiles,
   onAttachFiles,
   onRemoveFile,
+  onUpdateFile,
   pendingQuotes,
   onRemoveQuote,
   onJumpToQuote,
@@ -1049,7 +1051,11 @@ export default function ChatInput({
         )}
 
         {/* Attached files preview (rendered above textarea) */}
-        <AttachmentPreview attachedFiles={attachedFiles} onRemoveFile={onRemoveFile} />
+        <AttachmentPreview
+          attachedFiles={attachedFiles}
+          onRemoveFile={onRemoveFile}
+          onUpdateFile={onUpdateFile}
+        />
 
         {/* Staged "quote to chat" references */}
         <AnimatedCollapse open={!!pendingQuotes?.length}>

--- a/src/components/chat/input/pastedTextAttachment.test.ts
+++ b/src/components/chat/input/pastedTextAttachment.test.ts
@@ -5,6 +5,7 @@ import {
   getPastedTextFileMeta,
   PASTED_TEXT_ATTACHMENT_SOURCE,
   shouldCreatePastedTextAttachment,
+  updatePastedTextAttachment,
 } from "./pastedTextAttachment"
 
 describe("pastedTextAttachment", () => {
@@ -26,5 +27,18 @@ describe("pastedTextAttachment", () => {
     expect(await file.text()).toBe(text)
     expect(meta?.source).toBe(PASTED_TEXT_ATTACHMENT_SOURCE)
     expect(meta?.lineCount).toBe(42)
+  })
+
+  test("keeps pasted text metadata when edited", async () => {
+    const file = createPastedTextAttachment("title\n" + "body\n".repeat(35))
+    const updated = updatePastedTextAttachment(file, "edited\nbody")
+    const meta = getPastedTextFileMeta(updated)
+
+    expect(updated.name).toBe(file.name)
+    expect(updated.type).toBe("text/plain")
+    expect(await updated.text()).toBe("edited\nbody")
+    expect(meta?.source).toBe(PASTED_TEXT_ATTACHMENT_SOURCE)
+    expect(meta?.lineCount).toBe(2)
+    expect(meta?.charCount).toBe("edited\nbody".length)
   })
 })

--- a/src/components/chat/input/pastedTextAttachment.ts
+++ b/src/components/chat/input/pastedTextAttachment.ts
@@ -21,17 +21,14 @@ export function shouldCreatePastedTextAttachment(text: string): boolean {
 export function createPastedTextAttachment(text: string): File {
   const normalized = normalizePastedText(text)
   const title = pastedTextTitle(normalized)
-  const file = new File([normalized], `${title}.txt`, {
-    type: "text/plain",
-    lastModified: Date.now(),
-  })
-  metaByFile.set(file, {
-    source: PASTED_TEXT_ATTACHMENT_SOURCE,
-    title,
-    charCount: normalized.length,
-    lineCount: lineCount(normalized),
-  })
-  return file
+  return createPastedTextFile(normalized, `${title}.txt`, title)
+}
+
+export function updatePastedTextAttachment(file: File, text: string): File {
+  const normalized = normalizePastedText(text)
+  const existingMeta = metaByFile.get(file)
+  const title = existingMeta?.title || titleFromFileName(file.name) || pastedTextTitle(normalized)
+  return createPastedTextFile(normalized, file.name, title)
 }
 
 export function getPastedTextFileMeta(file: File): PastedTextFileMeta | undefined {
@@ -44,6 +41,24 @@ function normalizePastedText(text: string): string {
 
 function lineCount(text: string): number {
   return text.length === 0 ? 0 : text.split("\n").length
+}
+
+function createPastedTextFile(text: string, fileName: string, title: string): File {
+  const file = new File([text], fileName, {
+    type: "text/plain",
+    lastModified: Date.now(),
+  })
+  metaByFile.set(file, {
+    source: PASTED_TEXT_ATTACHMENT_SOURCE,
+    title,
+    charCount: text.length,
+    lineCount: lineCount(text),
+  })
+  return file
+}
+
+function titleFromFileName(fileName: string): string {
+  return fileName.replace(/\.txt$/i, "").trim()
 }
 
 function pastedTextTitle(text: string): string {

--- a/src/components/knowledge/chat/KnowledgeChatPanel.tsx
+++ b/src/components/knowledge/chat/KnowledgeChatPanel.tsx
@@ -432,6 +432,11 @@ export const KnowledgeChatPanel = forwardRef<KnowledgeChatPanelHandle, Props>(
             onRemoveFile={(i) =>
               stream.setAttachedFiles((prev) => prev.filter((_, idx) => idx !== i))
             }
+            onUpdateFile={(index, file) =>
+              stream.setAttachedFiles((prev) =>
+                prev.map((existing, idx) => (idx === index ? file : existing)),
+              )
+            }
             pendingQuotes={stream.pendingQuotes}
             onRemoveQuote={(i) =>
               stream.setPendingQuotes((prev) => prev.filter((_, idx) => idx !== i))


### PR DESCRIPTION
## 变更

- 修复长文本粘贴附件预览弹窗的宽高约束和内容溢出问题
- 将只读预览改为可编辑文本框，支持复制、取消和保存
- 保存后替换待发送文件并刷新字符数、行数及粘贴文本元数据
- 接通主对话、快速对话和知识空间对话的附件更新回调
- 增加附件编辑及元数据更新测试

## 根因

原预览使用只读 `pre`，长内容的固有尺寸会破坏弹窗布局；弹窗与内容区也缺少完整的响应式高度约束。粘贴文本附件创建后没有更新入口，因此用户无法在发送前修订内容。

## 影响

长文本自动转成 `.txt` 附件后，预览在常规窗口、最小窗口和较窄视口下保持稳定；用户可以直接编辑并保存，发送时使用更新后的文件内容。

## 验证

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `cargo test -p ha-core -p ha-server --locked`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`（54 个测试文件，301 个测试通过）