### PR TITLE
feat(dev): 新增桌面开发模式选择器

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,12 @@ Tauri 命令 → `invoke_handler!`；HTTP 端点 → `build_router_with_cors`；
 ## 开发命令
 
 ```bash
-pnpm tauri dev                        # 开发（改 ha-browser-host 后先 pnpm dev:browser-host）
+pnpm desktop                          # 交互选择下面四种桌面开发模式
+pnpm dev:desktop                      # 默认桌面开发（不构建 Browser Host / Eval Sidecar）
+pnpm dev:desktop:browser              # Chrome 插件联调（仅构建 Browser Host）
+pnpm dev:desktop:eval                 # 评测功能开发（仅构建 Eval Sidecar）
+pnpm dev:desktop:full                 # 完整桌面能力（构建两者）
+pnpm tauri dev                        # 兼容旧入口（等价于完整能力，构建两者）
 node scripts/sync-i18n.mjs --check    # 翻译缺失（--apply 补齐）
 cargo run -p ha-eval --locked -- validate   # 评测资产校验
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **设计空间设备预览新增主流机型与自定义视口**:桌面、平板和手机改为分组选择器,内置 iPad、Surface、iPhone、Pixel 与 Galaxy 等常用 CSS 逻辑尺寸;自定义模式支持直接输入宽高,或拖动预览框右边、底边和右下角,选择与尺寸按产物记忆。拖拽期间会固定起始显示缩放并锚定左上边,避免居中适配导致手柄与指针脱节。 (#568)
 
+### Changed
+
+- **桌面开发按需构建 Browser Host 与 Eval Sidecar**：可通过 `pnpm desktop` 交互选择模式；默认 `pnpm dev:desktop` 不再等待两个可选二进制，Chrome 插件、评测与完整能力开发分别使用 `pnpm dev:desktop:browser`、`pnpm dev:desktop:eval`、`pnpm dev:desktop:full`；生产构建与兼容旧入口 `pnpm tauri dev` 仍会构建两者。
+
 ## [0.25.0] - 2026-07-28
 
 ### Fixed

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -38,7 +38,7 @@ git checkout -b feat/xxx   # or fix/xxx, docs/xxx
 
 ```bash
 pnpm install              # frontend deps + Husky pre-push hooks
-pnpm tauri dev            # desktop dev mode (frontend + Rust backend hot-reload)
+pnpm dev:desktop          # default desktop dev (frontend + Rust backend hot-reload)
 ```
 
 Full command list in [AGENTS.md "开发命令"](AGENTS.md#开发命令).
@@ -121,7 +121,7 @@ Translation files in [`src/i18n/locales/`](src/i18n/locales/). PR guidelines:
 
 - One PR covers one or a few related languages
 - Key paths must match `zh` exactly
-- Verify by running `pnpm tauri dev` and switching the UI language
+- Verify by running `pnpm dev:desktop` and switching the UI language
 
 ## Plugin-style contributions (Skill / Provider / Channel)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ git checkout -b feat/xxx   # 或 fix/xxx, docs/xxx
 
 ```bash
 pnpm install              # 装前端依赖 + Husky pre-push 钩子
-pnpm tauri dev            # 启动桌面开发模式（前端 + Rust 后端 + 热重载）
+pnpm dev:desktop          # 启动默认桌面开发模式（前端 + Rust 后端 + 热重载）
 ```
 
 详细命令清单见 [AGENTS.md "开发命令"](AGENTS.md#开发命令)。
@@ -123,7 +123,7 @@ node scripts/sync-i18n.mjs --apply   # 从模板补齐
 
 - 一个 PR 只覆盖一个或几个相关语言
 - key 路径必须和 `zh` 完全一致
-- 测试方式：`pnpm tauri dev` 在 UI 切到目标语言验证
+- 测试方式：`pnpm dev:desktop` 在 UI 切到目标语言验证
 
 ## 插件式贡献（Skill / Provider / Channel）
 

--- a/README.en.md
+++ b/README.en.md
@@ -293,7 +293,7 @@ For docker-compose, the optional Ollama sidecar for local LLMs, LAN exposure, re
 git clone https://github.com/shiwenwen/hope-agent.git
 cd hope-agent
 pnpm install
-pnpm tauri dev         # desktop dev (frontend + Rust hot reload)
+pnpm dev:desktop       # default desktop dev (frontend + Rust hot reload)
 
 # Other useful commands
 pnpm typecheck         # frontend typecheck (tsc -b)
@@ -301,13 +301,25 @@ pnpm lint              # lint
 pnpm tauri build       # production build
 ```
 
