### PR TITLE
🦭fix(chat): 修复流式落盘等待丢通知致整轮回复消失

### DIFF
--- a/crates/ha-core/src/chat_engine/durability.rs
+++ b/crates/ha-core/src/chat_engine/durability.rs
@@ -771,6 +771,18 @@ impl TurnDurabilitySink for StreamCoordinator {
         global_writer_notify().notify_one();
         let wait = async {
             loop {
+                // Arm the waiter BEFORE reading the watermark. `durable_notify` is
+                // only ever signalled with `notify_waiters()`, which stores no
+                // permit, so a publish landing between the read and the arming is
+                // lost outright — and nothing re-fires it: once the queue drains,
+                // `take_pending_batch` returns None and `finish_prepared` is never
+                // reached again. The waiter would then burn the full `HARD_LAG`
+                // and `fail_fatal`, skipping the terminal commit that materializes
+                // the turn. Same register-then-recheck shape as `tools::job_status`.
+                let notified = self.durable_notify.notified();
+                tokio::pin!(notified);
+                notified.as_mut().enable();
+
                 if let Some(error) = lock_state(&self.state).fatal_error.clone() {
                     anyhow::bail!("persistence unavailable: {error}");
                 }
@@ -778,7 +790,13 @@ impl TurnDurabilitySink for StreamCoordinator {
                 if durable >= target {
                     return Ok(durable);
                 }
-                self.durable_notify.notified().await;
+
+                // Re-poll on a bounded interval so any wakeup we still manage to
+                // miss costs latency rather than the whole turn.
+                tokio::select! {
+                    _ = notified => {}
+                    _ = tokio::time::sleep(FLUSH_INTERVAL) => {}
+                }
             }
         };
         match tokio::time::timeout(HARD_LAG, wait).await {


### PR DESCRIPTION
## 缺陷

`StreamCoordinator::flush`（`chat_engine/durability.rs`）先读 `durable_seq`，**之后**才构造 `notified()`。而 `durable_notify` 的四个生产端一律用 `notify_waiters()` 发布——它**不留 permit**。

落在「读水位线」与「登记等待者」之间的那一次发布会被彻底丢掉，并且**无人重发**：队列一旦排空，`take_pending_batch` 返回 `None`，`finish_prepared` 再也不会被触及。等待方于是干等满 `HARD_LAG`（10s），随后 `fail_fatal`。

后果被 `flush` 的位置放大——它是终态收敛的**第一条语句**（`engine.rs`），返回 `Err` 就跳过了唯一负责物化本轮的 `commit_interrupted_turn`。助手消息、思考块与上下文**全部不落库**，界面上整轮回复当场消失（要到下次启动才由恢复流程补回）。

慢盘、被杀毒软件拦截、或数据目录放在云同步文件夹时更容易撞上——正是 AGENTS.md 已经点名的那几种环境。

## 修法

与仓库里已有的正确范式 `tools::job_status` 同形：

1. **登记在前、检查在后** —— `notified()` + `tokio::pin!` + `as_mut().enable()` 提到读水位线之前，窗口不复存在。
2. **有界重轮询** —— `select!` 里加 `FLUSH_INTERVAL` 兜底，使「仍被漏掉的通知」退化为**延迟**而不是整轮失败。

19 行，自包含，不改任何契约。

## 实验验证（真实产品代码上的 A/B，非替身复现）

在 load→arm 窗口注入 `std::thread::sleep(300ms)` 强制该交错：

| 变体 | 结果 |
|---|---|
| 原实现 + 阻塞 | **FAILED** — panic 于 `engine.rs:2985`「thinking block should be persisted」，**耗时 10.20s** |
| 本 PR + 同一阻塞 | **PASSED** — 耗时 0.47s |

10.20s 正是 `HARD_LAG` 特征时长，与 CI 上观察到的偶发失败**逐字一致**。实验脚手架已全部移除（`grep TEMP-EXPERIMENT` 无残留）。

## 发现路径

`final_failure_preserves_thinking_only_without_text_bubble` 在 v0.21.0 发版前的 pre-push 全量测试中偶发失败（约 1/9）；隔离运行 5/5 绿、三平台 CI 全绿、随后 3 次全量也全绿。

按常理这就是 flake，重推即可。但该断言恰好守着 #510「不再丢失流式内容」这一卖点——若为真，等于在「修复内容丢失」的功能里发布一个内容丢失竞态。故深挖而非重推。**若当时用 `HA_SKIP_PREPUSH=1` 绕过，这个缺陷会静默发布。**

## 不加 CHANGELOG 条目

#510 与本修复同在 v0.21.0 首发，用户从未遇到过该缺陷；记一条「修复……」反而暗示他们遇到过。

## 验证

pre-push 全套门禁通过：`cargo fmt --all --check` / `cargo clippy -p ha-core -p ha-server --all-targets --locked -- -D warnings` / `cargo test -p ha-core -p ha-server --locked` / `pnpm typecheck` / `pnpm lint` / `pnpm test`

阻塞 v0.21.0 发版；合入后在新 HEAD 重新打 tag。

🤖 Generated with [Claude Code](https://claude.com/claude-code)