### PR TITLE
🦭fix(hooks): pre-push 排空 stdin,避免推送被 SIGPIPE 静默中断

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,6 +8,16 @@
 #                              pushing a WIP branch and don't need the 1–3 min
 #                              test run locally; CI will still catch it)
 
+# Drain the ref list git streams on our stdin. We don't use it, but exiting
+# without reading leaves git writing into a closed pipe — it then dies of
+# SIGPIPE (exit 141) *after* the checks pass, so the push silently never
+# happens. The longer the hook runs, the wider that window, and this one runs
+# for minutes. `-t 0` keeps a manual `.husky/pre-push` run from blocking on the
+# terminal. Must stay above every exit path below.
+if [ ! -t 0 ]; then
+  cat > /dev/null 2>&1 || true
+fi
+
 if [ "${HA_SKIP_PREPUSH:-}" = "1" ]; then
   echo "[pre-push] HA_SKIP_PREPUSH=1 — skipping all checks"
   exit 0


### PR DESCRIPTION
## 问题

git 会把待推送的 ref 列表写进 `pre-push` 钩子的 stdin。本钩子从不读取它，退出后 git 继续向已关闭的管道写入就会收到 **SIGPIPE，以 141 退出**。

要命的是它发生在所有检查都打印 `[pre-push] all checks passed` **之后**：

```
[pre-push] all checks passed
exit=141          ← 分支根本没推上去，且没有任何报错
```

表现为「门禁全绿，但远端没有分支」，很容易被当成网络抖动而反复重试——每次重试又要再跑一遍好几分钟的 `cargo test`。钩子跑得越久，窗口越大。

## 复现

在本仓库推送一个含 Rust 改动的分支（钩子会跑满 `cargo clippy` + `cargo test`）：

- `git push origin HEAD:some-branch` → 检查全过，`exit=141`，`git ls-remote` 查不到分支
- `HA_SKIP_PREPUSH=1 git push --dry-run ...` → `exit=0`，正常（钩子立即退出，几乎不给 git 写入的机会）

后者证明网络与认证路径没问题，问题就在钩子。

## 修复

在**所有 exit 路径之前**把 stdin 读干净：

```sh
if [ ! -t 0 ]; then
  cat > /dev/null 2>&1 || true
fi
```

- 放在 `HA_SKIP_PREPUSH` 早退分支**之上**——任何不读 stdin 就退出的路径都会留下同样的破管道
- `-t 0` 判断避免手动执行 `.husky/pre-push` 时阻塞在终端输入上

## 验证

**这个 PR 的推送本身就是验证**：带完整门禁（含 `cargo test`，即之前必炸的路径）推送，`exit=0` 且分支正常落地；同样条件下修复前连续三次都是 `exit=141`。

另外本地验证：`sh -n .husky/pre-push` 语法通过；模拟 git 喂入 ref 列表能正常读完退出；`< /dev/null` 时不阻塞。

## 范围

纯开发工具链修复，不影响产物与用户可感知行为，故未动 CHANGELOG；两个 skip 标志的语义也没变，AGENTS.md 无需更新。