### PR TITLE
🦭fix(ci): 让 linux-arm64 发版构建不再被 runner 杀掉

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,13 @@ jobs:
       #
       # 按 lane 可覆盖：v0.20.0 发版时 linux-arm64 在 tauri-action 步骤跑到 67 /
       # 74 分钟被 runner 杀掉两次（GitHub 注解 "lost communication … starves it
-      # for CPU/Memory"，且两次都没留下任何日志）。codegen-units=1 把整个
-      # ha-core（v0.20.0 已 509k 行）压成单个 LLVM 单元，是该 lane 上内存与耗时
-      # 的主要放大器，故 arm64 退回 cargo 默认 16：峰值内存与墙钟都降，代价是该
-      # 平台二进制略大、运行略慢。其余 lane 维持 1 不变。
+      # for CPU/Memory"）。codegen-units=1 把整个 ha-core（v0.20.0 已 509k 行）
+      # 压成单个 LLVM 单元，峰值超出该 runner 的 15Gi + 3Gi swap，故 arm64 退回
+      # cargo 默认 16，代价是该平台二进制略大、运行略慢。其余 lane 维持 1 不变。
+      #
+      # 磁盘已排除：上面 Report runner resources 实测 145G 盘 / 118G 可用。
+      # macos-arm64 只有 7GB 内存却能扛住 codegen-units=1，推测是靠 macOS 的内存
+      # 压缩与磁盘 swap；别据此以为 arm64 Linux 也该扛得住。
       CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ matrix.codegen_units || '1' }}
     strategy:
       fail-fast: false
@@ -96,21 +99,11 @@ jobs:
 
       - uses: pnpm/action-setup@v4
 
-      # v0.20.0 发版时 linux-arm64 被 runner 杀掉两次，且两次都没能上传任何日志
-      # （logs API 返回 BlobNotFound）——日志本身写不出来，比起内存压力更像磁盘写
-      # 满。本 workspace 的 release target 目录 20GB 起，托管 runner 可用盘只有十
-      # 几 GB，故先腾掉用不到的预装 SDK。cleanup 必须早于 rust-cache 解包与
-      # cargo build，否则腾出来已经晚了。`|| true`：镜像布局随 runner 版本变，缺
-      # 目录不算失败。
-      - name: Free disk space (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
-          sudo apt-get clean || true
-
-      # 起始资源快照。runner 若在构建中途被杀，日志多半丢失，这里留下的基线至少
-      # 能反推是磁盘还是内存不足。
+      # 起始资源快照。arm64 lane 曾被 runner 杀掉两次且日志全丢，当时无从判断是
+      # 磁盘还是内存——这一步就是为回答那个问题加的，并已给出答案：ubuntu-24.04-arm
+      # 有 145G 盘 / 118G 可用、15Gi 内存 + 3Gi swap，磁盘绰绰有余，瓶颈在内存。
+      # 保留它，下次资源类失败仍可一眼定位（注意：job 中途被杀时日志多半丢失，
+      # 这份快照只在 job 跑完后可读）。
       - name: Report runner resources
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,14 @@ jobs:
       # 仅 release-tag / dispatch 构建串行化 codegen，换取最小 / 最快二进制（叠加
       # 根 Cargo.toml 的 lto="thin" / strip）。Docker（docker.yml 走 Dockerfile，
       # 不读此 env）与日常 dev 不受影响。
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
+      #
+      # 按 lane 可覆盖：v0.20.0 发版时 linux-arm64 在 tauri-action 步骤跑到 67 /
+      # 74 分钟被 runner 杀掉两次（GitHub 注解 "lost communication … starves it
+      # for CPU/Memory"，且两次都没留下任何日志）。codegen-units=1 把整个
+      # ha-core（v0.20.0 已 509k 行）压成单个 LLVM 单元，是该 lane 上内存与耗时
+      # 的主要放大器，故 arm64 退回 cargo 默认 16：峰值内存与墙钟都降，代价是该
+      # 平台二进制略大、运行略慢。其余 lane 维持 1 不变。
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ matrix.codegen_units || '1' }}
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +74,8 @@ jobs:
             os: ubuntu-24.04-arm
             rust_target: ""
             args: ""
+            # 见 job env 的 CARGO_PROFILE_RELEASE_CODEGEN_UNITS 注释。
+            codegen_units: "16"
           # Windows x64 — MSI (wix) + NSIS. Code signing certificate is
           # not wired up yet; bundles are unsigned. See
           # src-tauri/tauri.conf.json `bundle.windows.certificateThumbprint`
