### PR TITLE
🦭ci: 消除 node20 弃用警告（批次 1，不碰 release.yml）

### DIFF
--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           node-version: 20
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -97,7 +97,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: docker-digest-${{ matrix.arch }}
           path: /tmp/digests/*
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7.0.0
         with:
           path: /tmp/digests
           pattern: docker-digest-*

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
GitHub 已把声明 node20 的 action 强制跑在 node24 上并打弃用警告。**当前没坏**，但 node20 运行时被彻底移除后，声明 node20 的 action 将**无法启动**——`lint.yml` 是 8 项 required check 之一，届时所有 PR 会卡死无法合并。

## 只升到消除警告所需的最低版本，不追 latest

追 latest 会把 pnpm 11 默认值、`download-artifact` v8 的 `digest-mismatch=error` 与条件解压一并揽进来，零收益、纯给发版链路加风险。

| 文件 | 改动 | 说明 |
|---|---|---|
| `lint.yml` / `build-macos-x64.yml` | `pnpm/action-setup` `@v4` → `@v5` | 见下方陷阱 |
| `docker.yml` | `actions/upload-artifact` `@v4` → `v6.0.0` | v5 仍是 node20，**v6 才切 node24** |
| `docker.yml` | `actions/download-artifact` `@v4` → `v7.0.0` | v6 仍是 node20，**v7 才切 node24** |

## 两个反直觉的坑（已实测各版本 `action.yml` 的 `runs.using`）

1. **`pnpm/action-setup` 的浮动 tag `@v4` 永久冻结在 v4.3.0/node20，从未前移。** 继续写 `@v4` 永远消不掉警告。`@v5` 与 `v4.4.0` 是同一个 commit（`fc06bc12`），相对 v4.3.0 的 diff 只有一行 `runs.using` 提升，零行为变化。
2. **`download-artifact` v6.0.0 仍是 `node20`**，尽管其 release note 写着 "supports Node v24.x"——措辞极具误导性。真正切 node24 的是 v7.0.0。

## 用法安全性

- `docker.yml` download 侧用 `merge-multiple: true`，正是 v5 解压路径变更官方**明确排除**的场景
- upload 侧只用 `name` / `path` / `if-no-files-found`，跨版本契约未变

## 验证

`lint.yml` 是本 PR 自己的 required check —— **它跑绿就是验证**。

## 不在本 PR 范围

`release.yml` 的三处同类升级（`pnpm/action-setup@v4`、`upload-artifact@v4`、`download-artifact@v4`）留给批次 2：它们在 bare-binary 与 `patch latest.json` 链路上，坏了等于 updater 清单残缺、自动更新静默失效，必须配 dry-run 单独验证。`tauri-action` 升级再单列批次 3（**目标是 v0.6.0 而非 v1.0.0**——v1 把 `includeUpdaterJson` 重命名为 `uploadUpdaterJson`，旧名会成为未知输入导致 `latest.json` 不再上传）。