### PR TITLE
feat(chat): add project picker to plain drafts

### DIFF
--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -3934,36 +3934,38 @@ export default function ChatScreen({
                         />
                       </div>
                     )}
-                    {!session.currentSessionId && currentProject && !incognitoEnabled ? (
-                      <ProjectSessionDraftBar
-                        project={currentProject}
-                        projects={projects}
-                        draft={draftProjectRuntime}
-                        disabled={session.loading}
-                        progressStage={projectBootstrapProgress?.stage ?? null}
-                        progressError={projectBootstrapProgress?.error ?? null}
-                        onDraftChange={handleProjectRuntimeDraftChange}
-                        onSelectProject={(projectId, defaultAgentId) => {
-                          void handleNewChatInProject(projectId, defaultAgentId)
-                        }}
-                        onRemoveProject={() => {
-                          void handleStartNewChat(currentAgentId)
-                        }}
-                        onRetry={() => {
-                          setProjectBootstrapProgress(null)
-                          window.setTimeout(() => {
-                            void stream.handleSend()
-                          }, 0)
-                        }}
-                        onUseLocal={() => {
-                          handleProjectRuntimeDraftChange({
-                            ...draftProjectRuntime,
-                            launchMode: "local",
-                          })
-                        }}
-                      />
-                    ) : null}
                     <ChatInput
+                      topAccessory={
+                        !session.currentSessionId && !incognitoEnabled ? (
+                          <ProjectSessionDraftBar
+                            project={currentProject}
+                            projects={projects}
+                            draft={draftProjectRuntime}
+                            disabled={session.loading}
+                            progressStage={projectBootstrapProgress?.stage ?? null}
+                            progressError={projectBootstrapProgress?.error ?? null}
+                            onDraftChange={handleProjectRuntimeDraftChange}
+                            onSelectProject={(projectId, defaultAgentId) => {
+                              void handleNewChatInProject(projectId, defaultAgentId)
+                            }}
+                            onRemoveProject={() => {
+                              void handleStartNewChat(currentAgentId)
+                            }}
+                            onRetry={() => {
+                              setProjectBootstrapProgress(null)
+                              window.setTimeout(() => {
+                                void stream.handleSend()
+                              }, 0)
+                            }}
+                            onUseLocal={() => {
+                              handleProjectRuntimeDraftChange({
+                                ...draftProjectRuntime,
+                                launchMode: "local",
+                              })
+                            }}
+                          />
+                        ) : undefined
+                      }
                       input={stream.input}
                       onInputChange={stream.setInput}
                       inputHistory={inputHistory}

--- a/src/components/chat/ChatWelcomeHero.tsx
+++ b/src/components/chat/ChatWelcomeHero.tsx
@@ -72,7 +72,7 @@ export function ChatWelcomeHero({
             }}
           />
         </p>
