### PR TITLE
🦭fix(hooks): 修 pre-push 长门禁致 push 静默 141 的真因（SSH 闲置连接被服务端掐断）

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -8,12 +8,18 @@
 #                              pushing a WIP branch and don't need the 1–3 min
 #                              test run locally; CI will still catch it)
 
-# Drain the ref list git streams on our stdin. We don't use it, but exiting
-# without reading leaves git writing into a closed pipe — it then dies of
-# SIGPIPE (exit 141) *after* the checks pass, so the push silently never
-# happens. The longer the hook runs, the wider that window, and this one runs
-# for minutes. `-t 0` keeps a manual `.husky/pre-push` run from blocking on the
-# terminal. Must stay above every exit path below.
+# Drain the ref list git streams on our stdin — we don't use it, and leaving it
+# unread is untidy. `-t 0` keeps a manual `.husky/pre-push` run from blocking on
+# the terminal.
+#
+# NOTE: this drain is NOT what protects the push. The "gates pass, then git dies
+# of SIGPIPE (141) and the branch never moves" failure has a different cause:
+# git opens the connection to the remote BEFORE running this hook, so the socket
+# sits idle for the 10-15 minutes we spend here and GitHub's SSH server closes
+# it ("Connection to ssh.github.com closed by remote host"). The pack write right
+# after the gates then hits a dead socket. The fix is the SSH keepalive that
+# `scripts/setup-ssh-keepalive.mjs` configures (via `pnpm install`); measured, a
+# 15-minute hook exits 141 without it and 0 with it.
 if [ ! -t 0 ]; then
   cat > /dev/null 2>&1 || true
 fi

