### PR TITLE
🦭ci(linux-repo): apt/dnf 源迁到 Cloudflare R2

### DIFF
--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -340,7 +340,7 @@ jobs:
             n=0
             while IFS= read -r -d '' f; do
               key="${f#./}"
-              if ! wrangler r2 object put "${R2_BUCKET}/${key}" --file="$f" --remote; then
+              if ! wrangler r2 object put "${R2_BUCKET}/${key}" --file="$f"; then
                 echo "::error::wrangler put failed for ${key}"
                 exit 1
               fi

--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -60,7 +60,10 @@ env:
   RCLONE_CONFIG_R2_REGION: auto
   RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
   RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-  RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+  # RCLONE_CONFIG_R2_ENDPOINT is derived from R2_ACCOUNT_ID in the
+  # "Resolve R2 endpoint" step (normalized + validated) rather than
+  # interpolated here, so a pasted full endpoint URL / stray whitespace
+  # gives a clear error instead of a cryptic TLS handshake failure.
 
 jobs:
   update-linux-repo:
@@ -84,6 +87,36 @@ jobs:
             echo "::error::missing required R2 secret(s): ${missing[*]} — see linux-repo/README.md"
             exit 1
           fi
+
+      - name: Resolve R2 endpoint from account id
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          # Accept either the bare 32-hex Cloudflare account id OR a pasted
+          # full S3 endpoint (host or URL, incl. jurisdiction variants like
+          # <id>.eu.r2.cloudflarestorage.com). Strip whitespace + scheme, then:
+          #   - if it already names the R2 endpoint host, use it verbatim
+          #     (preserves any .eu. jurisdiction label);
+          #   - otherwise treat it as a bare account id and build the host,
+          #     validating it is 32 lowercase hex first.
+          # This turns the common "pasted the whole endpoint URL" mistake —
+          # which otherwise surfaces as an opaque `tls: handshake failure` —
+          # into either a correct endpoint or a clear, actionable error.
+          raw="$(printf '%s' "$R2_ACCOUNT_ID" | tr -d '[:space:]')"
+          raw="${raw#http://}"; raw="${raw#https://}"; raw="${raw%/}"
+          if [[ "$raw" == *".r2.cloudflarestorage.com" ]]; then
+            host="$raw"
+          else
+            id="$raw"
+            if [[ ! "$id" =~ ^[0-9a-f]{32}$ ]]; then
+              echo "::error::R2_ACCOUNT_ID must be the 32-char hex Cloudflare account id (or the full S3 endpoint host). Got something that normalizes to length ${#id}. Do NOT paste the whole 'https://<id>.r2.cloudflarestorage.com' URL — paste only the account id shown on the R2 overview page. See linux-repo/README.md."
+              exit 1
+            fi
+            host="${id}.r2.cloudflarestorage.com"
+          fi
+          echo "RCLONE_CONFIG_R2_ENDPOINT=https://${host}" >> "$GITHUB_ENV"
+          echo "R2 endpoint host: ${host}"
 
       - name: Resolve version from tag
         id: ver

--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -1,21 +1,36 @@
 name: Update Linux Repo
 
-# Build & sign the apt + dnf/yum indexes hosted at
-# https://shiwenwen.github.io/hope-agent-linux-repo/, then push them
-# back to the bucket repo whenever a Release is published.
+# Build & sign the apt + dnf/yum indexes, then publish them to the
+# Cloudflare R2 bucket served at https://repo.hopeagent.ai/ whenever a
+# Release is published.
+#
+# WHY R2 (not GitHub Pages): apt/dnf indexes reference the package files by
+# URL under one base, so the .deb/.rpm must live at that base. GitHub's
+# 100 MB per-file limit (and Pages' repo size limits) rejected every
+# .deb/.rpm once the app crossed ~100 MB, so the old git-committed Pages
+# bucket was structurally stuck. R2 has no per-object size limit and zero
+# egress fees — the natural host for a download-heavy package repo. The
+# reprepro / createrepo_c / GPG build logic below is UNCHANGED; only the
+# publish target moved from `git commit + push` to `rclone` against R2.
 #
 # Triggers:
 #   - release.published — auto-fires after a draft Release is manually
 #     published (see docs/release-process.md §1.4).
-#   - workflow_dispatch — manual re-run against an existing tag.
+#   - workflow_dispatch — manual re-run / initial seed against a tag.
 #
 # Required repo secrets:
-#   GPG_SIGNING_KEY    — ASCII-armored ed25519 private key for repo metadata
-#                        signing. Generated 2026-05-11 in a docker container.
-#                        Fingerprint must match the public key published at
-#                        https://shiwenwen.github.io/hope-agent-linux-repo/pubkey.gpg
-#   LINUX_REPO_TOKEN   — fine-grained PAT with `Contents: Read and write`
-#                        on shiwenwen/hope-agent-linux-repo only.
+#   GPG_SIGNING_KEY       — ASCII-armored ed25519 private key for repo
+#                           metadata signing. Its public half is exported
+#                           to pubkey.gpg by this workflow (no longer a
+#                           manual step). Fingerprint must match the key
+#                           advertised at https://repo.hopeagent.ai/pubkey.gpg
+#   R2_ACCOUNT_ID         — Cloudflare account id (the R2 S3 endpoint host).
+#   R2_ACCESS_KEY_ID      — R2 API token access key id (S3-compatible).
+#   R2_SECRET_ACCESS_KEY  — R2 API token secret access key.
+#   R2_BUCKET             — R2 bucket name (e.g. hope-agent-linux-repo).
+#
+# First-time / rotation setup on the Cloudflare side (bucket, custom domain
+# repo.hopeagent.ai, API token) is documented in linux-repo/README.md.
 
 on:
   release:
@@ -23,7 +38,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to sync (for example v0.1.2)
+        description: Release tag to sync / seed (for example v0.21.0)
         required: true
         type: string
 
@@ -34,16 +49,41 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Public base URL served by the R2 bucket's custom domain. Baked into the
+  # apt sources.list line and the dnf .repo file; keep in lockstep with
+  # README.md / README.en.md / linux-repo/rpm/hope-agent.repo.
+  PUBLIC_BASE: https://repo.hopeagent.ai
+  # rclone remote "r2" configured entirely from env (no rclone.conf file).
+  RCLONE_CONFIG_R2_TYPE: s3
+  RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+  RCLONE_CONFIG_R2_REGION: auto
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+  RCLONE_CONFIG_R2_ENDPOINT: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
+
 jobs:
   update-linux-repo:
     runs-on: ubuntu-latest
     env:
-      LINUX_REPO: shiwenwen/hope-agent-linux-repo
       TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
 
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v6
+
+      - name: Preflight — required R2 secrets present
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -n "${{ secrets.R2_ACCOUNT_ID }}"        ]] || missing+=(R2_ACCOUNT_ID)
+          [[ -n "${{ secrets.R2_ACCESS_KEY_ID }}"     ]] || missing+=(R2_ACCESS_KEY_ID)
+          [[ -n "${{ secrets.R2_SECRET_ACCESS_KEY }}" ]] || missing+=(R2_SECRET_ACCESS_KEY)
+          [[ -n "${{ secrets.R2_BUCKET }}"            ]] || missing+=(R2_BUCKET)
+          if (( ${#missing[@]} )); then
+            echo "::error::missing required R2 secret(s): ${missing[*]} — see linux-repo/README.md"
+            exit 1
+          fi
 
       - name: Resolve version from tag
         id: ver
@@ -55,7 +95,6 @@ jobs:
             echo "::error::tag '$tag' does not look like a release tag (expected vX.Y.Z[-pre])"
             exit 1
           fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "VERSION=$version" >> "$GITHUB_ENV"
           # All four artefact filenames, by arch. Missing arches are
           # tolerated downstream (e.g. v0.1.0 ~ v0.1.2 had no arm64/aarch64
@@ -65,10 +104,11 @@ jobs:
           echo "RPM_X86_64=Hope.Agent-${version}-1.x86_64.rpm"    >> "$GITHUB_ENV"
           echo "RPM_AARCH64=Hope.Agent-${version}-1.aarch64.rpm"  >> "$GITHUB_ENV"
 
-      - name: Install build dependencies (reprepro + createrepo_c)
+      - name: Install build dependencies (reprepro + createrepo_c + rclone)
         run: |
+          set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y -qq reprepro createrepo-c
+          sudo apt-get install -y -qq reprepro createrepo-c rclone
 
       - name: Download all deb + rpm from release (any arch present)
         env:
@@ -91,7 +131,7 @@ jobs:
           test -f "artifacts/$DEB_AMD64"   || { echo "::error::missing $DEB_AMD64";   exit 1; }
           test -f "artifacts/$RPM_X86_64"  || { echo "::error::missing $RPM_X86_64";  exit 1; }
 
-      - name: Import GPG signing key
+      - name: Import GPG signing key + export public key
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
         run: |
@@ -114,12 +154,20 @@ jobs:
           echo -e "5\ny\n" | gpg --batch --command-fd 0 --edit-key "$KEY_ID" trust 2>&1 | tail -3
           echo "Imported and trusted GPG key: $KEY_ID"
 
-      - name: Checkout linux-repo bucket
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.LINUX_REPO }}
-          token: ${{ secrets.LINUX_REPO_TOKEN }}
-          path: bucket
+      - name: Pull existing repo state from R2
+        run: |
+          set -euo pipefail
+          mkdir -p bucket
+          # R2 is the single source of truth. Mirror the current published
+          # tree DOWN so reprepro's apt/db state and createrepo_c's existing
+          # repodata are intact for an incremental update. Empty on the very
+          # first seed run — reprepro/createrepo then build from scratch.
+          # `copy` (never `sync`) so a transient partial download can never
+          # delete anything; egress from R2 is free.
+          rclone copy "r2:${{ secrets.R2_BUCKET }}" bucket \
+            --fast-list --transfers=16 --checkers=32 --stats=0 2>&1 | tail -5
+          echo "--- pulled state ---"
+          find bucket -maxdepth 3 -type d | sort | head -30
 
       - name: Build apt index (reprepro)
         run: |
@@ -131,10 +179,6 @@ jobs:
           # Rebuilding it every run means rotating the GPG key needs no
           # template change — the workflow picks up the new fingerprint
           # automatically from the imported secret.
-          # Architectures: list both amd64 and arm64 even when this release
-          # only has amd64 — reprepro will simply produce an empty
-          # binary-arm64/Packages index when no arm64 deb is included,
-          # and apt clients on the missing arch report "no candidate".
           cat > apt/conf/distributions <<EOF
           Codename: stable
           Suite: stable
@@ -150,10 +194,6 @@ jobs:
           # all architectures because reprepro tracks by source name.
           reprepro -b apt remove stable hope-agent || true
 
-          # `-S utils -P optional` provides default Section + Priority for
-          # the deb. Tauri's bundler historically did not emit a Section
-          # field — for v0.1.3+ the field is set in tauri.conf.json, but
-          # the flag stays as belt-and-braces.
           for deb in "$DEB_AMD64" "$DEB_ARM64"; do
             if [[ -f "$GITHUB_WORKSPACE/artifacts/$deb" ]]; then
               echo "Including $deb"
@@ -201,31 +241,56 @@ jobs:
           done
 
           # Sync the .repo template from the main repo (single source of
-          # truth: linux-repo/rpm/hope-agent.repo). dnf substitutes
-          # $basearch at install time so a single .repo covers both arches.
+          # truth: linux-repo/rpm/hope-agent.repo) to the bucket root.
           cp -f "$GITHUB_WORKSPACE/linux-repo/rpm/hope-agent.repo" rpm/hope-agent.repo
 
-      - name: Commit and push if changed
-        working-directory: bucket
+          # Publish the signing key's PUBLIC half at the bucket root so the
+          # apt `signed-by` keyring and dnf `gpgkey=` can fetch it. Exporting
+          # from the imported private key (rather than committing a static
+          # file) makes rotation self-maintaining: rotate the secret and the
+          # advertised pubkey follows automatically.
+          gpg --armor --export "$GPG_KEY_ID" > pubkey.gpg
+          test -s pubkey.gpg || { echo "::error::pubkey.gpg export is empty"; exit 1; }
+
+      - name: Publish to R2
         run: |
           set -euo pipefail
-          git config user.name  "hope-agent-bot"
-          git config user.email "hope-agent-bot@users.noreply.github.com"
+          cd bucket
+          # Non-destructive `copy` up: new/changed objects (regenerated
+          # dists/ Packages / InRelease / repomd.xml + new pool file) are
+          # uploaded; unchanged historical packages are skipped by checksum;
+          # nothing is ever deleted. reprepro/createrepo regenerate the
+          # index files with new content, so those DO overwrite.
+          rclone copy . "r2:${{ secrets.R2_BUCKET }}" \
+            --fast-list --transfers=16 --checkers=32 --stats=0 2>&1 | tail -5
+          echo "Published tree to r2:${{ secrets.R2_BUCKET }}"
 
-          # Stage everything we touched. Same gotcha as before: `git diff`
-          # alone ignores untracked paths, so stage first and inspect
-          # `git diff --cached`.
-          git add apt rpm
-
-          if git diff --cached --quiet; then
-            echo "No repo changes for $TAG; skipping push."
-            exit 0
-          fi
-
-          git commit -m "hope-agent ${VERSION}
-
-          arches: $(ls "$GITHUB_WORKSPACE/artifacts" | tr '\n' ' ')
-          Source: ${{ github.repository }}@${TAG}
-          GPG key: ${GPG_KEY_ID}
-          "
-          git push origin HEAD
+      - name: Verify published repo is live and well-formed
+        run: |
+          set -euo pipefail
+          # Fetch back over the PUBLIC custom-domain URL that users actually
+          # hit — catches a broken publish (or an unwired custom domain) in
+          # CI instead of leaving users on a silently-stale source. Retries
+          # absorb custom-domain / cache propagation latency.
+          #
+          # NOTE: on the very first seed run this step fails until the R2
+          # bucket's custom domain (repo.hopeagent.ai) is connected. Wire the
+          # domain first (linux-repo/README.md), then re-run — the upload is
+          # idempotent so a re-run just re-verifies.
+          check() {
+            local url="$1" needle="$2" body="" attempt
+            for attempt in 1 2 3 4 5 6; do
+              if body=$(curl -fsSL --max-time 20 "$url" 2>/dev/null) && grep -q "$needle" <<<"$body"; then
+                echo "OK   $url"
+                return 0
+              fi
+              echo "…retry $attempt  $url"
+              sleep $((attempt * 10))
+            done
+            echo "::error::verification failed for $url (expected to contain '$needle')"
+            return 1
+          }
+          check "${PUBLIC_BASE}/apt/dists/stable/InRelease" "Codename: stable"
+          check "${PUBLIC_BASE}/rpm/stable/x86_64/repodata/repomd.xml" "<repomd"
+          check "${PUBLIC_BASE}/pubkey.gpg" "BEGIN PGP PUBLIC KEY"
+          echo "Published repo verified live at ${PUBLIC_BASE}"

--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -41,6 +41,12 @@ on:
         description: Release tag to sync / seed (for example v0.21.0)
         required: true
         type: string
+      via:
+        description: "Uploader. rclone = S3 API (default, normal path). wrangler = Cloudflare API bridge — use only to SEED a fresh/empty bucket while a brand-new account's S3-endpoint TLS cert is not yet provisioned. Requires CLOUDFLARE_API_TOKEN."
+        required: false
+        type: choice
+        options: [rclone, wrangler]
+        default: rclone
 
 concurrency:
   group: update-linux-repo
@@ -87,6 +93,10 @@ jobs:
             echo "::error::missing required R2 secret(s): ${missing[*]} — see linux-repo/README.md"
             exit 1
           fi
+          if [[ "${{ github.event.inputs.via }}" == "wrangler" && -z "${{ secrets.CLOUDFLARE_API_TOKEN }}" ]]; then
+            echo "::error::via=wrangler needs the CLOUDFLARE_API_TOKEN secret (API token with 'Workers R2 Storage: Edit'). See linux-repo/README.md."
+            exit 1
+          fi
 
       - name: Resolve R2 endpoint from account id
         env:
@@ -131,6 +141,9 @@ jobs:
             host="${id}.r2.cloudflarestorage.com"
           fi
           echo "RCLONE_CONFIG_R2_ENDPOINT=https://${host}" >> "$GITHUB_ENV"
+          # Bare 32-hex account id (first label of the host) for Wrangler's
+          # CLOUDFLARE_ACCOUNT_ID on the bridge path.
+          echo "CF_ACCOUNT_ID=${host%%.*}" >> "$GITHUB_ENV"
           echo "R2 endpoint host: ${host}"
 
       - name: Resolve version from tag
@@ -206,16 +219,23 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p bucket
-          # R2 is the single source of truth. Mirror the current published
-          # tree DOWN so reprepro's apt/db state and createrepo_c's existing
-          # repodata are intact for an incremental update. Empty on the very
-          # first seed run — reprepro/createrepo then build from scratch.
-          # `copy` (never `sync`) so a transient partial download can never
-          # delete anything; egress from R2 is free.
-          rclone copy "r2:${{ secrets.R2_BUCKET }}" bucket \
-            --fast-list --transfers=16 --checkers=32 --stats=0 2>&1 | tail -5
-          echo "--- pulled state ---"
-          find bucket -maxdepth 3 -type d | sort | head -30
+          if [[ "${{ github.event.inputs.via }}" == "wrangler" ]]; then
+            # Bridge path: the pull would use the very S3 endpoint whose cert
+            # isn't provisioned yet. Wrangler is SEED-ONLY (fresh/empty bucket):
+            # build the tree from scratch and push it up via the Cloudflare API.
+            echo "Wrangler bridge: skipping pull, seeding from an empty local tree."
+          else
+            # R2 is the single source of truth. Mirror the current published
+            # tree DOWN so reprepro's apt/db state and createrepo_c's existing
+            # repodata are intact for an incremental update. Empty on the very
+            # first seed run — reprepro/createrepo then build from scratch.
+            # `copy` (never `sync`) so a transient partial download can never
+            # delete anything; egress from R2 is free.
+            rclone copy "r2:${{ secrets.R2_BUCKET }}" bucket \
+              --fast-list --transfers=16 --checkers=32 --stats=0 2>&1 | tail -5
+            echo "--- pulled state ---"
+            find bucket -maxdepth 3 -type d | sort | head -30
+          fi
 
       - name: Build apt index (reprepro)
         run: |
@@ -301,17 +321,42 @@ jobs:
           test -s pubkey.gpg || { echo "::error::pubkey.gpg export is empty"; exit 1; }
 
       - name: Publish to R2
+        env:
+          VIA: ${{ github.event.inputs.via }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ env.CF_ACCOUNT_ID }}
         run: |
           set -euo pipefail
           cd bucket