-For local Web GUI development with live reload, run `pnpm tauri dev` and open `http://localhost:1420` in your browser. That is the Vite dev server, sharing the same frontend HMR as the Tauri window. `http://localhost:8420` is the embedded HTTP/WS server's static Web GUI entry, served from `dist/` / the embedded bundle, so it behaves like the packaged browser entry and does not HMR with source changes. If your local server has an API key enabled, the `1420` page may get 401s from `8420`; for development, temporarily clear the Server API Key in Settings and restart.
+Desktop development enables extra binaries only when they are needed, so ordinary UI and business-logic work does not wait for unrelated Rust crates:
+
+| Command                    | Browser Host | Eval Sidecar | Use case                         |
+| -------------------------- | ------------ | ------------ | -------------------------------- |
+| `pnpm desktop`             | As selected  | As selected  | Interactively choose a mode      |
+| `pnpm dev:desktop`         | Not built    | Not built    | Default UI / business development |
+| `pnpm dev:desktop:browser` | Built        | Not built    | Chrome extension integration     |
+| `pnpm dev:desktop:eval`    | Not built    | Built        | Evaluation feature development   |
+| `pnpm dev:desktop:full`    | Built        | Built        | Full desktop capability check    |
+
+The default command delegates to `pnpm exec tauri dev --config src-tauri/tauri.dev.conf.json`. Prefer the scripts above so startup flags and optional-component conventions stay aligned. Production `pnpm tauri build` still builds and bundles both the Browser Host and Eval Sidecar.
+
+For local Web GUI development with live reload, run `pnpm dev:desktop` and open `http://localhost:1420` in your browser. That is the Vite dev server, sharing the same frontend HMR as the Tauri window. `http://localhost:8420` is the embedded HTTP/WS server's static Web GUI entry, served from `dist/` / the embedded bundle, so it behaves like the packaged browser entry and does not HMR with source changes. If your local server has an API key enabled, the `1420` page may get 401s from `8420`; for development, temporarily clear the Server API Key in Settings and restart.
 
 ## Run Modes
 
 | Mode             | How to start                                                                      | When to use                                                                       |
 | ---------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Desktop GUI      | Double-click the app / `pnpm tauri dev`                                        | The most complete entry point: full GUI plus an embedded HTTP/WS server, so the desktop can serve remote clients while you use it |
+| Desktop GUI      | Double-click the app / `pnpm dev:desktop`                                      | The most complete entry point: full GUI plus an embedded HTTP/WS server, so the desktop can serve remote clients while you use it |
 | Server + Web GUI (HTTP/WS) | `server start` subcommand; `server install` registers a launchd / systemd service | Headless always-on daemon for IM channels and cron jobs; **the React frontend is `rust-embed`-baked into the server binary, so opening `http://<server>:port` in any browser gives you the full Web GUI** — phone, tablet, any computer can connect directly without installing a client |
 | ACP (stdio)      | `acp` subcommand                                                                  | IDE integration — any ACP-capable editor can call Hope Agent as its agent backend |
 
