### PR TITLE
feat(ui): redesign right panel dock

### DIFF
--- a/scripts/i18n-translations.json
+++ b/scripts/i18n-translations.json
@@ -120,7 +120,15 @@
       "rightPanel": {
         "collapse": "右パネルを折りたたむ",
         "expand": "右側のパネルを展開します",
-        "switch": "右パネルを切り替えます"
+        "switch": "右パネルを切り替えます",
+        "dock": "右パネルドック",
+        "openPanel": "{{panel}}を開く",
+        "switchToPanel": "{{panel}}に切り替える",
+        "collapsePanel": "{{panel}}を折りたたむ",
+        "expandPanel": "{{panel}}を展開する",
+        "workflowActiveCount": "{{count}}件のアクティブなワークフロー",
+        "workflowAttentionCount": "{{count}}件のワークフローに対応が必要です",
+        "backgroundRunningCount": "{{count}}件のバックグラウンドタスクが実行中"
       }
     },
     "effort": {
@@ -2022,7 +2030,15 @@
       "rightPanel": {
         "collapse": "오른쪽 패널 접기",
         "expand": "오른쪽 패널 펼치기",
-        "switch": "오른쪽 패널 전환"
+        "switch": "오른쪽 패널 전환",
+        "dock": "오른쪽 패널 도크",
+        "openPanel": "{{panel}} 열기",
+        "switchToPanel": "{{panel}} 패널로 전환",
+        "collapsePanel": "{{panel}} 접기",
+        "expandPanel": "{{panel}} 펼치기",
+        "workflowActiveCount": "활성 워크플로 {{count}}개",
+        "workflowAttentionCount": "주의가 필요한 워크플로 {{count}}개",
+        "backgroundRunningCount": "백그라운드 작업 {{count}}개 실행 중"
       }
     },
     "effort": {
@@ -3924,7 +3940,15 @@
       "rightPanel": {
         "collapse": "折疊右側面板",
         "expand": "展開右側面板",
-        "switch": "切換右側面板"
+        "switch": "切換右側面板",
+        "dock": "右側面板停駐列",
+        "openPanel": "開啟{{panel}}",
+        "switchToPanel": "切換至{{panel}}",
+        "collapsePanel": "收合{{panel}}",
+        "expandPanel": "展開{{panel}}",
+        "workflowActiveCount": "{{count}} 個作用中的工作流程",
+        "workflowAttentionCount": "{{count}} 個工作流程需要處理",
+        "backgroundRunningCount": "{{count}} 個背景任務正在執行"
       }
     },
     "effort": {
@@ -5809,7 +5833,15 @@
       "rightPanel": {
         "collapse": "Sağ paneli daralt",
         "expand": "Sağ paneli genişlet",
-        "switch": "Sağ paneli değiştir"
+        "switch": "Sağ paneli değiştir",
+        "dock": "Sağ panel çubuğu",
+        "openPanel": "{{panel}} panelini aç",
+        "switchToPanel": "{{panel}} paneline geç",
+        "collapsePanel": "{{panel}} panelini daralt",
+        "expandPanel": "{{panel}} panelini genişlet",
+        "workflowActiveCount": "{{count}} etkin iş akışı",
+        "workflowAttentionCount": "{{count}} iş akışı ilgilenmenizi bekliyor",
+        "backgroundRunningCount": "{{count}} arka plan görevi çalışıyor"
       }
     },
     "effort": {
@@ -7711,7 +7743,15 @@
       "rightPanel": {
         "collapse": "Thu gọn bảng bên phải",
         "expand": "Mở rộng bảng bên phải",
-        "switch": "Chuyển bảng bên phải"
+        "switch": "Chuyển bảng bên phải",
+        "dock": "Thanh panel bên phải",
+        "openPanel": "Mở {{panel}}",
+        "switchToPanel": "Chuyển sang {{panel}}",
+        "collapsePanel": "Thu gọn {{panel}}",
+        "expandPanel": "Mở rộng {{panel}}",
+        "workflowActiveCount": "{{count}} quy trình đang hoạt động",
+        "workflowAttentionCount": "{{count}} quy trình cần chú ý",
+        "backgroundRunningCount": "{{count}} tác vụ nền đang chạy"
       }
     },
     "effort": {
@@ -9613,7 +9653,15 @@
       "rightPanel": {
         "collapse": "Recolher painel direito",
         "expand": "Expandir painel direito",
-        "switch": "Alternar painel direito"
+        "switch": "Alternar painel direito",
+        "dock": "Dock de painéis à direita",
+        "openPanel": "Abrir {{panel}}",
+        "switchToPanel": "Alternar para {{panel}}",
+        "collapsePanel": "Recolher {{panel}}",
+        "expandPanel": "Expandir {{panel}}",
+        "workflowActiveCount": "{{count}} fluxos de trabalho ativos",
+        "workflowAttentionCount": "{{count}} fluxos de trabalho precisam de atenção",
+        "backgroundRunningCount": "{{count}} tarefas em segundo plano em execução"
       }
     },
     "effort": {
@@ -11515,7 +11563,15 @@
       "rightPanel": {
         "collapse": "Свернуть правую панель",
         "expand": "Развернуть правую панель",
-        "switch": "Переключить правую панель"
+        "switch": "Переключить правую панель",
+        "dock": "Панель закрепления справа",
+        "openPanel": "Открыть {{panel}}",
+        "switchToPanel": "Переключиться на {{panel}}",
+        "collapsePanel": "Свернуть {{panel}}",
+        "expandPanel": "Развернуть {{panel}}",
+        "workflowActiveCount": "Активных процессов: {{count}}",
+        "workflowAttentionCount": "Требуют внимания: {{count}}",
+        "backgroundRunningCount": "Фоновых задач выполняется: {{count}}"
       }
     },
     "effort": {
@@ -13417,7 +13473,15 @@
       "rightPanel": {
         "collapse": "طي اللوحة اليمنى",
         "expand": "قم بتوسيع اللوحة اليمنى",
-        "switch": "تبديل اللوحة اليمنى"
+        "switch": "تبديل اللوحة اليمنى",
+        "dock": "شريط اللوحات الجانبية",
+        "openPanel": "فتح {{panel}}",
+        "switchToPanel": "التبديل إلى {{panel}}",
+        "collapsePanel": "طي {{panel}}",
+        "expandPanel": "توسيع {{panel}}",
+        "workflowActiveCount": "{{count}} من مهام سير العمل النشطة",
+        "workflowAttentionCount": "{{count}} من مهام سير العمل تحتاج إلى الانتباه",
+        "backgroundRunningCount": "{{count}} من المهام في الخلفية قيد التشغيل"
       }
     },
     "effort": {
@@ -15319,7 +15383,15 @@
       "rightPanel": {
         "collapse": "Contraer panel derecho",
         "expand": "Expandir el panel derecho",
-        "switch": "Cambiar panel derecho"
+        "switch": "Cambiar panel derecho",
+        "dock": "Barra de paneles derechos",
+        "openPanel": "Abrir {{panel}}",
+        "switchToPanel": "Cambiar a {{panel}}",
+        "collapsePanel": "Contraer {{panel}}",
+        "expandPanel": "Expandir {{panel}}",
+        "workflowActiveCount": "{{count}} flujos de trabajo activos",
+        "workflowAttentionCount": "{{count}} flujos de trabajo requieren atención",
+        "backgroundRunningCount": "{{count}} tareas en segundo plano en ejecución"
       }
     },
     "effort": {
@@ -17221,7 +17293,15 @@
       "rightPanel": {
         "collapse": "Runtuhkan panel kanan",
         "expand": "Kembangkan panel kanan",
-        "switch": "Tukar panel kanan"
+        "switch": "Tukar panel kanan",
+        "dock": "Dok panel kanan",
+        "openPanel": "Buka {{panel}}",
+        "switchToPanel": "Tukar kepada {{panel}}",
+        "collapsePanel": "Runtuhkan {{panel}}",
+        "expandPanel": "Kembangkan {{panel}}",
+        "workflowActiveCount": "{{count}} aliran kerja aktif",
+        "workflowAttentionCount": "{{count}} aliran kerja memerlukan perhatian",
+        "backgroundRunningCount": "{{count}} tugasan latar belakang sedang berjalan"
       }
     },
     "effort": {
@@ -19225,7 +19305,15 @@
       "rightPanel": {
         "collapse": "折叠右侧面板",
         "expand": "展开右侧面板",
-        "switch": "切换右侧面板"
+        "switch": "切换右侧面板",
+        "dock": "右侧面板停靠栏",
+        "openPanel": "打开{{panel}}",
+        "switchToPanel": "切换到{{panel}}",
+        "collapsePanel": "收起{{panel}}",
+        "expandPanel": "展开{{panel}}",
+        "workflowActiveCount": "{{count}} 个活跃工作流",
+        "workflowAttentionCount": "{{count}} 个工作流需要处理",
+        "backgroundRunningCount": "{{count}} 个后台任务正在运行"
       }
     },
     "slashCommands": {

--- a/src/components/chat/BrowserPanel.tsx
+++ b/src/components/chat/BrowserPanel.tsx
@@ -31,6 +31,7 @@ interface BrowserPanelProps {
   reservedMainWidth?: number
   collapsed?: boolean
   overlay?: boolean
+  animateOnMount?: boolean
   onClose: () => void
 }
 
@@ -50,6 +51,7 @@ export default function BrowserPanel({
   reservedMainWidth,
   collapsed = false,
   overlay = false,
+  animateOnMount = false,
   onClose,
 }: BrowserPanelProps) {
   const { t } = useTranslation()
@@ -136,6 +138,7 @@ export default function BrowserPanel({
       reservedMainWidth={reservedMainWidth}
       collapsed={collapsed}
       overlay={overlay}
+      animateOnMount={animateOnMount}
       contentKey="browser"
     >
       {/* Header */}

--- a/src/components/chat/CanvasPanel.tsx
+++ b/src/components/chat/CanvasPanel.tsx
@@ -54,6 +54,7 @@ interface CanvasPanelProps {
   visible?: boolean
   collapsed?: boolean
   overlay?: boolean
+  animateOnMount?: boolean
 }
 
 export const CLOSE_CANVAS_PANEL_EVENT = "hope-agent:close-canvas"
@@ -67,6 +68,7 @@ export default function CanvasPanel({
   visible = true,
   collapsed = false,
   overlay = false,
+  animateOnMount = false,
 }: CanvasPanelProps) {
   const { t } = useTranslation()
   const [canvas, setCanvas] = useState<CanvasInfo | null>(null)
@@ -420,6 +422,7 @@ export default function CanvasPanel({
         reservedMainWidth={reservedMainWidth}
         collapsed={collapsed}
         overlay={overlay}
+        animateOnMount={animateOnMount}
         contentKey="canvas-detached"
       >
         {/* Title Bar */}
@@ -463,6 +466,7 @@ export default function CanvasPanel({
       reservedMainWidth={reservedMainWidth}
       collapsed={collapsed}
       overlay={overlay}
+      animateOnMount={animateOnMount}
       contentKey="canvas"
     >
       {/* Title Bar */}

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -304,6 +304,26 @@ const EXCLUSIVE_RIGHT_PANEL_ICONS: Record<ExclusiveRightPanel, LucideIcon> = {
   preview: Eye,
 }
 
+const EXCLUSIVE_RIGHT_PANEL_LABEL_KEYS: Record<ExclusiveRightPanel, string> = {
+  workspace: "workspace.panelTitle",
+  "pull-request": "workspace.git.pullRequestPanelTitle",
+  diff: "diffPanel.title",
+  plan: "planMode.panelTitle",
+  files: "fileBrowser.panelTitle",
+  browser: "browser.panelTitle",
+  "mac-control": "macControl.panelTitle",
+  canvas: "canvas.panelTitle",
+  team: "team.panelTitle",
+  "background-jobs": "backgroundJobs.panelTitle",
+  preview: "filePreview.panelTitle",
+}
+
+const PERSISTENT_RIGHT_PANEL_ORDER: readonly ExclusiveRightPanel[] = [
+  "workspace",
+  "files",
+  "background-jobs",
+]
+
 const DEFAULT_RIGHT_PANEL_WIDTH = 520
 const CHAT_MAIN_MIN_INTERACTIVE_WIDTH = 420
 const CHAT_MAIN_COMPACT_MIN_INTERACTIVE_WIDTH = 320
@@ -2975,49 +2995,17 @@ export default function ChatScreen({
     [rightPanelVisibility],
   )
   const hasOpenExclusiveRightPanel = openExclusiveRightPanels.length > 0
+  const previousHasOpenRightPanelRef = useRef(false)
+  const animateRightPanelOnMount =
+    hasOpenExclusiveRightPanel && !previousHasOpenRightPanelRef.current
+  useLayoutEffect(() => {
+    previousHasOpenRightPanelRef.current = hasOpenExclusiveRightPanel
+  }, [hasOpenExclusiveRightPanel])
   const renderedExclusiveRightPanel =
     activeExclusiveRightPanel && rightPanelVisibility[activeExclusiveRightPanel]
       ? activeExclusiveRightPanel
       : (openExclusiveRightPanels[0] ?? null)
   const shouldRenderRightPanelContent = !!renderedExclusiveRightPanel
-  const getRightPanelLabel = useCallback(
-    (panel: ExclusiveRightPanel) => {
-      switch (panel) {
-        case "workspace":
-          return t("workspace.panelTitle", "工作台")
-        case "pull-request":
-          return t("workspace.git.pullRequestPanelTitle", "拉取请求")
-        case "diff":
-          return t("diffPanel.title", "Diff")
-        case "plan":
-          return t("planMode.panelTitle", "Plan")
-        case "files":
-          return t("fileBrowser.panelTitle", "Files")
-        case "browser":
-          return t("browser.panelTitle", "Browser")
-        case "mac-control":
-          return t("macControl.panelTitle", "Mac Control")
-        case "canvas":
-          return t("canvas.panelTitle", "Canvas")
-        case "team":
-          return t("team.panelTitle", "Team")
-        case "background-jobs":
-          return t("backgroundJobs.panelTitle", "后台任务")
-        case "preview":
-          return t("filePreview.panelTitle", "Preview")
-      }
-    },
-    [t],
-  )
-  const titleBarRightPanels = useMemo(
-    () =>
-      openExclusiveRightPanels.map((panel) => ({
-        id: panel,
-        label: getRightPanelLabel(panel),
-        icon: EXCLUSIVE_RIGHT_PANEL_ICONS[panel],
-      })),
-    [getRightPanelLabel, openExclusiveRightPanels],
-  )
   const handleSelectRightPanel = useCallback((panelId: string) => {
     if (!EXCLUSIVE_RIGHT_PANEL_ORDER.includes(panelId as ExclusiveRightPanel)) return
     setActiveExclusiveRightPanel(panelId as ExclusiveRightPanel)
@@ -3392,6 +3380,60 @@ export default function ChatScreen({
       runningCount: workflowTitleBarRuns.runs.filter(isRunning).length,
     }
   }, [workflowTitleBarRuns.activeCount, workflowTitleBarRuns.runs])
+  const titleBarRightPanels = useMemo(() => {
+    const persistentPanels = PERSISTENT_RIGHT_PANEL_ORDER.filter(
+      (panel) => panel !== "files" || !!effectiveWorkingDir,
+    )
+    const persistentSet = new Set<ExclusiveRightPanel>(persistentPanels)
+    const transientPanels = EXCLUSIVE_RIGHT_PANEL_ORDER.filter(
+      (panel) => !persistentSet.has(panel) && rightPanelVisibility[panel],
+    )
+    const workflowBadgeCount =
+      workflowTitleBarStatus.attentionCount || workflowTitleBarStatus.activeCount
+
+    return [...persistentPanels, ...transientPanels].map((panel) => {
+      const base = {
+        id: panel,
+        labelKey: EXCLUSIVE_RIGHT_PANEL_LABEL_KEYS[panel],
+        icon: EXCLUSIVE_RIGHT_PANEL_ICONS[panel],
+        open: rightPanelVisibility[panel],
+      }
+      if (panel === "workspace" && workflowBadgeCount > 0) {
+        return {
+          ...base,
+          badge: {
+            count: workflowBadgeCount,
+            labelKey:
+              workflowTitleBarStatus.attentionCount > 0
+                ? "chat.rightPanel.workflowAttentionCount"
+                : "chat.rightPanel.workflowActiveCount",
+            tone:
+              workflowTitleBarStatus.attentionCount > 0
+                ? ("attention" as const)
+                : workflowTitleBarStatus.runningCount > 0
+                  ? ("running" as const)
+                  : ("neutral" as const),
+          },
+        }
+      }
+      if (panel === "background-jobs" && backgroundJobs.runningCount > 0) {
+        return {
+          ...base,
+          badge: {
+            count: backgroundJobs.runningCount,
+            labelKey: "chat.rightPanel.backgroundRunningCount",
+            tone: "attention" as const,
+          },
+        }
+      }
+      return base
+    })
+  }, [
+    backgroundJobs.runningCount,
+    effectiveWorkingDir,
+    rightPanelVisibility,
+    workflowTitleBarStatus,
+  ])
   const workflowInputProgress = useMemo(() => {
     const visibleStates = new Set<WorkflowRun["state"]>([
       "awaiting_approval",
@@ -3432,14 +3474,42 @@ export default function ChatScreen({
     }
   }, [workflowTitleBarRuns.runs])
 
-  const handleToggleFilesPanel = useCallback(() => {
-    if (showFilesPanel) {
-      setShowFilesPanel(false)
-      return
-    }
-    setShowFilesPanel(true)
-    showRightPanelByUser("files")
-  }, [showFilesPanel, showRightPanelByUser])
+  const handleRightPanelAction = useCallback(
+    (panelId: string) => {
+      if (!EXCLUSIVE_RIGHT_PANEL_ORDER.includes(panelId as ExclusiveRightPanel)) return
+      const panel = panelId as ExclusiveRightPanel
+      if (panel === renderedExclusiveRightPanel) {
+        const nextCollapsed = !rightPanelCollapsed
+        autoCollapsedRightPanelRef.current = false
+        setManualRightPanelExpandedOverride(!nextCollapsed)
+        setRightPanelCollapsed(nextCollapsed)
+        return
+      }
+
+      if (panel === "workspace") {
+        openWorkspacePanel()
+        return
+      }
+      if (panel === "files") {
+        setShowFilesPanel(true)
+        showRightPanelByUser("files")
+        return
+      }
+      if (panel === "background-jobs") {
+        openBackgroundJobsPanel()
+        return
+      }
+      handleSelectRightPanel(panel)
+    },
+    [
+      handleSelectRightPanel,
+      openBackgroundJobsPanel,
+      openWorkspacePanel,
+      renderedExclusiveRightPanel,
+      rightPanelCollapsed,
+      showRightPanelByUser,
+    ],
+  )
 
   const rightPanelReservedMainWidth =
     manualRightPanelExpandedOverride && !rightPanelCollapsed
@@ -3671,41 +3741,10 @@ export default function ChatScreen({
           incognitoEnabled={incognitoEnabled}
           incognitoDisabledReason={incognitoDisabledReason}
           onIncognitoChange={handleIncognitoChange}
-          onToggleFilesPanel={effectiveWorkingDir ? handleToggleFilesPanel : undefined}
-          filesPanelOpen={showFilesPanel}
-          onToggleWorkspacePanel={() => {
-            if (showWorkspacePanel) {
-              workspacePanelDismissedRef.current = true
-              setShowWorkspacePanel(false)
-            } else {
-              openWorkspacePanel()
-            }
-          }}
-          workspacePanelOpen={showWorkspacePanel}
-          workspaceWorkflowStatus={workflowTitleBarStatus}
-          onToggleBackgroundJobsPanel={() => {
-            if (showBackgroundJobsPanel) {
-              closeBackgroundJobsPanel()
-            } else {
-              openBackgroundJobsPanel()
-            }
-          }}
-          backgroundJobsPanelOpen={showBackgroundJobsPanel}
-          backgroundJobsRunningCount={backgroundJobs.runningCount}
           rightPanels={titleBarRightPanels}
           activeRightPanelId={renderedExclusiveRightPanel}
           rightPanelCollapsed={rightPanelCollapsed}
-          onSelectRightPanel={handleSelectRightPanel}
-          onToggleRightPanelCollapsed={
-            hasOpenExclusiveRightPanel
-              ? () => {
-                  const nextCollapsed = !rightPanelCollapsed
-                  autoCollapsedRightPanelRef.current = false
-                  setManualRightPanelExpandedOverride(!nextCollapsed)
-                  setRightPanelCollapsed(nextCollapsed)
-                }
-              : undefined
-          }
+          onRightPanelAction={handleRightPanelAction}
         />
 
         <BrowserExtensionNudge
@@ -4069,6 +4108,7 @@ export default function ChatScreen({
               reservedMainWidth={rightPanelReservedMainWidth}
               collapsed={rightPanelCollapsed}
               overlay={rightPanelOverlay}
+              animateOnMount={animateRightPanelOnMount}
               contentKey="diff"
             >
               <DiffPanel
@@ -4096,6 +4136,7 @@ export default function ChatScreen({
                 reservedMainWidth={rightPanelReservedMainWidth}
                 collapsed={rightPanelCollapsed}
                 overlay={rightPanelOverlay}
+                animateOnMount={animateRightPanelOnMount}
                 contentKey={`pull-request:${session.currentSessionId}`}
               >
                 <PullRequestPanel
@@ -4116,6 +4157,7 @@ export default function ChatScreen({
               reservedMainWidth={rightPanelReservedMainWidth}
               collapsed={rightPanelCollapsed}
               overlay={rightPanelOverlay}
+              animateOnMount={animateRightPanelOnMount}
               contentKey="plan"
             >
               <PlanPanel
@@ -4149,6 +4191,7 @@ export default function ChatScreen({
             visible={shouldRenderRightPanelContent && renderedExclusiveRightPanel === "files"}
             collapsed={rightPanelCollapsed}
             overlay={rightPanelOverlay}
+            animateOnMount={animateRightPanelOnMount}
             panelWidth={rightPanelWidth}
             onPanelWidthChange={setRightPanelWidth}
             reservedMainWidth={rightPanelReservedMainWidth}
@@ -4165,6 +4208,7 @@ export default function ChatScreen({
             onOpenChange={setCanvasPanelOpen}
             collapsed={rightPanelCollapsed}
             overlay={rightPanelOverlay}
+            animateOnMount={animateRightPanelOnMount}
             reservedMainWidth={rightPanelReservedMainWidth}
             visible={shouldRenderRightPanelContent && renderedExclusiveRightPanel === "canvas"}
           />
@@ -4178,6 +4222,7 @@ export default function ChatScreen({
               onPanelWidthChange={setRightPanelWidth}
               collapsed={rightPanelCollapsed}
               overlay={rightPanelOverlay}
+              animateOnMount={animateRightPanelOnMount}
               reservedMainWidth={rightPanelReservedMainWidth}
               onClose={() => {
                 browserPanelDismissedRef.current = true
@@ -4195,6 +4240,7 @@ export default function ChatScreen({
               onPanelWidthChange={setRightPanelWidth}
               collapsed={rightPanelCollapsed}
               overlay={rightPanelOverlay}
+              animateOnMount={animateRightPanelOnMount}
               reservedMainWidth={rightPanelReservedMainWidth}
               onClose={() => {
                 macControlPanelDismissedRef.current = true
@@ -4213,6 +4259,7 @@ export default function ChatScreen({
                 onPanelWidthChange={setRightPanelWidth}
                 collapsed={rightPanelCollapsed}
                 overlay={rightPanelOverlay}
+                animateOnMount={animateRightPanelOnMount}
                 reservedMainWidth={rightPanelReservedMainWidth}
                 onClose={() => setShowTeamPanel(false)}
                 onViewSession={setSubagentPreviewSessionId}
@@ -4229,6 +4276,7 @@ export default function ChatScreen({
               reservedMainWidth={rightPanelReservedMainWidth}
               collapsed={rightPanelCollapsed}
               overlay={rightPanelOverlay}
+              animateOnMount={animateRightPanelOnMount}
               contentKey="workspace"
             >
               <WorkspacePanel
@@ -4292,6 +4340,7 @@ export default function ChatScreen({
               reservedMainWidth={rightPanelReservedMainWidth}
               collapsed={rightPanelCollapsed}
               overlay={rightPanelOverlay}
+              animateOnMount={animateRightPanelOnMount}
               contentKey="background-jobs"
             >
               <BackgroundJobsPanel
@@ -4317,6 +4366,7 @@ export default function ChatScreen({
               reservedMainWidth={rightPanelReservedMainWidth}
               collapsed={rightPanelCollapsed}
               overlay={rightPanelOverlay}
+              animateOnMount={animateRightPanelOnMount}
               contentKey="preview"
             >
               <FilePreviewPanel

--- a/src/components/chat/ChatTitleBar.test.tsx
+++ b/src/components/chat/ChatTitleBar.test.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react"
 import { afterEach, describe, expect, test, vi } from "vitest"
 import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { Eye, FolderOpen, Layers, LayoutDashboard } from "lucide-react"
 
 import ChatTitleBar from "./ChatTitleBar"
 import type { SessionMeta } from "@/types/chat"
@@ -21,7 +22,23 @@ vi.mock("react-i18next", () => ({
     init: vi.fn(),
   },
   useTranslation: () => ({
-    t: (key: string, fallback?: string) => (typeof fallback === "string" ? fallback : key),
+    t: (key: string, options?: string | Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        "chat.rightPanel.dock": "Right panel dock",
+        "chat.rightPanel.openPanel": "Open {{panel}}",
+        "chat.rightPanel.switchToPanel": "Switch to {{panel}}",
+        "chat.rightPanel.collapsePanel": "Collapse {{panel}}",
+        "chat.rightPanel.expandPanel": "Expand {{panel}}",
+        "chat.rightPanel.workflowAttentionCount": "{{count}} workflows need attention",
+        "workspace.panelTitle": "Workspace",
+        "fileBrowser.panelTitle": "Files",
+        "backgroundJobs.panelTitle": "Background Tasks",
+        "filePreview.panelTitle": "Preview",
+      }
+      const template = translations[key] ?? (typeof options === "string" ? options : key)
+      if (!options || typeof options === "string") return template
+      return template.replace(/{{(\w+)}}/g, (_, name: string) => String(options[name] ?? ""))
+    },
   }),
 }))
 
@@ -84,59 +101,97 @@ afterEach(() => {
   transportMock.call.mockImplementation(() => Promise.resolve("full"))
 })
 
-describe("ChatTitleBar working directory affordances", () => {
-  test("shows a visible workspace entry in the title bar", () => {
-    const onToggleWorkspacePanel = vi.fn()
+describe("ChatTitleBar right-panel dock", () => {
+  test("renders a single icon entry for each panel and dispatches its id", () => {
+    const onRightPanelAction = vi.fn()
     renderTitleBar({
-      onToggleWorkspacePanel,
+      onRightPanelAction,
+      rightPanels: [
+        {
+          id: "workspace",
+          labelKey: "workspace.panelTitle",
+          icon: LayoutDashboard,
+          open: false,
+        },
+        {
+          id: "background-jobs",
+          labelKey: "backgroundJobs.panelTitle",
+          icon: Layers,
+          open: false,
+        },
+      ],
     })
 
-    expect(screen.getByText("Workspace")).toBeTruthy()
-
-    const codingButton = screen.getByRole("button", { name: "Open workspace" })
-    fireEvent.click(codingButton)
-
-    expect(onToggleWorkspacePanel).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole("toolbar", { name: "Right panel dock" })).toBeTruthy()
+    expect(screen.getAllByRole("button", { name: "Open Workspace" })).toHaveLength(1)
+    fireEvent.click(screen.getByRole("button", { name: "Open Workspace" }))
+    expect(onRightPanelAction).toHaveBeenCalledWith("workspace")
   })
 
-  test("badges the workspace entry when workflow runs need attention", () => {
+  test("uses a neutral selected state and localizes the badge label", () => {
     renderTitleBar({
-      onToggleWorkspacePanel: vi.fn(),
-      workspaceWorkflowStatus: {
-        activeCount: 2,
-        attentionCount: 1,
-        runningCount: 1,
-      },
+      activeRightPanelId: "workspace",
+      rightPanels: [
+        {
+          id: "workspace",
+          labelKey: "workspace.panelTitle",
+          icon: LayoutDashboard,
+          open: true,
+          badge: {
+            count: 1,
+            labelKey: "chat.rightPanel.workflowAttentionCount",
+            tone: "attention",
+          },
+        },
+      ],
     })
 
-    expect(screen.getByRole("button", { name: "Open workspace" })).toBeTruthy()
-    expect(screen.getByText("1")).toBeTruthy()
+    const workspaceButton = screen.getByRole("button", { name: "Collapse Workspace" })
+    expect(workspaceButton.className.split(" ")).toContain("text-foreground")
+    expect(workspaceButton.dataset.panelState).toBe("active")
+    expect(screen.getByLabelText("1 workflows need attention")).toBeTruthy()
   })
 
-  test("shows file controls for an empty selected session with a working directory", () => {
-    const onToggleFilesPanel = vi.fn()
+  test("keeps open transient panels in the same dock", () => {
+    const onRightPanelAction = vi.fn()
+    renderTitleBar({
+      activeRightPanelId: "workspace",
+      onRightPanelAction,
+      rightPanels: [
+        {
+          id: "workspace",
+          labelKey: "workspace.panelTitle",
+          icon: LayoutDashboard,
+          open: true,
+        },
+        { id: "preview", labelKey: "filePreview.panelTitle", icon: Eye, open: true },
+      ],
+    })
+
+    const previewButton = screen.getByRole("button", { name: "Switch to Preview" })
+    fireEvent.click(previewButton)
+    expect(onRightPanelAction).toHaveBeenCalledWith("preview")
+  })
+
+  test("labels the active icon as expand when the rail is collapsed", () => {
+    renderTitleBar({
+      activeRightPanelId: "files",
+      rightPanelCollapsed: true,
+      rightPanels: [
+        { id: "files", labelKey: "fileBrowser.panelTitle", icon: FolderOpen, open: true },
+      ],
+    })
+
+    expect(screen.getByRole("button", { name: "Expand Files" })).toBeTruthy()
+  })
+
+  test("still shows the localized working-directory chip", () => {
     renderTitleBar({
       sessions: [sessionMeta({ workingDir: "/Users/me/repo" })],
       effectiveWorkingDir: "/Users/me/repo",
       workingDirSource: "session",
-      onToggleFilesPanel,
     })
 
     expect(screen.getByText("repo")).toBeTruthy()
-
-    const filesButton = screen.getByRole("button", { name: "Show files" })
-    fireEvent.click(filesButton)
-
-    expect(onToggleFilesPanel).toHaveBeenCalledTimes(1)
-  })
-
-  test("does not show file controls before a working directory exists", () => {
-    renderTitleBar({
-      sessions: [sessionMeta()],
-      effectiveWorkingDir: null,
-      onToggleFilesPanel: undefined,
-    })
-
-    expect(screen.queryByRole("button", { name: "Show files" })).toBeNull()
   })
 })

--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -15,17 +15,12 @@ import {
   FileText,
   Folder,
   FolderCheck,
-  FolderOpen,
-  Layers,
-  LayoutDashboard,
   Loader2,
   Search,
   Send,
   Ghost,
   Share2,
   PanelLeftDashed,
-  PanelRight,
-  PanelRightDashed,
   type LucideIcon,
 } from "lucide-react"
 import { ExportSessionDialog } from "@/components/chat/export/ExportSessionDialog"
@@ -66,14 +61,14 @@ import type { ProjectMeta } from "@/types/project"
 
 interface RightPanelTitleBarItem {
   id: string
-  label: string
+  labelKey: string
   icon: LucideIcon
-}
-
-interface WorkflowTitleBarStatus {
-  activeCount: number
-  attentionCount: number
-  runningCount: number
+  open: boolean
+  badge?: {
+    count: number
+    labelKey: string
+    tone: "attention" | "running" | "neutral"
+  }
 }
 
 interface ChatTitleBarProps {
@@ -133,32 +128,14 @@ interface ChatTitleBarProps {
   incognitoSaving?: boolean
   incognitoDisabledReason?: IncognitoDisabledReason
   onIncognitoChange?: (enabled: boolean) => void
-  /** Toggle the right-side file browser. Undefined when no working directory. */
-  onToggleFilesPanel?: () => void
-  /** Whether the file browser panel is currently open (controls active styling). */
-  filesPanelOpen?: boolean
-  /** Toggle the right-side workspace panel (tasks / files / sources). */
-  onToggleWorkspacePanel?: () => void
-  /** Whether the workspace panel is currently open (controls active styling). */
-  workspacePanelOpen?: boolean
-  /** Compact workflow run status for the Workflow workspace entry badge. */
-  workspaceWorkflowStatus?: WorkflowTitleBarStatus
-  /** Toggle the right-side background-jobs panel (R4). */
-  onToggleBackgroundJobsPanel?: () => void
-  /** Whether the background-jobs panel is currently open (controls active styling). */
-  backgroundJobsPanelOpen?: boolean
-  /** Count of running background jobs in this session (drives the header badge). */
-  backgroundJobsRunningCount?: number
-  /** Open right-side panels available for switching/collapsing. */
+  /** Available persistent entries plus currently-open transient right panels. */
   rightPanels?: RightPanelTitleBarItem[]
   /** Active right-side panel id. */
   activeRightPanelId?: string | null
   /** Whether the active right-side panel is collapsed. */
   rightPanelCollapsed?: boolean
-  /** Switch to an already-open right-side panel. */
-  onSelectRightPanel?: (panelId: string) => void
-  /** Collapse/expand the active right-side panel. */
-  onToggleRightPanelCollapsed?: () => void
+  /** Open, select, collapse or expand a right-side panel. */
+  onRightPanelAction?: (panelId: string) => void
 }
 
 export default function ChatTitleBar({
@@ -193,19 +170,10 @@ export default function ChatTitleBar({
   incognitoSaving = false,
   incognitoDisabledReason,
   onIncognitoChange,
-  onToggleFilesPanel,
-  filesPanelOpen = false,
-  onToggleWorkspacePanel,
-  workspacePanelOpen = false,
-  workspaceWorkflowStatus,
-  onToggleBackgroundJobsPanel,
-  backgroundJobsPanelOpen = false,
-  backgroundJobsRunningCount = 0,
   rightPanels = [],
   activeRightPanelId,
   rightPanelCollapsed = false,
-  onSelectRightPanel,
-  onToggleRightPanelCollapsed,
+  onRightPanelAction,
 }: ChatTitleBarProps) {
   const { t } = useTranslation()
   const appVersion = useAppVersion()
@@ -318,27 +286,6 @@ export default function ChatTitleBar({
   const currentModel = resolveCurrentModel(activeModel, availableModels)
   const showIncognitoToggle =
     !currentSessionId && onIncognitoChange && incognitoDisabledReason !== "project"
-  const activeRightPanel =
-    rightPanels.find((panel) => panel.id === activeRightPanelId) ?? rightPanels[0] ?? null
-  const rightPanelToggleLabel = rightPanelCollapsed
-    ? t("chat.rightPanel.expand", "展开右侧面板")
-    : t("chat.rightPanel.collapse", "收起右侧面板")
-  const workflowAttentionCount = workspaceWorkflowStatus?.attentionCount ?? 0
-  const workflowActiveCount = workspaceWorkflowStatus?.activeCount ?? 0
-  const workflowRunningCount = workspaceWorkflowStatus?.runningCount ?? 0
-  const workflowBadgeCount = workflowAttentionCount || workflowActiveCount
-  const workflowBadgeTone =
-    workflowAttentionCount > 0
-      ? "bg-amber-500 text-white"
-      : workflowRunningCount > 0
-        ? "bg-blue-500 text-white"
-        : "bg-muted-foreground text-background"
-  const workspaceEntryLabel = t("workspace.openPanel", "Open workspace")
-  const hasRightPanelControls =
-    !!onToggleFilesPanel ||
-    !!onToggleWorkspacePanel ||
-    !!onToggleBackgroundJobsPanel ||
-    (rightPanels.length > 0 && (rightPanels.length > 1 || !!onToggleRightPanelCollapsed))
   const workingDirChip = effectiveWorkingDir ? (
     <IconTip
       label={
@@ -361,121 +308,76 @@ export default function ChatTitleBar({
     </IconTip>
   ) : null
   const shouldShowWorkingDirChip = !project || workingDirSource === "session"
-  const rightPanelControls = hasRightPanelControls ? (
+  const rightPanelControls = rightPanels.length > 0 ? (
     <div className="ml-1 flex items-center gap-0.5 border-l border-border-soft pl-1">
-      {onToggleFilesPanel && (
-        <IconTip label={t("fileBrowser.open", "Show files")}>
-          <button
-            type="button"
-            className={cn(
-              "flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground",
-              filesPanelOpen && "text-foreground",
-            )}
-            aria-label={t("fileBrowser.open", "Show files")}
-            aria-pressed={filesPanelOpen}
-            onClick={onToggleFilesPanel}
-          >
-            <FolderOpen className="h-4 w-4" />
-          </button>
-        </IconTip>
-      )}
-      {onToggleWorkspacePanel && (
-        <IconTip label={workspaceEntryLabel}>
-          <button
-            type="button"
-            className={cn(
-              "relative flex h-7 max-w-[112px] items-center justify-center gap-1.5 rounded-md px-2 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground",
-              workspacePanelOpen && "bg-primary/10 text-primary ring-1 ring-primary/25",
-            )}
-            aria-label={workspaceEntryLabel}
-            aria-pressed={workspacePanelOpen}
-            onClick={onToggleWorkspacePanel}
-          >
-            <LayoutDashboard className="h-4 w-4 shrink-0" />
-            <span className="truncate">{t("workspace.panelTitle", "Workspace")}</span>
-            {workflowBadgeCount > 0 ? (
-              <span
+      <div
+        className="flex h-8 max-w-[248px] items-center gap-0.5 overflow-x-auto p-0.5"
+        role="toolbar"
+        aria-label={t("chat.rightPanel.dock")}
+      >
+        {rightPanels.map((panel) => {
+          const PanelIcon = panel.icon
+          const active = panel.id === activeRightPanelId
+          const panelLabel = t(panel.labelKey)
+          const actionLabel = active
+            ? t(
+                rightPanelCollapsed
+                  ? "chat.rightPanel.expandPanel"
+                  : "chat.rightPanel.collapsePanel",
+                { panel: panelLabel },
+              )
+            : t(panel.open ? "chat.rightPanel.switchToPanel" : "chat.rightPanel.openPanel", {
+                panel: panelLabel,
+              })
+          const badgeTone =
+            panel.badge?.tone === "attention"
+              ? "bg-amber-500 text-white"
+              : panel.badge?.tone === "running"
+                ? "bg-blue-500 text-white"
+                : "bg-muted-foreground text-background"
+          const badgeDescriptionId = panel.badge
+            ? `right-panel-${panel.id}-badge-description`
+            : undefined
+          return (
+            <IconTip key={panel.id} label={actionLabel}>
+              <button
+                type="button"
+                aria-label={actionLabel}
+                aria-pressed={active}
+                aria-expanded={active ? !rightPanelCollapsed : undefined}
+                aria-describedby={badgeDescriptionId}
+                data-panel-id={panel.id}
+                data-panel-state={active ? "active" : panel.open ? "open" : "closed"}
                 className={cn(
-                  "absolute -right-1 -top-1 z-10 flex h-[15px] min-w-[15px] items-center justify-center rounded-full border border-background px-0.5 text-[9px] font-semibold leading-none tabular-nums",
-                  workflowBadgeTone,
+                  "group relative flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors duration-150 hover:text-foreground",
+                  active && "text-foreground",
                 )}
+                onClick={() => onRightPanelAction?.(panel.id)}
               >
-                {workflowBadgeCount > 99 ? "99+" : workflowBadgeCount}
-              </span>
-            ) : null}
-          </button>
-        </IconTip>
-      )}
-      {onToggleBackgroundJobsPanel && (
-        <IconTip label={t("backgroundJobs.openPanel", "后台任务")}>
-          <button
-            type="button"
-            className={cn(
-              "relative flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-secondary/70 hover:text-foreground",
-              backgroundJobsPanelOpen && "text-foreground",
-            )}
-            aria-label={t("backgroundJobs.openPanel", "后台任务")}
-            aria-pressed={backgroundJobsPanelOpen}
-            onClick={onToggleBackgroundJobsPanel}
-          >
-            <Layers className="h-4 w-4" />
-            {backgroundJobsRunningCount > 0 && (
-              <span className="absolute -right-1 -top-1 z-10 flex h-[15px] min-w-[15px] items-center justify-center rounded-full border border-background bg-amber-500 px-0.5 text-[9px] font-semibold leading-none text-white tabular-nums">
-                {backgroundJobsRunningCount > 99 ? "99+" : backgroundJobsRunningCount}
-              </span>
-            )}
-          </button>
-        </IconTip>
-      )}
-      {rightPanels.length > 1 && activeRightPanel && (
-        <div
-          className="flex h-7 max-w-[184px] items-center gap-0.5 overflow-x-auto rounded-lg bg-secondary/40 p-0.5"
-          role="tablist"
-          aria-label={t("chat.rightPanel.switch", "切换右侧面板")}
-        >
-          {rightPanels.map((panel) => {
-            const PanelIcon = panel.icon
-            const active = panel.id === activeRightPanel.id
-            return (
-              <IconTip key={panel.id} label={panel.label}>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={active}
-                  aria-label={panel.label}
-                  className={cn(
-                    "flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-all hover:bg-background/80 hover:text-foreground",
-                    active && "bg-background text-foreground shadow-sm ring-1 ring-border/60",
-                  )}
-                  onClick={() => onSelectRightPanel?.(panel.id)}
-                >
-                  <PanelIcon className="h-3.5 w-3.5" />
-                </button>
-              </IconTip>
-            )
-          })}
-        </div>
-      )}
-      {onToggleRightPanelCollapsed && (
-        <IconTip label={rightPanelToggleLabel}>
-          <button
-            type="button"
-            className={cn(
-              "flex h-7 w-7 items-center justify-center rounded-md transition-colors hover:bg-secondary/70 hover:text-foreground",
-              rightPanelCollapsed ? "text-muted-foreground" : "text-foreground",
-            )}
-            aria-label={rightPanelToggleLabel}
-            aria-expanded={!rightPanelCollapsed}
-            onClick={onToggleRightPanelCollapsed}
-          >
-            {rightPanelCollapsed ? (
-              <PanelRightDashed className="h-4 w-4" />
-            ) : (
-              <PanelRight className="h-4 w-4" />
-            )}
-          </button>
-        </IconTip>
-      )}
+                <PanelIcon className="h-4 w-4" strokeWidth={active ? 2.15 : 1.9} />
+                {panel.open && !active && !panel.badge ? (
+                  <span
+                    className="pointer-events-none absolute bottom-0.5 h-1 w-1 rounded-full bg-foreground/50"
+                    aria-hidden
+                  />
+                ) : null}
+                {panel.badge && panel.badge.count > 0 ? (
+                  <span
+                    id={badgeDescriptionId}
+                    className={cn(
+                      "absolute -right-1 -top-1 z-10 flex h-[15px] min-w-[15px] items-center justify-center rounded-full border border-background px-0.5 text-[9px] font-semibold leading-none tabular-nums",
+                      badgeTone,
+                    )}
+                    aria-label={t(panel.badge.labelKey, { count: panel.badge.count })}
+                  >
+                    {panel.badge.count > 99 ? "99+" : panel.badge.count}
+                  </span>
+                ) : null}
+              </button>
+            </IconTip>
+          )
+        })}
+      </div>
     </div>
   ) : null
 

--- a/src/components/chat/FileBrowserPanel.tsx
+++ b/src/components/chat/FileBrowserPanel.tsx
@@ -45,6 +45,7 @@ interface FileBrowserPanelProps {
   visible: boolean
   collapsed?: boolean
   overlay?: boolean
+  animateOnMount?: boolean
   panelWidth: number
   onPanelWidthChange: (w: number) => void
   reservedMainWidth?: number
@@ -69,6 +70,7 @@ export function FileBrowserPanel({
   visible,
   collapsed = false,
   overlay = false,
+  animateOnMount = false,
   panelWidth,
   onPanelWidthChange,
   reservedMainWidth,
@@ -256,6 +258,7 @@ export function FileBrowserPanel({
       reservedMainWidth={reservedMainWidth}
       collapsed={collapsed}
       overlay={overlay}
+      animateOnMount={animateOnMount}
       contentKey={detached ? "files-detached" : "files"}
     >
       {body}

--- a/src/components/chat/MacControlPanel.tsx
+++ b/src/components/chat/MacControlPanel.tsx
@@ -50,6 +50,7 @@ interface MacControlPanelProps {
   reservedMainWidth?: number
   collapsed?: boolean
   overlay?: boolean
+  animateOnMount?: boolean
   onClose: () => void
 }
 
@@ -62,6 +63,7 @@ export default function MacControlPanel({
   reservedMainWidth,
   collapsed = false,
   overlay = false,
+  animateOnMount = false,
   onClose,
 }: MacControlPanelProps) {
   const { t } = useTranslation()
@@ -141,6 +143,7 @@ export default function MacControlPanel({
       reservedMainWidth={reservedMainWidth}
       collapsed={collapsed}
       overlay={overlay}
+      animateOnMount={animateOnMount}
       contentKey="mac-control"
     >
       <div className="flex items-center gap-2 px-3 py-2">

--- a/src/components/chat/right-panel/RightPanelShell.test.tsx
+++ b/src/components/chat/right-panel/RightPanelShell.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { RightPanelShell } from "./RightPanelShell"
 
@@ -40,5 +40,34 @@ describe("RightPanelShell", () => {
 
     fireEvent.mouseUp(document)
     expect(shell.className).toContain("transition-[width,min-width,max-width,padding]")
+  })
+
+  it("animates the first panel mount from zero to its configured width", () => {
+    let enterFrame: FrameRequestCallback | null = null
+    const requestFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        enterFrame = callback
+        return 1
+      })
+    const cancelFrame = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {})
+
+    const { container } = render(
+      <RightPanelShell width={520} resizeLabel="Resize panel" animateOnMount>
+        <div>Workspace Control Panel</div>
+      </RightPanelShell>,
+    )
+
+    const shell = container.firstElementChild as HTMLElement
+    expect(shell.style.width).toBe("0px")
+    expect(shell.getAttribute("aria-hidden")).toBe("true")
+
+    act(() => enterFrame?.(0))
+
+    expect(shell.getAttribute("aria-hidden")).toBeNull()
+    expect(shell.className.split(" ")).toContain("p-3")
+    expect(shell.lastElementChild?.className).toContain("opacity-100")
+    requestFrame.mockRestore()
+    cancelFrame.mockRestore()
   })
 })

--- a/src/components/chat/right-panel/RightPanelShell.tsx
+++ b/src/components/chat/right-panel/RightPanelShell.tsx
@@ -25,6 +25,8 @@ interface RightPanelShellProps {
   contentKey?: string | number | null
   surfaceClassName?: string
   bodyClassName?: string
+  /** Animate the rail from zero width when it is the first right panel to open. */
+  animateOnMount?: boolean
 }
 
 export function RightPanelShell({
@@ -42,15 +44,32 @@ export function RightPanelShell({
   contentKey,
   surfaceClassName,
   bodyClassName,
+  animateOnMount = false,
 }: RightPanelShellProps) {
   const shellRef = useRef<HTMLDivElement>(null)
   const resolvedContentKey = contentKey ?? "right-panel-content"
   const lastContentKeyRef = useRef<string | number>(resolvedContentKey)
   const transitionTimerRef = useRef<number | null>(null)
   const transitionFrameRef = useRef<number | null>(null)
+  const entryFrameRef = useRef<number | null>(null)
   const dragCleanupRef = useRef<(() => void) | null>(null)
   const [transitionVeilVisible, setTransitionVeilVisible] = useState(false)
   const [isResizing, setIsResizing] = useState(false)
+  const [entryVisible, setEntryVisible] = useState(!animateOnMount)
+
+  useLayoutEffect(() => {
+    if (entryVisible) return
+    entryFrameRef.current = window.requestAnimationFrame(() => {
+      setEntryVisible(true)
+      entryFrameRef.current = null
+    })
+    return () => {
+      if (entryFrameRef.current !== null) {
+        window.cancelAnimationFrame(entryFrameRef.current)
+        entryFrameRef.current = null
+      }
+    }
+  }, [entryVisible])
 
   useLayoutEffect(() => {
     if (Object.is(lastContentKeyRef.current, resolvedContentKey)) return
@@ -80,14 +99,20 @@ export function RightPanelShell({
         window.cancelAnimationFrame(transitionFrameRef.current)
         transitionFrameRef.current = null
       }
+      if (entryFrameRef.current !== null) {
+        window.cancelAnimationFrame(entryFrameRef.current)
+        entryFrameRef.current = null
+      }
       dragCleanupRef.current?.()
     },
     [],
   )
 
+  const visuallyCollapsed = collapsed || !entryVisible
+
   const handleDragStart = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      if (!onWidthChange || collapsed) return
+      if (!onWidthChange || visuallyCollapsed) return
       e.preventDefault()
       dragCleanupRef.current?.()
       setIsResizing(true)
@@ -133,11 +158,19 @@ export function RightPanelShell({
       document.body.style.cursor = "col-resize"
       document.body.style.userSelect = "none"
     },
-    [collapsed, maxViewportRatio, maxWidth, minWidth, onWidthChange, reservedMainWidth, width],
+    [
+      maxViewportRatio,
+      maxWidth,
+      minWidth,
+      onWidthChange,
+      reservedMainWidth,
+      visuallyCollapsed,
+      width,
+    ],
   )
 
   const availableWidthCss = `max(0px, calc(100% - ${reservedMainWidth}px))`
-  const panelStyle: CSSProperties = collapsed
+  const panelStyle: CSSProperties = visuallyCollapsed
     ? { width: 0, minWidth: 0, maxWidth: 0 }
     : {
         width: `min(${width}px, ${availableWidthCss})`,
@@ -151,6 +184,8 @@ export function RightPanelShell({
         className={cn(
           "fixed inset-0 z-50 flex min-h-0 flex-col overflow-hidden bg-surface-app",
           overlay && !maximized && "p-2 sm:p-3",
+          animateOnMount &&
+            "animate-in fade-in-0 slide-in-from-right-2 duration-[250ms] motion-reduce:animate-none",
           surfaceClassName,
         )}
       >
@@ -177,17 +212,17 @@ export function RightPanelShell({
         "relative flex h-full min-h-0 shrink-0 overflow-hidden",
         !isResizing &&
           "transition-[width,min-width,max-width,padding] duration-[250ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none",
-        collapsed ? "min-w-0 max-w-0 p-0 pointer-events-none" : "p-3 pl-2",
+        visuallyCollapsed ? "min-w-0 max-w-0 p-0 pointer-events-none" : "p-3 pl-2",
       )}
       style={panelStyle}
-      aria-hidden={collapsed ? true : undefined}
-      inert={collapsed ? true : undefined}
+      aria-hidden={visuallyCollapsed ? true : undefined}
+      inert={visuallyCollapsed ? true : undefined}
     >
       <div
         className={cn(
           "peer absolute left-0 top-3 bottom-3 z-10 w-4",
-          onWidthChange && !collapsed && "cursor-col-resize",
-          collapsed && "hidden",
+          onWidthChange && !visuallyCollapsed && "cursor-col-resize",
+          visuallyCollapsed && "hidden",
         )}
         onMouseDown={handleDragStart}
         role="separator"
@@ -198,7 +233,7 @@ export function RightPanelShell({
         className={cn(
           "flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-border-soft bg-surface-panel shadow-panel transition-[opacity,transform,border-color] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[opacity,transform] [contain:layout_paint] peer-hover:border-l-primary/35 motion-reduce:transition-none",
           isResizing && "border-l-primary/50",
-          collapsed ? "translate-x-4 opacity-0" : "translate-x-0 opacity-100",
+          visuallyCollapsed ? "translate-x-4 opacity-0" : "translate-x-0 opacity-100",
           bodyClassName,
         )}
       >

--- a/src/components/team/TeamPanel.tsx
+++ b/src/components/team/TeamPanel.tsx
@@ -19,6 +19,7 @@ interface TeamPanelProps {
   reservedMainWidth?: number
   collapsed?: boolean
   overlay?: boolean
+  animateOnMount?: boolean
   onClose: () => void
   onViewSession?: (sessionId: string) => void
 }
@@ -34,6 +35,7 @@ export function TeamPanel({
   reservedMainWidth,
   collapsed = false,
   overlay = false,
+  animateOnMount = false,
   onClose,
   onViewSession,
 }: TeamPanelProps) {
@@ -68,6 +70,7 @@ export function TeamPanel({
         reservedMainWidth={reservedMainWidth}
         collapsed={collapsed}
         overlay={overlay}
+        animateOnMount={animateOnMount}
         contentKey="team-loading"
       >
         <div className="flex h-full min-h-0 w-full items-center justify-center text-sm text-muted-foreground">
@@ -87,6 +90,7 @@ export function TeamPanel({
       reservedMainWidth={reservedMainWidth}
       collapsed={collapsed}
       overlay={overlay}
+      animateOnMount={animateOnMount}
       contentKey="team"
     >
       <div className="relative flex h-full min-h-0 w-full flex-col overflow-hidden">

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "طي اللوحة اليمنى",
       "expand": "قم بتوسيع اللوحة اليمنى",
-      "switch": "تبديل اللوحة اليمنى"
+      "switch": "تبديل اللوحة اليمنى",
+      "dock": "شريط اللوحات الجانبية",
+      "openPanel": "فتح {{panel}}",
+      "switchToPanel": "التبديل إلى {{panel}}",
+      "collapsePanel": "طي {{panel}}",
+      "expandPanel": "توسيع {{panel}}",
+      "workflowActiveCount": "{{count}} من مهام سير العمل النشطة",
+      "workflowAttentionCount": "{{count}} من مهام سير العمل تحتاج إلى الانتباه",
+      "backgroundRunningCount": "{{count}} من المهام في الخلفية قيد التشغيل"
     },
     "visionBridgeEngaged": "لا يمكن للنموذج الأساسي رؤية الصور، لذا قام {{model}} بوصفها نيابةً عنه.",
     "visionBridgeUnavailable": "تعذّر على نموذج الرؤية وصف الصورة، لذا تم تجاهلها.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "Collapse right panel",
       "expand": "Expand right panel",
-      "switch": "Switch right panel"
+      "switch": "Switch right panel",
+      "dock": "Right panel dock",
+      "openPanel": "Open {{panel}}",
+      "switchToPanel": "Switch to {{panel}}",
+      "collapsePanel": "Collapse {{panel}}",
+      "expandPanel": "Expand {{panel}}",
+      "workflowActiveCount": "{{count}} active workflows",
+      "workflowAttentionCount": "{{count}} workflows need attention",
+      "backgroundRunningCount": "{{count}} background tasks running"
     },
     "visionBridgeEngaged": "The primary model can't view images, so {{model}} described them for it.",
     "visionBridgeUnavailable": "The vision model couldn't describe the image, so it was left out.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "Contraer panel derecho",
       "expand": "Expandir el panel derecho",
-      "switch": "Cambiar panel derecho"
+      "switch": "Cambiar panel derecho",
+      "dock": "Barra de paneles derechos",
+      "openPanel": "Abrir {{panel}}",
+      "switchToPanel": "Cambiar a {{panel}}",
+      "collapsePanel": "Contraer {{panel}}",
+      "expandPanel": "Expandir {{panel}}",
+      "workflowActiveCount": "{{count}} flujos de trabajo activos",
+      "workflowAttentionCount": "{{count}} flujos de trabajo requieren atención",
+      "backgroundRunningCount": "{{count}} tareas en segundo plano en ejecución"
     },
     "visionBridgeEngaged": "El modelo principal no puede ver imágenes, así que {{model}} las describió por él.",
     "visionBridgeUnavailable": "El modelo de visión no pudo describir la imagen, por lo que se omitió.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "右パネルを折りたたむ",
       "expand": "右側のパネルを展開します",
-      "switch": "右パネルを切り替えます"
+      "switch": "右パネルを切り替えます",
+      "dock": "右パネルドック",
+      "openPanel": "{{panel}}を開く",
+      "switchToPanel": "{{panel}}に切り替える",
+      "collapsePanel": "{{panel}}を折りたたむ",
+      "expandPanel": "{{panel}}を展開する",
+      "workflowActiveCount": "{{count}}件のアクティブなワークフロー",
+      "workflowAttentionCount": "{{count}}件のワークフローに対応が必要です",
+      "backgroundRunningCount": "{{count}}件のバックグラウンドタスクが実行中"
     },
     "visionBridgeEngaged": "メインモデルは画像を扱えないため、{{model}} が画像の内容を説明しました。",
     "visionBridgeUnavailable": "画像モデルが画像を説明できなかったため、この画像は無視されました。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "오른쪽 패널 접기",
       "expand": "오른쪽 패널 펼치기",
-      "switch": "오른쪽 패널 전환"
+      "switch": "오른쪽 패널 전환",
+      "dock": "오른쪽 패널 도크",
+      "openPanel": "{{panel}} 열기",
+      "switchToPanel": "{{panel}} 패널로 전환",
+      "collapsePanel": "{{panel}} 접기",
+      "expandPanel": "{{panel}} 펼치기",
+      "workflowActiveCount": "활성 워크플로 {{count}}개",
+      "workflowAttentionCount": "주의가 필요한 워크플로 {{count}}개",
+      "backgroundRunningCount": "백그라운드 작업 {{count}}개 실행 중"
     },
     "visionBridgeEngaged": "기본 모델이 이미지를 볼 수 없어 {{model}}이(가) 이미지 내용을 설명했습니다.",
     "visionBridgeUnavailable": "비전 모델이 이미지를 설명하지 못해 해당 이미지는 제외되었습니다.",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "Runtuhkan panel kanan",
       "expand": "Kembangkan panel kanan",
-      "switch": "Tukar panel kanan"
+      "switch": "Tukar panel kanan",
+      "dock": "Dok panel kanan",
+      "openPanel": "Buka {{panel}}",
+      "switchToPanel": "Tukar kepada {{panel}}",
+      "collapsePanel": "Runtuhkan {{panel}}",
+      "expandPanel": "Kembangkan {{panel}}",
+      "workflowActiveCount": "{{count}} aliran kerja aktif",
+      "workflowAttentionCount": "{{count}} aliran kerja memerlukan perhatian",
+      "backgroundRunningCount": "{{count}} tugasan latar belakang sedang berjalan"
     },
     "visionBridgeEngaged": "Model utama tidak dapat melihat imej, jadi {{model}} menerangkannya bagi pihaknya.",
     "visionBridgeUnavailable": "Model penglihatan tidak dapat menerangkan imej itu, jadi ia diabaikan.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "Recolher painel direito",
       "expand": "Expandir painel direito",
-      "switch": "Alternar painel direito"
+      "switch": "Alternar painel direito",
+      "dock": "Dock de painéis à direita",
+      "openPanel": "Abrir {{panel}}",
+      "switchToPanel": "Alternar para {{panel}}",
+      "collapsePanel": "Recolher {{panel}}",
+      "expandPanel": "Expandir {{panel}}",
+      "workflowActiveCount": "{{count}} fluxos de trabalho ativos",
+      "workflowAttentionCount": "{{count}} fluxos de trabalho precisam de atenção",
+      "backgroundRunningCount": "{{count}} tarefas em segundo plano em execução"
     },
     "visionBridgeEngaged": "O modelo principal não consegue ver imagens, então {{model}} as descreveu para ele.",
     "visionBridgeUnavailable": "O modelo de visão não conseguiu descrever a imagem, então ela foi ignorada.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "Свернуть правую панель",
       "expand": "Развернуть правую панель",
-      "switch": "Переключить правую панель"
+      "switch": "Переключить правую панель",
+      "dock": "Панель закрепления справа",
+      "openPanel": "Открыть {{panel}}",
+      "switchToPanel": "Переключиться на {{panel}}",
+      "collapsePanel": "Свернуть {{panel}}",
+      "expandPanel": "Развернуть {{panel}}",
+      "workflowActiveCount": "Активных процессов: {{count}}",
+      "workflowAttentionCount": "Требуют внимания: {{count}}",
+      "backgroundRunningCount": "Фоновых задач выполняется: {{count}}"
     },
     "visionBridgeEngaged": "Основная модель не поддерживает изображения, поэтому {{model}} описала их за неё.",
     "visionBridgeUnavailable": "Модель зрения не смогла описать изображение, поэтому оно было пропущено.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "Sağ paneli daralt",
       "expand": "Sağ paneli genişlet",
-      "switch": "Sağ paneli değiştir"
+      "switch": "Sağ paneli değiştir",
+      "dock": "Sağ panel çubuğu",
+      "openPanel": "{{panel}} panelini aç",
+      "switchToPanel": "{{panel}} paneline geç",
+      "collapsePanel": "{{panel}} panelini daralt",
+      "expandPanel": "{{panel}} panelini genişlet",
+      "workflowActiveCount": "{{count}} etkin iş akışı",
+      "workflowAttentionCount": "{{count}} iş akışı ilgilenmenizi bekliyor",
+      "backgroundRunningCount": "{{count}} arka plan görevi çalışıyor"
     },
     "visionBridgeEngaged": "Ana model görselleri göremediği için {{model}} onları onun yerine tanımladı.",
     "visionBridgeUnavailable": "Görsel modeli görseli tanımlayamadı, bu yüzden görsel atlandı.",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "Thu gọn bảng bên phải",
       "expand": "Mở rộng bảng bên phải",
-      "switch": "Chuyển bảng bên phải"
+      "switch": "Chuyển bảng bên phải",
+      "dock": "Thanh panel bên phải",
+      "openPanel": "Mở {{panel}}",
+      "switchToPanel": "Chuyển sang {{panel}}",
+      "collapsePanel": "Thu gọn {{panel}}",
+      "expandPanel": "Mở rộng {{panel}}",
+      "workflowActiveCount": "{{count}} quy trình đang hoạt động",
+      "workflowAttentionCount": "{{count}} quy trình cần chú ý",
+      "backgroundRunningCount": "{{count}} tác vụ nền đang chạy"
     },
     "visionBridgeEngaged": "Mô hình chính không xem được hình ảnh, nên {{model}} đã mô tả chúng thay cho nó.",
     "visionBridgeUnavailable": "Mô hình thị giác không mô tả được hình ảnh, nên hình ảnh đã bị bỏ qua.",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "折疊右側面板",
       "expand": "展開右側面板",
-      "switch": "切換右側面板"
+      "switch": "切換右側面板",
+      "dock": "右側面板停駐列",
+      "openPanel": "開啟{{panel}}",
+      "switchToPanel": "切換至{{panel}}",
+      "collapsePanel": "收合{{panel}}",
+      "expandPanel": "展開{{panel}}",
+      "workflowActiveCount": "{{count}} 個作用中的工作流程",
+      "workflowAttentionCount": "{{count}} 個工作流程需要處理",
+      "backgroundRunningCount": "{{count}} 個背景任務正在執行"
     },
     "visionBridgeEngaged": "主模型不支援看圖，已用 {{model}} 轉述圖片內容。",
     "visionBridgeUnavailable": "視覺模型轉述圖片失敗，已忽略該圖片。",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -892,7 +892,15 @@
     "rightPanel": {
       "collapse": "折叠右侧面板",
       "expand": "展开右侧面板",
-      "switch": "切换右侧面板"
+      "switch": "切换右侧面板",
+      "dock": "右侧面板停靠栏",
+      "openPanel": "打开{{panel}}",
+      "switchToPanel": "切换到{{panel}}",
+      "collapsePanel": "收起{{panel}}",
+      "expandPanel": "展开{{panel}}",
+      "workflowActiveCount": "{{count}} 个活跃工作流",
+      "workflowAttentionCount": "{{count}} 个工作流需要处理",
+      "backgroundRunningCount": "{{count}} 个后台任务正在运行"
     },
     "visionBridgeEngaged": "主模型不支持看图，已用 {{model}} 转述图片内容。",
     "visionBridgeUnavailable": "视觉模型转述图片失败，已忽略该图片。",


### PR DESCRIPTION
## Summary

- consolidate the chat title bar into a single icon-only right-panel dock
- add neutral active/open states, unified collapse/expand behavior, and first-open panel animation
- localize dock tooltips, status counts, and accessibility labels across all 12 supported locales

## Why

The previous title bar rendered persistent panel launchers and open-panel switchers at the same time, which duplicated Workspace and Background Tasks and made the active state unclear. First-time panel mounts also skipped the existing width transition because the panel entered at its final width.

## User impact

The dock now exposes one control per panel, keeps transient panels switchable, uses a minimal neutral selected state, and animates the first panel appearance without replaying the width transition during panel switches.

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- `cargo test -p ha-core -p ha-server --locked`
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings remain)
- `pnpm test` (168 files, 891 tests passed)
- `node scripts/sync-i18n.mjs --check` (all locales complete)