### PR TITLE
fix(ui): keep editor shortcuts focus-ring quiet

### DIFF
--- a/docs/architecture/ui-interaction-system.md
+++ b/docs/architecture/ui-interaction-system.md
@@ -119,11 +119,13 @@ value + `SelectValue` placeholder，并禁用 Trigger。
 ### 状态模型
 
 - `html[data-input-modality="pointer"]`：鼠标或触摸是最近输入方式，不画焦点轮廓。
-- `html[data-input-modality="keyboard"]`：Tab、快捷键或非文本控件键盘交互，画轻量焦点轮廓。
+- `html[data-input-modality="keyboard"]`：Tab 或非文本控件键盘交互，画轻量焦点轮廓。
 - `html[data-focus-indicators="enhanced"]`：用户手动开启增强提示，所有输入方式都画增强轮廓。
 - `prefers-contrast: more` / `forced-colors: active`：系统偏好优先，自动增强。
 
-鼠标聚焦文本框后输入文字不会切换到 Keyboard；Tab 和带修饰键的快捷键仍会切换。
+鼠标聚焦文本框后输入文字、移动光标或使用编辑快捷键（包括打开搜索）不会切换到 Keyboard；
+文本框内的 Tab 和非文本控件上的键盘交互仍会切换。键盘用户通过 Tab 进入文本框时已经处于
+Keyboard，因此编辑期间会持续保留焦点提示。
 运行时只在 `src/main.tsx` 安装一次，因此主窗口、Quick Chat 和分离窗口行为一致。首屏偏好
 读取有 2 秒上限；后端无响应时回退普通自动模式，不阻塞窗口挂载。
 

--- a/src/lib/focus-visibility.test.ts
+++ b/src/lib/focus-visibility.test.ts
@@ -33,7 +33,7 @@ describe("focus visibility input modality", () => {
     expect(document.documentElement.dataset.inputModality).toBe("pointer")
   })
 
-  test("typing in a pointer-focused editor does not paint a focus ring", () => {
+  test("editing a pointer-focused editor does not paint a focus ring", () => {
     install()
     const input = document.createElement("input")
     document.body.append(input)
@@ -58,7 +58,27 @@ describe("focus visibility input modality", () => {
     expect(document.documentElement.dataset.inputModality).toBe("pointer")
 
     input.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true, bubbles: true }))
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "a", metaKey: true, bubbles: true }))
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }))
+    expect(document.documentElement.dataset.inputModality).toBe("pointer")
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }))
     expect(document.documentElement.dataset.inputModality).toBe("keyboard")
+  })
+
+  test("an editor shortcut that opens another editor remains quiet", () => {
+    install()
+    const input = document.createElement("input")
+    const search = document.createElement("input")
+    document.body.append(input, search)
+
+    input.dispatchEvent(new Event("pointerdown", { bubbles: true }))
+    input.focus()
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "f", metaKey: true, bubbles: true }))
+    expect(document.documentElement.dataset.inputModality).toBe("pointer")
+
+    search.focus()
+    expect(document.documentElement.dataset.inputModality).toBe("pointer")
   })
 
   test("keyboard interaction on non-editable controls enables the indicator", () => {

--- a/src/lib/focus-visibility.ts
+++ b/src/lib/focus-visibility.ts
@@ -13,34 +13,28 @@ const TEXT_ENTRY_INPUT_TYPES = new Set([
 
 let uninstallCurrentTracker: (() => void) | null = null
 
-function isEditableTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof Element)) return false
+function editableTarget(target: EventTarget | null): Element | null {
+  if (!(target instanceof Element)) return null
   const editable = target.closest(
     'input, textarea, [contenteditable="true"], [contenteditable=""], [role="textbox"]',
   )
-  if (!editable) return false
-  return !(editable instanceof HTMLInputElement) || TEXT_ENTRY_INPUT_TYPES.has(editable.type)
-}
-
-function isTextEntryKeystroke(event: KeyboardEvent): boolean {
-  if (event.isComposing || event.key === "Process" || event.key === "Dead") return true
-  if (event.getModifierState("AltGraph")) return true
-  if (!event.metaKey && !event.ctrlKey && !event.altKey) return true
-  // macOS Option+character produces text rather than an application shortcut.
-  return event.altKey && !event.metaKey && !event.ctrlKey && event.key.length === 1
+  if (!editable) return null
+  if (editable instanceof HTMLInputElement && !TEXT_ENTRY_INPUT_TYPES.has(editable.type)) {
+    return null
+  }
+  return editable
 }
 
 /**
- * Text typed into a pointer-focused editor must not suddenly paint a focus
- * ring. Tab always means keyboard navigation; shortcuts and key interaction
- * on non-editable controls do too.
+ * Keyboard use inside a pointer-focused editor must not suddenly paint a focus
+ * ring: the caret already communicates focus, and editing shortcuts do not
+ * move it. Tab always means keyboard navigation; keyboard interaction on
+ * non-editable controls does too.
  */
 export function shouldEnterKeyboardModality(event: KeyboardEvent): boolean {
   if (MODIFIER_ONLY_KEYS.has(event.key)) return false
   if (event.key === "Tab") return true
-  if (isEditableTarget(event.target) && isTextEntryKeystroke(event)) {
-    return false
-  }
+  if (editableTarget(event.target)) return false
   return true
 }
 


### PR DESCRIPTION
## Summary

- keep pointer-focused text editors visually quiet during typing, cursor movement, and editing shortcuts
- reserve automatic keyboard focus outlines for Tab navigation and keyboard interaction on non-editable controls
- add regression coverage for Cmd/Ctrl+F, Cmd+A, Ctrl+F, arrow keys, and Tab, and update the focus interaction contract

## Root cause

The global input-modality tracker treated any modified shortcut inside an editable control as keyboard navigation. That switched the whole CodeMirror focus scope into keyboard mode, so common shortcuts painted a large blue outline around the chat composer.

## User impact

Editing shortcuts such as copy, paste, select all, undo, and search no longer add the large composer outline after a pointer focus. Tab navigation, enhanced focus indicators, high-contrast preferences, and forced-color behavior remain available.

## Validation

- `pnpm typecheck`
- `git diff --check`
- pre-push checks intentionally skipped with `HA_SKIP_PREPUSH=1` as requested