-          # Non-destructive `copy` up: new/changed objects (regenerated
-          # dists/ Packages / InRelease / repomd.xml + new pool file) are
-          # uploaded; unchanged historical packages are skipped by checksum;
-          # nothing is ever deleted. reprepro/createrepo regenerate the
-          # index files with new content, so those DO overwrite.
-          rclone copy . "r2:${{ secrets.R2_BUCKET }}" \
-            --fast-list --transfers=16 --checkers=32 --stats=0 2>&1 | tail -5
-          echo "Published tree to r2:${{ secrets.R2_BUCKET }}"
+          if [[ "$VIA" == "wrangler" ]]; then
+            # Bridge path: upload every built file via the Cloudflare API
+            # (api.cloudflare.com), which has a valid cert — bypassing the
+            # unprovisioned per-account S3-endpoint cert. Seed-only: the bucket
+            # is empty, so a plain per-object put with no delete is complete
+            # and safe. Files are <=110MB, within Wrangler's 315MB put limit.
+            npm install -g wrangler@3 >/dev/null 2>&1
+            wrangler --version
+            n=0
+            while IFS= read -r -d '' f; do
+              key="${f#./}"
+              if ! wrangler r2 object put "${R2_BUCKET}/${key}" --file="$f" --remote; then
+                echo "::error::wrangler put failed for ${key}"
+                exit 1
+              fi
+              n=$((n + 1)); echo "put (${n}) ${key}"
+            done < <(find . -type f -print0)
+            echo "Uploaded ${n} objects to r2://${R2_BUCKET} via the Cloudflare API (Wrangler bridge)."
+          else
+            # Non-destructive `copy` up: new/changed objects (regenerated
+            # dists/ Packages / InRelease / repomd.xml + new pool file) are
+            # uploaded; unchanged historical packages are skipped by checksum;
+            # nothing is ever deleted. reprepro/createrepo regenerate the
+            # index files with new content, so those DO overwrite.
+            rclone copy . "r2:${R2_BUCKET}" \
+              --fast-list --transfers=16 --checkers=32 --stats=0 2>&1 | tail -5
+            echo "Published tree to r2:${R2_BUCKET}"
+          fi
 
       - name: Verify published repo is live and well-formed
         run: |

--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -91,6 +91,7 @@ jobs:
       - name: Resolve R2 endpoint from account id
         env:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
         run: |
           set -euo pipefail
           # Accept either the bare 32-hex Cloudflare account id OR a pasted
@@ -113,10 +114,41 @@ jobs:
               echo "::error::R2_ACCOUNT_ID must be the 32-char hex Cloudflare account id (or the full S3 endpoint host). Got something that normalizes to length ${#id}. Do NOT paste the whole 'https://<id>.r2.cloudflarestorage.com' URL — paste only the account id shown on the R2 overview page. See linux-repo/README.md."
               exit 1
             fi
+            # Common mixup: the R2 API token's Access Key ID is ALSO 32 hex and
+            # sits right next to the Account ID on the token screen. If someone
+            # pasted the Access Key ID into R2_ACCOUNT_ID, the endpoint host is
+            # wrong and Cloudflare rejects it at TLS (handshake failure), not
+            # with a 403. Catch the identical-value case with a clear message.
+            akid="$(printf '%s' "$R2_ACCESS_KEY_ID" | tr -d '[:space:]')"
+            if [[ -n "$akid" && "$id" == "$akid" ]]; then
+              echo "::error::R2_ACCOUNT_ID equals R2_ACCESS_KEY_ID — you pasted the API token's Access Key ID into R2_ACCOUNT_ID. They are DIFFERENT values: the Account ID is the 32-hex id in the dashboard URL dash.cloudflare.com/<ACCOUNT_ID> and in https://<ACCOUNT_ID>.r2.cloudflarestorage.com. Re-set R2_ACCOUNT_ID to the account id. See linux-repo/README.md."
+              exit 1
+            fi
             host="${id}.r2.cloudflarestorage.com"
           fi
           echo "RCLONE_CONFIG_R2_ENDPOINT=https://${host}" >> "$GITHUB_ENV"
           echo "R2 endpoint host: ${host}"
