### PR TITLE
🦭release: v0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Hope Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.1] - 2026-07-19
+
+### Fixed
+
+- **补回 Linux arm64 安装包**：v0.20.0 的 Linux arm64 构建在发版流水线中连续两次被 CI runner 中断，导致该平台的 deb、AppImage 与 rpm 全部缺失，更新清单里也没有对应条目——树莓派 4/5、Apple Silicon 上的 Asahi Linux 以及 Graviton / Ampere 云主机用户既装不上新版，也收不到更新提示。本版修复了流水线在该平台的内存瓶颈，arm64 安装包恢复正常提供。 (#507)
+- **恢复 AUR 软件源同步**：`hope-agent-bin` 同时声明 x86_64 与 aarch64 两种架构，v0.20.0 因缺少 arm64 包而同步失败，Arch Linux 用户停留在 v0.17.0。本版发布后自动恢复，可直接升级到最新版。 (#507)
+
 ## [0.20.0] - 2026-07-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3332,7 +3332,7 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hope-agent"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.20.0"
+version = "0.20.1"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.20.0"
+version = "0.20.1"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.20.1.en.md
+++ b/docs/release-notes/v0.20.1.en.md
@@ -1,0 +1,14 @@
+# Hope Agent 0.20.1 — Linux arm64 Builds Restored
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.20.1/docs/release-notes/v0.20.1.md) · **English**
+
+> Released: 2026-07-19
+
+> See [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.20.1/CHANGELOG.md#0201---2026-07-19) for the full list.
+
+v0.20.1 is a build fix that restores the Linux arm64 packages missing from [v0.20.0](https://github.com/shiwenwen/hope-agent/blob/v0.20.1/docs/release-notes/v0.20.0.en.md). It is functionally identical to v0.20.0 — users on other platforms don't need to upgrade for this.
+
+## Fixes
+
+- **Linux arm64 packages are back.** The Linux arm64 build was interrupted twice by the CI runner during the v0.20.0 release, so that platform's deb, AppImage, and rpm were all missing and the update manifest had no entry for it — leaving Raspberry Pi 4/5, Asahi Linux on Apple Silicon, and Graviton / Ampere cloud users unable to install the new version or even see an update. This release fixes the pipeline's memory bottleneck on that platform, and arm64 packages are published again.
+- **AUR sync restored.** `hope-agent-bin` declares both x86_64 and aarch64, so the v0.20.0 sync failed for want of an arm64 package and left Arch Linux users on v0.17.0. It recovers automatically with this release.

--- a/docs/release-notes/v0.20.1.md
+++ b/docs/release-notes/v0.20.1.md
@@ -1,0 +1,14 @@
+# Hope Agent 0.20.1 — 恢复 Linux arm64 安装包
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.20.1/docs/release-notes/v0.20.1.en.md)
+
+> 发布日期：2026-07-19
+
+> 详见 [`CHANGELOG.md`](https://github.com/shiwenwen/hope-agent/blob/v0.20.1/CHANGELOG.md#0201---2026-07-19)。
+
+v0.20.1 是一个构建修复版本，补回 [v0.20.0](https://github.com/shiwenwen/hope-agent/blob/v0.20.1/docs/release-notes/v0.20.0.md) 缺失的 Linux arm64 安装包。功能与 v0.20.0 完全相同，其它平台的用户无需专门升级。
+
+## 修复
+
+- **补回 Linux arm64 安装包**：v0.20.0 的 Linux arm64 构建在发版流水线中连续两次被 CI runner 中断，导致该平台的 deb、AppImage 与 rpm 全部缺失，更新清单里也没有对应条目——树莓派 4/5、Apple Silicon 上的 Asahi Linux 以及 Graviton / Ampere 云主机用户既装不上新版，也收不到更新提示。本版修复了流水线在该平台的内存瓶颈，arm64 安装包恢复正常提供。
+- **恢复 AUR 软件源同步**：`hope-agent-bin` 同时声明 x86_64 与 aarch64 两种架构，v0.20.0 因缺少 arm64 包而同步失败，Arch Linux 用户停留在 v0.17.0。本版发布后自动恢复，可直接升级到最新版。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.20.1",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.20.0"
+version = "0.20.1"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
补回 v0.20.0 缺失的 Linux arm64 安装包。功能与 v0.20.0 完全相同。

## 改动

- `CHANGELOG.md` 新增 `[0.20.1]` 段，两条面向用户的修复
- 新增中英双语 release notes（`docs/release-notes/v0.20.1{,.en}.md`）
- 版本号同步至 `package.json` / `src-tauri` / `ha-server` / `ha-core` / `Cargo.lock`

修复本体是已合并的 #507，本 PR 只做发版三件事。

## 背景

v0.20.0 的 `linux-arm64` 构建在流水线中连续两次被 runner 中断（67 / 74 分钟，`codegen-units=1` 使 509k 行的 `ha-core` 峰值内存超出该 runner 的 15Gi + 3Gi swap），导致：

- 该平台 deb / AppImage / rpm 全部缺失，`latest.json` 无 `linux-aarch64` 条目
- AUR 同步失败（`hope-agent-bin` 声明 `arch=('x86_64' 'aarch64')`），Arch 用户停留在 v0.17.0

#507 已修复并经 dry-run [29676062030](https://github.com/shiwenwen/hope-agent/actions/runs/29676062030) 验证：`linux-arm64` 66 分钟构建成功，跨过历史失败窗口。

## 验证

- `node scripts/verify-release-version.mjs --tag v0.20.1` — 通过
- release notes 全部链接为 tag-pin 绝对 URL，无相对路径
- 本地 pre-push 全套门禁通过

## 后续

合并后打 tag `v0.20.1` 触发构建，publish 后 AUR 自动恢复；#507 另行 cherry-pick 回 `main`。