### PR TITLE
fix: add missing es-toolkit dependency for Lobehub icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "clsx": "^2.1.1",
     "diff": "^9.0.0",
     "docx-preview": "^0.3.7",
+    "es-toolkit": "^1.45.1",
     "html2canvas": "^1.4.1",
     "i18next": "^26.0.3",
     "jspdf": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       docx-preview:
         specifier: ^0.3.7
         version: 0.3.7
+      es-toolkit:
+        specifier: ^1.45.1
+        version: 1.45.1
       html2canvas:
         specifier: ^1.4.1
         version: 1.4.1


### PR DESCRIPTION
## What changed

- Add `es-toolkit` as a direct application dependency.
- Record the dependency in the pnpm lockfile importer.

## Why

`@lobehub/icons@5.2.0` imports `kebabCase` from `es-toolkit`, but its published package manifest does not declare that dependency. With pnpm's strict dependency isolation, Vite can leave a bare `es-toolkit` import in the optimized dependency output and then fail to resolve it during development.

Declaring the dependency at the application level makes the import resolvable for clean installs and Vite dependency prebundling.

## Impact

Fixes the Vite development error when loading `@lobehub/icons`; there is no runtime behavior change beyond restoring icon module loading.

## Validation

- `pnpm install --offline --ignore-scripts --frozen-lockfile`
- Imported `es-toolkit` through Node ESM and verified `kebabCase` is available.
- Started Vite with forced dependency optimization and fetched the transformed `@lobehub/icons` module successfully.
- Verified the optimized module bundles `kebabCase` and contains no unresolved bare `from "es-toolkit"` import.
- `git diff --check`