### PR TITLE
fix design media generation and pet transparency

### DIFF
--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -6,7 +6,16 @@
   var dark =
     t === "dark" ||
     (t === "auto" && window.matchMedia("(prefers-color-scheme: dark)").matches)
+  var transparentWindow =
+    new URLSearchParams(window.location.search).get("window") === "pet"
   if (dark) document.documentElement.classList.add("dark")
-  document.documentElement.style.backgroundColor = dark ? "#0f0f0f" : "#ffffff"
+  // PetWindow is a transparent overlay. Seeding its root canvas with the
+  // normal opaque theme color would override the later `bg-transparent`
+  // utility because inline styles win the cascade.
+  document.documentElement.style.backgroundColor = transparentWindow
+    ? "transparent"
+    : dark
+      ? "#0f0f0f"
+      : "#ffffff"
   document.documentElement.style.colorScheme = dark ? "dark" : "light"
 })()

--- a/src/components/design/DesignView.tsx
+++ b/src/components/design/DesignView.tsx
@@ -6292,6 +6292,7 @@ export default function DesignView({
         kind={homeMediaGenKind}
         initialPrompt={homePrompt}
         allowEmptyPrompt={homeRefImages.length > 0}
+        referenceImageCount={homeRefImages.length}
         onClose={() => setHomeMediaGenOpen(false)}
         onConfirm={confirmHomeMediaGenerate}
         busy={generatingHome}

--- a/src/components/design/DesignView.tsx
+++ b/src/components/design/DesignView.tsx
@@ -1947,75 +1947,116 @@ export default function DesignView({
   // 后端按 (id, kind) 匹配、不匹配即回退，故换 kind 无需清空。
   const [homeRecipeId, setHomeRecipeId] = useState<string | null>(null)
   const [generatingHome, setGeneratingHome] = useState(false)
+  // image / audio 在首屏也先过能力驱动的媒体对话框：无可用模型时给配置入口，
+  // 有模型时收集该模型支持的参数，避免直接建项目后同步失败。
+  const [homeMediaGenOpen, setHomeMediaGenOpen] = useState(false)
+  const [homeMediaGenKind, setHomeMediaGenKind] = useState<"image" | "audio">("image")
 
   // 首屏「一句话 → 生成」：建项目 → 带 prompt 建产物（后端一次模型生成完整自包含设计）→ 打开。
   // 需求补全交给设计 Agent 在对话里按需追问（ask_user_question 的 discovery / direction-cards），
   // 首屏只收一句话，不再叠加静态简报表单。
-  const generateFromHome = useCallback(async () => {
-    const base = homePrompt.trim()
-    // 有图无文也可生成（后端固定「照图复刻」指令）。
-    if ((!base && homeRefImages.length === 0) || generatingHome) return
-    const prompt = base
-    const systemId = homeSystemId ?? designConfig?.defaultSystemId ?? undefined
-    let createdProjectId: string | null = null
-    setGeneratingHome(true)
-    try {
-      const project = await tx.call<DesignProject>("create_design_project_cmd", {
-        input: {
-          title: base.slice(0, 40),
-          // 首页选的模型带入项目：作为项目对话的初始模型（会话内切换照常）。
-          defaultModel: genModel ?? undefined,
-        },
-      })
-      createdProjectId = project.id
-      // 首屏一句话 → 流式生成（返回 generating 壳，前端挂稳定 iframe 后逐帧灌入）。
-      // 带参考图时选中的视觉模型**直接看原图**（真多模态）。
-      const artifact = await tx.call<DesignArtifact>("generate_design_artifact_cmd", {
-        input: {
-          projectId: project.id,
-          title: kindLabel(homeKind),
-          kind: homeKind,
-          prompt: prompt || undefined,
-          systemId,
-          recipeId: homeRecipeId ?? undefined,
-          referenceImages: homeRefImages.map((i) => ({ b64: i.b64, mime: i.mime })),
-          modelOverride: genModel ?? undefined,
-        },
-      })
-      setHomePrompt("")
-      setHomeRecipeId(null)
-      setHomeRefImages([])
-      openProject(project)
-      if (artifact) void openArtifact(artifact)
-    } catch (e) {
-      logger.error("design", "DesignView::generateFromHome", "generate failed", e)
-      toast.error(t("design.err.create", "创建失败"))
-      // 回滚：产物没建成，删掉刚建的孤儿空项目（否则每次重试堆积隐藏空项目）。
-      if (createdProjectId) {
-        try {
-          await tx.call("delete_design_project_cmd", { id: createdProjectId })
-        } catch {
-          /* best effort */
+  const generateFromHome = useCallback(
+    async (
+      mediaPayload?: MediaGeneratePayload,
+      kindOverride?: "image" | "audio",
+    ): Promise<boolean> => {
+      const base = (mediaPayload?.prompt ?? homePrompt).trim()
+      const selectedKind = kindOverride ?? homeKind
+      const media = mediaPayload
+        ? {
+            aspectRatio: mediaPayload.aspectRatio,
+            imageSize: mediaPayload.imageSize,
+            imageResolution: mediaPayload.imageResolution,
+            audioKind: mediaPayload.audioKind,
+            audioVoice: mediaPayload.audioVoice,
+            audioDurationSecs: mediaPayload.audioDurationSecs,
+          }
+        : undefined
+      // 有图无文也可生成（后端固定「照图复刻」指令）。
+      if ((!base && homeRefImages.length === 0) || generatingHome) return false
+      const prompt = base
+      const systemId = homeSystemId ?? designConfig?.defaultSystemId ?? undefined
+      let createdProjectId: string | null = null
+      setGeneratingHome(true)
+      try {
+        const project = await tx.call<DesignProject>("create_design_project_cmd", {
+          input: {
+            title: base.slice(0, 40),
+            // 首页选的模型带入项目：作为项目对话的初始模型（会话内切换照常）。
+            defaultModel: genModel ?? undefined,
+          },
+        })
+        createdProjectId = project.id
+        // 首屏一句话 → 流式生成（返回 generating 壳，前端挂稳定 iframe 后逐帧灌入）。
+        // 带参考图时选中的视觉模型**直接看原图**（真多模态）。
+        const artifact = await tx.call<DesignArtifact>("generate_design_artifact_cmd", {
+          input: {
+            projectId: project.id,
+            title: kindLabel(selectedKind),
+            kind: selectedKind,
+            prompt: prompt || undefined,
+            systemId,
+            recipeId: homeRecipeId ?? undefined,
+            referenceImages: homeRefImages.map((i) => ({ b64: i.b64, mime: i.mime })),
+            modelOverride: genModel ?? undefined,
+            ...media,
+          },
+        })
+        setHomePrompt("")
+        setHomeRecipeId(null)
+        setHomeRefImages([])
+        openProject(project)
+        if (artifact) void openArtifact(artifact)
+        return true
+      } catch (e) {
+        logger.error("design", "DesignView::generateFromHome", "generate failed", e)
+        toast.error(t("design.err.create", "创建失败"))
+        // 回滚：产物没建成，删掉刚建的孤儿空项目（否则每次重试堆积隐藏空项目）。
+        if (createdProjectId) {
+          try {
+            await tx.call("delete_design_project_cmd", { id: createdProjectId })
+          } catch {
+            /* best effort */
+          }
         }
+        return false
+      } finally {
+        setGeneratingHome(false)
       }
-    } finally {
-      setGeneratingHome(false)
+    },
+    [
+      tx,
+      homePrompt,
+      homeKind,
+      homeSystemId,
+      homeRecipeId,
+      homeRefImages,
+      genModel,
+      generatingHome,
+      designConfig,
+      kindLabel,
+      openProject,
+      openArtifact,
+      t,
+    ],
+  )
+
+  const requestGenerateFromHome = useCallback(() => {
+    if (homeKind === "image" || homeKind === "audio") {
+      setHomeMediaGenKind(homeKind)
+      setHomeMediaGenOpen(true)
+      return
     }
-  }, [
-    tx,
-    homePrompt,
-    homeKind,
-    homeSystemId,
-    homeRecipeId,
-    homeRefImages,
-    genModel,
-    generatingHome,
-    designConfig,
-    kindLabel,
-    openProject,
-    openArtifact,
-    t,
-  ])
+    void generateFromHome()
+  }, [generateFromHome, homeKind])
+
+  const confirmHomeMediaGenerate = useCallback(
+    async (payload: MediaGeneratePayload) => {
+      const generated = await generateFromHome(payload, homeMediaGenKind)
+      if (generated) setHomeMediaGenOpen(false)
+    },
+    [generateFromHome, homeMediaGenKind],
+  )
 
   // 品牌包：一句话 → 建项目 → 批量生成一组共享系统的协调产物（形态由弹窗自选）。
   // 带参考图时每件产物都真看原图（N 件 = N 次带图视觉调用，用户主动选择）。
@@ -4834,7 +4875,7 @@ export default function DesignView({
           systemId={homeSystemId}
           setSystemId={setHomeSystemId}
           generating={generatingHome}
-          onGenerate={() => void generateFromHome()}
+          onGenerate={requestGenerateFromHome}
           onBrandPack={() => setBrandPackOpen(true)}
           kindLabel={kindLabel}
           refImages={homeRefImages}
@@ -6247,6 +6288,16 @@ export default function DesignView({
 
       {/* Image / audio 参数化生成对话框（能力驱动参数区 + 空态引导） */}
       <MediaGenerateDialog
+        open={homeMediaGenOpen}
+        kind={homeMediaGenKind}
+        initialPrompt={homePrompt}
+        allowEmptyPrompt={homeRefImages.length > 0}
+        onClose={() => setHomeMediaGenOpen(false)}
+        onConfirm={confirmHomeMediaGenerate}
+        busy={generatingHome}
+      />
+
+      <MediaGenerateDialog
         open={mediaGenOpen}
         kind={mediaGenKind}
         onClose={() => setMediaGenOpen(false)}
@@ -7529,7 +7580,7 @@ function LaunchHome({
                 </span>
               </Button>
               {/* 视觉模型 chip：prompt dock 工具栏 ghost action（已登记例外）；传图态只亮视觉模型。 */}
-              {models.length > 0 && (
+              {models.length > 0 && kind !== "image" && kind !== "audio" && (
                 <ModelSelector
                   value={genModel ? `${genModel.providerId}::${genModel.modelId}` : ""}
                   onChange={onModelChange}

--- a/src/components/design/MediaGenerateDialog.logic.ts
+++ b/src/components/design/MediaGenerateDialog.logic.ts
@@ -1,0 +1,31 @@
+import type {
+  ImageEditCaps,
+  ImageModelCaps,
+  MediaAudioKind,
+  MediaCandidateOverview,
+} from "@/components/settings/media-gen/types"
+
+export function inferAudioKindFromPrompt(prompt: string): MediaAudioKind | null {
+  const lead = prompt.trimStart().toLowerCase()
+  return lead.startsWith("[music]") ? "music" : lead.startsWith("[sfx]") ? "sfx" : null
+}
+
+export function resolveImageRequestCapability(
+  candidates: MediaCandidateOverview[],
+  referenceImageCount: number,
+): {
+  candidate: MediaCandidateOverview | null
+  caps: ImageModelCaps | ImageEditCaps | null
+} {
+  if (referenceImageCount <= 0) {
+    const candidate = candidates[0] ?? null
+    return { candidate, caps: candidate?.image ?? null }
+  }
+
+  const candidate =
+    candidates.find((item) => {
+      const edit = item.image?.edit
+      return edit != null && edit.maxInputImages >= referenceImageCount
+    }) ?? null
+  return { candidate, caps: candidate?.image?.edit ?? null }
+}

--- a/src/components/design/MediaGenerateDialog.test.ts
+++ b/src/components/design/MediaGenerateDialog.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest"
+import type { ImageEditCaps, MediaCandidateOverview } from "@/components/settings/media-gen/types"
+import {
+  inferAudioKindFromPrompt,
+  resolveImageRequestCapability,
+} from "./MediaGenerateDialog.logic"
+
+function imageCandidate(providerId: string, edit: ImageEditCaps | null): MediaCandidateOverview {
+  return {
+    providerId,
+    providerName: providerId,
+    vendor: "fal",
+    modelId: `${providerId}-model`,
+    modelName: `${providerId} model`,
+    supportsVoiceListing: false,
+    image: {
+      maxN: 1,
+      supportsSize: false,
+      supportsAspectRatio: true,
+      supportsResolution: true,
+      sizes: [],
+      aspectRatios: ["1:1", "16:9"],
+      resolutions: ["1K", "2K"],
+      supportsMask: false,
+      edit,
+    },
+  }
+}
+
+describe("MediaGenerateDialog request state", () => {
+  test("infers an audio kind from a seeded prompt", () => {
+    expect(inferAudioKindFromPrompt("  [MUSIC] ambient piano")).toBe("music")
+    expect(inferAudioKindFromPrompt("[sfx] closing door")).toBe("sfx")
+    expect(inferAudioKindFromPrompt("plain narration")).toBeNull()
+  })
+
+  test("uses generation capabilities when there are no reference images", () => {
+    const candidate = imageCandidate("generation", {
+      maxN: 1,
+      maxInputImages: 1,
+      supportsSize: false,
+      supportsAspectRatio: false,
+      supportsResolution: false,
+    })
+
+    const resolved = resolveImageRequestCapability([candidate], 0)
+
+    expect(resolved.candidate?.providerId).toBe("generation")
+    expect(resolved.caps?.supportsAspectRatio).toBe(true)
+    expect(resolved.caps?.supportsResolution).toBe(true)
+  })
+
+  test("selects a compatible edit candidate and uses its narrower capabilities", () => {
+    const generationOnly = imageCandidate("generation-only", null)
+    const oneImage = imageCandidate("one-image", {
+      maxN: 1,
+      maxInputImages: 1,
+      supportsSize: false,
+      supportsAspectRatio: true,
+      supportsResolution: true,
+    })
+    const multiImage = imageCandidate("multi-image", {
+      maxN: 1,
+      maxInputImages: 4,
+      supportsSize: false,
+      supportsAspectRatio: false,
+      supportsResolution: false,
+    })
+
+    const resolved = resolveImageRequestCapability([generationOnly, oneImage, multiImage], 2)
+
+    expect(resolved.candidate?.providerId).toBe("multi-image")
+    expect(resolved.caps?.supportsAspectRatio).toBe(false)
+    expect(resolved.caps?.supportsResolution).toBe(false)
+  })
+})

--- a/src/components/design/MediaGenerateDialog.tsx
+++ b/src/components/design/MediaGenerateDialog.tsx
@@ -41,6 +41,10 @@ import {
   openMediaModelSettings,
 } from "@/components/settings/media-gen/types"
 import { fetchMediaGenOverview } from "@/components/settings/media-gen/useMediaGenData"
+import {
+  inferAudioKindFromPrompt,
+  resolveImageRequestCapability,
+} from "./MediaGenerateDialog.logic"
 
 /** 确认回调载荷：可选参数只在用户显式选择（非「自动 / 默认」）时携带。 */
 export interface MediaGeneratePayload {
@@ -60,6 +64,8 @@ interface Props {
   initialPrompt?: string
   /** Reference-image-only generation may intentionally omit a text prompt. */
   allowEmptyPrompt?: boolean
+  /** Positive values select image-edit candidates and their narrower capabilities. */
+  referenceImageCount?: number
   onClose: () => void
   onConfirm: (payload: MediaGeneratePayload) => void | Promise<void>
   busy?: boolean
@@ -80,6 +86,7 @@ export function MediaGenerateDialog({
   kind,
   initialPrompt = "",
   allowEmptyPrompt = false,
+  referenceImageCount = 0,
   onClose,
   onConfirm,
   busy = false,
@@ -104,7 +111,7 @@ export function MediaGenerateDialog({
 
   // 每次 open 拉一次 overview；「重新检查」复用。fetch 期间关闭 / 重开用代际计数丢弃陈旧结果。
   const loadGen = useRef(0)
-  const loadOverview = useCallback(async (audioTarget?: "audio") => {
+  const loadOverview = useCallback(async (audioTarget?: MediaAudioKind) => {
     const gen = ++loadGen.current
     setOverviewLoading(true)
     const ov = await fetchMediaGenOverview()
@@ -113,10 +120,12 @@ export function MediaGenerateDialog({
     setOverviewLoading(false)
     setVoices(null) // 候选可能已变（重新检查场景），废弃已拉音色
     setVoicesLoading(false)
-    // 默认语音；语音无可用模型时落到首个可用的音频 kind。
-    if (ov && audioTarget === "audio" && !ov.speech.available) {
-      const fallback = (["music", "sfx"] as const).find((k) => ov[k].available)
-      if (fallback) setAudioKind(fallback)
+    // 优先保留 prompt 前缀推断的类型；不可用时才落到首个可用音频功能位。
+    if (ov && audioTarget) {
+      const resolved = ov[audioTarget].available
+        ? audioTarget
+        : AUDIO_KINDS.find((audioKind) => ov[audioKind].available)
+      if (resolved) setAudioKind(resolved)
     }
   }, [])
 
@@ -125,29 +134,35 @@ export function MediaGenerateDialog({
       loadGen.current++ // 丢弃在途 fetch
       return
     }
+    const seededAudioKind = inferAudioKindFromPrompt(initialPrompt) ?? "speech"
     setOverview(null)
     setPrompt(initialPrompt)
     setAspect(AUTO)
     setResolution(AUTO)
-    setAudioKind("speech")
+    setAudioKind(seededAudioKind)
     setVoice(DEFAULT_VOICE)
     setCustomVoiceMode(false)
     setCustomVoice("")
     setDuration(DEFAULT_DURATION)
     setVoices(null)
     setVoicesLoading(false)
-    void loadOverview(kind === "audio" ? "audio" : undefined)
+    void loadOverview(kind === "audio" ? seededAudioKind : undefined)
   }, [open, kind, initialPrompt, loadOverview])
 
   // 当前功能位（image 或所选音频 kind）的首候选 = 「将使用」的模型。
   const fnKey: MediaFunctionKey = kind === "image" ? "image" : audioKind
   const fn = overview ? overview[fnKey] : null
-  const cand = fn?.candidates[0] ?? null
+  const imageRequest = useMemo(
+    () => resolveImageRequestCapability(fn?.candidates ?? [], referenceImageCount),
+    [fn, referenceImageCount],
+  )
+  const cand = kind === "image" ? imageRequest.candidate : (fn?.candidates[0] ?? null)
+  const imageCaps = kind === "image" ? imageRequest.caps : null
 
   const audioAllUnavailable =
     overview != null && AUDIO_KINDS.every((k) => !overview[k].available)
   const showEmpty =
-    overview != null && (kind === "image" ? !overview.image.available : audioAllUnavailable)
+    overview != null && (kind === "image" ? cand == null : audioAllUnavailable)
 
   const aspectChoices = useMemo(
     () =>
@@ -175,12 +190,7 @@ export function MediaGenerateDialog({
     (v: string) => {
       setPrompt(v)
       if (kind !== "audio") return
-      const lead = v.trimStart().toLowerCase()
-      const target: MediaAudioKind | null = lead.startsWith("[music]")
-        ? "music"
-        : lead.startsWith("[sfx]")
-          ? "sfx"
-          : null
+      const target = inferAudioKindFromPrompt(v)
       if (target && target !== audioKind && (!overview || overview[target].available)) {
         setAudioKind(target)
       }
@@ -213,10 +223,10 @@ export function MediaGenerateDialog({
       // Only carry a parameter the resolved model actually supports —
       // otherwise the backend capability check skips the sole candidate and
       // the whole generation fails.
-      if (cand?.image?.supportsAspectRatio && aspect !== AUTO) {
+      if (imageCaps?.supportsAspectRatio && aspect !== AUTO) {
         payload.aspectRatio = aspect
       }
-      if (cand?.image?.supportsResolution && resolution !== AUTO) {
+      if (imageCaps?.supportsResolution && resolution !== AUTO) {
         payload.imageResolution = resolution
       }
     } else {
@@ -236,7 +246,7 @@ export function MediaGenerateDialog({
     kind,
     aspect,
     resolution,
-    cand,
+    imageCaps,
     audioKind,
     needsVoice,
     customVoiceMode,
@@ -326,7 +336,7 @@ export function MediaGenerateDialog({
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => void loadOverview(kind === "audio" ? "audio" : undefined)}
+                onClick={() => void loadOverview(kind === "audio" ? audioKind : undefined)}
               >
                 {t("design.gen.recheck", "重新检查")}
               </Button>
@@ -385,9 +395,9 @@ export function MediaGenerateDialog({
             />
 
             {kind === "image" &&
-              (cand?.image?.supportsAspectRatio || cand?.image?.supportsResolution) && (
+              (imageCaps?.supportsAspectRatio || imageCaps?.supportsResolution) && (
               <div className="space-y-3">
-                {cand?.image?.supportsAspectRatio && (
+                {imageCaps?.supportsAspectRatio && (
                   <div className="space-y-1.5">
                     <span className="text-sm text-muted-foreground">
                       {t("design.gen.aspectRatio", "宽高比")}
@@ -406,7 +416,7 @@ export function MediaGenerateDialog({
                     />
                   </div>
                 )}
-                {cand?.image?.supportsResolution && (
+                {imageCaps?.supportsResolution && (
                   <div className="space-y-1.5">
                     <span className="text-sm text-muted-foreground">
                       {t("design.gen.resolution", "分辨率")}

--- a/src/components/design/MediaGenerateDialog.tsx
+++ b/src/components/design/MediaGenerateDialog.tsx
@@ -56,6 +56,10 @@ export interface MediaGeneratePayload {
 interface Props {
   open: boolean
   kind: "image" | "audio"
+  /** Optional seed used by the launch-page composer. */
+  initialPrompt?: string
+  /** Reference-image-only generation may intentionally omit a text prompt. */
+  allowEmptyPrompt?: boolean
   onClose: () => void
   onConfirm: (payload: MediaGeneratePayload) => void | Promise<void>
   busy?: boolean
@@ -71,7 +75,15 @@ const DEFAULT_DURATION = "__default__"
 
 const AUDIO_KINDS: MediaAudioKind[] = ["speech", "music", "sfx"]
 
-export function MediaGenerateDialog({ open, kind, onClose, onConfirm, busy = false }: Props) {
+export function MediaGenerateDialog({
+  open,
+  kind,
+  initialPrompt = "",
+  allowEmptyPrompt = false,
+  onClose,
+  onConfirm,
+  busy = false,
+}: Props) {
   const { t } = useTranslation()
 
   const [overview, setOverview] = useState<MediaGenOverview | null>(null)
@@ -114,7 +126,7 @@ export function MediaGenerateDialog({ open, kind, onClose, onConfirm, busy = fal
       return
     }
     setOverview(null)
-    setPrompt("")
+    setPrompt(initialPrompt)
     setAspect(AUTO)
     setResolution(AUTO)
     setAudioKind("speech")
@@ -125,7 +137,7 @@ export function MediaGenerateDialog({ open, kind, onClose, onConfirm, busy = fal
     setVoices(null)
     setVoicesLoading(false)
     void loadOverview(kind === "audio" ? "audio" : undefined)
-  }, [open, kind, loadOverview])
+  }, [open, kind, initialPrompt, loadOverview])
 
   // 当前功能位（image 或所选音频 kind）的首候选 = 「将使用」的模型。
   const fnKey: MediaFunctionKey = kind === "image" ? "image" : audioKind
@@ -195,7 +207,7 @@ export function MediaGenerateDialog({ open, kind, onClose, onConfirm, busy = fal
 
   const handleConfirm = useCallback(() => {
     const p = prompt.trim()
-    if (!p) return
+    if (!p && !allowEmptyPrompt) return
     const payload: MediaGeneratePayload = { prompt: p }
     if (kind === "image") {
       // Only carry a parameter the resolved model actually supports —
@@ -220,6 +232,7 @@ export function MediaGenerateDialog({ open, kind, onClose, onConfirm, busy = fal
     void onConfirm(payload)
   }, [
     prompt,
+    allowEmptyPrompt,
     kind,
     aspect,
     resolution,
@@ -516,7 +529,10 @@ export function MediaGenerateDialog({ open, kind, onClose, onConfirm, busy = fal
               <Button variant="ghost" onClick={onClose}>
                 {t("common.cancel", "取消")}
               </Button>
-              <Button onClick={handleConfirm} disabled={busy || !prompt.trim()}>
+              <Button
+                onClick={handleConfirm}
+                disabled={busy || (!allowEmptyPrompt && !prompt.trim())}
+              >
                 {busy && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 {t("design.generate", "生成")}
               </Button>


### PR DESCRIPTION
## Summary

- Route Design Space launch-page image and audio generation through the capability-aware media dialog.
- Forward only supported media parameters, preserve reference-image-only generation, and keep orphan-project rollback behavior.
- Keep the desktop Pet root canvas transparent during the early theme bootstrap.

## Root cause

The Design Space launch action bypassed the media capability/configuration flow and created a project before attempting generation, so missing or model-specific media configuration surfaced as a direct failure.

For the Pet window, `theme-init.js` wrote an opaque inline background color to `<html>` before React booted. That inline style had higher cascade priority than the later `bg-transparent` utility, leaving the release Pet window white in light mode.

## Impact

Image/audio generation from the Design Space home screen now gets the same model availability guidance and supported parameter controls as artifact-level generation. The Pet overlay remains transparent without changing normal light or dark window backgrounds.

## Validation

- User verified the macOS arm64 Release app and confirmed the Pet background fix.
- `pnpm typecheck`
- `pnpm lint` (passes with 3 pre-existing warnings)
- updater public-key consistency check
- `vitest run`: 220 files, 1140 tests passed
- Local `pnpm tauri build --bundles app` produced `Hope Agent.app`; updater signing was unavailable locally because the release private key is not present.
