### PR TITLE
🦭ci: patch-latest-json 对必需平台改为 fail-fast

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,7 +415,12 @@ jobs:
           mkdir -p manifest
           gh release download "${RELEASE_TAG}" --pattern "latest.json" --dir manifest
       - name: Patch latest.json with bare_binary entries
-        run: node scripts/patch-latest-json.mjs manifest/latest.json artifacts "${RELEASE_TAG}"
+        # --require 必须与上面 build job 的 matrix 平台列表一致：少写一个，那个
+        # 平台的产物丢失又会变成静默的残缺清单；多写一个（如已禁用的 macos-x64）
+        # 则每次发版都失败。改 matrix 时同步改这里。
+        run: |
+          node scripts/patch-latest-json.mjs manifest/latest.json artifacts "${RELEASE_TAG}" \
+            --require=macos-arm64,linux-x64,linux-arm64,windows-x64
       - name: Re-upload patched latest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/patch-latest-json.mjs
+++ b/scripts/patch-latest-json.mjs
@@ -7,6 +7,21 @@
 //
 // Usage:
 //   node scripts/patch-latest-json.mjs <latest.json> <artifacts-dir> <version>
+//                                      [--require=<platform,...>]
+//
+// `--require` names the platforms that MUST yield a bare_binary entry; a
+// missing one is a hard error instead of a warning. Without it the script
+// stays best-effort, which is what a single-platform backfill wants.
+//
+// Why this exists: every platform used to be skipped with a console.warn, so
+// a lost or half-uploaded artifact produced a manifest missing that
+// platform's bare_binary entry — CI green, and headless self-update for that
+// platform silently dead until someone noticed. release.yml now passes its
+// full build matrix, so the release fails loudly instead.
+//
+// It cannot simply require every platform in PLATFORM_MAP: `macos-x64` has
+// been a disabled lane since v0.2.0 (see release.yml matrix), so its artifact
+// dir is legitimately absent on every run.
 //
 // Layout expected under `<artifacts-dir>`:
 //   bare-binary-macos-arm64/hope-agent-<v>-darwin-aarch64.tar.gz
