### PR TITLE
🦭ci: macOS / Windows 发版 lane 放宽 codegen-units 到 4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,13 @@ jobs:
             os: macos-14
             rust_target: aarch64-apple-darwin
             args: "--target aarch64-apple-darwin"
+            # 这条 lane 是整个 release 的关键路径：v0.20.1 实测 147 分钟，其余
+            # lane 66 / 67 / 100，总时长完全由它决定。macos-14 只有 3 核，
+            # codegen-units=1 又恰好掐掉唯一能吃满多核的阶段。取 4 而非 arm64
+            # Linux 的 16：3 核上 4 块已够并行，优化损失（跨块内联失效）远小于
+            # 16，lto="thin" 还能补回一部分。与 linux-arm64 不同，这里不是 OOM
+            # 规避而是纯提速——该 lane 未出现过 runner 杀进程。
+            codegen_units: "4"
           # macOS x64 lane remains disabled (since v0.2.0). GitHub-hosted
           # macos-13 Intel runners are capacity-constrained and frequently
           # queue >1h. An earlier v0.2.1 attempt to re-add this lane with
@@ -87,6 +94,10 @@ jobs:
             os: windows-latest
             rust_target: ""
             args: ""
+            # 同 macos-arm64：纯提速，非 OOM 规避。macOS 降到 ~90 分钟后这条
+            # lane（v0.20.1 实测 100 分钟）会接替成为关键路径。4 核比 macOS 多
+            # 一核，仍取 4 保持两条 lane 的优化档位一致。
+            codegen_units: "4"
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## 背景

v0.20.1 发版实测各 lane 耗时:

| lane | runner 核数 | codegen-units | 耗时 |
|---|---|---|---|
| **macos-arm64** | 3 | 1 | **147min** ← 关键路径 |
| windows-x64 | 4 | 1 | 100min |
| linux-x64 | 4 | 1 | 67min |
| linux-arm64 | 4 | 16 | 66min |

总时长(2h28m)完全由 macOS 决定。而 `codegen-units=1` 的作用恰恰是禁止 codegen 阶段并行 —— 在只有 3 核的 macos-14 上,等于主动放弃唯一能吃满多核的环节。

## 改动

macos-arm64 与 windows-x64 覆盖 `codegen_units: "4"`,`lto = "thin"` 保持不动。

取 4 而非 linux-arm64 的 16:3-4 核上 4 块已足够并行,跨块内联失效带来的优化损失远小于 16,thin LTO 还能补回一部分。

与 linux-arm64 不同,**这两条 lane 是纯提速,不是 OOM 规避** —— 它们未出现过 runner 因内存杀进程。

## 预期

macOS ~90min、Windows ~65min,总时长 **147 → ~95min**。

## 代价

产物略大、运行时略慢(通常 1-2%)。影响仅限 workspace 自身 crate;fastembed / oxc / image / pdfium 等计算密集依赖是独立 crate,不受本改动影响。而 ha-core 自身以编排、状态管理、DB 调用为主,无紧凑热循环。

## 未包含

另一条独立的优化线索(release 缓存 100% miss)不在本 PR:`pnpm sync:version` 每次发版改写 `Cargo.lock` 里三个 workspace crate 的版本号 → rust-cache 的 lock-hash 变 → key 必变 → 每次发版都是冷构建(实测上次 release 存完缓存 13 分钟后启动的下一次仍 `No cache found`)。修复需改 cache key 策略,单独开 PR 以便归因。