### PR TITLE
perf(release): eval-sidecar profile 改用 thin LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,15 +177,22 @@ strip = "symbols"
 # every user's download.
 #
 # codegen-units 1 → 16（v0.24.0）：本 profile 编译的是 ha-eval，而它依赖
-# ha-core，所以发版每条 lane 都要把 ha-core 整个再编一遍——macOS 实测 27 分钟，
-# 且设置与主构建的 release profile 不同、无法复用产物。dry-run 实测该阶段
-# 27 → 19 分钟，sidecar 26.2 → 27.9 MB。保留 lto="fat"：DCE 靠它，实测改 thin
-# 虽更快但 sidecar 涨到 38.8 MB（+48%），而 sidecar 是 externalBin、计入每个
-# 平台的下载包，不值得。
+# ha-core，所以发版每条 lane 都要把 ha-core 整个再编一遍。注意这份重编无法靠
+# 「让本 profile 设置对齐 release」消除——cargo 按 profile 名分目录
+# （target/<triple>/eval-sidecar/ vs .../release/），设置再一致也不共享产物；
+# 真要复用只能直接用 --release，但 Linux/Windows 主构建不带 --target、目录同样
+# 对不上。
+#
+# lto fat → thin（v0.25.0 后）：v0.25.0 发版日志逐 crate 拆解显示，本阶段
+# macOS 23.2 分 / Windows 27.6 分里，三方依赖只占约 2 / 4 分，ha-core 前端编译
+# 约 2 分，其余约 17 / 20 分全是 fat LTO 链接 ha-eval。fat 换 thin 直接砍掉这段。
+# 代价是 sidecar 体积上涨（早期单点实测 26.2 → 38.8 MB），sidecar 是 externalBin
+# 计入每个平台的下载包——v0.24.0 时按体积优先否掉过这个改动，现按构建时间优先
+# 采纳。opt-level="z" 保留，部分抵消体积上涨。
 [profile.eval-sidecar]
 inherits = "release"
 opt-level = "z"
-lto = "fat"
+lto = "thin"
 codegen-units = 16
 panic = "abort"
 strip = "symbols"


### PR DESCRIPTION
## 背景

v0.25.0 发版日志的逐 crate 时间线拆解显示，一条 lane 的时间分布与此前假设不同：

| 阶段 | macOS | Windows |
|---|---|---|
| 三方依赖编译 | 4.5 分 | 8.8 分 |
| ha-core + ha-server + ha-eval-spec | 2.3 分 | 4.5 分 |
| `hope-agent` 最终二进制（thin LTO + 链接） | 58.7 分 | 60.3 分 |
| **eval-sidecar 阶段** | **23.2 分** | **27.6 分** |
| 其余（checkout / 打包 / 上传） | 4.4 分 | 5.5 分 |
| lane 合计 | 93.3 分 | 106.7 分 |

eval-sidecar 阶段内部再拆：三方依赖约 2 / 4 分，ha-core 前端编译约 2 分，**剩余约 17 / 20 分全是 fat LTO 链接 ha-eval**。

数据来源：release run 30363651127 的 `build (macos-arm64)` / `build (windows-x64)` 日志，按 `Compiling` 行时间戳与本地路径前缀区分三方 / workspace crate。

## 改动

`[profile.eval-sidecar]` 的 `lto` 从 `fat` 改为 `thin`，一行。

## 为什么现在改，v0.24.0 时否掉过

v0.24.0 调 codegen-units 时评估过 fat → thin，当时按**体积优先**否掉（单点实测 sidecar 26.2 → 38.8 MB，+48%；sidecar 是 `externalBin`，计入每个平台的下载包）。现按**构建时间优先**采纳。`opt-level="z"` 保留，部分抵消体积上涨。

## 为什么不走「复用 release 产物」

更彻底的做法是让 sidecar 直接用 `--release` 从而复用主构建的 ha-core 产物，但不可行：

- cargo 按 **profile 名**分目录（`target/<triple>/eval-sidecar/` vs `.../release/`），即使把本 profile 的设置调得与 release 完全一致也不共享产物
- 真要复用只能改成 `--release`，但 Linux/Windows 主构建不带 `--target`（产物落 `target/release/`），而 [scripts/prepare-eval-sidecar.mjs](scripts/prepare-eval-sidecar.mjs) 恒带 `--target`（落 `target/<triple>/release/`），目录仍对不上，需要连带改 release.yml 的 target_dir 与 `check-release-paths.mjs`

且从数据看重编 ha-core 只占约 2 分钟，不是本阶段的成本大头，不值得这个改动面。

## 验证

- `cargo check -p ha-eval --locked` 通过
- dry-run 待跑（`release.yml` workflow_dispatch，`tag=v0.0.0-dryrun` + `dry_run=true`），实测数据回填本 PR 与 Cargo.toml 注释后再合并