### PR TITLE
fix(chat): 修正消息 Fork 边界并保留用户草稿

### DIFF
--- a/crates/ha-core/src/session/db.rs
+++ b/crates/ha-core/src/session/db.rs
@@ -2137,7 +2137,27 @@ impl SessionDB {
         source_session_id: &str,
         before_message_id: i64,
     ) -> Result<crate::session::ForkSessionResult> {
-        self.fork_session_with_boundary(source_session_id, Some(before_message_id), true)
+        let result =
+            self.fork_session_with_boundary(source_session_id, Some(before_message_id), true);
+        match &result {
+            Ok(forked) => crate::app_info!(
+                "session",
+                "fork",
+                "exclusive fork completed: source_session_id={} before_message_id={} forked_session_id={}",
+                source_session_id,
+                before_message_id,
+                forked.session.id
+            ),
+            Err(error) => crate::app_warn!(
+                "session",
+                "fork",
+                "exclusive fork failed: source_session_id={} before_message_id={} error={}",
+                source_session_id,
+                before_message_id,
+                error
+            ),
+        }
+        result
     }
 
     fn fork_session_with_boundary(

--- a/crates/ha-core/src/session/db.rs
+++ b/crates/ha-core/src/session/db.rs
@@ -2112,8 +2112,42 @@ impl SessionDB {
         source_session_id: &str,
         source_message_id: Option<i64>,
     ) -> Result<SessionMeta> {
+        self.fork_session_with_boundary(source_session_id, source_message_id, false)
+            .map(|result| result.session)
+    }
+
+    /// Fork a session with a transcript boundary immediately before a source
+    /// message. Unlike a full or inclusive fork, this intentionally permits an
+    /// empty copied transcript when `before_message_id` is the first message.
+    pub fn fork_session_before_message(
+        &self,
+        source_session_id: &str,
+        before_message_id: i64,
+    ) -> Result<SessionMeta> {
+        self.fork_session_before_message_with_draft(source_session_id, before_message_id)
+            .map(|result| result.session)
+    }
+
+    /// Same boundary semantics as [`Self::fork_session_before_message`], plus
+    /// the selected user prompt's attachment metadata rewritten to files owned
+    /// by the new session. This is consumed by GUI transports to reconstruct an
+    /// editable composer draft.
+    pub fn fork_session_before_message_with_draft(
+        &self,
+        source_session_id: &str,
+        before_message_id: i64,
+    ) -> Result<crate::session::ForkSessionResult> {
+        self.fork_session_with_boundary(source_session_id, Some(before_message_id), true)
+    }
+
+    fn fork_session_with_boundary(
+        &self,
+        source_session_id: &str,
+        source_message_id: Option<i64>,
+        exclude_boundary: bool,
+    ) -> Result<crate::session::ForkSessionResult> {
         let new_session_id = uuid::Uuid::new_v4().to_string();
-        let fork_result = (|| -> Result<()> {
+        let fork_result = (|| -> Result<Option<String>> {
             let mut conn = self
                 .conn
                 .lock()
@@ -2214,12 +2248,27 @@ impl SessionDB {
                 }
             }
 
+            let boundary_attachments_meta = if exclude_boundary {
+                let (role, attachments_meta): (String, Option<String>) = tx.query_row(
+                    "SELECT role, attachments_meta FROM messages
+                     WHERE session_id = ?1 AND id = ?2",
+                    params![source_session_id, source_message_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )?;
+                if role != MessageRole::User.as_str() {
+                    anyhow::bail!("exclusive fork boundary must be a user message");
+                }
+                attachments_meta
+            } else {
+                None
+            };
+
             let active_streaming_rows: i64 = tx.query_row(
                 "SELECT COUNT(*) FROM messages
              WHERE session_id = ?1
-               AND (?2 IS NULL OR id <= ?2)
+               AND (?2 IS NULL OR (?3 = 0 AND id <= ?2) OR (?3 = 1 AND id < ?2))
                AND stream_status = 'streaming'",
-                params![source_session_id, source_message_id],
+                params![source_session_id, source_message_id, exclude_boundary],
                 |row| row.get(0),
             )?;
             if active_streaming_rows > 0 {
@@ -2231,11 +2280,11 @@ impl SessionDB {
             let copied_count: i64 = tx.query_row(
                 "SELECT COUNT(*) FROM messages
              WHERE session_id = ?1
-               AND (?2 IS NULL OR id <= ?2)",
-                params![source_session_id, source_message_id],
+               AND (?2 IS NULL OR (?3 = 0 AND id <= ?2) OR (?3 = 1 AND id < ?2))",
+                params![source_session_id, source_message_id, exclude_boundary],
                 |row| row.get(0),
             )?;
-            if copied_count == 0 {
+            if copied_count == 0 && !exclude_boundary {
                 anyhow::bail!("cannot fork an empty session");
             }
 
@@ -2248,11 +2297,11 @@ impl SessionDB {
                 tx.query_row(
                     "SELECT content FROM messages
                  WHERE session_id = ?1
-                   AND (?2 IS NULL OR id <= ?2)
+                   AND (?2 IS NULL OR (?3 = 0 AND id <= ?2) OR (?3 = 1 AND id < ?2))
                    AND role = 'user'
                    AND length(trim(content)) > 0
                  ORDER BY id ASC LIMIT 1",
-                    params![source_session_id, source_message_id],
+                    params![source_session_id, source_message_id, exclude_boundary],
                     |row| row.get::<_, String>(0),
                 )
                 .optional()?
@@ -2283,6 +2332,18 @@ impl SessionDB {
                 None => None,
             };
 
+            let copied_through_message_id = if source_message_id.is_some() {
+                tx.query_row(
+                    "SELECT MAX(id) FROM messages
+                     WHERE session_id = ?1
+                       AND (?2 IS NULL OR (?3 = 0 AND id <= ?2) OR (?3 = 1 AND id < ?2))",
+                    params![source_session_id, source_message_id, exclude_boundary],
+                    |row| row.get::<_, Option<i64>>(0),
+                )?
+            } else {
+                None
+            };
+
             let now = chrono::Utc::now().to_rfc3339();
             tx.execute(
             "INSERT INTO sessions (
@@ -2311,7 +2372,7 @@ impl SessionDB {
                 working_dir,
                 kind,
                 source_session_id,
-                source_message_id,
+                copied_through_message_id,
             ],
         )?;
 
@@ -2327,25 +2388,33 @@ impl SessionDB {
                 tokens_in, tokens_out, reasoning_effort, tool_call_id, tool_name,
                 tool_arguments, tool_result, tool_duration_ms, is_error, thinking,
                 ttft_ms, tokens_in_last, tokens_cache_creation, tokens_cache_read,
-                tool_metadata, stream_status, source
+                tool_metadata,
+                CASE WHEN stream_status = 'orphaned' THEN 'recovered' ELSE stream_status END,
+                source
              FROM messages
              WHERE session_id = ?2
-               AND (?3 IS NULL OR id <= ?3)
+               AND (?3 IS NULL OR (?4 = 0 AND id <= ?3) OR (?4 = 1 AND id < ?3))
              ORDER BY id ASC",
-                params![new_session_id, source_session_id, source_message_id],
+                params![
+                    new_session_id,
+                    source_session_id,
+                    source_message_id,
+                    exclude_boundary
+                ],
             )?;
 
             let attachment_meta_rewrites = {
                 let mut stmt = tx.prepare(
                     "SELECT DISTINCT attachments_meta FROM messages
                  WHERE session_id = ?1
-                   AND (?2 IS NULL OR id <= ?2)
+                   AND (?2 IS NULL OR (?3 = 0 AND id <= ?2) OR (?3 = 1 AND id < ?2))
                    AND attachments_meta IS NOT NULL",
                 )?;
                 let raw_values = stmt
-                    .query_map(params![source_session_id, source_message_id], |row| {
-                        row.get::<_, String>(0)
-                    })?
+                    .query_map(
+                        params![source_session_id, source_message_id, exclude_boundary],
+                        |row| row.get::<_, String>(0),
+                    )?
                     .collect::<std::result::Result<Vec<_>, _>>()?;
                 raw_values
                     .into_iter()
@@ -2369,6 +2438,17 @@ impl SessionDB {
                     )?;
                 }
             }
+
+            let draft_attachments_meta = boundary_attachments_meta
+                .as_deref()
+                .map(|raw| {
+                    crate::attachments::fork_attachments_meta(
+                        source_session_id,
+                        &new_session_id,
+                        raw,
+                    )
+                })
+                .transpose()?;
 
             // 设计线程 fork：补建 `design_chat_threads` 锚点，让设计工具经
             // `project_for_session` 解析回源设计项目（否则会落到新草稿项目）。以锚表为
@@ -2416,18 +2496,26 @@ impl SessionDB {
             }
 
             tx.commit()?;
-            Ok(())
+            Ok(draft_attachments_meta)
         })();
 
-        if let Err(error) = fork_result {
-            if let Ok(attachments_dir) = crate::paths::attachments_dir(&new_session_id) {
-                let _ = std::fs::remove_dir_all(attachments_dir);
+        let draft_attachments_meta = match fork_result {
+            Ok(meta) => meta,
+            Err(error) => {
+                if let Ok(attachments_dir) = crate::paths::attachments_dir(&new_session_id) {
+                    let _ = std::fs::remove_dir_all(attachments_dir);
+                }
+                return Err(error);
             }
-            return Err(error);
-        }
+        };
 
-        self.get_session(&new_session_id)?
-            .ok_or_else(|| anyhow::anyhow!("forked session disappeared: {}", new_session_id))
+        let session = self
+            .get_session(&new_session_id)?
+            .ok_or_else(|| anyhow::anyhow!("forked session disappeared: {}", new_session_id))?;
+        Ok(crate::session::ForkSessionResult {
+            session,
+            draft_attachments_meta,
+        })
     }
 
     /// Split a session title into its base and optional trailing ` (N)` sequence.
@@ -7464,6 +7552,150 @@ mod tests {
         assert!(
             visible.iter().any(|session| session.id == forked.id),
             "forked session must remain a first-class sidebar session"
+        );
+
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn fork_session_before_user_message_excludes_prompt_and_allows_empty_history() {
+        let db_path = temp_db_path("session-fork-before-user");
+        let db = SessionDB::open(&db_path).expect("open session db");
+        ensure_channel_conversations_table(&db);
+
+        let source = db.create_session("ha-main").expect("source session");
+        db.update_session_title_with_source(
+            &source.id,
+            "Original task",
+            crate::session_title::TITLE_SOURCE_LLM,
+        )
+        .expect("title");
+        let first_user = db
+            .append_message(&source.id, &NewMessage::user("first prompt"))
+            .expect("append first user");
+        let first_answer = db
+            .append_message(&source.id, &NewMessage::assistant("first answer"))
+            .expect("append first answer");
+        let second_user = db
+            .append_message(&source.id, &NewMessage::user("second prompt"))
+            .expect("append second user");
+
+        let from_second = db
+            .fork_session_before_message(&source.id, second_user)
+            .expect("fork before second prompt");
+        let copied = db
+            .load_session_messages(&from_second.id)
+            .expect("load forked messages");
+        assert_eq!(
+            copied
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first prompt", "first answer"]
+        );
+        assert_eq!(from_second.forked_from_message_id, Some(first_answer));
+
+        let from_first = db
+            .fork_session_before_message(&source.id, first_user)
+            .expect("fork before first prompt");
+        assert_eq!(from_first.message_count, 0);
+        assert_eq!(from_first.forked_from_message_id, None);
+        assert!(db
+            .load_session_messages(&from_first.id)
+            .expect("load empty fork")
+            .is_empty());
+
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn fork_session_before_user_message_returns_new_session_owned_draft_attachments() {
+        let db_path = temp_db_path("session-fork-user-draft-attachments");
+        let db = SessionDB::open(&db_path).expect("open session db");
+        ensure_channel_conversations_table(&db);
+
+        let source = db.create_session("ha-main").expect("source session");
+        let source_dir = crate::paths::attachments_dir(&source.id).expect("source attachments dir");
+        std::fs::create_dir_all(&source_dir).expect("create source attachments dir");
+        let source_path = source_dir.join("prompt-image.png");
+        std::fs::write(&source_path, b"png bytes").expect("write source attachment");
+
+        let mut prompt = NewMessage::user("");
+        prompt.attachments_meta = Some(
+            serde_json::json!([{
+                "name": "prompt-image.png",
+                "mime_type": "image/png",
+                "size": 9,
+                "path": source_path,
+                "source": "upload"
+            }])
+            .to_string(),
+        );
+        let prompt_id = db
+            .append_message(&source.id, &prompt)
+            .expect("append attachment-only prompt");
+
+        let forked = db
+            .fork_session_before_message_with_draft(&source.id, prompt_id)
+            .expect("fork before attachment prompt");
+        assert_eq!(forked.session.message_count, 0);
+        let draft_meta: serde_json::Value = serde_json::from_str(
+            forked
+                .draft_attachments_meta
+                .as_deref()
+                .expect("fork draft attachment metadata"),
+        )
+        .expect("parse fork draft metadata");
+        let forked_path = std::path::PathBuf::from(
+            draft_meta[0]["path"]
+                .as_str()
+                .expect("forked draft attachment path"),
+        );
+        let forked_dir =
+            crate::paths::attachments_dir(&forked.session.id).expect("fork attachments dir");
+        assert!(forked_path.starts_with(&forked_dir));
+        assert_eq!(
+            std::fs::read(&forked_path).expect("read forked draft attachment"),
+            b"png bytes"
+        );
+
+        db.delete_session(&source.id)
+            .expect("delete source session");
+        assert!(
+            forked_path.exists(),
+            "fork draft must not depend on source files"
+        );
+        db.delete_session(&forked.session.id)
+            .expect("delete fork session");
+        let _ = std::fs::remove_file(&db_path);
+    }
+
+    #[test]
+    fn fork_session_normalizes_orphaned_assistant_rows_to_recovered() {
+        let db_path = temp_db_path("session-fork-orphaned-status");
+        let db = SessionDB::open(&db_path).expect("open session db");
+        ensure_channel_conversations_table(&db);
+
+        let source = db.create_session("ha-main").expect("source session");
+        db.append_message(&source.id, &NewMessage::user("prompt"))
+            .expect("append user");
+        let mut interrupted = NewMessage::assistant("partial answer");
+        interrupted.stream_status = Some("orphaned".to_string());
+        let boundary = db
+            .append_message(&source.id, &interrupted)
+            .expect("append interrupted assistant");
+
+        let forked = db
+            .fork_session(&source.id, Some(boundary))
+            .expect("fork interrupted assistant");
+        let messages = db
+            .load_session_messages(&forked.id)
+            .expect("load fork messages");
+        assert_eq!(
+            messages
+                .last()
+                .and_then(|message| message.stream_status.as_deref()),
+            Some("recovered")
         );
 
         let _ = std::fs::remove_file(&db_path);

--- a/crates/ha-core/src/session/mod.rs
+++ b/crates/ha-core/src/session/mod.rs
@@ -60,8 +60,8 @@ pub use turn_queue::{
 pub use turns::{ChatTurn, ChatTurnInterruptReason, ChatTurnStatus};
 pub use types::{
     build_chat_user_attachments_meta, build_tool_media_items_attachments_meta, ChannelSessionInfo,
-    MessageRole, NewMessage, PendingCountdown, SessionDefaultsInput, SessionKind,
-    SessionMemoryPolicy, SessionMemoryPolicyValue, SessionMessage, SessionMeta,
+    ForkSessionResult, MessageRole, NewMessage, PendingCountdown, SessionDefaultsInput,
+    SessionKind, SessionMemoryPolicy, SessionMemoryPolicyValue, SessionMessage, SessionMeta,
     UnreadSessionTarget, ATTACHMENT_META_KEY_ACTIVE_MEMORY, ATTACHMENT_META_KEY_RETRIEVAL_PLANNER,
     ATTACHMENT_META_KEY_TOOL_MEDIA_ITEMS, ATTACHMENT_META_KEY_USED_MEMORY_REFS,
 };

--- a/crates/ha-core/src/session/types.rs
+++ b/crates/ha-core/src/session/types.rs
@@ -316,6 +316,30 @@ pub struct SessionMeta {
     pub kind: SessionKind,
 }
 
+/// Result returned by the user-facing fork APIs. The session fields stay
+/// flattened for backwards compatibility with clients that deserialize a
+/// fork response directly as [`SessionMeta`]. When a user prompt is forked,
+/// its attachments are copied into the new session and returned separately so
+/// the client can restore them into the composer without retaining a reference
+/// to the source session's files.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForkSessionResult {
+    #[serde(flatten)]
+    pub session: SessionMeta,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub draft_attachments_meta: Option<String>,
+}
+
+impl From<SessionMeta> for ForkSessionResult {
+    fn from(session: SessionMeta) -> Self {
+        Self {
+            session,
+            draft_attachments_meta: None,
+        }
+    }
+}
+
 /// The next regular unread conversation that the sidebar should reveal.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/ha-server/src/routes/sessions.rs
+++ b/crates/ha-server/src/routes/sessions.rs
@@ -107,6 +107,10 @@ pub struct ForkSessionBody {
     /// Optional source message boundary. When omitted, the full transcript is
     /// copied. When set, messages are copied through this ID inclusive.
     pub message_id: Option<i64>,
+    /// Alternative exclusive boundary used when forking from a user prompt.
+    /// Messages before this ID are copied; the selected prompt is left out so
+    /// the client can put it back into the new conversation's composer.
+    pub before_message_id: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -230,16 +234,42 @@ fn rewrite_user_attachments_meta_for_http(msg: &mut SessionMessage, api_key: Opt
     let Some(raw) = msg.attachments_meta.as_deref() else {
         return;
     };
-    let Ok(Value::Array(items)) = serde_json::from_str::<Value>(raw) else {
-        return;
-    };
+    if let Some(rewritten) = rewrite_user_attachments_json_for_http(&msg.session_id, raw, api_key) {
+        msg.attachments_meta = Some(rewritten);
+    }
+}
 
-    let Some(rewritten_items) =
-        rewrite_user_attachment_items_for_http(&msg.session_id, items, api_key)
-    else {
+fn rewrite_fork_draft_attachments_for_http(
+    result: &mut ha_core::session::ForkSessionResult,
+    api_key: Option<&str>,
+) {
+    let Some(raw) = result.draft_attachments_meta.as_deref() else {
         return;
     };
-    msg.attachments_meta = Some(Value::Array(rewritten_items).to_string());
+    if let Some(rewritten) =
+        rewrite_user_attachments_json_for_http(&result.session.id, raw, api_key)
+    {
+        result.draft_attachments_meta = Some(rewritten);
+    }
+}
+
+fn rewrite_user_attachments_json_for_http(
+    session_id: &str,
+    raw: &str,
+    api_key: Option<&str>,
+) -> Option<String> {
+    let Ok(mut meta) = serde_json::from_str::<Value>(raw) else {
+        return None;
+    };
+    let items = match &mut meta {
+        Value::Array(items) => items,
+        Value::Object(object) => object.get_mut("user_attachments")?.as_array_mut()?,
+        _ => return None,
+    };
+    let rewritten =
+        rewrite_user_attachment_items_for_http(session_id, std::mem::take(items), api_key)?;
+    *items = rewritten;
+    Some(meta.to_string())
 }
 
 fn rewrite_user_attachment_items_for_http(
@@ -653,12 +683,21 @@ pub async fn fork_session(
     State(ctx): State<Arc<AppContext>>,
     Path(id): Path<String>,
     Json(body): Json<ForkSessionBody>,
-) -> Result<Json<ha_core::session::SessionMeta>, AppError> {
-    let meta = ctx
+) -> Result<Json<ha_core::session::ForkSessionResult>, AppError> {
+    if body.message_id.is_some() && body.before_message_id.is_some() {
+        return Err(AppError::bad_request(
+            "messageId and beforeMessageId are mutually exclusive",
+        ));
+    }
+    let mut result = ctx
         .session_db
-        .run(move |db| db.fork_session(&id, body.message_id))
+        .run(move |db| match body.before_message_id {
+            Some(boundary) => db.fork_session_before_message_with_draft(&id, boundary),
+            None => db.fork_session(&id, body.message_id).map(Into::into),
+        })
         .await?;
-    Ok(Json(meta))
+    rewrite_fork_draft_attachments_for_http(&mut result, ctx.api_key.as_deref());
+    Ok(Json(result))
 }
 
 /// `GET /api/sessions` — list sessions with optional filtering and pagination.

--- a/docs/architecture/api-reference.md
+++ b/docs/architecture/api-reference.md
@@ -461,6 +461,7 @@ KB 文件预览端点是**纯 owner 平面，无 session 参数、无 owner fall
 | `list_archived_sessions_cmd` | `GET /api/sessions/archived?limit=&offset=` | ✅（跨普通 / 项目 / IM / Subagent / Cron / Knowledge / Design 的归档管理列表） |
 | `create_session_cmd` | `POST /api/sessions` | ✅ |
 | `get_session_cmd` | `GET /api/sessions/{id}` | ✅ |
+| `fork_session_cmd` | `POST /api/sessions/{sessionId}/fork` | ✅（body 的 `messageId` 为含边界；`beforeMessageId` 为不含边界，二者互斥且同时传入返回 400；响应保持 `SessionMeta` 扁平字段，并可附带 `draftAttachmentsMeta`） |
 | `set_session_incognito` | `PATCH /api/sessions/{sessionId}/incognito` | ✅ |
 | `set_session_working_dir` | `PATCH /api/sessions/{sessionId}/working-dir` | ✅ |
 | `update_session_agent_cmd` | `PATCH /api/sessions/{sessionId}/agent` | ✅ |

--- a/docs/architecture/session.md
+++ b/docs/architecture/session.md
@@ -74,7 +74,7 @@ Session 模块是 Hope Agent 的会话与消息持久化系统，基于 SQLite W
 | `is_cron` | `bool` | 是否为定时任务创建的会话 |
 | `parent_session_id` | `Option<String>` | 父会话 ID（子 Agent 会话） |
 | `forked_from_session_id` | `Option<String>` | Fork 来源会话 ID；用于“在新会话中继续”的用户可见 lineage，**不得**复用 `parent_session_id` |
-| `forked_from_message_id` | `Option<i64>` | Fork 来源消息边界；复制到该消息（含）为止，`None` 表示复制完整 transcript |
+| `forked_from_message_id` | `Option<i64>` | Fork 实际复制到的末条来源消息；完整 transcript Fork 与首条 user 之前的空 Fork 均为 `None` |
 | `forked_from_session_title` | `Option<String>` | 来源会话当前标题的只读 JOIN 投影；来源删除或无标题时为空 |
 | `plan_mode` | `PlanModeState` | Plan Mode 状态（snake_case 序列化）：`off` / `planning` / `review` / `executing` / `completed`（默认 off） |
 | `permission_mode` | `SessionMode` | 会话级权限模式（snake_case 序列化）：`default` / `smart` / `yolo`（默认 default） |
@@ -579,19 +579,19 @@ Fork 用于把当前会话派生为一个新的、可独立继续的普通会话
 
 ### 数据语义
 
-- `forked_from_session_id` / `forked_from_message_id` 是普通会话 lineage，只用于“接续自”提示和跳转原会话。
+- `forked_from_session_id` / `forked_from_message_id` 是普通会话 lineage，只用于“接续自”提示和跳转原会话；后者记录实际复制到的新末条消息，首条 user 消息之前的空 Fork 为 `None`。
 - `parent_session_id` 仍只表示子 Agent 会话。Fork 出来的会话必须保留 `parent_session_id = NULL`，否则会被 sidebar、未读和子会话 UI 当成隐藏子会话处理。
 - `SESSION_META_SELECT` 追加 `forked_from_session_title` 作为只读来源标题投影；来源会话删除后，fork 会话仍保留来源 ID，但标题为空。
 
 ### 复制范围
 
-`SessionDB::fork_session(source_session_id, source_message_id)` 以数据库事务和失败清理共同保证一致性：
+`SessionDB::fork_session(source_session_id, source_message_id)` 与 `fork_session_before_message(source_session_id, before_message_id)` 以数据库事务和失败清理共同保证一致性：
 
 1. 校验来源是普通顶层会话：非 incognito、非 cron、非 subagent、`kind = regular`。
-2. 校验 `source_message_id` 属于来源会话；为空时复制完整 transcript，非空时复制到该消息 ID（含）为止。
+2. 校验消息边界属于来源会话；`source_message_id` 为空时复制完整 transcript，非空时复制到该消息 ID（含）为止；`before_message_id` 必须指向普通 user 消息，只复制它之前的 transcript，并允许首条消息之前得到空历史。GUI 点 assistant 的 Fork 走含边界；点普通 user 消息走不含边界，再把该 user 的正文、上传/粘贴文件、文件 quote 与消息 quote 恢复成新会话的可编辑 composer 草稿并聚焦输入框；文件先复制进新会话附件目录，远端只返回新会话自己的受控 URL。
 3. 拒绝复制 `stream_status = 'streaming'` 的未完成行，避免派生出半条 assistant/tool 输出。
 4. 创建新 `sessions` 行，复制 agent/model/project/workdir、permission/sandbox/execution/workflow mode 等稳定配置。
-5. 复制 `messages` 行，保留原消息时间戳、tool metadata、token 和 source 字段。普通上传与 `tool_media_items` 引用的会话私有文件会复制到新会话附件目录，并将 `path` / `localPath` / `/api/attachments/{session}/...` URL 改写为新会话；工作区 quote 等外部引用保持原样。这样删除来源会话后，派生会话的附件仍可独立读取。
+5. 复制 `messages` 行，保留原消息时间戳、tool metadata、token 和 source 字段；已终止的 `orphaned` 行在副本中规范化为 `recovered`，避免启动恢复器把静态 fork 误认成待恢复运行。普通上传与 `tool_media_items` 引用的会话私有文件会复制到新会话附件目录，并将 `path` / `localPath` / `/api/attachments/{session}/...` URL 改写为新会话；工作区 quote 等外部引用保持原样。这样删除来源会话后，派生会话的附件仍可独立读取。
 6. 将新会话 `last_read_message_id` 设为复制后的末尾消息，避免复制历史立刻变成未读。
 
 附件复制或写库任一步失败时，数据库事务回滚并删除已创建的新附件目录；提交后先释放 writer mutex，再通过读连接加载新 `SessionMeta`，避免同线程重复获取写锁。

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -46,11 +46,20 @@ pub async fn create_session_cmd(
 pub async fn fork_session_cmd(
     session_id: String,
     message_id: Option<i64>,
+    before_message_id: Option<i64>,
     state: State<'_, AppState>,
-) -> Result<session::SessionMeta, CmdError> {
+) -> Result<session::ForkSessionResult, CmdError> {
+    if message_id.is_some() && before_message_id.is_some() {
+        return Err(CmdError::from(anyhow::anyhow!(
+            "message_id and before_message_id are mutually exclusive"
+        )));
+    }
     state
         .session_db
-        .run(move |db| db.fork_session(&session_id, message_id))
+        .run(move |db| match before_message_id {
+            Some(boundary) => db.fork_session_before_message_with_draft(&session_id, boundary),
+            None => db.fork_session(&session_id, message_id).map(Into::into),
+        })
         .await
         .map_err(Into::into)
 }

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -9,6 +9,11 @@ import { subscribeAskAiQuotes } from "@/lib/manual/askAi"
 import type { SettingsSection } from "@/components/settings/types"
 import { requestMemoryFocus } from "@/components/settings/memory-panel/memoryFocus"
 import { memorySourceLabel } from "./message/memoryTraceFormat"
+import {
+  forkComposerDraftForMessage,
+  forkSessionRequestForMessage,
+  type ForkComposerDraft,
+} from "./message/messageFork"
 import { BrowserExtensionNudge } from "./BrowserExtensionNudge"
 import { useViewportMediaQuery } from "@/hooks/useViewportMediaQuery"
 import { useReadableSurface } from "@/hooks/useReadableSurface"
@@ -37,6 +42,7 @@ import type {
   ActiveModel,
   AvailableModel,
   ChatRuntimeDefaults,
+  ForkSessionResult,
   Message,
   PendingMessageQuote,
   SessionMessage,
@@ -748,6 +754,10 @@ export default function ChatScreen({
   const browserPanelDismissedRef = useRef(false)
   const [showFilesPanel, setShowFilesPanel] = useState(false)
   const [composerFocusSignal, setComposerFocusSignal] = useState<number | undefined>(undefined)
+  const pendingForkComposerRef = useRef<{
+    sessionId: string
+    draft: ForkComposerDraft
+  } | null>(null)
   // Clicking a staged quote chip reveals that file in the browser. The nonce
   // makes each click a fresh signal, even when re-revealing the same path.
   const revealQuoteNonce = useRef(0)
@@ -2052,6 +2062,23 @@ export default function ChatScreen({
     activeSessionReadableRef,
   })
 
+  useEffect(() => {
+    const pending = pendingForkComposerRef.current
+    if (!pending || session.currentSessionId !== pending.sessionId) return
+    pendingForkComposerRef.current = null
+    stream.setInput(pending.draft.text)
+    stream.setAttachedFiles(pending.draft.attachedFiles)
+    stream.setPendingQuotes(pending.draft.pendingQuotes)
+    stream.setPendingMessageQuotes(pending.draft.pendingMessageQuotes)
+    setComposerFocusSignal((value) => (value ?? 0) + 1)
+  }, [
+    session.currentSessionId,
+    stream.setAttachedFiles,
+    stream.setInput,
+    stream.setPendingMessageQuotes,
+    stream.setPendingQuotes,
+  ])
+
   // Ambient file-action wiring for persisted resources and renderer-only drafts.
   const setAttachedFiles = stream.setAttachedFiles
   const replaceDraftAttachment = useCallback(
@@ -2980,15 +3007,19 @@ export default function ChatScreen({
   )
 
   const handleForkFromMessage = useCallback(
-    async (messageId: number) => {
+    async (message: Message) => {
       const sourceSessionId = session.currentSessionId
       if (!sourceSessionId) return
+      const request = forkSessionRequestForMessage(sourceSessionId, message)
+      if (!request) return
       try {
-        const forked = await getTransport().call<SessionMeta>("fork_session_cmd", {
-          sessionId: sourceSessionId,
-          messageId,
+        const forked = await getTransport().call<ForkSessionResult>("fork_session_cmd", {
+          ...request,
         })
+        const composerDraft = await forkComposerDraftForMessage(message, forked)
         await reloadSessions()
+        pendingForkComposerRef.current =
+          composerDraft == null ? null : { sessionId: forked.id, draft: composerDraft }
         await rawHandleSwitchSession(forked.id)
         toast.success(
           t("chat.fork.created", {
@@ -2996,6 +3027,7 @@ export default function ChatScreen({
           }),
         )
       } catch (e) {
+        pendingForkComposerRef.current = null
         logger.error("ui", "ChatScreen::forkSession", "Failed to fork session", e)
         toast.error(
           e instanceof Error

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -119,7 +119,7 @@ interface MessageListProps {
       | import("@/types/chat").FileChangesMetadata,
   ) => void
   onResume?: (message: string) => void
-  onForkFromMessage?: (messageId: number) => void
+  onForkFromMessage?: (message: Message) => void
   onOpenMemorySettings?: () => void
   onOpenKnowledge?: () => void
   onAddQuickPrompt?: (content: string) => void

--- a/src/components/chat/chatUtils.test.ts
+++ b/src/components/chat/chatUtils.test.ts
@@ -51,6 +51,31 @@ describe("parseSessionMessages events", () => {
       persistenceRunId: "run-1",
       contentBlocks: [{ type: "text", content: "durable prefix" }],
     })
+    expect(parsed.at(-1)?.forkBoundaryId).toBe(2)
+  })
+
+  test("only exposes a fork boundary after an assistant checkpoint is no longer streaming", () => {
+    const streaming = parseSessionMessages([
+      sessionMessage({ id: 1, role: "user", content: "question" }),
+      sessionMessage({
+        id: 2,
+        role: "text_block",
+        content: "partial answer",
+        streamStatus: "streaming",
+      }),
+    ])
+    const interrupted = parseSessionMessages([
+      sessionMessage({ id: 1, role: "user", content: "question" }),
+      sessionMessage({
+        id: 2,
+        role: "text_block",
+        content: "partial answer",
+        streamStatus: "recovered",
+      }),
+    ])
+
+    expect(streaming.at(-1)?.forkBoundaryId).toBeUndefined()
+    expect(interrupted.at(-1)?.forkBoundaryId).toBe(2)
   })
 
   test("only collapses duplicate startup recovery events within one user turn", () => {

--- a/src/components/chat/chatUtils.ts
+++ b/src/components/chat/chatUtils.ts
@@ -551,6 +551,9 @@ export function parseUserAttachmentsMeta(
         mimeType,
         sizeBytes: numberField(obj, "size", "sizeBytes"),
         kind: inferAttachmentKind(mimeType),
+        ...(stringField(obj, "source") === "pasted_text"
+          ? { semanticSource: "pasted_text" as const }
+          : {}),
         ...(localPath ? { localPath } : {}),
         ...(url ? { url } : {}),
       })
@@ -661,11 +664,15 @@ export function parseSessionMessages(
   const pendingTools: ToolCall[] = []
   const pendingBlocks: ContentBlock[] = []
   let pendingPersistenceRunId: string | undefined
+  let pendingForkBoundaryId: number | undefined
+  let pendingHasStreamingRow = false
   let firstUserSeen = false
   const seenPlainEventContentSinceLastUser = new Set<string>()
   for (const msg of msgs) {
     if (msg.role === "user") {
       pendingPersistenceRunId = undefined
+      pendingForkBoundaryId = undefined
+      pendingHasStreamingRow = false
       seenPlainEventContentSinceLastUser.clear()
       // Detect sub-agent result / cron trigger / plan trigger messages via attachments_meta marker
       let isSubagentResult = false
@@ -767,6 +774,8 @@ export function parseSessionMessages(
       })
     } else if (msg.role === "tool" && msg.toolCallId) {
       pendingPersistenceRunId ||= msg.persistenceRunId || undefined
+      pendingForkBoundaryId = msg.id
+      pendingHasStreamingRow ||= msg.streamStatus === "streaming"
       // Extract media info from tool results (for DB-loaded history):
       //   - image_generate still uses the old "Saved to:" text lines (mediaUrls)
       //   - send_attachment and future tools emit a `__MEDIA_ITEMS__<json>` header
@@ -833,6 +842,8 @@ export function parseSessionMessages(
       }
     } else if (msg.role === "thinking_block") {
       pendingPersistenceRunId ||= msg.persistenceRunId || undefined
+      pendingForkBoundaryId = msg.id
+      pendingHasStreamingRow ||= msg.streamStatus === "streaming"
       // Intermediate thinking emitted before tool calls — preserve multi-round thinking ordering
       if (msg.content) {
         const interrupted = isInterruptedStreamStatus(msg.streamStatus)
@@ -845,6 +856,8 @@ export function parseSessionMessages(
       }
     } else if (msg.role === "text_block") {
       pendingPersistenceRunId ||= msg.persistenceRunId || undefined
+      pendingForkBoundaryId = msg.id
+      pendingHasStreamingRow ||= msg.streamStatus === "streaming"
       // Intermediate text emitted before tool calls — preserve ordering
       if (msg.content) {
         const interrupted = isInterruptedStreamStatus(msg.streamStatus)
@@ -901,6 +914,8 @@ export function parseSessionMessages(
         ...(retrievalPlanner ? { retrievalPlanner } : {}),
       })
       pendingPersistenceRunId = undefined
+      pendingForkBoundaryId = undefined
+      pendingHasStreamingRow = false
     } else if (msg.role === "event") {
       let slashEvent: Message["slashEvent"] | undefined
       if (msg.attachmentsMeta) {
@@ -951,6 +966,7 @@ export function parseSessionMessages(
       toolCalls: pendingTools.length > 0 ? [...pendingTools] : undefined,
       timestamp: new Date().toISOString(),
       persistenceRunId: pendingPersistenceRunId,
+      forkBoundaryId: pendingHasStreamingRow ? undefined : pendingForkBoundaryId,
     })
   }
   return displayMessages

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -1150,6 +1150,13 @@ export function useChatStream({
 
       if (filesToSend.length > 64)
         throw new Error(t("attachments.tooMany", "A message can contain at most 64 files"))
+      const unavailable = filesToSend.find((draft) => draft.status === "error")
+      if (unavailable) {
+        throw new Error(
+          unavailable.error ||
+            t("attachments.uploadFailedShort", "Upload failed"),
+        )
+      }
       if (filesToSend.length > 0) {
         const filesystemConfig = await readFilesystemConfig(transport).catch(() => null)
         if (filesystemConfig) {

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -80,6 +80,7 @@ import {
   TOOL_JOB_STATUSES,
 } from "./asyncResultPayload"
 import { isQuickPromptEligibleUserMessage } from "../quick-prompts/messageQuickPrompts"
+import { isForkableConversationMessage } from "./messageFork"
 import { goalCompletionReportFromMessage, type GoalCompletionReport } from "./goalCompletionReport"
 import {
   requestMemoryFocus,
@@ -230,7 +231,7 @@ export interface MessageBubbleProps {
       | import("@/types/chat").FileChangesMetadata,
   ) => void
   onResume?: (message: string) => void
-  onForkFromMessage?: (messageId: number) => void
+  onForkFromMessage?: (message: Message) => void
   onOpenMemorySettings?: () => void
   onOpenKnowledge?: () => void
   displayMode?: ChatDisplayMode
@@ -1487,8 +1488,7 @@ function MessageBubbleInner({
     !!onForkFromMessage &&
     !!sessionId &&
     !loading &&
-    typeof msg.dbId === "number" &&
-    (msg.role === "user" || msg.role === "assistant")
+    isForkableConversationMessage(msg)
   const hasToolbarActions = hasTextContent || hasDetails || canAddQuickPrompt || canForkFromMessage
   // Always-visible total turn duration, shown at the message bottom once the
   // assistant turn has finished (the per-step / per-group times live above).
@@ -1587,7 +1587,7 @@ function MessageBubbleInner({
     <IconTip label={t("chat.fork.continueInNewSession", "Continue in new session")}>
       <button
         type="button"
-        onClick={() => onForkFromMessage?.(msg.dbId!)}
+        onClick={() => onForkFromMessage?.(msg)}
         className={toolbarButtonClass}
       >
         <GitFork className="h-3.5 w-3.5" />

--- a/src/components/chat/message/messageFork.test.ts
+++ b/src/components/chat/message/messageFork.test.ts
@@ -131,6 +131,48 @@ describe("message fork semantics", () => {
     ])
   })
 
+  test("keeps the fork draft when one copied file cannot be restored", async () => {
+    setTransport({
+      resolveMediaUrl: (item: MediaItem) => item.url || null,
+    } as unknown as Transport)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) =>
+        url.includes("available.png")
+          ? new Response(new Blob(["image bytes"], { type: "image/png" }))
+          : new Response("unavailable", { status: 503 }),
+      ),
+    )
+    const message: Message = { role: "user", content: "revise this", dbId: 47 }
+    const forked = {
+      id: "fork-2",
+      draftAttachmentsMeta: JSON.stringify([
+        {
+          name: "available.png",
+          mime_type: "image/png",
+          size: 11,
+          url: "/api/attachments/fork-2/available.png",
+        },
+        {
+          name: "missing.png",
+          mime_type: "image/png",
+          size: 12,
+          url: "/api/attachments/fork-2/missing.png",
+        },
+      ]),
+    } as ForkSessionResult
+
+    const draft = await forkComposerDraftForMessage(message, forked)
+
+    expect(draft?.attachedFiles).toHaveLength(2)
+    expect(draft?.attachedFiles[0]).toMatchObject({ status: "ready" })
+    expect(draft?.attachedFiles[1]).toMatchObject({
+      status: "error",
+      error: "Failed to restore fork attachment: missing.png",
+    })
+    expect(draft?.attachedFiles[1]?.file.name).toBe("missing.png")
+  })
+
   test("rejects in-progress replies and internal user-shaped messages", () => {
     expect(
       isForkableConversationMessage({ role: "assistant", content: "streaming" }),

--- a/src/components/chat/message/messageFork.test.ts
+++ b/src/components/chat/message/messageFork.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import type { Transport } from "@/lib/transport"
+import { setTransport } from "@/lib/transport-provider"
+import type { ForkSessionResult, MediaItem, Message } from "@/types/chat"
+
+import {
+  forkComposerDraftForMessage,
+  forkComposerTextForMessage,
+  forkSessionRequestForMessage,
+  isForkableConversationMessage,
+} from "./messageFork"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("message fork semantics", () => {
+  test("includes a completed assistant reply in the fork", () => {
+    const message: Message = { role: "assistant", content: "answer", dbId: 42 }
+
+    expect(isForkableConversationMessage(message)).toBe(true)
+    expect(forkSessionRequestForMessage("session-1", message)).toEqual({
+      sessionId: "session-1",
+      messageId: 42,
+    })
+    expect(forkComposerTextForMessage(message)).toBeNull()
+  })
+
+  test("includes a terminated assistant checkpoint without a final assistant row", () => {
+    const message: Message = {
+      role: "assistant",
+      content: "",
+      contentBlocks: [{ type: "text", content: "partial answer", interrupted: true }],
+      forkBoundaryId: 41,
+    }
+
+    expect(isForkableConversationMessage(message)).toBe(true)
+    expect(forkSessionRequestForMessage("session-1", message)).toEqual({
+      sessionId: "session-1",
+      messageId: 41,
+    })
+  })
+
+  test("forks before a user prompt and returns it for composer editing", () => {
+    const message: Message = { role: "user", content: "try another direction", dbId: 43 }
+
+    expect(isForkableConversationMessage(message)).toBe(true)
+    expect(forkSessionRequestForMessage("session-1", message)).toEqual({
+      sessionId: "session-1",
+      beforeMessageId: 43,
+    })
+    expect(forkComposerTextForMessage(message)).toBe("try another direction")
+  })
+
+  test("offers fork for an attachment-only human prompt", () => {
+    const message: Message = {
+      role: "user",
+      content: "",
+      dbId: 44,
+      attachments: [
+        {
+          name: "reference.png",
+          mimeType: "image/png",
+          sizeBytes: 123,
+          kind: "image",
+          url: "/api/attachments/source/reference.png",
+        },
+      ],
+    }
+
+    expect(isForkableConversationMessage(message)).toBe(true)
+    expect(forkSessionRequestForMessage("session-1", message)).toEqual({
+      sessionId: "session-1",
+      beforeMessageId: 44,
+    })
+  })
+
+  test("restores copied files and quotes into the new composer draft", async () => {
+    setTransport({
+      resolveMediaUrl: (item: MediaItem) => item.url || null,
+    } as unknown as Transport)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(new Blob(["image bytes"], { type: "image/png" }))),
+    )
+    const message: Message = { role: "user", content: "revise this", dbId: 46 }
+    const forked = {
+      id: "fork-1",
+      draftAttachmentsMeta: JSON.stringify([
+        {
+          name: "reference.png",
+          mime_type: "image/png",
+          size: 11,
+          source: "upload",
+          url: "/api/attachments/fork-1/reference.png",
+        },
+        {
+          kind: "quote",
+          name: "brief.md",
+          path: "brief.md",
+          lines: "3-5",
+          content: "quoted lines",
+        },
+        {
+          kind: "message_quote",
+          role: "assistant",
+          content: "quoted answer",
+        },
+      ]),
+    } as ForkSessionResult
+
+    const draft = await forkComposerDraftForMessage(message, forked)
+
+    expect(draft?.text).toBe("revise this")
+    expect(draft?.attachedFiles[0]?.file).toMatchObject({
+      name: "reference.png",
+      type: "image/png",
+    })
+    expect(draft?.pendingQuotes).toEqual([
+      {
+        path: "brief.md",
+        name: "brief.md",
+        startLine: 3,
+        endLine: 5,
+        content: "quoted lines",
+      },
+    ])
+    expect(draft?.pendingMessageQuotes).toEqual([
+      { role: "assistant", content: "quoted answer" },
+    ])
+  })
+
+  test("rejects in-progress replies and internal user-shaped messages", () => {
+    expect(
+      isForkableConversationMessage({ role: "assistant", content: "streaming" }),
+    ).toBe(false)
+    expect(
+      isForkableConversationMessage({
+        role: "user",
+        content: "execute plan",
+        dbId: 45,
+        isPlanTrigger: true,
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/components/chat/message/messageFork.ts
+++ b/src/components/chat/message/messageFork.ts
@@ -1,0 +1,150 @@
+import type {
+  ForkSessionResult,
+  MediaItem,
+  Message,
+  MessageAttachment,
+  PendingFileQuote,
+  PendingMessageQuote,
+} from "@/types/chat"
+import { getTransport } from "@/lib/transport-provider"
+import {
+  createDraftAttachment,
+  type DraftAttachment,
+} from "@/components/chat/files/types"
+import { parseUserAttachmentsMeta } from "../chatUtils"
+
+import { isHumanAuthoredUserMessage } from "../quick-prompts/messageQuickPrompts"
+
+export type ForkSessionRequest =
+  | { sessionId: string; messageId: number }
+  | { sessionId: string; beforeMessageId: number }
+
+export interface ForkComposerDraft {
+  text: string
+  attachedFiles: DraftAttachment[]
+  pendingQuotes: PendingFileQuote[]
+  pendingMessageQuotes: PendingMessageQuote[]
+}
+
+/**
+ * A finalized assistant row or a settled interrupted checkpoint is forkable.
+ * Human-authored user rows are also forkable, but internal/user-shaped
+ * protocol messages are not.
+ */
+export function isForkableConversationMessage(msg: Message): boolean {
+  if (msg.role === "assistant") {
+    return typeof (msg.dbId ?? msg.forkBoundaryId) === "number"
+  }
+  return (
+    typeof msg.dbId === "number" &&
+    isHumanAuthoredUserMessage(msg) &&
+    (msg.content.trim().length > 0 || (msg.attachments?.length ?? 0) > 0)
+  )
+}
+
+/**
+ * Assistant forks include the completed reply. User forks stop immediately
+ * before the selected prompt so the prompt can be edited in the new composer.
+ */
+export function forkSessionRequestForMessage(
+  sessionId: string,
+  msg: Message,
+): ForkSessionRequest | null {
+  if (!isForkableConversationMessage(msg)) return null
+  return msg.role === "user"
+    ? { sessionId, beforeMessageId: msg.dbId! }
+    : { sessionId, messageId: (msg.dbId ?? msg.forkBoundaryId)! }
+}
+
+export function forkComposerTextForMessage(msg: Message): string | null {
+  return msg.role === "user" ? msg.content : null
+}
+
+function mediaItemFromAttachment(attachment: MessageAttachment): MediaItem {
+  return {
+    url: attachment.url ?? "",
+    ...(attachment.localPath ? { localPath: attachment.localPath } : {}),
+    name: attachment.name,
+    mimeType: attachment.mimeType,
+    sizeBytes: attachment.sizeBytes,
+    kind: attachment.kind === "image" ? "image" : "file",
+  }
+}
+
+function parseQuoteRange(lines: string | undefined): { start: number; end: number } {
+  const match = lines?.trim().match(/^(\d+)(?:-(\d+))?$/)
+  if (!match) return { start: 1, end: 1 }
+  const start = Math.max(1, Number(match[1]))
+  const end = Math.max(start, Number(match[2] ?? match[1]))
+  return { start, end }
+}
+
+async function restoreFileAttachment(attachment: MessageAttachment): Promise<DraftAttachment> {
+  const url = getTransport().resolveMediaUrl(mediaItemFromAttachment(attachment))
+  if (!url) throw new Error(`Fork attachment is unavailable: ${attachment.name}`)
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to restore fork attachment: ${attachment.name}`)
+  }
+  const blob = await response.blob()
+  const file = new File([blob], attachment.name, {
+    type: attachment.mimeType || blob.type || "application/octet-stream",
+  })
+  return createDraftAttachment(
+    file,
+    "picker",
+    attachment.semanticSource === "pasted_text" ? "pasted_text" : "upload",
+  )
+}
+
+/** Rebuild the selected user prompt as a real composer draft. File metadata in
+ * the fork response points at copies owned by the new session, so loading it
+ * cannot make the draft depend on the source session's attachment directory. */
+export async function forkComposerDraftForMessage(
+  msg: Message,
+  forked: ForkSessionResult,
+): Promise<ForkComposerDraft | null> {
+  if (msg.role !== "user") return null
+  const attachments = parseUserAttachmentsMeta(forked.draftAttachmentsMeta)
+  const attachedFiles = await Promise.all(
+    (attachments ?? [])
+      .filter(
+        (attachment): attachment is MessageAttachment & { kind: "file" | "image" } =>
+          attachment.kind === "file" || attachment.kind === "image",
+      )
+      .map(restoreFileAttachment),
+  )
+  const pendingQuotes = (attachments ?? []).flatMap((attachment): PendingFileQuote[] => {
+    if (
+      attachment.kind !== "quote" ||
+      !attachment.quotePath ||
+      attachment.quoteContent == null
+    ) {
+      return []
+    }
+    const range = parseQuoteRange(attachment.quoteLines)
+    return [
+      {
+        path: attachment.quotePath,
+        name: attachment.name,
+        startLine: range.start,
+        endLine: range.end,
+        content: attachment.quoteContent,
+      },
+    ]
+  })
+  const pendingMessageQuotes = (attachments ?? []).flatMap(
+    (attachment): PendingMessageQuote[] =>
+      attachment.kind === "message_quote" &&
+      attachment.messageQuoteRole &&
+      attachment.quoteContent != null
+        ? [{ role: attachment.messageQuoteRole, content: attachment.quoteContent }]
+        : [],
+  )
+  return {
+    text: msg.content,
+    attachedFiles,
+    pendingQuotes,
+    pendingMessageQuotes,
+  }
+}

--- a/src/components/chat/message/messageFork.ts
+++ b/src/components/chat/message/messageFork.ts
@@ -97,6 +97,30 @@ async function restoreFileAttachment(attachment: MessageAttachment): Promise<Dra
   )
 }
 
+async function restoreFileAttachmentOrError(
+  attachment: MessageAttachment,
+): Promise<DraftAttachment> {
+  try {
+    return await restoreFileAttachment(attachment)
+  } catch (error) {
+    const draft = createDraftAttachment(
+      new File([], attachment.name, {
+        type: attachment.mimeType || "application/octet-stream",
+      }),
+      "picker",
+      attachment.semanticSource === "pasted_text" ? "pasted_text" : "upload",
+    )
+    return {
+      ...draft,
+      status: "error",
+      error:
+        error instanceof Error && error.message
+          ? error.message
+          : `Failed to restore fork attachment: ${attachment.name}`,
+    }
+  }
+}
+
 /** Rebuild the selected user prompt as a real composer draft. File metadata in
  * the fork response points at copies owned by the new session, so loading it
  * cannot make the draft depend on the source session's attachment directory. */
@@ -112,7 +136,7 @@ export async function forkComposerDraftForMessage(
         (attachment): attachment is MessageAttachment & { kind: "file" | "image" } =>
           attachment.kind === "file" || attachment.kind === "image",
       )
-      .map(restoreFileAttachment),
+      .map(restoreFileAttachmentOrError),
   )
   const pendingQuotes = (attachments ?? []).flatMap((attachment): PendingFileQuote[] => {
     if (

--- a/src/components/chat/quick-prompts/messageQuickPrompts.ts
+++ b/src/components/chat/quick-prompts/messageQuickPrompts.ts
@@ -1,6 +1,6 @@
 import type { Message } from "@/types/chat"
 
-export function isQuickPromptEligibleUserMessage(msg: Message): boolean {
+export function isHumanAuthoredUserMessage(msg: Message): boolean {
   return (
     msg.role === "user" &&
     !msg.fromAgentId &&
@@ -13,9 +13,12 @@ export function isQuickPromptEligibleUserMessage(msg: Message): boolean {
     !msg.planComment &&
     !msg.isMeta &&
     !msg.slashEvent &&
-    !msg.channelInbound &&
-    msg.content.trim().length > 0
+    !msg.channelInbound
   )
+}
+
+export function isQuickPromptEligibleUserMessage(msg: Message): boolean {
+  return isHumanAuthoredUserMessage(msg) && msg.content.trim().length > 0
 }
 
 export function recentUserInputHistory(messages: Message[], limit = 50): string[] {

--- a/src/components/design/chat/DesignChatPanel.tsx
+++ b/src/components/design/chat/DesignChatPanel.tsx
@@ -42,7 +42,17 @@ import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import type { ChatAttachment } from "@/lib/transport"
 import { createDraftAttachment } from "@/components/chat/files/types"
-import type { ActiveModel, Message, PendingFileQuote } from "@/types/chat"
+import {
+  forkComposerDraftForMessage,
+  forkSessionRequestForMessage,
+  type ForkComposerDraft,
+} from "@/components/chat/message/messageFork"
+import type {
+  ActiveModel,
+  ForkSessionResult,
+  Message,
+  PendingFileQuote,
+} from "@/types/chat"
 import type { DesignRecipe } from "@/types/design"
 import { useDesignChat } from "./useDesignChat"
 import { DesignConversationHistory } from "./DesignConversationHistory"
@@ -340,6 +350,28 @@ export const DesignChatPanel = forwardRef<DesignChatPanelHandle, Props>(function
     draftDesignProjectId: projectId,
     getExtraAttachments,
   })
+  const [composerFocusSignal, setComposerFocusSignal] = useState<number | undefined>(undefined)
+  const pendingForkComposerRef = useRef<{
+    sessionId: string
+    draft: ForkComposerDraft
+  } | null>(null)
+
+  useEffect(() => {
+    const pending = pendingForkComposerRef.current
+    if (!pending || session.currentSessionId !== pending.sessionId) return
+    pendingForkComposerRef.current = null
+    stream.setInput(pending.draft.text)
+    stream.setAttachedFiles(pending.draft.attachedFiles)
+    stream.setPendingQuotes(pending.draft.pendingQuotes)
+    stream.setPendingMessageQuotes(pending.draft.pendingMessageQuotes)
+    setComposerFocusSignal((value) => (value ?? 0) + 1)
+  }, [
+    session.currentSessionId,
+    stream.setAttachedFiles,
+    stream.setInput,
+    stream.setPendingMessageQuotes,
+    stream.setPendingQuotes,
+  ])
 
   // Live streaming flag for the imperative submitPrompt guard (avoid firing a
   // second turn while one is in flight) without rebuilding the handle each tick.
@@ -490,18 +522,23 @@ export const DesignChatPanel = forwardRef<DesignChatPanelHandle, Props>(function
   // 拒进行中流式 / 边界裁剪），产物仍是本项目的设计线程（后端补建 design_chat_threads 锚点）。
   // 切到新线程继续探索另一方向而不丢原线。交互与普通对话「消息下方 fork」一致。
   const handleForkFromMessage = useCallback(
-    async (messageId: number) => {
+    async (message: Message) => {
       const sid = session.currentSessionId
       if (!sid) return
+      const request = forkSessionRequestForMessage(sid, message)
+      if (!request) return
       try {
-        const forked = await getTransport().call<{ id: string }>("fork_session_cmd", {
-          sessionId: sid,
-          messageId,
+        const forked = await getTransport().call<ForkSessionResult>("fork_session_cmd", {
+          ...request,
         })
+        const composerDraft = await forkComposerDraftForMessage(message, forked)
         await session.reloadThreads()
+        pendingForkComposerRef.current =
+          composerDraft == null ? null : { sessionId: forked.id, draft: composerDraft }
         await session.switchThread(forked.id)
         toast.success(t("design.chat.forked", "已分支为新对话"))
       } catch (e) {
+        pendingForkComposerRef.current = null
         logger.error("design", "DesignChatPanel", "fork failed", e)
         toast.error(
           e instanceof Error && e.message ? e.message : t("design.chat.forkFailed", "分支失败"),
@@ -786,6 +823,7 @@ export const DesignChatPanel = forwardRef<DesignChatPanelHandle, Props>(function
             stream.setPendingQuotes((prev) => prev.filter((_, idx) => idx !== i))
           }
           onJumpToQuote={onJumpToQuote}
+          focusSignal={composerFocusSignal}
           pendingMessage={stream.pendingMessage}
           onCancelPending={() => stream.setPendingMessage(null)}
           // 生成中排队多条：接内核已有 pendingSends 队列 UI（逐条编辑/删除/工具边界 force-insert 插队），

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -95,6 +95,8 @@ export interface MessageAttachment {
   localPath?: string
   url?: string
   previewUrl?: string
+  /** Original composer semantics for persisted user files. */
+  semanticSource?: "upload" | "pasted_text"
   /** For `kind === "quote"` (file-browser "quote to chat"): referenced path,
    *  1-based line range (e.g. "12-20"), and the quoted snippet. */
   quotePath?: string
@@ -368,6 +370,9 @@ export interface Message {
   }
   /** Database row ID, used for deduplication during streaming append */
   dbId?: number
+  /** Last persisted row that may be used as an inclusive fork boundary when
+   *  an interrupted assistant turn has blocks but no final assistant row. */
+  forkBoundaryId?: number
   /** Durable run which owns this canonical/checkpoint projection. Used only
    *  by the reload handshake to replace an in-flight projection idempotently. */
   persistenceRunId?: string
@@ -587,6 +592,12 @@ export interface SessionMeta {
   } | null
   /** Dedicated spaces use non-regular kinds and never enter regular unread. */
   kind?: "regular" | "knowledge" | "design" | "eval_fixture" | string
+}
+
+/** Fork responses remain SessionMeta-compatible and optionally carry the
+ * selected user prompt's attachments, already copied into the new session. */
+export interface ForkSessionResult extends SessionMeta {
+  draftAttachmentsMeta?: string | null
 }
 
 export interface UnreadSessionTarget {


### PR DESCRIPTION
## What changed

- Show Fork on completed or terminated assistant responses and fork through the selected assistant boundary.
- Fork user messages before the selected prompt, then restore the prompt into the new composer.
- Preserve uploaded/pasted files, file quotes, and message quotes by copying attachment files into the forked session before restoring the draft.
- Normalize copied `orphaned` assistant rows to `recovered`.
- Return HTTP 400 when `messageId` and `beforeMessageId` are supplied together.
- Keep Tauri/HTTP adapters and architecture documentation in sync.

## Why

Fork was also appearing on user messages, but the previous behavior copied that prompt into history instead of making it editable. Terminated assistant turns also lacked a stable fork boundary, and user-message forks could silently drop attachments.

## User impact

Users can branch from a completed or terminated response, or branch before any ordinary user prompt and immediately edit/resend the full original draft without losing its attachments.

## Root cause

The UI only passed an inclusive database message ID to the backend. Synthetic interrupted assistant projections did not retain their persisted boundary, while user prompts had no exclusive-boundary API or attachment handoff into the new composer.

## Validation

- `pnpm typecheck`
- `pnpm test` — 205 files, 1072 tests passed
- `pnpm exec vitest run src/components/chat/message/messageFork.test.ts` — 6 tests passed
- `cargo check -p ha-core`
- `cargo check -p ha-server`
- `cargo test -p ha-core fork_session` — 8 tests passed
- `TAURI_CONFIG='{"bundle":{"externalBin":[],"resources":[]}}' cargo check -p hope-agent`
- `cargo fmt --all -- --check`
- `git diff --check`