### PR TITLE
fix(sidebar): 修复会话加载动画冻结

### DIFF
--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -700,7 +700,12 @@ export default function ChatSidebar({
             <div
               className={cn(
                 "flex-1 overflow-y-auto overflow-x-hidden [overscroll-behavior-y:none]",
-                sidebarMotionDisabled && "[&_*]:!animate-none [&_*]:!transition-none",
+                // Suppress layout/hover transitions until the sidebar has
+                // finished hydrating, but keep semantic activity animations
+                // (loading spinners and pending indicators) alive. Disabling
+                // every descendant animation froze a running session's
+                // Loader2 until the user first interacted with the sidebar.
+                sidebarMotionDisabled && "[&_*]:!transition-none",
               )}
               onScroll={(e) => {
                 if (isHistorySearching) return


### PR DESCRIPTION
## 改动

- 将侧栏初始化阶段的全局动效抑制从“禁用所有动画和过渡”收窄为“仅禁用过渡”
- 保留会话加载转圈和待处理状态脉冲等语义动画

## 根因

侧栏在首次 hydration 完成且用户尚未交互时，会通过后代选择器强制设置 `animation: none !important`。这同时冻结了运行中会话的 `Loader2`，导致转圈图标停在静态状态，直到用户首次与侧栏交互。

## 影响

运行中的会话现在会持续显示动态加载状态，同时仍避免侧栏首次载入时出现折叠和布局过渡动画。

## 验证

- `git diff --check`
- `pnpm typecheck`
- pre-push：`cargo fmt --all --check`
- pre-push：`cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings`
- pre-push：`pnpm lint`
- pre-push：`pnpm test`（203 个测试文件，1053 项测试通过）
- pre-push：`cargo test -p ha-core -p ha-server --locked`