@@ -32,14 +47,41 @@ const PLATFORM_MAP = {
 
 function usage() {
   console.error(
-    "Usage: node scripts/patch-latest-json.mjs <latest.json> <artifacts-dir> <version>",
+    "Usage: node scripts/patch-latest-json.mjs <latest.json> <artifacts-dir> <version> [--require=<platform,...>]",
   );
   process.exit(2);
 }
 
-const [, , manifestPath, artifactsDir, versionRaw] = process.argv;
+const argv = process.argv.slice(2);
+const requireFlag = argv.find((a) => a.startsWith("--require="));
+const [manifestPath, artifactsDir, versionRaw] = argv.filter(
+  (a) => !a.startsWith("--"),
+);
 if (!manifestPath || !artifactsDir || !versionRaw) usage();
 const version = versionRaw.replace(/^v/, "");
+
+const required = new Set(
+  (requireFlag ? requireFlag.slice("--require=".length) : "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+// A typo here would silently require nothing, which is exactly the
+// fail-open behaviour this flag exists to remove.
+for (const p of required) {
+  if (!PLATFORM_MAP[p]) {
+    console.error(
+      `[patch-latest-json] --require names unknown platform "${p}" (known: ${Object.keys(PLATFORM_MAP).join(", ")})`,
+    );
+    process.exit(1);
+  }
+}
+
+const failures = [];
+function miss(platform, message) {
+  if (required.has(platform)) failures.push(`${platform}: ${message}`);
+  else console.warn(`[patch-latest-json] skip ${platform}: ${message}`);
+}
 
 const repoUrl = `https://github.com/shiwenwen/hope-agent/releases/download/v${version}`;
 
@@ -51,19 +93,22 @@ const bareBinaryPlatforms = {};
 for (const [platformDir, meta] of Object.entries(PLATFORM_MAP)) {
   const dir = path.join(artifactsDir, `bare-binary-${platformDir}`);
   if (!fs.existsSync(dir)) {
-    console.warn(`[patch-latest-json] skip ${platformDir}: artifact dir not found (${dir})`);
+    miss(platformDir, `artifact dir not found (${dir})`);
     continue;
   }
   const ext = meta.archive === "tar_gz" ? ".tar.gz" : ".zip";
   const archiveFile = `hope-agent-${version}-${meta.key}${ext}`;
   const archivePath = path.join(dir, archiveFile);
   const sigPath = `${archivePath}.sig`;
+  // A present dir with a missing archive / signature means the upload was
+  // truncated rather than the lane being absent — always fatal, even when
+  // the platform was not explicitly required.
   if (!fs.existsSync(archivePath)) {
-    console.warn(`[patch-latest-json] skip ${meta.key}: archive missing (${archivePath})`);
+    failures.push(`${platformDir}: artifact dir exists but archive missing (${archivePath})`);
     continue;
   }
   if (!fs.existsSync(sigPath)) {
-    console.warn(`[patch-latest-json] skip ${meta.key}: signature missing (${sigPath})`);
+    failures.push(`${platformDir}: artifact dir exists but signature missing (${sigPath})`);
     continue;
   }
   const signature = fs.readFileSync(sigPath, "utf8").trim();
@@ -82,6 +127,12 @@ for (const [platformDir, meta] of Object.entries(PLATFORM_MAP)) {
 // platforms we found artifacts for in this run. This lets independent
 // best-effort workflows (e.g. build-macos-x64.yml) backfill a single
 // platform's entry without wiping the other four.
+if (failures.length) {
+  console.error("[patch-latest-json] refusing to write an incomplete manifest:");
+  for (const f of failures) console.error(`  - ${f}`);
+  process.exit(1);
+}
+
 const existing = manifest.bare_binary?.platforms || {};
 manifest.bare_binary = { platforms: { ...existing, ...bareBinaryPlatforms } };
 fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + "\n");


### PR DESCRIPTION
## 问题

`scripts/patch-latest-json.mjs` 此前对每个平台缺失都只 `console.warn` 后跳过。于是一个丢失或半截上传的产物会产出**缺该平台 `bare_binary` 条目的 `latest.json`**——CI 全绿，而那个平台的 headless 自更新静默失效，直到有人发现。

v0.20.0 是靠 build job 失败连带 skip 掉整个 `patch-manifest` 才没踩上，**不是靠这个脚本挡住的**。

## 改动

新增 `--require=<platform,...>`：列出的平台缺失即 `exit 1`；不带该参数时维持 best-effort。`release.yml` 传入其 build matrix 的四个平台。

**为什么不能简单地"要求 `PLATFORM_MAP` 里每个平台都在"**：`macos-x64` 自 v0.2.0 起就是禁用 lane（见 release.yml matrix 注释），其产物目录每次都合法缺席——那样写会让**每次发版都失败**。

另外两处收紧：

- **目录存在但归档 / 签名缺失，一律 fatal**（不论是否 required）。这是上传被截断而非 lane 缺席，两者语义不同。
- **`--require` 里写了未知平台名直接报错**。否则一个拼写错误会静默地什么都不要求，正是本参数要消除的 fail-open。

## 验证

⚠️ **`patch-manifest` job 在 dry-run 下被整体跳过**（`if: dry_run != 'true'`），**CI 与 dry-run 都覆盖不到本改动**，故以本地用例验证：

| 用例 | 期望 | 结果 |
|---|---|---|
| 四平台齐全 + `--require` | exit 0，4 条目 | ✅ |
| 必需的 linux-arm64 目录缺失 | exit 1 | ✅ |
| 目录在但签名缺失（未 require） | exit 1 | ✅ |
| 禁用 lane macos-x64 缺席 | exit 0，仅 warn | ✅ |
| `--require` 写了未知平台名 | exit 1 + 提示 | ✅ |
| 无 `--require` 的单平台 backfill | exit 0 | ✅ |

并用 **v0.20.1 的真实产物布局**复跑，确认输出与现状逐字一致（4 条目、macos-x64 照常 warn 跳过、exit 0）。

## 补充事实

`build-macos-x64.yml` **并不调用**本脚本——它有意内联了自己的补丁逻辑（因为 checkout 钉在 release tag 的 commit 上，那里的脚本版本可能较旧）。故本脚本的唯一调用者是 `release.yml`。