### PR TITLE
fix(homebrew): support older macOS dependency semantics

### DIFF
--- a/homebrew/hope-agent-arm-only.rb.tmpl
+++ b/homebrew/hope-agent-arm-only.rb.tmpl
@@ -18,7 +18,7 @@ cask "hope-agent" do
   # Intel Mac users have no installable arm64 path (Rosetta 2 translates
   # Intel → Apple Silicon, not the reverse) and should stay on the prior
   # dual-arch release until the next version that ships an x64 DMG.
-  depends_on macos: :big_sur, arch: :arm64
+  depends_on macos: ">= :big_sur", arch: :arm64
 
   app "Hope Agent.app"
 

--- a/homebrew/hope-agent.rb.tmpl
+++ b/homebrew/hope-agent.rb.tmpl
@@ -16,7 +16,7 @@ cask "hope-agent" do
   end
 
   auto_updates true
-  depends_on macos: :big_sur
+  depends_on macos: ">= :big_sur"
 
   app "Hope Agent.app"
 

--- a/scripts/check-release-paths.mjs
+++ b/scripts/check-release-paths.mjs
@@ -191,14 +191,14 @@ for (const p of requiredPlatforms) {
 }
 
 // ─── Check 6 ─────────────────────────────────────────────────────────
-// Homebrew deprecated string-style macOS comparisons in casks. The
-// templates should use symbols such as `depends_on macos: :big_sur`
-// so the generated public tap does not warn during `brew install`.
+// Homebrew <= 5.1.10 interprets a bare macOS symbol as an exact-version
+// requirement, while >= 5.1.11 interprets it as a minimum. Keep the
+// explicit comparator so the public tap works across both semantics.
 for (const template of ["hope-agent.rb.tmpl", "hope-agent-arm-only.rb.tmpl"]) {
   const templatePath = path.join("homebrew", template)
   const cask = readFileSync(path.join(repoRoot, templatePath), "utf8")
-  if (/depends_on\s+macos:\s*["']/.test(cask)) {
-    errors.push(`${templatePath}: uses deprecated string-style depends_on macos syntax; use a symbol such as macos: :big_sur.`)
+  if (!/depends_on\s+macos:\s*["']>=\s*:big_sur["']/.test(cask)) {
+    errors.push(`${templatePath}: must use the backward-compatible minimum macOS requirement macos: ">= :big_sur".`)
   }
 }
 


### PR DESCRIPTION
## Summary

- use an explicit `>= :big_sur` comparator in both Homebrew cask templates
- update the release-path guard to preserve compatibility with old and new Homebrew semantics

## Root cause

Homebrew 5.1.10 and earlier interpret a bare `macos: :big_sur` symbol as an exact-version requirement. On newer macOS releases this rejects installation even though Hope Agent only requires Big Sur or later. Homebrew 5.1.11 changed the same symbol form to mean a minimum version, so the explicit comparison string is required for cross-version compatibility.

A reported environment reproduced the affected combination: Homebrew 5.0.16 on macOS 26.3.1 arm64.

## Impact

Users on older Homebrew versions can install Hope Agent on macOS releases newer than Big Sur. Newer Homebrew versions continue to accept the explicit comparison.

## Validation

- `ruby -c homebrew/hope-agent.rb.tmpl`
- `ruby -c homebrew/hope-agent-arm-only.rb.tmpl`
- `node scripts/check-release-paths.mjs`
- `git diff --check`

The pre-push suite was skipped as requested. After merge, rerun `update-homebrew-tap.yml` for `v0.17.0` to backfill the public tap.