### PR TITLE
ci(release): 显式安装 xdg-utils 修复 arm64 AppImage 打包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,11 @@ jobs:
       # xcap (screen capture) needs the full Wayland screenshot stack:
       # libpipewire-0.3-dev, libgbm-dev, libegl-dev, libwayland-dev
       # (otherwise `-lgbm` link-step fails).
+      # xdg-utils supplies /usr/bin/xdg-mime, which the AppImage bundler shells
+      # out to. It ships preinstalled on the x64 runner image but NOT on
+      # ubuntu-24.04-arm — v0.24.0's first arm64 leg died with "xdg-mime binary
+      # not found" after the .deb / .rpm had already bundled, losing every arm64
+      # Linux asset. Install it explicitly so neither lane depends on image drift.
       - name: Install Linux build deps
         if: runner.os == 'Linux'
         run: |
@@ -159,6 +164,7 @@ jobs:
             libegl-dev \
             libwayland-dev \
             patchelf \
+            xdg-utils \
             mold
           # mold 加速 Linux 桌面 bundle 链接（仅本 Linux leg 生效）。WebKit2GTK
           # 链接量大，已由 release dry-run 验证；若与某 -sys crate 链接脚本冲突，


### PR DESCRIPTION
## 背景

v0.24.0 首次发版流水线（[run 30265914715](https://github.com/shiwenwen/hope-agent/actions/runs/30265914715)）的 `build (linux-arm64)` 失败：

```
Bundling Hope Agent_0.24.0_aarch64.AppImage
failed to bundle project xdg-mime binary not found /usr/bin/xdg-mime: No such file or directory (os error 2)
```

`.deb` 与 `.rpm` 都已打包完成，卡在其后的 AppImage 步骤，job 失败导致该平台**全部**资产（deb / rpm / tar.gz / AppImage）都没上传，arm64 Linux 用户既拿不到安装包也无法自升级。

`xdg-utils` 在 x64 runner 镜像里预装、在 `ubuntu-24.04-arm` 上没有，所以只有 arm64 暴露。两天前 v0.23.0 在同一 runner 标签上还能产出 `Hope.Agent_0.23.0_aarch64.AppImage`，属镜像漂移而非本仓改动引入。

## 改动

Linux 构建依赖显式加 `xdg-utils`，两条 lane 都不再依赖镜像预装。

## 验证

- `pnpm check:release-paths` 通过（唯一 warning 为既有的 macos-x64 已下线项）
- 不需要 dry-run：改动只是 apt 依赖列表，未触及 bundle path / matrix / `beforeBuildCommand`