+
+      - name: Probe R2 endpoint (isolate TLS/account vs auth/key failures)
+        run: |
+          set -euo pipefail
+          # Objectively isolate which secret is wrong BEFORE the opaque rclone
+          # error. Hitting the endpoint root with no auth should complete the
+          # TLS handshake and return an HTTP status (400/403) — R2 exists there.
+          #   - No HTTP status (curl 000 / SSL error)  => TLS handshake failed
+          #       => the ENDPOINT HOST is wrong => R2_ACCOUNT_ID is not your
+          #          real Account ID (likely the Access Key ID or a zone id).
+          #   - Any HTTP status                        => TLS + host are fine
+          #       => a subsequent rclone failure is about the KEYS
+          #          (R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY) or R2_BUCKET.
+          host="${RCLONE_CONFIG_R2_ENDPOINT#https://}"
+          code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "https://${host}/" 2>/tmp/curlerr || true)"
+          if [[ -z "$code" || "$code" == "000" ]]; then
+            echo "curl transport error:"; cat /tmp/curlerr || true
+            echo "::error::TLS handshake to the R2 endpoint failed. R2_ACCOUNT_ID is almost certainly NOT your Cloudflare Account ID. Use the 32-hex id from dash.cloudflare.com/<ACCOUNT_ID> (same as https://<ACCOUNT_ID>.r2.cloudflarestorage.com) — NOT the token's Access Key ID. See linux-repo/README.md."
+            exit 1
+          fi
+          echo "TLS + endpoint host OK (HTTP ${code} without auth, as expected). Any auth failure below is about the access key / secret / bucket, not the account id."
 
       - name: Resolve version from tag
         id: ver

--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -105,7 +105,11 @@ jobs:
           # which otherwise surfaces as an opaque `tls: handshake failure` —
           # into either a correct endpoint or a clear, actionable error.
           raw="$(printf '%s' "$R2_ACCOUNT_ID" | tr -d '[:space:]')"
-          raw="${raw#http://}"; raw="${raw#https://}"; raw="${raw%/}"
+          raw="${raw#http://}"; raw="${raw#https://}"
+          # Cloudflare's bucket "S3 API" panel shows the endpoint WITH the
+          # bucket path (…r2.cloudflarestorage.com/<bucket>). Strip any path
+          # so pasting that whole string resolves to the endpoint host.
+          raw="${raw%%/*}"
           if [[ "$raw" == *".r2.cloudflarestorage.com" ]]; then
             host="$raw"
           else

--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -133,27 +133,6 @@ jobs:
           echo "RCLONE_CONFIG_R2_ENDPOINT=https://${host}" >> "$GITHUB_ENV"
           echo "R2 endpoint host: ${host}"
 
-      - name: Probe R2 endpoint (isolate TLS/account vs auth/key failures)
-        run: |
-          set -euo pipefail
-          # Objectively isolate which secret is wrong BEFORE the opaque rclone
-          # error. Hitting the endpoint root with no auth should complete the
-          # TLS handshake and return an HTTP status (400/403) — R2 exists there.
-          #   - No HTTP status (curl 000 / SSL error)  => TLS handshake failed
-          #       => the ENDPOINT HOST is wrong => R2_ACCOUNT_ID is not your
-          #          real Account ID (likely the Access Key ID or a zone id).
-          #   - Any HTTP status                        => TLS + host are fine
-          #       => a subsequent rclone failure is about the KEYS
-          #          (R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY) or R2_BUCKET.
-          host="${RCLONE_CONFIG_R2_ENDPOINT#https://}"
-          code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "https://${host}/" 2>/tmp/curlerr || true)"
-          if [[ -z "$code" || "$code" == "000" ]]; then
-            echo "curl transport error:"; cat /tmp/curlerr || true
-            echo "::error::TLS handshake to the R2 endpoint failed — Cloudflare only completes the handshake for an account-id host that names a REAL, provisioned R2 endpoint, so this value is not resolving to your account's endpoint. Fix: copy the exact 'S3 API' endpoint Cloudflare shows under R2 > your bucket > Settings (or on the API token page), including a '.eu.' segment if your account is EU-jurisdiction, and set R2_ACCOUNT_ID to that whole https://<...>.r2.cloudflarestorage.com value (this workflow accepts the full endpoint host verbatim). Do NOT use the token's Access Key ID. See linux-repo/README.md."
-            exit 1
-          fi
-          echo "TLS + endpoint host OK (HTTP ${code} without auth, as expected). Any auth failure below is about the access key / secret / bucket, not the account id."
-
       - name: Resolve version from tag
         id: ver
         run: |

--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -145,7 +145,7 @@ jobs:
           code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "https://${host}/" 2>/tmp/curlerr || true)"
           if [[ -z "$code" || "$code" == "000" ]]; then
             echo "curl transport error:"; cat /tmp/curlerr || true
-            echo "::error::TLS handshake to the R2 endpoint failed. R2_ACCOUNT_ID is almost certainly NOT your Cloudflare Account ID. Use the 32-hex id from dash.cloudflare.com/<ACCOUNT_ID> (same as https://<ACCOUNT_ID>.r2.cloudflarestorage.com) — NOT the token's Access Key ID. See linux-repo/README.md."
+            echo "::error::TLS handshake to the R2 endpoint failed — Cloudflare only completes the handshake for an account-id host that names a REAL, provisioned R2 endpoint, so this value is not resolving to your account's endpoint. Fix: copy the exact 'S3 API' endpoint Cloudflare shows under R2 > your bucket > Settings (or on the API token page), including a '.eu.' segment if your account is EU-jurisdiction, and set R2_ACCOUNT_ID to that whole https://<...>.r2.cloudflarestorage.com value (this workflow accepts the full endpoint host verbatim). Do NOT use the token's Access Key ID. See linux-repo/README.md."
             exit 1
           fi
           echo "TLS + endpoint host OK (HTTP ${code} without auth, as expected). Any auth failure below is about the access key / secret / bucket, not the account id."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **对话底部新增内嵌终端**：支持多标签交互式 PTY、拖拽高度、最大化、`⌘/Ctrl+J` 快捷开关与有界输出重放；新终端会自动进入当前会话或项目 Worktree 的有效工作目录，并随应用亮色 / 暗色主题切换高对比度配色。桌面与 HTTP/Web 共用同一核心实现，远程终端默认关闭并受 `filesystem.allowRemoteWrites` 实时权限门保护，撤权会立即终止远程创建的 Shell。
 
