### PR TITLE
fix(cli): 修复 onboarding 模型价格类型

### DIFF
--- a/src-tauri/src/cli_onboarding/steps/provider.rs
+++ b/src-tauri/src/cli_onboarding/steps/provider.rs
@@ -115,6 +115,7 @@ pub fn run(step: u32, total: u32) -> Result<bool> {
         return Ok(false);
     }
     let model_id = prompt_input("Primary model id", Some(tpl.model_id))?;
+    let token_cost = matches!(tpl.kind, TemplateKind::Local).then_some(0.0);
 
     let mut provider = ProviderConfig::new(provider_name, tpl.api_type.clone(), base_url, api_key);
     provider.models = vec![ModelConfig {
@@ -125,8 +126,8 @@ pub fn run(step: u32, total: u32) -> Result<bool> {
         max_tokens: 8192,
         reasoning: false,
         thinking_style: None,
-        cost_input: 0.0,
-        cost_output: 0.0,
+        cost_input: token_cost,
+        cost_output: token_cost,
     }];
     ha_core::provider::add_and_activate_provider(provider, model_id, "cli-onboarding")?;
 


### PR DESCRIPTION
## 变更内容

- 将 CLI onboarding 创建模型时的 `cost_input` / `cost_output` 改为 `Option<f64>`。
- 本地 Ollama 模板使用 `Some(0.0)`，明确表示不按 token 计费。
- 云端与自定义 API 模板使用 `None`，表示价格未知并保留成本估算回退语义。

## 原因

`ModelConfig` 的价格字段在 #489 中从 `f64` 改为 `Option<f64>`，但 `src-tauri` 的 CLI onboarding 构造点未同步，导致 `hope-agent` 编译时报 `E0308`。

## 影响

修复桌面/CLI crate 的编译错误，同时避免把所有云端模型误标为免费。

## 验证

- `cargo check -p hope-agent`
- pre-push 全量门禁：`cargo fmt`、Clippy、Rust tests、TypeScript、ESLint、Vitest（198 files / 1008 tests）全部通过。