-        <div className="mx-auto mt-7 grid w-full max-w-[1040px] grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="mx-auto mt-5 flex w-full max-w-[900px] flex-wrap justify-center gap-2">
           {PROJECT_WELCOME_SUGGESTIONS.map((suggestion) => {
             const Icon = suggestion.icon
             const title = t(`chat.projectWelcomeSuggestions.${suggestion.key}.title`)
@@ -85,15 +85,15 @@ export function ChatWelcomeHero({
                 type="button"
                 onClick={() => onProjectSuggestion?.(prompt)}
                 disabled={!onProjectSuggestion}
-                className="group flex min-h-28 cursor-pointer flex-col items-start justify-between rounded-2xl border border-border/70 bg-background/55 p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-border hover:bg-muted/30 hover:shadow-md disabled:cursor-default disabled:hover:translate-y-0 disabled:hover:border-border/70 disabled:hover:bg-background/55 disabled:hover:shadow-sm"
+                className="group inline-flex h-9 cursor-pointer items-center gap-2 rounded-full border border-border/70 bg-background/55 px-3.5 text-left text-xs font-medium text-foreground shadow-sm transition-colors hover:border-border hover:bg-muted/40 disabled:cursor-default disabled:opacity-60 disabled:hover:border-border/70 disabled:hover:bg-background/55"
               >
                 <Icon
                   className={cn(
-                    "h-5 w-5 shrink-0 transition-transform group-hover:-translate-y-px",
+                    "h-4 w-4 shrink-0 transition-transform group-hover:scale-105",
                     suggestion.iconClassName,
                   )}
                 />
-                <span className="mt-5 text-sm font-medium leading-snug text-foreground">{title}</span>
+                <span className="whitespace-nowrap">{title}</span>
               </button>
             )
           })}

--- a/src/components/chat/input/ChatInput.tsx
+++ b/src/components/chat/input/ChatInput.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useRef, useEffect, useLayoutEffect, useCallback, useMemo, useState } from "react"
+import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -355,6 +356,8 @@ interface ChatInputProps {
   workspacePanelVisible?: boolean
   /** Larger centered presentation for a brand-new empty conversation. */
   hero?: boolean
+  /** Optional surface fused to the top of the input dock. */
+  topAccessory?: ReactNode
   /** Context-window fullness, rendered as a thin bar fused into the dock's
    *  bottom border (green → amber → red). Null hides the bar. */
   contextUsage?: ContextUsageInfo | null
@@ -545,6 +548,7 @@ export default function ChatInput({
   workflowProgressCount = 0,
   workspacePanelVisible = false,
   hero = false,
+  topAccessory,
   contextUsage,
 }: ChatInputProps) {
   const { t } = useTranslation()
@@ -1597,6 +1601,7 @@ export default function ChatInput({
   )?.id
   const hasPendingQueue = pendingQueueItems.length > 0
   const topStripBase =
+    !topAccessory &&
     !hasVisibleTaskProgress &&
     attachedFiles.length === 0 &&
     !pendingQuotes?.length &&
@@ -1837,6 +1842,8 @@ export default function ChatInput({
           ],
         )}
       >
+        {topAccessory}
+
         {/* Slash Command Menu */}
         <SlashCommandMenu
           open={slash.isOpen}
@@ -1902,6 +1909,7 @@ export default function ChatInput({
             snapshot={visibleTaskProgressSnapshot}
             executionState={taskExecutionState}
             variant="embedded"
+            className={topAccessory ? "rounded-t-none" : undefined}
             onOpenWorkspace={onOpenWorkspace}
             workspaceOpen={workspacePanelVisible}
           />

--- a/src/components/chat/project/ProjectSessionDraftBar.tsx
+++ b/src/components/chat/project/ProjectSessionDraftBar.tsx
@@ -38,7 +38,7 @@ export function ProjectSessionDraftBar({
   onRetry,
   onUseLocal,
 }: {
-  project: ProjectMeta
+  project: ProjectMeta | null
   projects: ProjectMeta[]
   draft: ProjectRuntimeDraft
   disabled?: boolean
@@ -63,6 +63,7 @@ export function ProjectSessionDraftBar({
   const projectMenuRef = useRef<HTMLDivElement>(null)
   const launchMenuRef = useRef<HTMLDivElement>(null)
   const branchMenuRef = useRef<HTMLDivElement>(null)
+  const projectId = project?.id ?? null
 
   useClickOutside(projectMenuRef, useCallback(() => setProjectOpen(false), []))
   useClickOutside(launchMenuRef, useCallback(() => setLaunchOpen(false), []))
@@ -72,13 +73,18 @@ export function ProjectSessionDraftBar({
     let cancelled = false
     queueMicrotask(() => {
       if (cancelled) return
-      setGitLoading(true)
+      setGitLoading(!!projectId)
       setGitError(null)
       setGitNotice(null)
       setGitInfo(null)
     })
+    if (!projectId) {
+      return () => {
+        cancelled = true
+      }
+    }
     getTransport()
-      .call<GitInfo | null>("project_git_info", { scope: "project", scopeId: project.id })
+      .call<GitInfo | null>("project_git_info", { scope: "project", scopeId: projectId })
       .then((info) => {
         if (cancelled) return
         setGitInfo(info)
@@ -92,7 +98,7 @@ export function ProjectSessionDraftBar({
     return () => {
       cancelled = true
     }
-  }, [project.id])
+  }, [projectId])
 
   useEffect(() => {
     if (!gitInfo) return
@@ -196,7 +202,7 @@ export function ProjectSessionDraftBar({
     "relative inline-flex min-w-0 items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm text-foreground transition-colors hover:bg-background/70 disabled:pointer-events-none disabled:opacity-50"
 
   return (
-    <div className="mb-2 rounded-xl border border-border/70 bg-muted/35 px-2 py-1.5">
+    <div className="rounded-t-input-dock border-b border-border-soft bg-surface-subtle/60 px-2 py-1.5">
       <div className="flex min-w-0 flex-wrap items-center gap-1">
         <div ref={projectMenuRef} className="relative min-w-0">
           <div className="flex min-w-0 items-center rounded-lg hover:bg-background/70">
@@ -207,19 +213,23 @@ export function ProjectSessionDraftBar({
               onClick={() => setProjectOpen((open) => !open)}
             >
               <Folder className="h-4 w-4 shrink-0" />
-              <span className="truncate">{project.name}</span>
+              <span className="truncate">
+                {project?.name ?? t("chat.projectRuntime.selectProject", "选择项目")}
+              </span>
               <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
             </button>
-            <button
-              type="button"
-              disabled={disabled}
-              aria-label={t("chat.projectRuntime.removeProject", "不在项目中工作")}
-              data-ha-title-tip={t("chat.projectRuntime.removeProject", "不在项目中工作")}
-              className="mr-1 rounded-full p-0.5 text-muted-foreground hover:bg-foreground hover:text-background disabled:pointer-events-none"
-              onClick={onRemoveProject}
-            >
-              <X className="h-3.5 w-3.5" />
-            </button>
+            {project ? (
+              <button
+                type="button"
+                disabled={disabled}
+                aria-label={t("chat.projectRuntime.removeProject", "不在项目中工作")}
+                data-ha-title-tip={t("chat.projectRuntime.removeProject", "不在项目中工作")}
+                className="mr-1 rounded-full p-0.5 text-muted-foreground hover:bg-foreground hover:text-background disabled:pointer-events-none"
+                onClick={onRemoveProject}
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
           </div>
           <FloatingMenu
             open={projectOpen}
@@ -241,11 +251,11 @@ export function ProjectSessionDraftBar({
               type="button"
               className={FLOATING_MENU_ITEM_CLASS}
               onClick={() => {
-                onRemoveProject()
+                if (project) onRemoveProject()
                 setProjectOpen(false)
               }}
             >
-              <X className="h-4 w-4" />
+              {project ? <X className="h-4 w-4" /> : <Check className="h-4 w-4" />}
               {t("chat.projectRuntime.noProject", "不在项目中")}
             </button>
             <div className="max-h-64 overflow-y-auto">
@@ -261,14 +271,14 @@ export function ProjectSessionDraftBar({
                 >
                   <Folder className="h-4 w-4 text-muted-foreground" />
                   <span className="min-w-0 flex-1 truncate">{candidate.name}</span>
-                  {candidate.id === project.id ? <Check className="h-4 w-4" /> : null}
+                  {candidate.id === project?.id ? <Check className="h-4 w-4" /> : null}
                 </button>
               ))}
             </div>
           </FloatingMenu>
         </div>
 
-        <div ref={launchMenuRef} className="relative">
+        <div ref={launchMenuRef} className={cn("relative", !project && "hidden")}>
           <button
             type="button"
             disabled={disabled}
@@ -317,7 +327,7 @@ export function ProjectSessionDraftBar({
           </FloatingMenu>
         </div>
 
-        {gitLoading || gitInfo ? (
+        {project && (gitLoading || gitInfo) ? (
           <div ref={branchMenuRef} className="relative min-w-0">
             <button
               type="button"
@@ -356,7 +366,7 @@ export function ProjectSessionDraftBar({
         ) : null}
       </div>
 
-      {selectedBranch ? (
+      {project && selectedBranch ? (
         <div className="px-2.5 pb-0.5 pt-1 text-[11px] text-muted-foreground">
           {draft.launchMode === "worktree"
             ? draft.includeLocalChanges && dirtyCount > 0
@@ -386,13 +396,13 @@ export function ProjectSessionDraftBar({
         </div>
       ) : null}
 
-      {gitNotice ? (
+      {project && gitNotice ? (
         <div className="px-2.5 pb-0.5 pt-1 text-[11px] text-amber-600 dark:text-amber-400">
           {gitNotice}
         </div>
       ) : null}
 
-      {progressStage ? (
+      {project && progressStage ? (
         <div
           className={cn(
             "flex items-center gap-2 px-2.5 pb-0.5 pt-1 text-xs",

--- a/src/components/chat/project/ProjectSessionDraftBar.tsx
+++ b/src/components/chat/project/ProjectSessionDraftBar.tsx
@@ -151,6 +151,33 @@ export function ProjectSessionDraftBar({
     ? t("chat.projectRuntime.noBranches", "Git 仓库中没有可用分支")
     : gitError || t("chat.projectRuntime.notGit", "项目工作目录不在 Git 仓库中")
   const dirtyCount = gitInfo?.dirty.changedFiles ?? 0
+  const selectedBranchSummary = selectedBranch
+    ? draft.launchMode === "worktree"
+      ? draft.includeLocalChanges && dirtyCount > 0
+        ? t("chat.projectRuntime.includeChanges", "将包含 {{count}} 个本地改动", {
+            count: dirtyCount,
+          })
+        : selectedBranch.isCurrent
+          ? t("chat.projectRuntime.cleanBranch", "当前分支没有未提交改动")
+          : t("chat.projectRuntime.excludeChanges", "不会包含当前工作区的未提交改动")
+      : selectedBranch.isCurrent
+        ? dirtyCount > 0
+          ? t("chat.projectRuntime.localKeepsChanges", "将在当前分支工作，保留 {{count}} 个本地改动", {
+              count: dirtyCount,
+            })
+          : t("chat.projectRuntime.localCurrentBranch", "将在当前分支工作")
+        : selectedBranch.kind === "remote"
+          ? t(
+              "chat.projectRuntime.localSwitchRemote",
+              "将从 {{branch}} 创建跟踪分支；当前工作区必须干净",
+              { branch: selectedBranch.name },
+            )
+          : t(
+              "chat.projectRuntime.localSwitchBranch",
+              "将把本地工作区切换到 {{branch}}；当前工作区必须干净",
+              { branch: selectedBranch.name },
+            )
+    : null
 
   const chooseLaunchMode = (mode: "local" | "worktree") => {
     if (mode === "worktree" && !canUseWorktree) return
@@ -332,6 +359,7 @@ export function ProjectSessionDraftBar({
             <button
               type="button"
               disabled={disabled || gitLoading}
+              data-ha-title-tip={selectedBranchSummary ?? undefined}
               className={cn(controlClass, "max-w-[300px]")}
               onClick={() => setBranchOpen((open) => !open)}
             >
@@ -365,36 +393,6 @@ export function ProjectSessionDraftBar({
           </div>
         ) : null}
       </div>
-
-      {project && selectedBranch ? (
-        <div className="px-2.5 pb-0.5 pt-1 text-[11px] text-muted-foreground">
-          {draft.launchMode === "worktree"
-            ? draft.includeLocalChanges && dirtyCount > 0
-              ? t("chat.projectRuntime.includeChanges", "将包含 {{count}} 个本地改动", {
-                  count: dirtyCount,
-                })
-              : selectedBranch.isCurrent
-                ? t("chat.projectRuntime.cleanBranch", "当前分支没有未提交改动")
-                : t("chat.projectRuntime.excludeChanges", "不会包含当前工作区的未提交改动")
-            : selectedBranch.isCurrent
-              ? dirtyCount > 0
-                ? t("chat.projectRuntime.localKeepsChanges", "将在当前分支工作，保留 {{count}} 个本地改动", {
-                    count: dirtyCount,
-                  })
-                : t("chat.projectRuntime.localCurrentBranch", "将在当前分支工作")
-              : selectedBranch.kind === "remote"
-                ? t(
-                    "chat.projectRuntime.localSwitchRemote",
-                    "将从 {{branch}} 创建跟踪分支；当前工作区必须干净",
-                    { branch: selectedBranch.name },
-                  )
-                : t(
-                    "chat.projectRuntime.localSwitchBranch",
-                    "将把本地工作区切换到 {{branch}}；当前工作区必须干净",
-                    { branch: selectedBranch.name },
-                  )}
-        </div>
-      ) : null}
 
       {project && gitNotice ? (
         <div className="px-2.5 pb-0.5 pt-1 text-[11px] text-amber-600 dark:text-amber-400">

--- a/src/components/settings/KnowledgePanel.test.tsx
+++ b/src/components/settings/KnowledgePanel.test.tsx
@@ -323,7 +323,9 @@ describe("KnowledgePanel", () => {
 
     const mediaTitle = await screen.findByText("Original media retention")
     const mediaSection = mediaTitle.closest(".rounded-lg") as HTMLElement
-    expect(within(mediaSection).getByText("Failed to load original media retention settings")).toBeTruthy()
+    expect(
+      await within(mediaSection).findByText("Failed to load original media retention settings"),
+    ).toBeTruthy()
     expect(within(mediaSection).getByText("Details: media load token=[redacted]")).toBeTruthy()
     expect(screen.queryByText(/media-load-secret/)).toBeNull()
   })

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "Select project",
       "removeProject": "Work outside this project",
       "searchProjects": "Search projects",
       "noProject": "Not in a project",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1090,6 +1090,7 @@
       }
     },
     "projectRuntime": {
+      "selectProject": "选择项目",
       "removeProject": "不在项目中工作",
       "searchProjects": "搜索项目",
       "noProject": "不在项目中",


### PR DESCRIPTION
## 变更

- 普通新会话输入框顶部增加项目选择入口
- 复用项目会话的本地处理、工作树与分支选择
- 移除已选项目后保留“选择项目”入口
- 将项目选择条作为输入框顶部附件，统一边框、圆角与阴影
- 分支说明改为悬浮提示，使输入区保持单行紧凑布局
- 项目欢迎建议改为更小的胶囊按钮
- 修正顶部附件存在时任务进度条的圆角衔接
- 补齐相关多语言文案
- 修复 KnowledgePanel 异步错误断言竞态，避免前端 CI 偶发失败

## 验证

- `pnpm exec vitest run src/components/settings/KnowledgePanel.test.tsx`：11/11 通过
- push 门禁通过：Rust fmt、clippy、cargo test、前端 typecheck、ESLint、Vitest
- 前端 Vitest：168 个测试文件、891 个测试通过

UI 由人工验收。