@@ -362,7 +374,7 @@ The main branch is under active development — issues and PRs are welcome. Plea
 Common commands:
 
 ```bash
-pnpm tauri dev                    # desktop dev
+pnpm dev:desktop                  # default desktop dev
 cargo check --workspace              # Rust dep / type check
 cargo test -p ha-core -p ha-server   # core tests
 node scripts/sync-i18n.mjs --check   # i18n completeness check

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ docker run -d \
 git clone https://github.com/shiwenwen/hope-agent.git
 cd hope-agent
 pnpm install
-pnpm tauri dev         # 桌面开发模式（前端 + Rust 热重载）
+pnpm dev:desktop       # 默认桌面开发（前端 + Rust 热重载）
 
 # 其他常用命令
 pnpm typecheck         # 前端类型检查（tsc -b）
@@ -301,13 +301,25 @@ pnpm lint              # Lint
 pnpm tauri build       # 打生产包
 ```
 
-本地开发时如果想在浏览器里看“网页版”并实时刷新，运行 `pnpm tauri dev` 后打开 `http://localhost:1420`。这是 Vite dev server，和 Tauri 窗口共用前端热更新；`http://localhost:8420` 是内嵌 HTTP/WS 服务提供的静态 Web GUI（来自 `dist/` / embedded bundle），用于模拟打包后的浏览器入口，不会跟随源码 HMR。若本地 Server 开了 API Key，`1420` 页面请求 `8420` 可能返回 401，开发时可先在设置里临时清空 Server API Key 后重启。
+桌面开发按需启用额外二进制，避免普通 UI / 业务开发等待不相关的 Rust crate：
+
+| 命令                       | Browser Host | Eval Sidecar | 用途              |
+| -------------------------- | ------------ | ------------ | ----------------- |
+| `pnpm desktop`             | 按选择       | 按选择       | 交互选择以下模式   |
+| `pnpm dev:desktop`         | 不构建       | 不构建       | 默认 UI / 业务开发 |
+| `pnpm dev:desktop:browser` | 构建         | 不构建       | Chrome 插件联调    |
+| `pnpm dev:desktop:eval`    | 不构建       | 构建         | 评测功能开发       |
+| `pnpm dev:desktop:full`    | 构建         | 构建         | 完整桌面能力验证   |
+
+默认命令底层执行 `pnpm exec tauri dev --config src-tauri/tauri.dev.conf.json`；一般使用上面的脚本，避免启动参数与可选组件约定漂移。生产 `pnpm tauri build` 仍会构建并打包 Browser Host 和 Eval Sidecar。
+
+本地开发时如果想在浏览器里看“网页版”并实时刷新，运行 `pnpm dev:desktop` 后打开 `http://localhost:1420`。这是 Vite dev server，和 Tauri 窗口共用前端热更新；`http://localhost:8420` 是内嵌 HTTP/WS 服务提供的静态 Web GUI（来自 `dist/` / embedded bundle），用于模拟打包后的浏览器入口，不会跟随源码 HMR。若本地 Server 开了 API Key，`1420` 页面请求 `8420` 可能返回 401，开发时可先在设置里临时清空 Server API Key 后重启。
 
 ## 运行模式
 
 | 模式                        | 启动方式                                                                         | 场景                                                                                                                                                                                              |
 | --------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 桌面 GUI                    | 双击图标 / `pnpm tauri dev`                                                      | 功能最全的入口：完整 GUI 体验，并内嵌 HTTP/WS 服务，桌面在用的同时可对外提供接入                                                                                                                  |
+| 桌面 GUI                    | 双击图标 / `pnpm dev:desktop`                                                    | 功能最全的入口：完整 GUI 体验，并内嵌 HTTP/WS 服务，桌面在用的同时可对外提供接入                                                                                                                  |
 | Server + Web GUI（HTTP/WS） | 通过 `server start` 子命令；`server install` 可注册成 launchd / systemd 开机自启 | 无 GUI 守护进程，24 小时在线，IM 渠道 / Cron 不断线；**前端 React UI 通过 `rust-embed` 内嵌进 server 二进制，浏览器打开 `http://<server>:port` 即得完整 Web GUI**，手机 / 平板 / 任意电脑都能直连 |
 | ACP（stdio）                | 通过 `acp` 子命令                                                                | IDE 直连，兼容 ACP 协议的编辑器把 Hope Agent 当 agent 后端调                                                                                                                                      |
 
