### PR TITLE
fix: 设置页默认打开首个分区

### DIFF
--- a/src/components/settings/SettingsView.tsx
+++ b/src/components/settings/SettingsView.tsx
@@ -253,6 +253,8 @@ const SECTIONS: SettingsSectionItem[] = [
     : []),
 ]
 
+const DEFAULT_SECTION = SECTIONS[0].id
+
 export default function SettingsView({
   onBack,
   onCodexAuth,
@@ -285,7 +287,7 @@ export default function SettingsView({
   const { draftCount: skillDraftCount } = useDraftSkillsStore()
   const skillDraftBadgeLabel = skillDraftCount > 99 ? "99+" : String(skillDraftCount)
   const [activeSection, setActiveSection] = useState<SettingsSection>(() => {
-    const initial = initialSection ?? "modelConfig"
+    const initial = initialSection ?? DEFAULT_SECTION
     // Release builds don't ship the developer panel; fall back if anything
     // (initialSection prop, settings:navigate event, stale storage) tries
     // to land here so the user doesn't see an empty pane.


### PR DESCRIPTION
## 改动内容

- 设置页未指定 section 时，默认选中导航列表的第一个分区
- 点击侧边栏底部设置齿轮后，不再自动锚定“模型设置”
- 保持模型、记忆等显式深链跳转行为不变

## 原因

侧边栏设置齿轮没有传入 section，但设置页此前将缺省 section 硬编码为 `modelConfig`，因此普通打开设置页也会落到模型设置。

## 影响

普通进入设置页时会打开首个分区“个人设置”；显式指定 section 的入口不受影响。

## 验证

- `git diff --check` 通过
- 按要求使用 `HA_SKIP_PREPUSH=1` 跳过 pre-push 检查
- 当前工作树未安装 `node_modules`，未运行 `pnpm typecheck`