### PR TITLE
🦭backport: linux-arm64 发版构建修复回种 main (#507)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,17 @@ jobs:
       # 仅 release-tag / dispatch 构建串行化 codegen，换取最小 / 最快二进制（叠加
       # 根 Cargo.toml 的 lto="thin" / strip）。Docker（docker.yml 走 Dockerfile，
       # 不读此 env）与日常 dev 不受影响。
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1"
+      #
+      # 按 lane 可覆盖：v0.20.0 发版时 linux-arm64 在 tauri-action 步骤跑到 67 /
+      # 74 分钟被 runner 杀掉两次（GitHub 注解 "lost communication … starves it
+      # for CPU/Memory"）。codegen-units=1 把整个 ha-core（v0.20.0 已 509k 行）
+      # 压成单个 LLVM 单元，峰值超出该 runner 的 15Gi + 3Gi swap，故 arm64 退回
+      # cargo 默认 16，代价是该平台二进制略大、运行略慢。其余 lane 维持 1 不变。
+      #
+      # 磁盘已排除：上面 Report runner resources 实测 145G 盘 / 118G 可用。
+      # macos-arm64 只有 7GB 内存却能扛住 codegen-units=1，推测是靠 macOS 的内存
+      # 压缩与磁盘 swap；别据此以为 arm64 Linux 也该扛得住。
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ matrix.codegen_units || '1' }}
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +77,8 @@ jobs:
             os: ubuntu-24.04-arm
             rust_target: ""
             args: ""
+            # 见 job env 的 CARGO_PROFILE_RELEASE_CODEGEN_UNITS 注释。
+            codegen_units: "16"
           # Windows x64 — MSI (wix) + NSIS. Code signing certificate is
           # not wired up yet; bundles are unsigned. See
           # src-tauri/tauri.conf.json `bundle.windows.certificateThumbprint`
@@ -86,6 +98,18 @@ jobs:
           node-version: 20
 
       - uses: pnpm/action-setup@v4
+
+      # 起始资源快照。arm64 lane 曾被 runner 杀掉两次且日志全丢，当时无从判断是
+      # 磁盘还是内存——这一步就是为回答那个问题加的，并已给出答案：ubuntu-24.04-arm
+      # 有 145G 盘 / 118G 可用、15Gi 内存 + 3Gi swap，磁盘绰绰有余，瓶颈在内存。
+      # 保留它，下次资源类失败仍可一眼定位（注意：job 中途被杀时日志多半丢失，
+      # 这份快照只在 job 跑完后可读）。
+      - name: Report runner resources
+        shell: bash
+        run: |
+          echo "--- disk ---"; df -h || true
+          echo "--- memory ---"; (free -h || vm_stat || true)
+          echo "--- cpus ---"; (nproc || sysctl -n hw.ncpu || true)
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
把 #507 从 `release/v0.20` cherry-pick 回 `main`。**不 backport 的话 v0.21.0 会原样重蹈 v0.20.0 的 arm64 覆辙**（AGENTS.md 红线：release 分支上的修复必须回种 main）。

## 背景

v0.20.0 的 `linux-arm64` 构建在流水线中连续两次被 runner 中断（67 / 74 分钟），导致该平台 deb / AppImage / rpm 全部缺失、`latest.json` 无 `linux-aarch64` 条目、AUR 同步失败。

根因：`codegen-units=1` 把 509k 行的 `ha-core` 压成单个 LLVM 单元，峰值内存超出 `ubuntu-24.04-arm` 的 15Gi + 3Gi swap。

## 改动

cherry-pick `2409423c2`（`-x` 保留来源），仅动 `.github/workflows/release.yml`：

- `CARGO_PROFILE_RELEASE_CODEGEN_UNITS` 改为矩阵可覆盖，`linux-arm64` 用 cargo 默认 16；其余三个 lane 回落 `1`，行为不变
- 新增 `Report runner resources`（`df -h` / `free -h` / `nproc`）

## 与 main 上并行改动的关系

`main` 有 #506 对同一文件的改动（bare binary 打包 `ha-browser-host`）。cherry-pick 自动合并成功，已逐项核对：

- arm64 三要素全部到位（矩阵覆盖 / `codegen_units: "16"` / 资源快照）
- #506 的 `ha-browser-host` 相关 4 处**全部保留**，未被覆盖
- 相对 `main` 的 diff 只有 arm64 那些行

## 验证

- dry-run [29676062030](https://github.com/shiwenwen/hope-agent/actions/runs/29676062030)（在 release/v0.20 侧）：四平台全部成功，`linux-arm64` 66 分钟跨过历史失败窗口
- v0.20.1 正式发版构建同步进行中，四平台结果将进一步确认
- `node scripts/check-release-paths.mjs` 通过
- 本地 pre-push 全套门禁通过