### PR TITLE
perf(release): eval-sidecar profile codegen-units 1 → 16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,14 +172,21 @@ strip = "symbols"
 
 # The desktop bundle carries `hope-agent-eval` as an isolated Sidecar.  It
 # links ha-core for registered evaluators, while the latency-sensitive Agent
-# itself runs in the separately packaged Hope product binary.  Whole-program
-# size optimization therefore removes otherwise retained ha-core code without
-# slowing the product binary or changing the normal release/CI profile.
+# itself runs in the separately packaged Hope product binary.  `opt-level="z"`
+# therefore stays: the sidecar ships inside the bundle, so its size is part of
+# every user's download.
+#
+# codegen-units 1 → 16（v0.24.0）：本 profile 编译的是 ha-eval，而它依赖
+# ha-core，所以发版每条 lane 都要把 ha-core 整个再编一遍——macOS 实测 27 分钟，
+# 且设置与主构建的 release profile 不同、无法复用产物。保留 lto="fat"：DCE 靠
+# 它，实测改 thin 会让 sidecar 从 26.2 涨到 38.8 MB，而 sidecar 是 externalBin、
+# 计入每个平台的下载包。放宽 codegen-units 只影响 LTO 后的机器码分块，不削弱
+# 全程序优化。
 [profile.eval-sidecar]
 inherits = "release"
 opt-level = "z"
 lto = "fat"
-codegen-units = 1
+codegen-units = 16
 panic = "abort"
 strip = "symbols"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,10 +178,10 @@ strip = "symbols"
 #
 # codegen-units 1 → 16（v0.24.0）：本 profile 编译的是 ha-eval，而它依赖
 # ha-core，所以发版每条 lane 都要把 ha-core 整个再编一遍——macOS 实测 27 分钟，
-# 且设置与主构建的 release profile 不同、无法复用产物。保留 lto="fat"：DCE 靠
-# 它，实测改 thin 会让 sidecar 从 26.2 涨到 38.8 MB，而 sidecar 是 externalBin、
-# 计入每个平台的下载包。放宽 codegen-units 只影响 LTO 后的机器码分块，不削弱
-# 全程序优化。
+# 且设置与主构建的 release profile 不同、无法复用产物。dry-run 实测该阶段
+# 27 → 19 分钟，sidecar 26.2 → 27.9 MB。保留 lto="fat"：DCE 靠它，实测改 thin
+# 虽更快但 sidecar 涨到 38.8 MB（+48%），而 sidecar 是 externalBin、计入每个
+# 平台的下载包，不值得。
 [profile.eval-sidecar]
 inherits = "release"
 opt-level = "z"

--- a/docs/architecture/live-model-evaluation.md
+++ b/docs/architecture/live-model-evaluation.md
@@ -594,4 +594,4 @@ commit SHA 是比较轴，不进入功能 compatibility key。trial seed 因包�
 - 同一 request/资产/runtime/model 生成稳定 plan/digest；本地 App evidence 必须保持 local source，不能通过保留的 release verifier。
 - 比较测试必须覆盖“不同 commit → seed 不同但逻辑 trial identity 相同”，预算测试必须覆盖小于模型数时拒绝且任何切分不增加总量。
 - `cargo test -p ha-core -p ha-server --locked` 仍不链接/运行完整 Runner；普通 PR 和 GitHub Actions 不运行 fake smoke，也不配置 Provider Key。需要时在本地显式运行 smoke。
-- 三平台发布前测量 Sidecar 压缩增量；目标不超过 35 MB。打包脚本使用独立 `eval-sidecar` profile（size opt、fat LTO、单 codegen unit、strip、panic abort）；panic 只终止隔离 Sidecar/worker，不改变产品 Agent 的 unwind 策略。超出时继续做依赖裁剪，不能降级为不校验的在线下载。
+- 三平台发布前测量 Sidecar 压缩增量；目标不超过 35 MB。打包脚本使用独立 `eval-sidecar` profile（size opt、fat LTO、16 codegen units、strip、panic abort；体积靠 fat LTO 的全程序 DCE，codegen units 只影响 LTO 后的机器码分块与发版构建耗时）；panic 只终止隔离 Sidecar/worker，不改变产品 Agent 的 unwind 策略。超出时继续做依赖裁剪，不能降级为不校验的在线下载。


### PR DESCRIPTION
## 背景

`hope-agent-eval` 作为 `externalBin` 打进 App bundle，所以发版每条 lane 都要先 `cargo build -p ha-eval --profile eval-sidecar`。而 ha-eval 依赖 ha-core，于是每条 lane 都用最贵的档位把 ha-core 整个再编一遍。这 27 分钟不受 release.yml 里 `CARGO_PROFILE_RELEASE_CODEGEN_UNITS` 影响——那个 env 只覆盖 `profile.release`，本 profile 在 Cargo.toml 里写死 `codegen-units = 1`。

## 改动

`codegen-units` 1 → 16。保留 `lto = "fat"` 与 `opt-level = "z"`。

## dry-run 实测（[run 30340121448](https://github.com/shiwenwen/hope-agent/actions/runs/30340121448)，success）

macOS lane 相位拆解：

| 阶段 | 改前 | 改后 |
|---|---|---|
| `prepare:browser-host` | 13 秒 | 13 秒 |
| **`prepare:eval-sidecar`** | **27 min** | **19 min** |
| vite | 1.4 min | 0.9 min |
| 主 tauri build | 72 min | 66.5 min（同配置，噪声） |
| **lane 合计** | **103 min** | **89 min** |

体积（本地同机对比）：

| 档位 | sidecar 裸体积 |
|---|---|
| fat + cu=1（现状） | 26.2 MB |
| **fat + cu=16（本 PR）** | **27.9 MB（+1.7 / +6.5%）** |
| thin + cu=16（未采用） | 38.8 MB（+12.6 / +48%） |

## 为什么不进一步改 lto=thin

thin 预计能把该阶段再压到 8–10 分钟，但 sidecar 涨 12.6 MB。为再省约 11 分钟让每个平台的用户每次更新多下约 5 MB（压缩后），交换比不划算。

## 说明

这 8 分钟不是大头。真正的浪费是发版构建 **100% 冷编译**——两次发版的 rust-cache 输出都是 `No cache found.`，10 GB 缓存预算被 rust.yml 的 clippy / test 缓存占满（17 条，release lane 0 条），几百个未变动的第三方 crate 每次重编。那件事单独处理。