### PR TITLE
🦭fix(dashboard): 成本按用户配置的单价结算，内置表仅作兜底

### DIFF
--- a/crates/ha-core/src/dashboard/cost.rs
+++ b/crates/ha-core/src/dashboard/cost.rs
@@ -1,5 +1,47 @@
 // ── Cost Estimation ─────────────────────────────────────────────
 
+/// 结算一次用量的成本。
+///
+/// 用户可以在设置里逐个模型改单价（`ModelEditor` 的输入/输出成本），所以**用户配置才是
+/// 「他实际付多少」的真相源**——此前大盘完全无视配置、只认下面那张内置价目表，用户把价格
+/// 改对了大盘照样算错。这里优先按 `(provider_id, model_id)` 回查配置，查不到才回退估算表。
+///
+/// 按 provider 回查还顺带解决了估算表结构上解不了的问题：同一模型在不同渠道价格不同
+/// （kimi-k2.6 直连 $0.95、OpenRouter $0.8），而估算表只按 model_id 匹配、只能存一个值。
+///
+/// `provider_id` 为 `None` 时（历史行未记录该列）同样回退估算表。
+pub(super) fn resolve_cost(
+    provider_id: Option<&str>,
+    model_id: &str,
+    input_tokens: u64,
+    output_tokens: u64,
+) -> f64 {
+    match provider_id.and_then(|pid| configured_price(pid, model_id)) {
+        Some((ci, co)) => (input_tokens as f64 * ci + output_tokens as f64 * co) / 1_000_000.0,
+        None => estimate_cost(model_id, input_tokens, output_tokens),
+    }
+}
+
+/// 从用户配置里取该 provider 下该模型的单价。
+///
+/// **0/0 视为「未标价」而非「免费」，返回 `None` 回退估算表**——模板里 0 是重载的：既表示
+/// 包月端点无按量计费（kimi-coding），也表示厂商单价未知（step-3.5-flash、qwen 新模型）。
+/// 两者无法区分，取回退可保持这些模型与改动前一致的行为，避免把「未知」静默报成 $0。
+fn configured_price(provider_id: &str, model_id: &str) -> Option<(f64, f64)> {
+    let cfg = crate::config::cached_config();
+    let model = cfg
+        .providers
+        .iter()
+        .find(|p| p.id == provider_id)?
+        .models
+        .iter()
+        .find(|m| m.id == model_id)?;
+    if model.cost_input == 0.0 && model.cost_output == 0.0 {
+        return None;
+    }
+    Some((model.cost_input, model.cost_output))
+}
+
 pub(super) fn estimate_cost(model_id: &str, input_tokens: u64, output_tokens: u64) -> f64 {
     // Pricing per 1M tokens: (input_price, output_price)
     let (input_price, output_price) = match model_id {
@@ -165,7 +207,108 @@ pub(super) fn estimate_cost(model_id: &str, input_tokens: u64, output_tokens: u6
 
 #[cfg(test)]
 mod tests {
-    use super::estimate_cost;
+    use super::{estimate_cost, resolve_cost};
+    use crate::config::AppConfig;
+    use crate::provider::{ApiType, ModelConfig, ProviderConfig};
+    use crate::test_support::replace_config_cache;
+
+    fn model(id: &str, cost_input: f64, cost_output: f64) -> ModelConfig {
+        ModelConfig {
+            id: id.to_string(),
+            name: id.to_string(),
+            input_types: vec!["text".to_string()],
+            context_window: 200_000,
+            max_tokens: 8_192,
+            reasoning: false,
+            thinking_style: None,
+            cost_input,
+            cost_output,
+        }
+    }
+
+    fn config_with(provider_id: &str, models: Vec<ModelConfig>) -> AppConfig {
+        let mut provider = ProviderConfig::new(
+            "Test".to_string(),
+            ApiType::OpenaiChat,
+            "https://example.invalid".to_string(),
+            "k".to_string(),
+        );
+        provider.id = provider_id.to_string();
+        provider.models = models;
+        AppConfig {
+            providers: vec![provider],
+            ..Default::default()
+        }
+    }
+
+    /// 用户在设置里改的单价必须真的影响大盘——这正是本次修复的核心。
+    #[test]
+    fn configured_price_overrides_the_builtin_table() {
+        // 表里 claude-opus-4-8 是 $5/$25；用户配置成 $1/$2。
+        let _guard =
+            replace_config_cache(config_with("p1", vec![model("claude-opus-4-8", 1.0, 2.0)]));
+
+        assert_eq!(
+            resolve_cost(Some("p1"), "claude-opus-4-8", 1_000_000, 0),
+            1.0
+        );
+        assert_eq!(
+            resolve_cost(Some("p1"), "claude-opus-4-8", 0, 1_000_000),
+            2.0
+        );
+        // 未按 provider 解析时仍走内置表，保持既有行为。
+        assert_eq!(resolve_cost(None, "claude-opus-4-8", 1_000_000, 0), 5.0);
+    }
+
+    /// 同一模型在不同渠道价格不同——这是按 model_id 匹配的估算表结构上解不了的。
+    #[test]
+    fn same_model_resolves_per_provider() {
+        let mut cfg = config_with("direct", vec![model("kimi-k2.6", 0.95, 4.0)]);
+        let mut gateway = ProviderConfig::new(
+            "Gateway".to_string(),
+            ApiType::OpenaiChat,
+            "https://gateway.invalid".to_string(),
+            "k".to_string(),
+        );
+        gateway.id = "gw".to_string();
+        gateway.models = vec![model("kimi-k2.6", 0.8, 3.5)];
+        cfg.providers.push(gateway);
+        let _guard = replace_config_cache(cfg);
+
+        assert_eq!(
+            resolve_cost(Some("direct"), "kimi-k2.6", 1_000_000, 0),
+            0.95
+        );
+        assert_eq!(resolve_cost(Some("gw"), "kimi-k2.6", 1_000_000, 0), 0.80);
+    }
+
+    /// 0/0 在模板里是「未标价」而非「免费」，必须回退估算表，不能把未知静默报成 $0。
+    #[test]
+    fn unpriced_model_falls_back_to_the_table() {
+        let _guard =
+            replace_config_cache(config_with("p1", vec![model("claude-opus-4-8", 0.0, 0.0)]));
+        assert_eq!(
+            resolve_cost(Some("p1"), "claude-opus-4-8", 1_000_000, 0),
+            5.0
+        );
+    }
+
+    /// provider 被删 / 模型已从配置移除 / 历史行无 provider_id —— 都回退，不能算成 0。
+    #[test]
+    fn unknown_provider_or_model_falls_back_to_the_table() {
+        let _guard =
+            replace_config_cache(config_with("p1", vec![model("some-other-model", 1.0, 2.0)]));
+
+        assert_eq!(
+            resolve_cost(Some("deleted"), "claude-opus-4-8", 1_000_000, 0),
+            5.0
+        );
+        assert_eq!(
+            resolve_cost(Some("p1"), "claude-opus-4-8", 1_000_000, 0),
+            5.0
+        );
+        assert_eq!(resolve_cost(None, "claude-opus-4-8", 1_000_000, 0), 5.0);
+    }
 
     /// Price per 1M tokens, recovered by billing exactly 1M of one kind.
     fn prices(model_id: &str) -> (f64, f64) {

--- a/crates/ha-core/src/dashboard/insights.rs
+++ b/crates/ha-core/src/dashboard/insights.rs
@@ -11,7 +11,7 @@ use crate::cron::CronDB;
 use crate::logging::LogDB;
 use crate::session::SessionDB;
 
-use super::cost::estimate_cost;
+use super::cost::resolve_cost;
 use super::filters::{
     build_log_filter, build_model_usage_filter, build_session_filter, params_ref,
 };
@@ -76,10 +76,11 @@ pub fn query_cost_trend(
         "SELECT DATE(u.timestamp) as d,
                 COALESCE(u.model_id, 'unknown') as model,
                 COALESCE(SUM(u.input_tokens), 0),
-                COALESCE(SUM(u.output_tokens), 0)
+                COALESCE(SUM(u.output_tokens), 0),
+                u.provider_id
          FROM model_usage_events u
          {}
-         GROUP BY d, model
+         GROUP BY d, model, u.provider_id
          ORDER BY d ASC",
         f.where_sql
     );
@@ -90,14 +91,15 @@ pub fn query_cost_trend(
             r.get::<_, String>(1)?,
             crate::sql_u64(r, 2)?,
             crate::sql_u64(r, 3)?,
+            r.get::<_, Option<String>>(4)?,
         ))
     })?;
 
     // Aggregate daily costs by summing per-model cost within each day
     let mut points: Vec<CostTrendPoint> = Vec::new();
     for row in rows {
-        let (date, model, tokens_in, tokens_out) = row?;
-        let cost = estimate_cost(&model, tokens_in, tokens_out);
+        let (date, model, tokens_in, tokens_out, provider_id) = row?;
+        let cost = resolve_cost(provider_id.as_deref(), &model, tokens_in, tokens_out);
         if let Some(last) = points.last_mut() {
             if last.date == date {
                 last.cost_usd += cost;
@@ -266,7 +268,8 @@ pub fn query_top_sessions(
                 COALESCE(SUM(u.input_tokens), 0) + COALESCE(SUM(u.output_tokens), 0) as total_tokens,
                 COALESCE(SUM(u.input_tokens), 0),
                 COALESCE(SUM(u.output_tokens), 0),
-                s.updated_at
+                s.updated_at,
+                u.provider_id
          FROM model_usage_events u
          JOIN sessions s ON s.id = u.session_id
          {}
@@ -286,8 +289,12 @@ pub fn query_top_sessions(
         let tokens_in: u64 = crate::sql_u64(r, 6)?;
         let tokens_out: u64 = crate::sql_u64(r, 7)?;
         let updated_at: String = r.get(8)?;
+        // `GROUP BY s.id` 下 model_id / provider_id 都是 bare column，SQLite 取任意一行；
+        // 二者若来自不同行则配置查不到，`resolve_cost` 自动回退估算表——退化即现状，安全。
+        let provider_id: Option<String> = r.get(9)?;
         let model_ref = model_id.as_deref().unwrap_or("unknown");
-        let estimated_cost_usd = estimate_cost(model_ref, tokens_in, tokens_out);
+        let estimated_cost_usd =
+            resolve_cost(provider_id.as_deref(), model_ref, tokens_in, tokens_out);
         Ok(TopSession {
             id,
             title,
@@ -321,10 +328,11 @@ pub fn query_model_efficiency(
                 COUNT(*) as call_cnt,
                 COALESCE(SUM(u.input_tokens), 0),
                 COALESCE(SUM(u.output_tokens), 0),
-                AVG(u.ttft_ms)
+                AVG(u.ttft_ms),
+                u.provider_id
          FROM model_usage_events u
          {}
-         GROUP BY u.model_id, u.provider_name
+         GROUP BY u.model_id, u.provider_name, u.provider_id
          ORDER BY SUM(u.input_tokens) + SUM(u.output_tokens) DESC",
         f.where_sql
     );
@@ -336,8 +344,14 @@ pub fn query_model_efficiency(
         let input_tokens: u64 = crate::sql_u64(r, 3)?;
         let output_tokens: u64 = crate::sql_u64(r, 4)?;
         let avg_ttft_ms: Option<f64> = r.get(5)?;
+        let provider_id: Option<String> = r.get(6)?;
         let total_tokens = input_tokens + output_tokens;
-        let total_cost_usd = estimate_cost(&model_id, input_tokens, output_tokens);
+        let total_cost_usd = resolve_cost(
+            provider_id.as_deref(),
+            &model_id,
+            input_tokens,
+            output_tokens,
+        );
         let avg_tokens_per_message = if message_count > 0 {
             total_tokens as f64 / message_count as f64
         } else {

--- a/crates/ha-core/src/dashboard/queries.rs
+++ b/crates/ha-core/src/dashboard/queries.rs
@@ -8,7 +8,7 @@ use crate::cron::CronDB;
 use crate::logging::LogDB;
 use crate::session::SessionDB;
 
-use super::cost::estimate_cost;
+use super::cost::resolve_cost;
 use super::filters::{
     build_log_filter, build_model_usage_filter, build_session_filter, params_ref,
 };
@@ -114,27 +114,31 @@ pub fn query_overview(
         .lock()
         .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
     let f = build_model_usage_filter(filter, "u");
+    // 按 provider_id 一并分组，成本才能按各渠道自己的配置单价结算（见 cost::resolve_cost）。
+    // 分组更细只是多几行，求和后总额不变。
     let sql = format!(
         "SELECT COALESCE(u.model_id, 'unknown'),
+                u.provider_id,
                 COALESCE(SUM(u.input_tokens), 0),
                 COALESCE(SUM(u.output_tokens), 0)
          FROM model_usage_events u
          {}
-         GROUP BY u.model_id",
+         GROUP BY u.model_id, u.provider_id",
         f.where_sql
     );
     let mut stmt = sess_conn.prepare(&sql)?;
     let rows = stmt.query_map(params_ref(&f.params).as_slice(), |r| {
         Ok((
             r.get::<_, String>(0)?,
-            crate::sql_u64(r, 1)?,
+            r.get::<_, Option<String>>(1)?,
             crate::sql_u64(r, 2)?,
+            crate::sql_u64(r, 3)?,
         ))
     })?;
     let mut estimated_cost_usd = 0.0;
     for row in rows {
-        let (model, inp, out) = row?;
-        estimated_cost_usd += estimate_cost(&model, inp, out);
+        let (model, provider_id, inp, out) = row?;
+        estimated_cost_usd += resolve_cost(provider_id.as_deref(), &model, inp, out);
     }
 
     Ok(OverviewStats {
@@ -228,10 +232,11 @@ pub fn query_token_usage(
                 COALESCE(u.provider_name, 'unknown'),
                 COALESCE(SUM(u.input_tokens), 0),
                 COALESCE(SUM(u.output_tokens), 0),
-                AVG(u.ttft_ms)
+                AVG(u.ttft_ms),
+                u.provider_id
          FROM model_usage_events u
          {}
-         GROUP BY u.model_id, u.provider_name
+         GROUP BY u.model_id, u.provider_name, u.provider_id
          ORDER BY SUM(u.input_tokens) + SUM(u.output_tokens) DESC",
         f.where_sql
     );
@@ -242,8 +247,14 @@ pub fn query_token_usage(
         let input_tokens: u64 = crate::sql_u64(r, 2)?;
         let output_tokens: u64 = crate::sql_u64(r, 3)?;
         let avg_ttft_ms: Option<f64> = r.get(4)?;
+        let provider_id: Option<String> = r.get(5)?;
         Ok(TokenByModel {
-            estimated_cost_usd: estimate_cost(&model_id, input_tokens, output_tokens),
+            estimated_cost_usd: resolve_cost(
+                provider_id.as_deref(),
+                &model_id,
+                input_tokens,
+                output_tokens,
+            ),
             model_id,
             provider_name,
             input_tokens,
@@ -265,10 +276,11 @@ pub fn query_token_usage(
                 COALESCE(SUM(COALESCE(u.context_input_tokens, u.input_tokens)), 0),
                 COALESCE(SUM(COALESCE(u.fresh_input_tokens, u.input_tokens)), 0),
                 AVG(u.duration_ms),
-                AVG(u.ttft_ms)
+                AVG(u.ttft_ms),
+                u.provider_id
          FROM model_usage_events u
          {}
-         GROUP BY u.kind, u.model_id
+         GROUP BY u.kind, u.model_id, u.provider_id
          ORDER BY u.kind ASC",
         f.where_sql
     );
@@ -286,6 +298,7 @@ pub fn query_token_usage(
             crate::sql_u64(r, 8)?,
             r.get::<_, Option<f64>>(9)?,
             r.get::<_, Option<f64>>(10)?,
+            r.get::<_, Option<String>>(11)?,
         ))
     })?;
     let mut by_kind_map: std::collections::BTreeMap<String, TokenByKind> =
@@ -303,6 +316,7 @@ pub fn query_token_usage(
             fresh_input_tokens,
             avg_duration_ms,
             avg_ttft_ms,
+            provider_id,
         ) = row?;
         let entry = by_kind_map.entry(kind.clone()).or_insert(TokenByKind {
             kind,
@@ -325,7 +339,12 @@ pub fn query_token_usage(
         entry.cache_read_input_tokens += cache_read_input_tokens;
         entry.context_input_tokens += context_input_tokens;
         entry.fresh_input_tokens += fresh_input_tokens;
-        entry.estimated_cost_usd += estimate_cost(&model_id, input_tokens, output_tokens);
+        entry.estimated_cost_usd += resolve_cost(
+            provider_id.as_deref(),
+            &model_id,
+            input_tokens,
+            output_tokens,
+        );
         entry.avg_duration_ms = merge_weighted_avg(
             entry.avg_duration_ms,
             old_calls,
@@ -357,10 +376,11 @@ pub fn query_token_usage(
                 COALESCE(SUM(u.cache_creation_input_tokens), 0),
                 COALESCE(SUM(u.cache_read_input_tokens), 0),
                 AVG(u.duration_ms),
-                AVG(u.ttft_ms)
+                AVG(u.ttft_ms),
+                u.provider_id
          FROM model_usage_events u
          {}
-         GROUP BY u.operation, u.model_id
+         GROUP BY u.operation, u.model_id, u.provider_id
          ORDER BY u.operation ASC",
         f.where_sql
     );
@@ -376,6 +396,7 @@ pub fn query_token_usage(
             crate::sql_u64(r, 6)?,
             r.get::<_, Option<f64>>(7)?,
             r.get::<_, Option<f64>>(8)?,
+            r.get::<_, Option<String>>(9)?,
         ))
     })?;
     let mut by_operation_map: std::collections::BTreeMap<String, TokenByOperation> =
@@ -391,6 +412,7 @@ pub fn query_token_usage(
             cache_read_input_tokens,
             avg_duration_ms,
             avg_ttft_ms,
+            provider_id,
         ) = row?;
         let domain = operation_domain(&operation).to_string();
         let entry = by_operation_map
@@ -413,7 +435,12 @@ pub fn query_token_usage(
         entry.output_tokens += output_tokens;
         entry.cache_creation_input_tokens += cache_creation_input_tokens;
         entry.cache_read_input_tokens += cache_read_input_tokens;
-        entry.estimated_cost_usd += estimate_cost(&model_id, input_tokens, output_tokens);
+        entry.estimated_cost_usd += resolve_cost(
+            provider_id.as_deref(),
+            &model_id,
+            input_tokens,
+            output_tokens,
+        );
         entry.avg_duration_ms = merge_weighted_avg(
             entry.avg_duration_ms,
             old_calls,

--- a/crates/ha-core/src/dashboard/queries.rs
+++ b/crates/ha-core/src/dashboard/queries.rs
@@ -257,6 +257,7 @@ pub fn query_token_usage(
             ),
             model_id,
             provider_name,
+            provider_id,
             input_tokens,
             output_tokens,
             avg_ttft_ms,

--- a/crates/ha-core/src/dashboard/types.rs
+++ b/crates/ha-core/src/dashboard/types.rs
@@ -57,6 +57,9 @@ pub struct TokenUsageTrend {
 pub struct TokenByModel {
     pub model_id: String,
     pub provider_name: String,
+    /// 同一模型可经多个 Provider 使用（各自单价不同，见 `cost::resolve_cost`），此时会有多行
+    /// 共用同一 `model_id`。前端必须用 `(provider_id, model_id)` 作行标识，不能只用 model_id。
+    pub provider_id: Option<String>,
     pub input_tokens: u64,
     pub output_tokens: u64,
     pub estimated_cost_usd: f64,

--- a/src/components/dashboard/TokenUsageSection.tsx
+++ b/src/components/dashboard/TokenUsageSection.tsx
@@ -150,19 +150,23 @@ const TokenUsageSection = React.memo(function TokenUsageSection({
 
   const pieData = (() => {
     if (!data?.byModel) return []
-    const sorted = [...data.byModel].sort(
-      (a, b) => b.inputTokens + b.outputTokens - (a.inputTokens + a.outputTokens),
-    )
+    // byModel 按 (模型, Provider) 分行——同一模型经多个 Provider 使用会有多行。饼图是按
+    // 模型看占比，故先按 modelId 合并，否则同名切片会重复出现、且各自只占该模型的一部分。
+    const byModelId = new Map<string, number>()
+    for (const m of data.byModel) {
+      byModelId.set(m.modelId, (byModelId.get(m.modelId) ?? 0) + m.inputTokens + m.outputTokens)
+    }
+    const sorted = [...byModelId.entries()].sort((a, b) => b[1] - a[1])
     const top8 = sorted.slice(0, 8)
     const rest = sorted.slice(8)
-    const result = top8.map((m) => ({
-      name: m.modelId,
-      value: m.inputTokens + m.outputTokens,
+    const result = top8.map(([modelId, value]) => ({
+      name: modelId,
+      value,
     }))
     if (rest.length > 0) {
       result.push({
         name: t("dashboard.token.other"),
-        value: rest.reduce((acc, m) => acc + m.inputTokens + m.outputTokens, 0),
+        value: rest.reduce((acc, [, value]) => acc + value, 0),
       })
     }
     return result
@@ -533,7 +537,7 @@ const TokenUsageSection = React.memo(function TokenUsageSection({
               <>
                 {data.byModel.map((m) => (
                   <div
-                    key={m.modelId}
+                    key={`${m.providerId ?? m.providerName}::${m.modelId}`}
                     className="grid grid-cols-6 gap-2 text-xs py-2 border-b border-border/50 hover:bg-muted/50"
                   >
                     <div className="truncate font-medium">{m.modelId}</div>

--- a/src/components/dashboard/types.ts
+++ b/src/components/dashboard/types.ts
@@ -39,6 +39,8 @@ export interface TokenUsageTrend {
 export interface TokenByModel {
   modelId: string
   providerName: string
+  /** 同一模型可经多个 Provider 使用，此时多行共用同一 modelId；行标识须用 (providerId, modelId)。 */
+  providerId: string | null
   inputTokens: number
   outputTokens: number
   estimatedCostUsd: number


### PR DESCRIPTION
> **Stacked on #484** —— base 指向 `feat/provider-templates-sonnet5`，#484 合并后本 PR 会自动改指 `main`。只看本 PR 自己的那个提交即可。

## 起因

#484 的评审指出「模板改价后 `dashboard/cost.rs` 没同步」。那条已在 #484 里修完（实测 33/95 对不上，全部对齐）。但评审同时提了另一个方案：

> update the estimator in lockstep **or derive the rate from provider configuration**

这个 PR 做后者——因为前者治标。

## 真正的问题：用户改了价，大盘不认

Provider 编辑页里，用户**可以逐个模型改输入/输出单价**（`ModelEditor` 的成本输入框）。但大盘完全无视这份配置，只认 `cost.rs` 里那张按 `model_id` 做 substring 匹配的内置表。

**也就是说：用户在设置里把价格改对了，大盘照样按内置表算错。** 这不是维护性问题，是功能 bug。

内置表还有两个结构性缺陷，光靠同步修不掉：

1. **同一模型在不同渠道价格不同**——kimi-k2.6 直连 $0.95、OpenRouter $0.8，两个都对；但表只按 `model_id` 匹配，只能存一个值，另一个必然错。
2. **每次刷新模板都要人工同步**——已经漂移过三次，#484 实测 33/95 不符。

## 改法

`model_usage_events` 本就有 `provider_id` 列，只是所有查询都没 select。

新增 `cost::resolve_cost(provider_id, model_id, ..)`：优先按 `(provider_id, model_id)` 回查用户配置的单价，查不到才回退内置表。7 处调用点（`insights.rs` ×3 + `queries.rs` ×4）的 SQL 补上 `provider_id` 并加入 `GROUP BY`。

内置表保留为兜底，覆盖：provider 已删、模型已从配置移除、历史行没记 `provider_id`。

## 两处刻意的语义选择（想请你重点看这两条）

**1. `0/0` 视为「未标价」而非「免费」，回退内置表。**

模板里 `0` 是重载的：既表示包月端点无按量计费（kimi-coding、modelstudio），也表示厂商单价未知（step-3.5-flash、qwen 新模型、nvidia 全系）。二者在数据上无法区分。

选择回退可让这些模型**与改动前行为完全一致**，避免把「未知」静默报成 $0（那会让 nvidia/chutes 等的成本凭空归零）。代价是包月端点仍按内置表估价——但那本来就是现状，没有回归。

根治需要在 `ModelConfig` 上把「免费/已含」与「未知」区分开，那是独立的数据模型改动，另议。

**2. 分组变细不改总额。**

`GROUP BY` 多带一个 `provider_id` 只是多几行，求和后总量不变；按 provider 分别结算反而更准。

## 一个已知的退化点

`top_sessions` 的 `GROUP BY s.id` 下 `model_id` / `provider_id` 都是 bare column，SQLite 取任意一行——二者可能来自不同行。此时配置查不到、自动回退内置表。**退化即现状，安全**；且该查询本来就是「用一个代表模型估算整个会话成本」的近似。

## 验证

新增 4 个测试：配置单价覆盖内置表、同模型跨渠道分别结算、`0/0` 回退、以及 provider 已删 / 模型已移除 / 历史行无 `provider_id` 三种回退路径。

`cargo fmt` / `clippy -p ha-core -p ha-server` / `cargo test -p ha-core -p ha-server` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)