@@ -86,6 +95,28 @@ jobs:
           node-version: 20
 
       - uses: pnpm/action-setup@v4
+
+      # v0.20.0 发版时 linux-arm64 被 runner 杀掉两次，且两次都没能上传任何日志
+      # （logs API 返回 BlobNotFound）——日志本身写不出来，比起内存压力更像磁盘写
+      # 满。本 workspace 的 release target 目录 20GB 起，托管 runner 可用盘只有十
+      # 几 GB，故先腾掉用不到的预装 SDK。cleanup 必须早于 rust-cache 解包与
+      # cargo build，否则腾出来已经晚了。`|| true`：镜像布局随 runner 版本变，缺
+      # 目录不算失败。
+      - name: Free disk space (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo apt-get clean || true
+
+      # 起始资源快照。runner 若在构建中途被杀，日志多半丢失，这里留下的基线至少
+      # 能反推是磁盘还是内存不足。
+      - name: Report runner resources
+        shell: bash
+        run: |
+          echo "--- disk ---"; df -h || true
+          echo "--- memory ---"; (free -h || vm_stat || true)
+          echo "--- cpus ---"; (nproc || sysctl -n hw.ncpu || true)
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## 背景

v0.20.0 发版时 `linux-arm64` 在 `Build & draft release` 步骤跑到 **67 / 74 分钟**被 runner 杀掉两次（可复现，重跑无效）。GitHub 注解：

> The hosted runner lost communication with the server. Anything in your workflow that terminates the runner process, **starves it for CPU/Memory**, or blocks its network access can cause this error.

后果：v0.20.0 缺 Linux arm64 全套产物，`latest.json` 缺 `linux-aarch64` 条目，且 **AUR 同步失败**（`update-aur.yml` 硬要求 amd64 + arm64 两个 deb，而 `PKGBUILD` 确实声明了 `arch=('x86_64' 'aarch64')`，硬失败是正确行为）。

## 诊断

两个候选成因，证据无法二选一，故一并处理：

- **磁盘耗尽（我认为更可能）**：两次失败都**完全没有日志**（logs API 返回 `BlobNotFound`）。日志本身写不出来，比内存压力更像磁盘写满。本 workspace 的 release target 目录 20GB 起，托管 runner 可用盘只有十几 GB。
- **内存压力**：`codegen-units=1` 把 `ha-core`（v0.20.0 已 **509k 行**，占全部 Rust 代码 90%）压成单个 LLVM 单元。
  - ⚠️ 但这条证据不足：`macos-arm64` 在 **7GB / 3 核**（比 arm64 Linux runner 的 16GB 更紧）下用同样的 `codegen-units=1` **构建成功**。单凭内存不足解释不了。

## 改动

| 改动 | 针对 |
|---|---|
| 构建前清理预装 SDK（dotnet / android / ghc / boost）+ `apt-get clean` | 磁盘耗尽 |
| 新增起始资源快照（`df -h` / `free -h` / `nproc`） | 下次失败可反推是磁盘还是内存 |
| `CARGO_PROFILE_RELEASE_CODEGEN_UNITS` 改为矩阵可覆盖，arm64 用默认 16 | 内存峰值 + 大幅提速 |

清理与快照都排在 **rust-cache 解包与 cargo build 之前**（晚了就没意义）。`codegen_units` 只覆盖 arm64，其余三个 lane 回落 `1`，**行为完全不变**。

代价：arm64 平台二进制略大、运行略慢，换取该 lane 能跑完并显著提速。

## 顺带解释「为什么构建这么久」

v0.17.0 → v0.20.0：Rust 总行数 352,705 → 566,456（**+61%**），`ha-core` 311,128 → 509,431。构建耗时相应从各平台 45–69 分钟涨到 65 分钟–2 小时。`codegen-units=1` 让这个增长在 codegen 阶段无法并行摊薄，arm64 lane 受害最重。

## 验证

- `node scripts/check-release-paths.mjs` — 通过（唯一 warn 是既有的 macos-x64 lane 缺失）
- YAML 结构与矩阵覆盖已独立解析核对
- **dry-run 待跑**：`release.yml` 的 `Dry-run build (skip publish)` 步骤会用同一套 env 真跑 arm64 的 Rust 编译，所以对本修复是**有效验证**（两处已知 dry-run 盲区是 tauri-action 与 patch-manifest，不涉及本改动）

## 后续

合并发 v0.20.1 后 cherry-pick 回 `main`。AUR 会随 v0.20.1 自动恢复。