+### Changed
+
+- **apt / dnf 软件源迁移到新地址 `https://repo.hopeagent.ai`**：为解决安装包体积超过 GitHub 单文件 100MB 上限导致 Linux 软件源停更的问题，apt / dnf 源改由 Cloudflare R2 托管。**已在用旧源（`shiwenwen.github.io/hope-agent-linux-repo`）的用户需按 README 重新配置一次源地址**才能继续收到更新；直接下载 `.deb` / `.rpm` / AppImage 或桌面版自升级的用户不受影响。
+
 ### Fixed
 
 - **工作台「文件」分区不再把被工具产出的文件误标为「读」**：先读取、之后又被工具（图片生成 / 附件 / exec）产出的文件，在长会话里滚出当前消息窗口后会正确显示为「输出」并按产出时间排到最前，与窗口内的实时显示保持一致。(#527)

--- a/README.en.md
+++ b/README.en.md
@@ -193,9 +193,9 @@ Pre-built binary package (repackaged from the GitHub Release `.deb`) — no sour
 ##### Debian / Ubuntu (apt)
 
 ```bash
-curl -fsSL https://shiwenwen.github.io/hope-agent-linux-repo/pubkey.gpg | \
+curl -fsSL https://repo.hopeagent.ai/pubkey.gpg | \
   sudo gpg --dearmor -o /usr/share/keyrings/hope-agent.gpg
-echo "deb [signed-by=/usr/share/keyrings/hope-agent.gpg] https://shiwenwen.github.io/hope-agent-linux-repo/apt stable main" | \
+echo "deb [signed-by=/usr/share/keyrings/hope-agent.gpg] https://repo.hopeagent.ai/apt stable main" | \
   sudo tee /etc/apt/sources.list.d/hope-agent.list
 sudo apt update
 sudo apt install hope-agent
@@ -204,7 +204,7 @@ sudo apt install hope-agent
 ##### Fedora / RHEL / CentOS (dnf / yum)
 
 ```bash
-sudo curl -fsSL https://shiwenwen.github.io/hope-agent-linux-repo/rpm/hope-agent.repo \
+sudo curl -fsSL https://repo.hopeagent.ai/rpm/hope-agent.repo \
   -o /etc/yum.repos.d/hope-agent.repo
 sudo dnf install hope-agent     # or `sudo yum install hope-agent`
 ```
@@ -214,7 +214,7 @@ sudo dnf install hope-agent     # or `sudo yum install hope-agent`
 openSUSE users:
 
 ```bash
-sudo zypper addrepo https://shiwenwen.github.io/hope-agent-linux-repo/rpm/hope-agent.repo
+sudo zypper addrepo https://repo.hopeagent.ai/rpm/hope-agent.repo
 sudo zypper install hope-agent
 ```
 

--- a/README.md
+++ b/README.md
@@ -193,9 +193,9 @@ yay -S hope-agent-bin   # 或 paru / 任意 AUR helper
 ##### Debian / Ubuntu（apt）
 
 ```bash
-curl -fsSL https://shiwenwen.github.io/hope-agent-linux-repo/pubkey.gpg | \
+curl -fsSL https://repo.hopeagent.ai/pubkey.gpg | \
   sudo gpg --dearmor -o /usr/share/keyrings/hope-agent.gpg
-echo "deb [signed-by=/usr/share/keyrings/hope-agent.gpg] https://shiwenwen.github.io/hope-agent-linux-repo/apt stable main" | \
+echo "deb [signed-by=/usr/share/keyrings/hope-agent.gpg] https://repo.hopeagent.ai/apt stable main" | \
   sudo tee /etc/apt/sources.list.d/hope-agent.list
 sudo apt update
 sudo apt install hope-agent
@@ -204,7 +204,7 @@ sudo apt install hope-agent
 ##### Fedora / RHEL / CentOS（dnf / yum）
 
 ```bash
-sudo curl -fsSL https://shiwenwen.github.io/hope-agent-linux-repo/rpm/hope-agent.repo \
+sudo curl -fsSL https://repo.hopeagent.ai/rpm/hope-agent.repo \
   -o /etc/yum.repos.d/hope-agent.repo
 sudo dnf install hope-agent     # 或 sudo yum install hope-agent
 ```
@@ -214,7 +214,7 @@ sudo dnf install hope-agent     # 或 sudo yum install hope-agent
 openSUSE 用户：
 
 ```bash
-sudo zypper addrepo https://shiwenwen.github.io/hope-agent-linux-repo/rpm/hope-agent.repo
+sudo zypper addrepo https://repo.hopeagent.ai/rpm/hope-agent.repo
 sudo zypper install hope-agent
 ```
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -192,30 +192,31 @@ Publish Release 后 [`.github/workflows/update-homebrew-tap.yml`](../.github/wor
 
 ### 1.9 Linux apt + dnf/yum 软件源自动同步
 
-托管在 GitHub Pages（[shiwenwen.github.io/hope-agent-linux-repo](https://shiwenwen.github.io/hope-agent-linux-repo/)），用户安装命令见根仓 [`README.md`](../README.md) 「普通用户 → Linux → Debian/Ubuntu」/「Fedora/RHEL/CentOS」段（dnf 与 yum 同 URL 通用，curl 下载 `.repo` 文件方式兼容 dnf4 / dnf5 / yum / zypper）。
+托管在 **Cloudflare R2**，用户经自定义域名 **`https://repo.hopeagent.ai/`** 访问；用户安装命令见根仓 [`README.md`](../README.md) 「普通用户 → Linux → Debian/Ubuntu」/「Fedora/RHEL/CentOS」段（dnf 与 yum 同 URL 通用，curl 下载 `.repo` 文件方式兼容 dnf4 / dnf5 / yum / zypper）。
+
+> **为何 R2 而非 GitHub Pages**：apt/dnf 索引按同一 base URL 引用包文件，故 `.deb`/`.rpm` 必须托管在该 base 下。GitHub 单文件 100MB 硬上限在包体积破百后会整体拒 push（v0.20.1 arm64 `.deb` 首次越界，v0.21.0 四个包全线越界），旧的 git-commit-to-Pages 方案结构性卡死。R2 无单文件上限、**egress 全免**，是高频下载软件源的自然托管。reprepro / createrepo_c / GPG 构建逻辑不变，只换了发布落点。
 
 Release publish 后 [`.github/workflows/update-linux-repo.yml`](../.github/workflows/update-linux-repo.yml) 由 `release.published` 自动触发：
 
-1. `gh release download` 拉本次 release 的 `Hope.Agent_<v>_amd64.deb` + `Hope.Agent-<v>-1.x86_64.rpm`
+1. `gh release download` 拉本次 release 的 `Hope.Agent_<v>_amd64.deb` + `Hope.Agent-<v>-1.x86_64.rpm`（arm64/aarch64 若在则一并）
 2. `gpg --batch --import` 把 `GPG_SIGNING_KEY` secret 导入临时 `GNUPGHOME`，从 imported key 解出 long fingerprint
-3. CI 在 bucket repo 动态渲染 `apt/conf/distributions`，`SignWith:` 填入当前 fingerprint（密钥轮换无需改模板）
-4. `reprepro -b apt includedeb stable …` 重建 apt index 并签 `InRelease` / `Release.gpg`（reprepro 自动用 SignWith 字段指向的 key 签）
-5. `createrepo_c --update rpm/stable/x86_64/` 增量更新 yum index
-6. `gpg --detach-sign --armor` 签 `repomd.xml`（产 `repomd.xml.asc`），让 dnf `repo_gpgcheck=1` 能验签
-7. 同步 [`linux-repo/rpm/hope-agent.repo`](../linux-repo/rpm/hope-agent.repo) 模板到 bucket repo 根 `rpm/hope-agent.repo`
-8. 用 `LINUX_REPO_TOKEN`（fine-grained PAT，仅授 `shiwenwen/hope-agent-linux-repo` 的 `Contents: Read and write`）push 到 bucket repo
-9. GitHub Pages ~1 min 后重新发布
+3. **`rclone copy r2:$R2_BUCKET → ./bucket`** 把当前已发布的整棵树镜像下来（R2 是单一真相源），令 reprepro `apt/db` 与 createrepo_c 既有 repodata 完整、可增量更新；首次 seed 时为空、从零构建
+4. CI 动态渲染 `apt/conf/distributions`（`SignWith:` 填当前 fingerprint，密钥轮换无需改模板），`reprepro -b apt includedeb stable …` 重建 apt index 并签 `InRelease` / `Release.gpg`
+5. `createrepo_c --update rpm/stable/<arch>/` 增量更新 yum index，`gpg --detach-sign --armor` 签 `repomd.xml`（产 `repomd.xml.asc`），让 dnf `repo_gpgcheck=1` 能验签
+6. 同步 [`linux-repo/rpm/hope-agent.repo`](../linux-repo/rpm/hope-agent.repo) 模板到 `rpm/hope-agent.repo`；从私钥导出公钥到 `pubkey.gpg`（不再手动维护）
+7. **`rclone copy ./bucket → r2:$R2_BUCKET`** 非破坏上传（`copy` 非 `sync`）：重生成的索引覆盖、历史包按 checksum 跳过、绝不删除
+8. **回抓校验**：经 `https://repo.hopeagent.ai/…` 拉回 `InRelease` / `repomd.xml` / `pubkey.gpg` 断言 live 且格式正确——坏发布（或自定义域名未接好）在 CI 里失败，而非静默把用户留在陈旧源
 
-手动重跑：`gh workflow run update-linux-repo.yml -f tag=vX.Y.Z`（同 tag 重跑是幂等的——reprepro 先 `remove`，createrepo_c `--update` 覆盖）。
+手动重跑：`gh workflow run update-linux-repo.yml -f tag=vX.Y.Z`（同 tag 重跑幂等——reprepro 先 `remove`，R2 上传非破坏）。
 
-**首次配置 + 密钥轮换流程**：详见 [`linux-repo/README.md`](../linux-repo/README.md)。两个必备 secret：
+**首次配置（建桶 / 连自定义域名 / R2 API Token / GitHub secrets）+ 密钥轮换流程**：详见 [`linux-repo/README.md`](../linux-repo/README.md)。必备 secret：
 
 - `GPG_SIGNING_KEY` — ed25519 私钥（专用密钥，与 maintainer 个人身份独立）
-- `LINUX_REPO_TOKEN` — fine-grained PAT，仅 `Contents: Read and write` on `shiwenwen/hope-agent-linux-repo`
+- `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_BUCKET` — R2 S3 兼容凭据 + 桶名（旧 `LINUX_REPO_TOKEN` 已退役）
 
-**模板单一真相源在主仓 [`linux-repo/`](../linux-repo/)**。不要直接 push bucket repo 的 `apt/` / `rpm/`——下次发版会被 CI 覆盖。**`pubkey.gpg` 和 bucket repo 的 `README.md` 不由 CI 维护**，密钥轮换时手动 PUT。
+**模板单一真相源在主仓 [`linux-repo/`](../linux-repo/)**。不要直接改 R2 上的 `apt/` / `rpm/`——下次发版 CI 会覆盖。`pubkey.gpg` 现由 CI 从 `GPG_SIGNING_KEY` 导出上传，不再手动 PUT。
 
-> reprepro 的 `apt/db/` 是 incremental state（包含 packages 的 sha256 索引），**必须 commit 到 bucket repo**，否则下次跑会丢失历史版本记录、重新生成所有 index。`apt/conf/distributions` 同样 commit（每次 CI 跑会覆盖渲染）。
+> reprepro 的 `apt/db/` 是 incremental state（含 packages 的 sha256 索引）：CI 每次先从 R2 `copy` 下来、改完再 `copy` 回去，故历史版本记录随 R2 持久保存；`apt/conf/distributions` 每次 CI 跑覆盖渲染。R2 上传用 `copy`（非 `sync`）永不删除，一次失败的下载不会误清空。
 
 ---
 

--- a/docs/user-guide/01-快速上手.md
+++ b/docs/user-guide/01-快速上手.md
@@ -58,15 +58,15 @@ scoop install hope-agent
 - **Arch / Manjaro**:`yay -S hope-agent-bin`(或 paru / 任意 AUR helper)
 - **Debian / Ubuntu(apt)**:
   ```bash
-  curl -fsSL https://shiwenwen.github.io/hope-agent-linux-repo/pubkey.gpg | \
+  curl -fsSL https://repo.hopeagent.ai/pubkey.gpg | \
     sudo gpg --dearmor -o /usr/share/keyrings/hope-agent.gpg
-  echo "deb [signed-by=/usr/share/keyrings/hope-agent.gpg] https://shiwenwen.github.io/hope-agent-linux-repo/apt stable main" | \
+  echo "deb [signed-by=/usr/share/keyrings/hope-agent.gpg] https://repo.hopeagent.ai/apt stable main" | \
     sudo tee /etc/apt/sources.list.d/hope-agent.list
   sudo apt update && sudo apt install hope-agent
   ```
 - **Fedora / RHEL / CentOS(dnf / yum)**:
   ```bash
-  sudo curl -fsSL https://shiwenwen.github.io/hope-agent-linux-repo/rpm/hope-agent.repo \
+  sudo curl -fsSL https://repo.hopeagent.ai/rpm/hope-agent.repo \
     -o /etc/yum.repos.d/hope-agent.repo
   sudo dnf install hope-agent
   ```

--- a/docs/user-guide/en/01-getting-started.md
+++ b/docs/user-guide/en/01-getting-started.md
@@ -58,15 +58,15 @@ Native builds are provided for both amd64 (x86_64) and arm64 (aarch64), covering
 - **Arch / Manjaro**: `yay -S hope-agent-bin` (or paru / any AUR helper)
 - **Debian / Ubuntu (apt)**:
   ```bash
-  curl -fsSL https://shiwenwen.github.io/hope-agent-linux-repo/pubkey.gpg | \
+  curl -fsSL https://repo.hopeagent.ai/pubkey.gpg | \
     sudo gpg --dearmor -o /usr/share/keyrings/hope-agent.gpg
-  echo "deb [signed-by=/usr/share/keyrings/hope-agent.gpg] https://shiwenwen.github.io/hope-agent-linux-repo/apt stable main" | \
+  echo "deb [signed-by=/usr/share/keyrings/hope-agent.gpg] https://repo.hopeagent.ai/apt stable main" | \
     sudo tee /etc/apt/sources.list.d/hope-agent.list
   sudo apt update && sudo apt install hope-agent
   ```
 - **Fedora / RHEL / CentOS (dnf / yum)**:
   ```bash
-  sudo curl -fsSL https://shiwenwen.github.io/hope-agent-linux-repo/rpm/hope-agent.repo \
+  sudo curl -fsSL https://repo.hopeagent.ai/rpm/hope-agent.repo \
     -o /etc/yum.repos.d/hope-agent.repo
   sudo dnf install hope-agent
   ```

--- a/linux-repo/README.md
+++ b/linux-repo/README.md
@@ -1,57 +1,85 @@
 # apt / yum repo templates
 
-Single source of truth for the [shiwenwen/hope-agent-linux-repo](https://github.com/shiwenwen/hope-agent-linux-repo) Debian + RPM repository that hosts Hope Agent on GitHub Pages.
+Single source of truth for the Hope Agent Debian + RPM repository, hosted on
+**Cloudflare R2** and served at **`https://repo.hopeagent.ai/`**.
+
+> **Why R2, not GitHub Pages.** apt/dnf indexes reference the package files by
+> URL under one base, so the `.deb`/`.rpm` must live at that base. GitHub's
+> 100 MB per-file limit rejected every package once the app crossed ~100 MB
+> (v0.20.1's arm64 `.deb` was the first casualty; by v0.21.0 all four packages
+> were over), so the old git-committed Pages bucket was structurally stuck. R2
+> has no per-object size limit and **zero egress fees** — the natural host for
+> a download-heavy package repo. The reprepro / createrepo_c / GPG build logic
+> is unchanged; only the publish target moved.
 
 ## Files
 
-- [`rpm/hope-agent.repo`](rpm/hope-agent.repo) — the `.repo` file dropped into `/etc/yum.repos.d/` by `dnf config-manager --add-repo …`. CI also copies this file into the bucket repo at `rpm/hope-agent.repo`.
+- [`rpm/hope-agent.repo`](rpm/hope-agent.repo) — the `.repo` file dropped into `/etc/yum.repos.d/`. CI also uploads this file to the bucket at `rpm/hope-agent.repo` so `curl …/rpm/hope-agent.repo` serves it.
 - The apt `conf/distributions` reprepro config is **generated on the fly inside CI** (the `SignWith:` line embeds the GPG fingerprint imported from the `GPG_SIGNING_KEY` secret), not committed here — that way rotating the signing key never needs a code change.
-- The bucket repo's own `README.md` is the user-facing install guide; this directory is for maintainers.
+- `pubkey.gpg` is **no longer a committed file**: CI exports the signing key's public half from `GPG_SIGNING_KEY` and uploads it to the bucket root every run, so it always matches the active key.
 
-## What CI does on every release
+## What CI does on every release ([`update-linux-repo.yml`](../.github/workflows/update-linux-repo.yml))
 
 See [`../docs/release-process.md`](../docs/release-process.md) §1.9 for the full flow. Summary:
 
-1. `gh release download` pulls every deb + rpm whose filename matches the release version — both amd64 / x86_64 and arm64 / aarch64 when present. Releases with only amd64 (e.g. v0.1.0 ~ v0.1.2) just produce two files instead of four; the workflow tolerates the gap and only requires the amd64 deb + x86_64 rpm as the minimum baseline.
-2. Import `GPG_SIGNING_KEY` secret into a fresh `GNUPGHOME`
-3. `reprepro -b apt includedeb stable …` loops over each deb arch and lets reprepro file it into the right `binary-<arch>` index. `Architectures: amd64 arm64` is declared in `apt/conf/distributions` even on amd64-only releases (reprepro just emits an empty `binary-arm64/Packages` in that case). reprepro signs `InRelease` / `Release.gpg` automatically using `SignWith:`.
-4. `createrepo_c --update rpm/stable/<arch>/` + `gpg --detach-sign --armor` on each `repodata/repomd.xml` builds the rpm index + signs the metadata. Per-arch subdirs (`x86_64` + `aarch64`) — dnf picks via `$basearch` in `hope-agent.repo`.
-5. `rpm --addsign` is **not** used — package-level signatures are skipped because reprepro/createrepo only require *repo metadata* signatures, and the rpm Tauri produces is already trusted via repo-level `repo_gpgcheck=1`
-6. `git commit + push` to `shiwenwen/hope-agent-linux-repo` via `LINUX_REPO_TOKEN`
-7. GitHub Pages re-publishes within ~1 minute
+1. `gh release download` pulls every deb + rpm whose filename matches the release version — both amd64 / x86_64 and arm64 / aarch64 when present. Only the amd64 deb + x86_64 rpm are required as the minimum baseline.
+2. Import `GPG_SIGNING_KEY` into a fresh `GNUPGHOME`.
+3. **`rclone copy r2:$R2_BUCKET → ./bucket`** — mirror the currently-published tree DOWN so reprepro's `apt/db` state and createrepo_c's existing repodata are intact for an incremental update. Empty on the very first seed run.
+4. `reprepro -b apt includedeb stable …` files each deb into the right `binary-<arch>` index and signs `InRelease` / `Release.gpg` via `SignWith:`.
+5. `createrepo_c --update rpm/stable/<arch>/` + `gpg --detach-sign --armor` on each `repodata/repomd.xml`. Per-arch subdirs (`x86_64` + `aarch64`); dnf picks via `$basearch`.
+6. Export `pubkey.gpg` from the imported key.
+7. **`rclone copy ./bucket → r2:$R2_BUCKET`** — non-destructive upload (`copy`, never `sync`): regenerated indexes overwrite, historical packages are skipped by checksum, nothing is deleted.
+8. **Verify** — fetch `InRelease`, `repomd.xml` and `pubkey.gpg` back over `https://repo.hopeagent.ai/…` and assert they are live and well-formed. A broken publish (or an unwired custom domain) fails the job here instead of silently leaving users on a stale source.
 
-## Bucket repo first-time setup
+`rpm --addsign` is **not** used — reprepro/createrepo only require *repo metadata* signatures; the rpm is trusted via repo-level `repo_gpgcheck=1`.
 
-Already done; recorded here for posterity.
+## R2 first-time setup (one-time, on the Cloudflare side)
 
-- Repo: `shiwenwen/hope-agent-linux-repo` (public)
-- Pages: `https://shiwenwen.github.io/hope-agent-linux-repo/` (from `main` branch root)
-- Public key: `pubkey.gpg` at repo root, also fetched by `gpgkey=…` in the rpm `.repo` file
-- Signing key: ed25519, fingerprint `5F80 16D5 0633 E725 909E  9AD7 F0F6 6A31 DFAA EA08`, expires 2027-05-11
+All of this is done in the Cloudflare dashboard + `gh` CLI; none of it is in code.
 
-### Required secrets (in main repo)
+1. **Create the bucket.** R2 → Create bucket, name it `hope-agent-linux-repo` (any name; it becomes the `R2_BUCKET` secret). Location: Automatic.
+2. **Connect the custom domain.** Bucket → Settings → Public access → **Custom Domains** → Connect `repo.hopeagent.ai`. This requires `hopeagent.ai`'s DNS to be on Cloudflare; Cloudflare auto-creates the CNAME. (Do **not** enable the `r2.dev` public URL for production — it is rate-limited.) Wait until `https://repo.hopeagent.ai/` resolves before running the seed.
+3. **Create an R2 API token.** R2 → Manage R2 API Tokens → Create → **Object Read & Write**, scoped to this one bucket. Note the **Access Key ID**, **Secret Access Key**, and your **Account ID** (shown on the R2 overview page / in the S3 endpoint `https://<account_id>.r2.cloudflarestorage.com`).
+4. **Add the four GitHub secrets** on `shiwenwen/hope-agent`:
+   ```bash
+   gh secret set R2_ACCOUNT_ID        --repo shiwenwen/hope-agent   # Cloudflare account id
+   gh secret set R2_ACCESS_KEY_ID     --repo shiwenwen/hope-agent   # from the API token
+   gh secret set R2_SECRET_ACCESS_KEY --repo shiwenwen/hope-agent   # from the API token
+   gh secret set R2_BUCKET            --repo shiwenwen/hope-agent   # e.g. hope-agent-linux-repo
+   ```
+   `GPG_SIGNING_KEY` is unchanged and stays. `LINUX_REPO_TOKEN` and the old
+   `shiwenwen/hope-agent-linux-repo` Pages repo are **retired** — you may leave
+   the old repo up (its stale packages don't hurt) or archive it.
+5. **Seed the repo.** With the domain live, run the workflow once against the current release:
+   ```bash
+   gh workflow run update-linux-repo.yml --repo shiwenwen/hope-agent -f tag=v0.21.0
+   ```
+   The verify step confirms `https://repo.hopeagent.ai/apt/dists/stable/InRelease` etc. are live. From then on it auto-fires on every `release.published`.
 
-- `GPG_SIGNING_KEY` — ASCII-armored private key for the ed25519 signing key. Stored 2026-05-11. Renew before 2027-05-11.
-- `LINUX_REPO_TOKEN` — fine-grained PAT with `Contents: Read and write` on `shiwenwen/hope-agent-linux-repo` only. Renew per token expiry.
+### Signing key info
+
+- Signing key: ed25519, fingerprint `5F80 16D5 0633 E725 909E  9AD7 F0F6 6A31 DFAA EA08`, expires 2027-05-11.
+- `GPG_SIGNING_KEY` — ASCII-armored private key. Stored 2026-05-11. Renew before 2027-05-11.
 
 ## Key rotation (every 12 months)
 
-1. Generate a new ed25519 keypair (same procedure as the original — a one-shot `gpg --batch --gen-key` inside a docker container, see `docs/release-process.md` §1.9).
-2. Export both armored pubkey and privkey.
-3. `gh secret set GPG_SIGNING_KEY --repo shiwenwen/hope-agent < new-privkey.asc` (replaces the old secret).
-4. Replace `pubkey.gpg` at the linux-repo root with the new armored pubkey (`gh api -X PUT ...`).
-5. Update the fingerprint in [`hope-agent-linux-repo/README.md`](https://github.com/shiwenwen/hope-agent-linux-repo/blob/main/README.md) "Key info".
-6. Re-run `gh workflow run update-linux-repo.yml -f tag=v<latest>` to re-sign the existing index with the new key.
-7. Users will see "key changed" warnings on `apt update` / `dnf update` after rotation. They need to re-import the public key:
+1. Generate a new ed25519 keypair (one-shot `gpg --batch --gen-key` in a docker container).
+2. `gh secret set GPG_SIGNING_KEY --repo shiwenwen/hope-agent < new-privkey.asc` (replaces the old secret).
+3. Re-run `gh workflow run update-linux-repo.yml -f tag=v<latest>` — CI re-exports `pubkey.gpg` from the new key and re-signs the index automatically (no manual `pubkey.gpg` PUT needed anymore).
+4. Update the fingerprint above.
+5. Users will see "key changed" warnings on `apt update` / `dnf update` after rotation and must re-import the public key:
    ```bash
-   curl -fsSL https://shiwenwen.github.io/hope-agent-linux-repo/pubkey.gpg | \
+   curl -fsSL https://repo.hopeagent.ai/pubkey.gpg | \
      sudo gpg --dearmor -o /usr/share/keyrings/hope-agent.gpg --yes
    ```
 
 ## Manual re-sync
 
-If the template changes (e.g. adding `arm64` architecture support) and you want it to take effect against an already-published release:
+If the template changes (e.g. new arch, retention tweak) and you want it to take effect against an already-published release:
 
 ```bash
 gh workflow run update-linux-repo.yml -f tag=vX.Y.Z
 ```
+
+Same-tag re-runs are idempotent — reprepro removes the version first and the R2
+upload is non-destructive.

--- a/linux-repo/README.md
+++ b/linux-repo/README.md
@@ -68,6 +68,16 @@ All of this is done in the Cloudflare dashboard + `gh` CLI; none of it is in cod
 > to check readiness from a clean network: `curl -sS -o /dev/null -w '%{http_code}\n'
 > https://<account_id>.r2.cloudflarestorage.com/` — once it returns an HTTP status
 > (e.g. 400) instead of an SSL error, the endpoint is ready.
+>
+> **Can't wait? Seed via the Wrangler bridge.** The workflow accepts a
+> `via` input: `gh workflow run update-linux-repo.yml -f tag=vX.Y.Z -f via=wrangler`.
+> This uploads the built tree through the **Cloudflare API** (`api.cloudflare.com`,
+> which has a valid cert) with `wrangler r2 object put` instead of the S3
+> endpoint, bypassing the unprovisioned cert entirely. It is **seed-only** (a
+> fresh/empty bucket, no pull) and needs a `CLOUDFLARE_API_TOKEN` secret — an API
+> token with **Account → Workers R2 Storage → Edit**. Once the S3-endpoint cert
+> provisions, drop the flag; normal releases go back to the default rclone path
+> (which does the efficient incremental pull+push the bridge can't).
 
 ### Signing key info
 

--- a/linux-repo/README.md
+++ b/linux-repo/README.md
@@ -56,6 +56,19 @@ All of this is done in the Cloudflare dashboard + `gh` CLI; none of it is in cod
    ```
    The verify step confirms `https://repo.hopeagent.ai/apt/dists/stable/InRelease` etc. are live. From then on it auto-fires on every `release.published`.
 
+> **New-account gotcha — `tls: handshake failure` on the first seed.** Cloudflare
+> provisions the **per-account TLS certificate for the S3 API endpoint**
+> (`<account_id>.r2.cloudflarestorage.com`) with a delay on **brand-new R2
+> accounts** — often ~20 minutes, sometimes a few hours (Cloudflare-side, see
+> cloudflare/cloudflare-docs#6252). Until it lands, rclone/aws-cli/curl all fail
+> at the TLS handshake (`alert 40`, no peer certificate) **even though the
+> account id, keys, bucket, and custom domain are all correct** — the custom
+> domain works immediately because it uses a different (Universal SSL) cert
+> path. This is not a misconfiguration: **wait and re-run the seed.** A quick way
+> to check readiness from a clean network: `curl -sS -o /dev/null -w '%{http_code}\n'
+> https://<account_id>.r2.cloudflarestorage.com/` — once it returns an HTTP status
+> (e.g. 400) instead of an SSL error, the endpoint is ready.
+
 ### Signing key info
 
 - Signing key: ed25519, fingerprint `5F80 16D5 0633 E725 909E  9AD7 F0F6 6A31 DFAA EA08`, expires 2027-05-11.

--- a/linux-repo/rpm/hope-agent.repo
+++ b/linux-repo/rpm/hope-agent.repo
@@ -1,7 +1,7 @@
 [hope-agent]
 name=Hope Agent
-baseurl=https://shiwenwen.github.io/hope-agent-linux-repo/rpm/stable/$basearch/
+baseurl=https://repo.hopeagent.ai/rpm/stable/$basearch/
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=https://shiwenwen.github.io/hope-agent-linux-repo/pubkey.gpg
+gpgkey=https://repo.hopeagent.ai/pubkey.gpg


### PR DESCRIPTION
## 背景

GitHub 单文件 **100MB 硬上限**在包体积破百后整体拒 push。v0.20.1 的 arm64 `.deb` 首次越界，到 v0.21.0 四个包（deb/rpm × amd64/arm64，100.95~109.16MB）全线越界，`update-linux-repo` 每次发版必挂——apt 用户停在 v0.20.0、dnf/aarch64 停在 v0.17.0。

体积趋势碾压瘦身技巧（详见另一处调研），且 arm64 天生比 x64 大（AArch64 定长指令编码），**靠瘦身救不回来**。R2 无单文件上限、**egress 全免**，是高频下载软件源的正解。

## 改动

**reprepro / createrepo_c / GPG 构建逻辑完全不变，只换发布落点。**

- **`update-linux-repo.yml`**：
  - 「checkout git 桶 → commit push」改为「`rclone copy r2→本地` → 构建 → `rclone copy 本地→r2`」。R2 是单一真相源；双向 `copy`（非 `sync`）非破坏、一次失败下载不会误清空。
  - **新增发布后回抓校验**：经 `repo.hopeagent.ai` 拉回 `InRelease` / `repomd.xml` / `pubkey.gpg` 断言 live 且格式正确——坏发布（或自定义域名没接好）在 CI 里暴露，而不是把用户静默留在陈旧源。
  - **`pubkey.gpg` 改由 CI 从私钥导出上传**，不再手动维护（顺带修掉旧流程「密钥轮换要手动 PUT pubkey」的坑）。
  - secrets：`LINUX_REPO_TOKEN` 退役；新增 `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_BUCKET`，并加 preflight 缺失即 fail。
- **用户装源 URL**：`shiwenwen.github.io/hope-agent-linux-repo` → `repo.hopeagent.ai`（README 中英 + **内置手册 01 中英** + `rpm/hope-agent.repo` 模板）。
- **维护文档**：`linux-repo/README.md` 重写（R2 首次配置 + 轮换）；`docs/release-process.md` §1.9 同步。
- **CHANGELOG [Unreleased]**：提示旧源用户需按 README 重配一次源。

## ⚠️ 合并后仍需 owner 在 Cloudflare 侧一次性操作（我做不了）

1. R2 建桶（名字即 `R2_BUCKET`）
2. 桶 → 连自定义域名 `repo.hopeagent.ai`（需 `hopeagent.ai` DNS 在 Cloudflare；**不要用 r2.dev 公开地址，会限流**）
3. 建 R2 API Token（Object Read & Write，限本桶），拿 Access Key / Secret / Account ID
4. `gh secret set` 上述 4 个 secret
5. 域名 live 后 `gh workflow run update-linux-repo.yml -f tag=v0.21.0` 播种

完整步骤在 `linux-repo/README.md`。**域名接好前不要跑 workflow**——回抓校验会红（上传其实已成功，接好域名重跑即绿，幂等）。

## 验证

- `node scripts/check-release-paths.mjs` OK（artifact 文件名模式不变）
- workflow YAML 语法校验通过
- 内置手册中英对称改动，`check-docs-parity` 保持

纯 CI / 文档改动，无 Rust / TS 代码变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)