### PR TITLE
perf(release): windows lane codegen-units 4 → 16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,10 +92,12 @@ jobs:
             os: windows-latest
             rust_target: ""
             args: ""
-            # 同 macos-arm64：纯提速，非 OOM 规避。macOS 降到 ~90 分钟后这条
-            # lane（v0.20.1 实测 100 分钟）会接替成为关键路径。4 核比 macOS 多
-            # 一核，仍取 4 保持两条 lane 的优化档位一致。
-            codegen_units: "4"
+            # 纯提速，非 OOM 规避。上一条注释预判的「macOS 降下来后本 lane 接替
+            # 成为关键路径」已经发生：v0.25.0 实测本 lane 108.5 分，其余三条
+            # 75~82 分。逐 crate 拆解显示本 lane 的 73.6 分主构建里约 60 分是最终
+            # 二进制的 LTO + codegen，正是 codegen-units 能并行化的部分。
+            # 4 → 16：对齐 macos-arm64（同改动实测 173 → 103 分）。
+            codegen_units: "16"
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## 背景

release.yml 里 windows-x64 的注释此前预判过：「macOS 降到 ~90 分钟后这条 lane 会接替成为关键路径」。v0.25.0 实测确认已经发生：

| lane | 总时长 |
|---|---|
| **windows-x64** | **108.5 分** |
| macos-arm64 | 93.3 分 |
| linux-x64 | 90.9 分 |
| linux-arm64 | 87.6 分 |

其余三条在 #566 的 dry-run 里已降到 75~82 分，windows 成为唯一瓶颈——**现在只有缩短 windows 才能缩短发版**。

## 依据

对 v0.25.0 发版日志（run 30363651127）按 `Compiling` 行时间戳逐 crate 拆解 windows lane：

| 阶段 | 耗时 |
|---|---|
| 三方依赖编译 | 8.8 分 |
| ha-core + ha-server + ha-eval-spec | 4.5 分 |
| **`hope-agent` 最终二进制（LTO + codegen + 链接）** | **60.3 分** |
| eval-sidecar 阶段 | 27.6 分 |
| 其余 | 5.5 分 |

60.3 分那一段正是 codegen-units 能并行化的部分：thin LTO 完成导入与优化后，各 codegen unit 各自生成机器码，切得越多并行度越高。

macos-arm64 做同样改动（#559，同为 4 → 16）实测 **173 → 103 分**。windows runner 4 核，比 macos-14 的 3 核还多一核。

## 改动

matrix 里 windows-x64 的 `codegen_units` 从 `"4"` 改为 `"16"`，一行。

## 代价

codegen unit 变多 → 跨单元内联与去重变弱 → 二进制变大。macOS 同改动实测裸二进制 192.4 → 225.3 MB、压缩包 84.8 → 95.3 MB（+12%）。windows 预期同量级，`Hope.Agent_<v>_x64-setup.exe` 约 108 MB 可能涨到 118 MB 上下。

**只影响 windows 一个平台**，这点与 #566 不同（那个改的是所有平台都带的 sidecar）。

## 验证

- `pnpm check:release-paths` 通过（1 个既有 warning，macos-x64 lane 按设计停用）
- dry-run 待跑，实测数据回填本 PR 与注释后再合并