@@ -362,7 +374,7 @@ skills/          内置技能（随应用发行）
 常用命令：
 
 ```bash
-pnpm tauri dev                    # 桌面开发
+pnpm dev:desktop                  # 默认桌面开发
 cargo check --workspace              # Rust 依赖 / 类型检查
 cargo test -p ha-core -p ha-server   # 核心测试
 node scripts/sync-i18n.mjs --check   # 检查翻译缺失

--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -315,7 +315,12 @@ CLI 直接消费或路径相关的环境变量。完整跨子系统列表分散�
 
 | 命令                                       | 用途                                                     | 来源                                                                 |
 | ------------------------------------------ | -------------------------------------------------------- | -------------------------------------------------------------------- |
-| `pnpm tauri dev`                           | 桌面 dev（前端 + Tauri 热重载）                          | [`package.json`](../../package.json)                                 |
+| `pnpm desktop`                            | 交互选择下面四种桌面 dev 模式                            | [`package.json`](../../package.json)                                 |
+| `pnpm dev:desktop`                         | 默认桌面 dev，不构建 Browser Host / Eval Sidecar         | 同上                                                                 |
+| `pnpm dev:desktop:browser`                 | Chrome 插件联调，仅构建 Browser Host                     | 同上                                                                 |
+| `pnpm dev:desktop:eval`                    | 评测功能开发，仅构建 Eval Sidecar                        | 同上                                                                 |
+| `pnpm dev:desktop:full`                    | 完整桌面能力验证，构建 Browser Host 与 Eval Sidecar      | 同上                                                                 |
+| `pnpm tauri dev`                           | 兼容旧入口；构建两个可选二进制后启动桌面 dev             | 同上                                                                 |
 | `pnpm dev`                                 | 仅前端 Vite 开发服务器                                   | 同上                                                                 |
 | `pnpm tauri build`                         | 构建桌面生产包                                           | 同上                                                                 |
 | `pnpm sync:version`                        | 把 `package.json` 版本同步到 `src-tauri`                 | [`scripts/sync-version.mjs`](../../scripts/sync-version.mjs)         |

--- a/docs/architecture/transport-modes.md
+++ b/docs/architecture/transport-modes.md
@@ -8,7 +8,7 @@
 
 | 模式 | 用户入口 | 前端通信 | 后端入口 | 说明 |
 | --- | --- | --- | --- | --- |
-| Tauri 桌面 GUI | `pnpm tauri dev` / 桌面 App | `TauriTransport` | `src-tauri` 命令薄壳 | React 运行在 Tauri WebView 中，请求走 `invoke()`，流式聊天主路径走 Tauri `Channel<string>`。 |
+| Tauri 桌面 GUI | `pnpm dev:desktop` / 桌面 App | `TauriTransport` | `src-tauri` 命令薄壳 | React 运行在 Tauri WebView 中，请求走 `invoke()`，流式聊天主路径走 Tauri `Channel<string>`。 |
 | HTTP/WS server Web GUI | `hope-agent server start` + 浏览器 | `HttpTransport` | `ha-server` axum 路由 | 请求走 REST，后端事件和聊天流走 `/ws/events`。内嵌 Web GUI 和远程浏览器使用同一套路径。 |
 | ACP stdio | `hope-agent acp` | 不经过前端 `Transport` | `ha-core::acp` | IDE/外部客户端通过 ACP NDJSON over stdio 直连核心协议，不加载 React，也不使用 `src/lib/transport.ts`。 |
 

--- a/docs/platform/windows-development.md
+++ b/docs/platform/windows-development.md
@@ -53,8 +53,10 @@ pnpm install
 cargo check --workspace    # 建议先跑一次，首次编译依赖较多会慢几分钟
 
 # 开发模式（前端热重载 + Tauri 窗口）
-pnpm tauri dev
+pnpm dev:desktop
 ```
+
+也可以运行 `pnpm desktop` 交互选择模式。需要直接指定时，Chrome 插件或评测功能分别使用 `pnpm dev:desktop:browser`、`pnpm dev:desktop:eval`；两者都需要时用 `pnpm dev:desktop:full`。
 
 ### 常见坑
 

