### PR TITLE
perf(release): macOS lane codegen-units 4 → 16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,11 @@ jobs:
             os: macos-14
             rust_target: aarch64-apple-darwin
             args: "--target aarch64-apple-darwin"
-            # 这条 lane 是整个 release 的关键路径：v0.20.1 实测 147 分钟，其余
-            # lane 66 / 67 / 100，总时长完全由它决定。macos-14 只有 3 核，
-            # codegen-units=1 又恰好掐掉唯一能吃满多核的阶段。取 4 而非 arm64
-            # Linux 的 16：3 核上 4 块已够并行，优化损失（跨块内联失效）远小于
-            # 16，lto="thin" 还能补回一部分。与 linux-arm64 不同，这里不是 OOM
-            # 规避而是纯提速——该 lane 未出现过 runner 杀进程。
-            codegen_units: "4"
+            # 关键路径 lane（macos-14 只有 3 核）。纯提速，非 OOM 规避。
+            # 4 → 16（v0.24.0）：ha-core 增 4710 行后本 lane 从 98 涨到 152 /
+            # 173 分钟。dry-run 实测 16 档为 103 分钟，代价是裸二进制
+            # 192.4 → 225.3 MB，用户实际下载的压缩包 84.8 → 95.3 MB（+12%）。
+            codegen_units: "16"
           # macOS x64 lane remains disabled (since v0.2.0). GitHub-hosted
           # macos-13 Intel runners are capacity-constrained and frequently
           # queue >1h. An earlier v0.2.1 attempt to re-add this lane with


### PR DESCRIPTION
## 问题

`macos-arm64` 是 release 的关键路径。v0.24.0 给 ha-core 加了 4710 行后，该 lane 耗时翻倍，其余 lane 基本不动：

| lane | v0.22.0 | v0.23.0 | v0.24.0 |
|---|---|---|---|
| linux-x64 | 78 | 84 | 86 / 80 |
| linux-arm64 | 75 | 89 | 86 / 86 |
| windows-x64 | 108 | 114 | 124 / 95 |
| **macos-arm64** | 108 | 98 | **152 / 173** |

（v0.24.0 一列是同一 tag 连跑两次的两个样本。）

## 改动

`codegen_units` 4 → 16，与 linux-arm64 取同一档位。

## dry-run 实测（[run 30323676384](https://github.com/shiwenwen/hope-agent/actions/runs/30323676384)，success）

| | cu=4（已发布 v0.24.0） | cu=16（本 PR） | 差 |
|---|---|---|---|
| macos-arm64 构建 | 152 / 173 min | **103 min** | **−40%** |
| 用户下载的压缩包 | 84.8 MB | **95.3 MB** | **+10.5 MB / +12%** |
| 裸二进制 | 192.4 MB | 225.3 MB | +32.9 MB / +17% |

- 构建时间基本回到 ha-core 变大之前的 98 分钟水平
- 未改配置的三条 lane 落在噪声区间内（linux 85 / 88，windows 108），符合预期

## 待定

省 70 分钟 CI 换每个 macOS 用户每次更新多下 10.5 MB，是否值得需要拍板。若嫌代价大，可改试 cu=8（需再跑一次 dry-run 约 2 小时）。