### PR TITLE
🦭test(memory): 修复 BudgetConfig retry 用例的加载态竞态

### DIFF
--- a/src/components/settings/memory-panel/BudgetConfig.test.tsx
+++ b/src/components/settings/memory-panel/BudgetConfig.test.tsx
@@ -168,8 +168,14 @@ describe("BudgetConfig", () => {
     await waitFor(() => {
       expect(screen.queryByText("Failed to load memory budget")).toBeNull()
     })
+    // The retry re-fetch clears the error and briefly shows a loading state
+    // before the success content mounts. Wait for that content (findByText)
+    // rather than asserting synchronously, otherwise the assertion races the
+    // loading frame under parallel CI load and intermittently fails. Once the
+    // content is present the second fetch has necessarily completed, so assert
+    // loadCalls afterwards.
+    expect(await screen.findByText("settings.memoryBudget.totalChars")).toBeTruthy()
     expect(loadCalls).toBe(2)
-    expect(screen.getByText("settings.memoryBudget.totalChars")).toBeTruthy()
   })
 
   it("saves the two budget sections sequentially after a full reset", async () => {


### PR DESCRIPTION
## 背景

`#477` 的 CI 上 `Frontend lint + typecheck` job 偶发失败在 `BudgetConfig.test.tsx:172`（重跑即绿）。本地全套 3× 均过 → 确认是 CI 并行负载下的测试竞态，非产品代码缺陷。

## 根因

`saves … after retry` 用例点「Retry」后，只 `await waitFor(错误消失)`，随即**同步** `getByText("settings.memoryBudget.totalChars")` 断言成功内容。但重取会先短暂进入 loading 态（"Loading…"）再挂载成功内容——错误消失 ≠ 成功内容已渲染，两者之间有一帧窗口。并行 CI 负载放大该窗口，同步 `getByText` 撞上 loading 帧 → 元素找不到。

## 修复

改用 `await findByText`（重试直到内容出现），并把 `loadCalls` 断言移到内容就绪之后（此时第二次 fetch 必已完成）。纯测试改动，不动产品代码。

本地 3× 通过 + `pnpm typecheck` 绿。