--- a/docs/user-guide/14-能力评测.md
+++ b/docs/user-guide/14-能力评测.md
@@ -59,7 +59,7 @@ Runner 通过真实 Hope Server 入口驱动任务，模型选择、Prompt、工
 
 如果同一个 Provider 有多个 Auth Profile，选择模型后可以指定凭据配置。一个实验内，同一 Provider 必须使用同一份凭据配置。
 
-> 开发版若提示 Sidecar 缺失，需要先由开发者执行 `pnpm prepare:eval-sidecar`；正式安装包会随应用携带匹配版本的 Sidecar。
+> 开发版若提示 Sidecar 缺失，请停止当前开发进程并改用 `pnpm dev:desktop:eval` 重新启动；正式安装包会随应用携带匹配版本的 Sidecar。
 
 ---
 

--- a/docs/user-guide/en/14-capability-evaluation.md
+++ b/docs/user-guide/en/14-capability-evaluation.md
@@ -59,7 +59,7 @@ Signed-in Codex OAuth models appear in the selectable list with a permanent “D
 
 If a Provider has multiple Auth Profiles, you can choose a credential profile after selecting the model. Within one experiment, all models from the same Provider must use the same credential profile.
 
-> If a development build reports a missing Sidecar, a developer must first run `pnpm prepare:eval-sidecar`. Release packages include a matching Sidecar with the application.
+> If a development build reports a missing Sidecar, stop the current development process and restart it with `pnpm dev:desktop:eval`. Release packages include a matching Sidecar with the application.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
   "packageManager": "pnpm@10.33.1+sha512.05ba3c1d5d1c18f68df06470d74055e62d41fc110a0c660db1b2dfb2785327f04cf0f68345d4609bc52089e7fa0343c31593b2f9594e2c5d5da426230acc9820",
   "scripts": {
     "dev": "vite",
+    "desktop": "node scripts/select-desktop-dev.mjs",
+    "dev:desktop": "pnpm exec tauri dev --config src-tauri/tauri.dev.conf.json",
+    "dev:desktop:browser": "pnpm dev:browser-host && pnpm dev:desktop",
+    "dev:desktop:eval": "pnpm dev:eval-sidecar && pnpm dev:desktop",
+    "dev:desktop:full": "pnpm dev:browser-host && pnpm dev:eval-sidecar && pnpm dev:desktop",
     "build": "tsc -b --pretty false && vite build",
     "typecheck": "tsc -b --pretty false",
     "lint": "eslint .",

--- a/scripts/prepare-browser-host.mjs
+++ b/scripts/prepare-browser-host.mjs
@@ -3,9 +3,9 @@ import { basename, dirname, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
-// `--dev` only builds the debug host. The dev app resolves it from Cargo's
-// target directory, while `tauri build` still copies the release host into
-// src-tauri/resources for packaging.
+// `--dev` builds the debug host and stages the resource required by the legacy
+// `pnpm tauri dev` entrypoint. The optimized dev config clears bundle resources,
+// while `tauri build` stages the release host here for packaging.
 const DEV = process.argv.includes("--dev")
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
@@ -51,12 +51,6 @@ if (!existsSync(source) || !statSync(source).isFile()) {
   process.exit(1)
 }
 
-if (DEV) {
-  console.log(`[prepare-browser-host] built ${source}`)
-  process.exit(0)
-}
-
-// Release: bundle into Tauri resources for packaging.
 const resourcesDir = join(repoRoot, "src-tauri", "resources", "browser-host")
 mkdirSync(resourcesDir, { recursive: true })
 const dest = join(resourcesDir, basename(hostName))

--- a/scripts/prepare-browser-host.mjs
+++ b/scripts/prepare-browser-host.mjs
@@ -3,9 +3,9 @@ import { basename, dirname, join, resolve } from "node:path"
 import { spawnSync } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
-// `--dev` builds a debug host and places it next to the dev binary so
-// `pnpm tauri dev` (which does NOT bundle resources) still has a fresh host.
-// Without it, `tauri build`'s release flow bundles into src-tauri/resources.
+// `--dev` only builds the debug host. The dev app resolves it from Cargo's
+// target directory, while `tauri build` still copies the release host into
+// src-tauri/resources for packaging.
 const DEV = process.argv.includes("--dev")
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
@@ -38,12 +38,6 @@ const build = spawnSync("cargo", cargoArgs, {
 })
 
 if (build.status !== 0) {
-  // In dev, a host build failure must not block the frontend dev server — warn
-  // and keep whatever host binary is already on disk.
-  if (DEV) {
-    console.warn("[prepare-browser-host] dev host build failed; keeping existing binary")
-    process.exit(0)
-  }
   process.exit(build.status ?? 1)
 }
 
@@ -54,27 +48,23 @@ const targetDir = targetTriple
 const source = join(targetDir, hostName)
 if (!existsSync(source) || !statSync(source).isFile()) {
   console.error(`[prepare-browser-host] missing built host binary: ${source}`)
-  process.exit(DEV ? 0 : 1)
+  process.exit(1)
 }
 
-// Dev: copy next to the dev binary where the running app's current_exe-relative
-// host lookup finds it (`<target>/debug/browser-host/`; cargo's direct
-// `<target>/debug/<host>` is already fresh too) AND into the Tauri resources
-// tree — `pnpm tauri dev` does not bundle resources, but tauri-build still
-// validates every declared resource path exists at compile time, so a fresh
-// checkout (resources/ is gitignored) would otherwise fail the build script.
+if (DEV) {
+  console.log(`[prepare-browser-host] built ${source}`)
+  process.exit(0)
+}
+
 // Release: bundle into Tauri resources for packaging.
 const resourcesDir = join(repoRoot, "src-tauri", "resources", "browser-host")
-const outDirs = DEV ? [join(targetDir, "browser-host"), resourcesDir] : [resourcesDir]
-for (const outDir of outDirs) {
-  mkdirSync(outDir, { recursive: true })
-  const dest = join(outDir, basename(hostName))
-  copyFileSync(source, dest)
-  if (process.platform !== "win32") {
-    chmodSync(dest, 0o755)
-  }
-  console.log(`[prepare-browser-host] copied ${source} -> ${dest}`)
+mkdirSync(resourcesDir, { recursive: true })
+const dest = join(resourcesDir, basename(hostName))
+copyFileSync(source, dest)
+if (process.platform !== "win32") {
+  chmodSync(dest, 0o755)
 }
+console.log(`[prepare-browser-host] copied ${source} -> ${dest}`)
 
 function inferTargetTriple(platform, arch) {
   if (!platform || !arch) return ""

--- a/scripts/prepare-eval-sidecar.mjs
+++ b/scripts/prepare-eval-sidecar.mjs
@@ -49,11 +49,6 @@ if (!existsSync(source) || !statSync(source).isFile()) {
   process.exit(1)
 }
 
-if (DEV) {
-  console.log(`[prepare-eval-sidecar] built ${source}`)
-  process.exit(0)
-}
-
 const binariesDirectory = join(repoRoot, "src-tauri", "binaries")
 mkdirSync(binariesDirectory, { recursive: true })
 const suffix = targetTriple.includes("windows") ? ".exe" : ""

--- a/scripts/prepare-eval-sidecar.mjs
+++ b/scripts/prepare-eval-sidecar.mjs
@@ -49,6 +49,11 @@ if (!existsSync(source) || !statSync(source).isFile()) {
   process.exit(1)
 }
 
+if (DEV) {
+  console.log(`[prepare-eval-sidecar] built ${source}`)
+  process.exit(0)
+}
+
 const binariesDirectory = join(repoRoot, "src-tauri", "binaries")
 mkdirSync(binariesDirectory, { recursive: true })
 const suffix = targetTriple.includes("windows") ? ".exe" : ""

--- a/scripts/select-desktop-dev.mjs
+++ b/scripts/select-desktop-dev.mjs
@@ -1,0 +1,76 @@
+import { spawnSync } from "node:child_process"
+import { dirname, resolve } from "node:path"
+import { createInterface } from "node:readline/promises"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+
+const modes = [
+  {
+    id: "1",
+    alias: "default",
+    script: "dev:desktop",
+    description: "Default UI / business development (no optional binaries)",
+  },
+  {
+    id: "2",
+    alias: "browser",
+    script: "dev:desktop:browser",
+    description: "Chrome extension integration (Browser Host)",
+  },
+  {
+    id: "3",
+    alias: "eval",
+    script: "dev:desktop:eval",
+    description: "Evaluation feature development (Eval Sidecar)",
+  },
+  {
+    id: "4",
+    alias: "full",
+    script: "dev:desktop:full",
+    description: "Full desktop capability check (both optional binaries)",
+  },
+]
+
+process.stdout.write("Select desktop development mode:\n")
+for (const mode of modes) {
+  process.stdout.write(`  ${mode.id}) ${mode.alias.padEnd(7)} ${mode.description}\n`)
+}
+
+const prompt = createInterface({ input: process.stdin, output: process.stdout })
+prompt.on("SIGINT", () => {
+  prompt.close()
+  process.exit(130)
+})
+
+let selected
+try {
+  while (!selected) {
+    const answer = (await prompt.question("Choose a mode [1]: ")).trim().toLowerCase() || "1"
+    selected = modes.find((mode) => mode.id === answer || mode.alias === answer)
+    if (!selected) {
+      process.stderr.write("Invalid mode. Enter 1-4 or default/browser/eval/full.\n")
+    }
+  }
+} finally {
+  prompt.close()
+}
+
+process.stdout.write(`\nStarting pnpm ${selected.script}...\n\n`)
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
+const forwardedArgs = process.argv.slice(2)
+const run = spawnSync(
+  pnpm,
+  ["run", selected.script, ...forwardedArgs],
+  {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  },
+)
+
+if (run.error) {
+  process.stderr.write(`Failed to start pnpm ${selected.script}: ${run.error.message}\n`)
+  process.exit(1)
+}
+process.exit(run.status ?? 1)

--- a/src-tauri/tauri.dev.conf.json
+++ b/src-tauri/tauri.dev.conf.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeDevCommand": "pnpm dev"
+  },
+  "bundle": {
+    "active": false,
+    "externalBin": [],
+    "resources": []
+  }
+}


### PR DESCRIPTION
## 改动

- 新增 `pnpm desktop` 交互入口，可选择 Default、Browser、Eval 或 Full 桌面开发模式
- 默认 `pnpm dev:desktop` 不再预构建 Browser Host 与 Eval Sidecar
- Browser / Eval / Full 模式只在进入 Tauri dev 前构建所需可选二进制，避免占用 Tauri 的 180 秒 dev server 等待窗口
- 保留 `pnpm tauri dev` 作为完整能力兼容入口，生产构建仍打包两个 sidecar
- 同步 README、AGENTS、CLI、Transport、Windows 开发指南与 CHANGELOG

## 原因

原来的 `beforeDevCommand` 串行构建 Browser Host、Eval Sidecar，最后才启动 Vite。冷构建超过 180 秒时，Tauri 会在前端服务尚未启动前超时。普通 UI / 业务开发也被迫等待不相关的可选组件。

## 影响

日常开发可直接使用 `pnpm desktop` 选择所需模式，或用 `pnpm dev:desktop*` 明确启动；发布构建行为不变。

## 验证

- `git diff --check`
- `node --check scripts/select-desktop-dev.mjs`
- `node --check scripts/prepare-browser-host.mjs`
- `node --check scripts/prepare-eval-sidecar.mjs`
- 交互烟测：`pnpm desktop --help` 选择 Default，确认菜单、脚本分派和参数透传
- Tauri dev config 烟测：确认自定义配置将 `beforeDevCommand` 覆盖为仅启动 `pnpm dev`

完整 pre-push 按要求通过 `HA_SKIP_PREPUSH=1` 跳过。