### PR TITLE
ci: 只在 main 保存 Rust 构建缓存

### DIFF
--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -91,7 +91,10 @@ jobs:
           workspaces: ". -> target"
           # 同 release.yml：本 workflow 由 release.published / dispatch 触发，
           # 缓存存在 tag 作用域下后续读不到，只会挤占仓库 10 GB 共享预算。
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # 用 false 而非按 ref 判断——dispatch 时 github.ref 是被派发的分支
+          # （通常是 main），checkout 切到的却是 `tag` 输入，按 ref 判断会把 tag
+          # 代码树的缓存存进 main 作用域。
+          save-if: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -89,6 +89,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
+          # 同 release.yml：本 workflow 由 release.published / dispatch 触发，
+          # 缓存存在 tag 作用域下后续读不到，只会挤占仓库 10 GB 共享预算。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,13 +128,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
-          # 不在 tag / dry-run 分支存缓存。GitHub 只允许 run 恢复「当前 ref」与
+          # 本 workflow 一律不存缓存。GitHub 只允许 run 恢复「当前 ref」与
           # 「默认分支」的缓存，所以 tag 作用域下存的这份（实测每条 lane
           # 1.55~1.73 GB，四条约 6.5 GB）下次发版打的是新 tag，永远读不到，却会
           # 把仓库 10 GB 预算挤满、连带 LRU 清掉 main 上给所有 PR 用的缓存。
+          #
+          # 刻意用 false 而非 `github.ref == 'refs/heads/main'`：本 workflow 有
+          # workflow_dispatch 入口，dispatch 时 github.ref 是被派发的分支（通常
+          # 就是 main），而 checkout 切到的是 `tag` 输入指定的 tag——按 ref 判断
+          # 会把 tag 代码树的缓存存进 main 作用域，正好吃掉本要省的预算。
+          #
           # 唯一损失是同一 run 内重跑失败 job 时不再有热缓存——v0.24.0 arm64
           # 失败那次实际走的是「修完重新打 tag」，新 ref 本就冷启，没有损失。
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: false
 
       # `ring` (via jsonwebtoken / rustls) assembles its Windows MSVC crypto
       # with NASM. Use Chocolatey instead of ilammy/setup-nasm (upstream still

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
+          # 不在 tag / dry-run 分支存缓存。GitHub 只允许 run 恢复「当前 ref」与
+          # 「默认分支」的缓存，所以 tag 作用域下存的这份（实测每条 lane
+          # 1.55~1.73 GB，四条约 6.5 GB）下次发版打的是新 tag，永远读不到，却会
+          # 把仓库 10 GB 预算挤满、连带 LRU 清掉 main 上给所有 PR 用的缓存。
+          # 唯一损失是同一 run 内重跑失败 job 时不再有热缓存——v0.24.0 arm64
+          # 失败那次实际走的是「修完重新打 tag」，新 ref 本就冷启，没有损失。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # `ring` (via jsonwebtoken / rustls) assembles its Windows MSVC crypto
       # with NASM. Use Chocolatey instead of ilammy/setup-nasm (upstream still

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -111,6 +111,12 @@ jobs:
           # rustup shims. A stale macOS cache can replace `cargo` with the
           # rustup installer and make `cargo test` fail before compilation.
           cache-bin: false
+          # 只在 main 存缓存。仓库 10 GB 预算是全局共享的，PR / 分支各存一份
+          # 同 key 的缓存纯属重复占用（实测同一 clippy key 曾在 main 与两个 PR
+          # ref 下各存 0.46~0.93 GB），把预算挤满后连发版 lane 的缓存都会被
+          # LRU 清掉。PR 与维护分支仍能读到：GitHub 允许 run 恢复「当前 ref」
+          # 与「默认分支」的缓存，main 这份对它们始终可见。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # `ring` (pulled in by jsonwebtoken / rustls) assembles its Windows
       # MSVC crypto with NASM. Chocolatey is pre-installed on windows-latest
@@ -186,6 +192,12 @@ jobs:
           # rustup shims. A stale macOS cache can replace `cargo` with the
           # rustup installer and make `cargo test` fail before compilation.
           cache-bin: false
+          # 只在 main 存缓存。仓库 10 GB 预算是全局共享的，PR / 分支各存一份
+          # 同 key 的缓存纯属重复占用（实测同一 clippy key 曾在 main 与两个 PR
+          # ref 下各存 0.46~0.93 GB），把预算挤满后连发版 lane 的缓存都会被
+          # LRU 清掉。PR 与维护分支仍能读到：GitHub 允许 run 恢复「当前 ref」
+          # 与「默认分支」的缓存，main 这份对它们始终可见。
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install NASM (Windows only)
         if: env.RUN_RUST_CI == 'true' && runner.os == 'Windows'


### PR DESCRIPTION
## 问题（实测）

仓库 Actions 缓存预算 10 GB **已用 9.87 GB**，11 条条目：

| ref | 条数 | 说明 |
|---|---|---|
| `refs/heads/main` | 7 | rust.yml 的 clippy / test |
| `refs/heads/perf/eval-sidecar-profile` | 3 | release.yml 在 dry-run 分支存的，1.55~1.73 GB/条 |
| `refs/pull/561/merge` | 1 | PR 分支存的 |
| `refs/tags/*` | 0 | 已被 LRU 清掉 |

GitHub 只允许一次 run 恢复**当前 ref** 与**默认分支**的缓存。由此：

- **发版 lane 存的缓存没有任何人能读到**。release.yml 每次发版在 tag 作用域下存约 6.5 GB（四条 lane × 1.55~1.73 GB），而下次发版打的是新 tag，读不到。两次发版的日志都是 `No cache found.`
- **PR / 分支存的是重复副本**。它们本来就能读 main 那份，自己再存一份只是占预算——实测同一个 clippy key 曾在 main 与两个 PR ref 下各存一份。
- 预算被挤满后，连 main 上给所有 PR 用的缓存都会被 LRU 清掉。

## 改动

`rust.yml`（两处）、`release.yml`、`build-macos-x64.yml` 的 `Swatinem/rust-cache` 统一加：

```yaml
save-if: ${{ github.ref == 'refs/heads/main' }}
```

其余 ref 仍可读 main 那份，PR CI 行为不变。

## 代价

同一个 run 内重跑失败 job 时不再有热缓存。v0.24.0 的 arm64 失败那次实际走的是「修完重新打 tag」，新 ref 本就冷启，这份缓存没起过作用。

## 说明

**本 PR 只腾预算，不加速任何构建。** 发版构建提速需要在 main 上预热 release 缓存（让 tag run 能从默认分支作用域命中），那一步要先测出第三方依赖占编译量的比例才值得投入，单独处理。