--- a/crates/ha-server/build.rs
+++ b/crates/ha-server/build.rs
@@ -39,8 +39,19 @@ p{line-height:1.6;margin:0 0 1rem 0}
 code{background:#1f232a;padding:.15rem .35rem;border-radius:4px;font-size:.9em}"#;
 
 fn main() {
-    // Resolve ../../dist relative to this crate.
-    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // Resolve ../../dist relative to this crate. Read CARGO_MANIFEST_DIR at RUN
+    // time, not with `env!`: that bakes the path in when the build script is
+    // compiled, and a shared CARGO_TARGET_DIR reuses one compiled build script
+    // across every worktree — so the placeholder lands in whichever worktree
+    // compiled it first (even a deleted one) and the current worktree fails
+    // with "#[derive(RustEmbed)] folder '../../dist' does not exist".
+    let manifest = match std::env::var("CARGO_MANIFEST_DIR") {
+        Ok(dir) => PathBuf::from(dir),
+        Err(e) => {
+            println!("cargo:warning=ha-server build.rs: CARGO_MANIFEST_DIR unavailable: {e}");
+            return;
+        }
+    };
     let dist = manifest.join("..").join("..").join("dist");
 
     if let Err(e) = fs::create_dir_all(&dist) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "fetch:vcredist": "node scripts/fetch-vcredist.mjs",
     "tauri": "tauri",
     "version": "node scripts/sync-version.mjs",
-    "prepare": "husky",
+    "prepare": "husky && node scripts/setup-ssh-keepalive.mjs",
     "postinstall": "node scripts/patch-codemirror-edit-context.mjs"
   },
   "dependencies": {

--- a/scripts/setup-ssh-keepalive.mjs
+++ b/scripts/setup-ssh-keepalive.mjs
@@ -44,10 +44,24 @@ if (git(["rev-parse", "--is-inside-work-tree"], { allowFailure: true }) !== "tru
 
 // Never clobber an existing setting: contributors using 1Password / a custom
 // identity / a proxy command have their own `core.sshCommand`, and silently
-// replacing it would break their auth. Plain `ssh` still reads ~/.ssh/config,
-// so the value we set stays compatible with per-host settings.
-const existing = git(["config", "--local", "--get", "core.sshCommand"], { allowFailure: true })
+// replacing it would break their auth.
+//
+// Query the EFFECTIVE value (no `--local`): such a setting usually lives in the
+// user's global config, and a local write would take precedence over it — so a
+// local-only lookup sees nothing, writes, and silently strips their working
+// auth setup. We can't safely append our flags to an arbitrary command either
+// (it may be a wrapper script that rejects `-o`), so we leave it untouched and
+// point at the equivalent ~/.ssh/config knob instead.
+const existing = git(["config", "--get", "core.sshCommand"], { allowFailure: true })
 if (existing) {
+  if (!existing.includes("ServerAliveInterval")) {
+    console.log(
+      `[setup-ssh-keepalive] core.sshCommand already set (${existing}) — leaving it alone.\n` +
+        `[setup-ssh-keepalive] If a long push dies with exit 141 after "all checks passed", add to ~/.ssh/config:\n` +
+        `[setup-ssh-keepalive]     Host github.com\n` +
+        `[setup-ssh-keepalive]       ServerAliveInterval 30`,
+    )
+  }
   process.exit(0)
 }
 

--- a/scripts/setup-ssh-keepalive.mjs
+++ b/scripts/setup-ssh-keepalive.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+//
+// Keep the push connection alive while `.husky/pre-push` runs its multi-minute
+// gates.
+//
+// `git push` opens the connection to the remote and negotiates refs BEFORE it
+// invokes pre-push (that negotiation is where the hook's remote-SHA arguments
+// come from) — verified with GIT_TRACE:
+//
+//   15:10:27.383  run_command: ssh git@github.com 'git-receive-pack ...'
+//   15:10:32.180  run_command: .husky/pre-push ...     <- 4.8s later
+//   15:10:32.536  run_command: git pack-objects ...    <- only after the hook
+//
+// Our hook runs fmt + clippy + typecheck + eslint + vitest + cargo test, i.e.
+// 10-15 minutes, and the connection sits idle that whole time. GitHub's SSH
+// server drops it ("Connection to ssh.github.com closed by remote host"), so
+// the pack write right after the gates hits a dead socket: git dies of SIGPIPE
+// (exit 141) *after* printing "all checks passed", and the push silently never
+// happens. Measured: a 5-minute hook survives, a 15-minute one does not.
+//
+// `ServerAliveInterval` makes ssh send keepalives during that idle window,
+// which keeps the connection open across the whole gate run (verified: same
+// 15-minute hook, exit 0 with keepalive vs 141 without).
+//
+// Runs from package.json `prepare`, so a plain `pnpm install` sets it up.
+
+import { execFileSync } from "node:child_process"
+
+const SSH_COMMAND = "ssh -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
+
+function git(args, { allowFailure = false } = {}) {
+  try {
+    return execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim()
+  } catch (err) {
+    if (allowFailure) return null
+    throw err
+  }
+}
+
+// Not a git checkout (tarball install, Docker build context) — nothing to do.
+if (git(["rev-parse", "--is-inside-work-tree"], { allowFailure: true }) !== "true") {
+  process.exit(0)
+}
+
+// Never clobber an existing setting: contributors using 1Password / a custom
+// identity / a proxy command have their own `core.sshCommand`, and silently
+// replacing it would break their auth. Plain `ssh` still reads ~/.ssh/config,
+// so the value we set stays compatible with per-host settings.
+const existing = git(["config", "--local", "--get", "core.sshCommand"], { allowFailure: true })
+if (existing) {
+  process.exit(0)
+}
+
+try {
+  git(["config", "--local", "core.sshCommand", SSH_COMMAND])
+  console.log(`[setup-ssh-keepalive] core.sshCommand = ${SSH_COMMAND}`)
+} catch {
+  // Best-effort: a missing/readonly config must not fail `pnpm install`.
+  console.warn("[setup-ssh-keepalive] could not set core.sshCommand; long pushes may fail with SIGPIPE")
+}


### PR DESCRIPTION
## 症状

`.husky/pre-push` 跑满十几分钟门禁后，`git push` 以 **exit 141 (SIGPIPE)** 死掉：日志停在 `[pre-push] all checks passed`、**没有任何传输输出**、远端 ref 纹丝不动。因为退出码常被管道吞掉（`git push | tail` 拿到的是 `tail` 的），这个失败极易被误判成"推上去了"。

`#503` 曾按「stdin 未排空导致 git 写入闭合管道」的假设修过，**合入后仍然复现**。

## 真因

`git push` 的顺序是**先建 SSH 连接协商 ref、再跑 pre-push、最后推包**——GIT_TRACE 时间戳实测：

```
15:10:27.383  run_command: ssh git@github.com 'git-receive-pack ...'
15:10:32.180  run_command: .husky/pre-push ...      ← 4.8 秒后
15:10:32.536  run_command: git pack-objects ...     ← 钩子放行后才推包
```

我们的门禁要跑 10–15 分钟，这条连接全程闲置，**GitHub 服务端主动掐断**——失败日志里的原话：

```
Connection to ssh.github.com closed by remote host.
```

钩子放行后 git 往这条死连接写包，即 SIGPIPE。**stdin 排空不在因果链上**，这是 #503 修了却没用的原因。

## 受控实验

每格只改一个变量，探针提交固定 **355 字节**（据此排除"包太大"这一常见误判）：

| 时长 | 远端 | keepalive | 结果 |
|---|---|---|---|
| 秒级 | 本地 | — | ✅ 0 |
| 秒级（2 万行输出） | 本地 | — | ✅ 0 |
| 5 min | 本地 | — | ✅ 0 |
| 秒级 | SSH | — | ✅ 0 |
| 5 min | SSH | 无 | ✅ 0 |
| **15 min** | **SSH** | **无** | **❌ 141** |
| 15 min | SSH | 有 | ✅ 0 |
| **15 min** | **SSH** | **本 PR 的脚本** | **✅ 0** |
| **真实门禁全套** | **SSH** | **本 PR 的脚本** | **✅ 0（本 PR 自身即由它推上来）** |

阈值落在 5–15 分钟之间，正好卡住真实门禁的时长——这解释了为什么它只在跑满门禁时发作。

## 修复

新增 `scripts/setup-ssh-keepalive.mjs`，挂在 `package.json` 的 `prepare` 上，`pnpm install` 时配置 `core.sshCommand`（`ServerAliveInterval=30`），让 ssh 在闲置窗口内发保活包。

两条安全边界（均已实测）：

- **非 git 目录直接跳过**（tarball 安装、Docker 构建上下文）
- **已有 `core.sshCommand` 绝不覆盖** —— 用 1Password / 自定义 identity / 代理的贡献者不会被弄坏 auth；且我们设的仍是普通 `ssh`，照常读 `~/.ssh/config`

同时更正 `.husky/pre-push` 里把 SIGPIPE 归因于 stdin 的注释——错误归因会把下一个人继续引向 #503 的死路。

## 附带修复（独立 commit，可拆分）

`crates/ha-server/build.rs` 用 `env!("CARGO_MANIFEST_DIR")` 在**编译期**烘焙路径，而 build.rs 产物在共享 `CARGO_TARGET_DIR` 下跨 worktree 复用——占位 `dist/` 因此被写进最先编译它的那个 worktree。实测：全新 worktree 编译 `ha-server` 失败并报 `#[derive(RustEmbed)] folder '../../dist' does not exist`，而占位文件出现在一个**已被删除**的旧 worktree 里（mtime 恰为本次编译时刻）。改为运行期 `std::env::var`。

发现过程：它挡住了本 PR 的端到端验证推送。

## 验证

本 PR 自身即为验证——它是在真实门禁跑满、keepalive 生效的条件下推上来的（`[pre-push] all checks passed` 后成功传输），而同样条件在修复前稳定复现 141。

🤖 Generated with [Claude Code](https://claude.com/claude-code)