### PR TITLE
fix(stt): unblock desktop streaming capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **修复 Markdown 外链图标需悬停后才加载站点 favicon**：网页链接进入视口附近时会自动加载站点图标，不再需要先把鼠标移到链接上或聚焦链接；屏幕外的历史消息保持懒加载，请求仍复用现有缓存、并发与数量限制，加载失败时继续显示网页占位图标。
+- **修复桌面端流式语音输入被 CSP 拦截**：PCM16 AudioWorklet 改为从同源静态资源加载，不再依赖被 Tauri `script-src` 禁止的 Blob URL；采集启动或运行失败、用户取消及组件卸载时会同步清理后端 STT 会话，并统一显示麦克风权限错误。 (#576)
 
 ## [0.26.0] - 2026-07-30
 

--- a/public/pcm16-downsampler.worklet.js
+++ b/public/pcm16-downsampler.worklet.js
@@ -1,0 +1,32 @@
+class Pcm16Downsampler extends AudioWorkletProcessor {
+  constructor() {
+    super()
+    this.targetRate = 16000
+    this.frameSamples = 1600
+    this.buffer = new Int16Array(this.frameSamples)
+    this.write = 0
+    this.sourceCursor = 0
+    this.step = sampleRate / this.targetRate
+  }
+
+  process(inputs) {
+    const input = inputs[0]
+    if (!input || !input[0]) return true
+    const channel = input[0]
+    for (let i = 0; i < channel.length; i += 1) {
+      this.sourceCursor += 1
+      if (this.sourceCursor >= this.step) {
+        this.sourceCursor -= this.step
+        const sample = Math.max(-1, Math.min(1, channel[i]))
+        this.buffer[this.write++] = sample < 0 ? sample * 0x8000 : sample * 0x7fff
+        if (this.write >= this.frameSamples) {
+          this.port.postMessage(this.buffer.slice(0))
+          this.write = 0
+        }
+      }
+    }
+    return true
+  }
+}
+
+registerProcessor("pcm16-downsampler", Pcm16Downsampler)

--- a/src/components/chat/input/useVoiceInput.test.tsx
+++ b/src/components/chat/input/useVoiceInput.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useVoiceInput } from "./useVoiceInput"
+
+const mocks = vi.hoisted(() => ({
+  call: vi.fn(),
+  listen: vi.fn(() => vi.fn()),
+  loggerError: vi.fn(),
+  loggerInfo: vi.fn(),
+  loggerWarn: vi.fn(),
+  recorderStart: vi.fn(),
+  recorderStop: vi.fn(),
+  recorderCancel: vi.fn(),
+  streamerStart: vi.fn(),
+  streamerStop: vi.fn(),
+  streamerCancel: vi.fn(),
+  providerKind: "azure-ws" as string,
+  streamerState: "idle" as string,
+  streamerError: null as Error | null,
+}))
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock("@/lib/transport-provider", () => ({
+  getTransport: () => ({ call: mocks.call, listen: mocks.listen }),
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: {
+    error: mocks.loggerError,
+    info: mocks.loggerInfo,
+    warn: mocks.loggerWarn,
+  },
+}))
+
+vi.mock("@/hooks/useAudioRecorder", () => ({
+  useAudioRecorder: () => ({
+    state: "idle",
+    durationMs: 0,
+    audioLevel: 0,
+    levels: [],
+    error: null,
+    start: mocks.recorderStart,
+    stop: mocks.recorderStop,
+    cancel: mocks.recorderCancel,
+  }),
+}))
+
+vi.mock("@/hooks/usePcm16Streamer", () => ({
+  usePcm16Streamer: () => ({
+    state: mocks.streamerState,
+    durationMs: 0,
+    audioLevel: 0,
+    levels: [],
+    error: mocks.streamerError,
+    start: mocks.streamerStart,
+    stop: mocks.streamerStop,
+    cancel: mocks.streamerCancel,
+  }),
+  pcm16ToBase64: vi.fn(() => "encoded"),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.call.mockImplementation(async (command: string) => {
+    if (command === "get_stt_providers") {
+      return [{ id: "azure", name: "Azure", kind: mocks.providerKind, enabled: true }]
+    }
+    if (command === "get_active_stt_model") {
+      return { providerId: "azure", modelId: "speech" }
+    }
+    if (command === "stt_start_session") return "stt_opened"
+    return undefined
+  })
+  mocks.recorderStart.mockResolvedValue(undefined)
+  mocks.streamerStart.mockResolvedValue(undefined)
+  mocks.providerKind = "azure-ws"
+  mocks.streamerState = "idle"
+  mocks.streamerError = null
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("useVoiceInput streaming session lifecycle", () => {
+  it("cancels an opened backend session when audio capture fails", async () => {
+    mocks.streamerStart.mockRejectedValue(
+      new DOMException("Unable to load the worklet module", "AbortError"),
+    )
+    const { result } = renderHook(() => useVoiceInput("chat-1"))
+
+    await act(async () => {
+      await result.current.start()
+    })
+
+    expect(mocks.call).toHaveBeenCalledWith("stt_cancel_session", {
+      sessionId: "stt_opened",
+    })
+    await waitFor(() => expect(result.current.errorMessage).toBe("voice.failed"))
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "voice",
+      "useVoiceInput::start",
+      expect.stringContaining("name=AbortError"),
+    )
+  })
+
+  it("cancels a live backend session when the composer unmounts", async () => {
+    const { result, unmount } = renderHook(() => useVoiceInput("chat-1"))
+
+    await act(async () => {
+      await result.current.start()
+    })
+    unmount()
+
+    await waitFor(() => {
+      expect(mocks.call).toHaveBeenCalledWith("stt_cancel_session", {
+        sessionId: "stt_opened",
+      })
+    })
+  })
+
+  it("cancels a live backend session when the worklet fails after startup", async () => {
+    const { result, rerender } = renderHook(() => useVoiceInput("chat-1"))
+
+    await act(async () => {
+      await result.current.start()
+    })
+    mocks.streamerState = "error"
+    mocks.streamerError = new Error("processor failed")
+    rerender()
+
+    await waitFor(() => {
+      expect(mocks.call).toHaveBeenCalledWith("stt_cancel_session", {
+        sessionId: "stt_opened",
+      })
+      expect(result.current.errorMessage).toBe("voice.failed")
+    })
+  })
+
+  it("surfaces batch microphone permission failures through the same contract", async () => {
+    mocks.providerKind = "openai-transcriptions"
+    mocks.recorderStart.mockRejectedValue(new DOMException("Permission denied", "NotAllowedError"))
+    const { result } = renderHook(() => useVoiceInput("chat-1"))
+
+    await act(async () => {
+      await result.current.start()
+    })
+
+    await waitFor(() => {
+      expect(result.current.errorMessage).toBe("voice.permissionDenied")
+    })
+    expect(mocks.call).not.toHaveBeenCalledWith("stt_start_session", expect.anything())
+  })
+})

--- a/src/components/chat/input/useVoiceInput.ts
+++ b/src/components/chat/input/useVoiceInput.ts
@@ -4,6 +4,10 @@ import { useTranslation } from "react-i18next"
 import { getTransport } from "@/lib/transport-provider"
 import { useAudioRecorder } from "@/hooks/useAudioRecorder"
 import type { RecorderState } from "@/hooks/useAudioRecorder"
+import {
+  isAudioCapturePermissionError,
+  normalizeAudioCaptureError,
+} from "@/hooks/audioCaptureError"
 import { usePcm16Streamer, pcm16ToBase64 } from "@/hooks/usePcm16Streamer"
 import { logger } from "@/lib/logger"
 import {
@@ -33,10 +37,7 @@ interface SessionErrorPayload {
   message: string
 }
 
-export type VoiceInputState =
-  | RecorderState
-  | "transcribing"
-  | "ready"
+export type VoiceInputState = RecorderState | "transcribing" | "ready"
 
 export interface UseVoiceInputResult {
   state: VoiceInputState
@@ -135,6 +136,25 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
     setPartialText("")
   }, [])
 
+  const cancelSessionBestEffort = useCallback(
+    async (
+      sessionId: string,
+      reason: "capture-start-failed" | "capture-runtime-failed" | "user-cancel" | "unmount",
+    ) => {
+      try {
+        await getTransport().call("stt_cancel_session", { sessionId })
+      } catch (e) {
+        const error = normalizeAudioCaptureError(e)
+        logger.warn(
+          "voice",
+          "useVoiceInput::cancelSession",
+          `session cancel failed sessionId=${sessionId} reason=${reason} name=${error.name} raw=${error.message}`,
+        )
+      }
+    },
+    [],
+  )
+
   const subscribeSessionEvents = useCallback((sessionId: string) => {
     const transport = getTransport()
     const onPartial = (payload: unknown) => {
@@ -174,15 +194,12 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
     try {
       await recorder.start()
     } catch (e) {
-      const m = e instanceof Error ? e.message : String(e)
-      const n = e instanceof Error ? e.name : "?"
-      logger.error(
-        "voice",
-        "useVoiceInput::start",
-        `recorder.start failed name=${n} raw=${m}`,
+      const error = normalizeAudioCaptureError(e)
+      setErrorMessage(
+        isAudioCapturePermissionError(error) ? t("voice.permissionDenied") : t("voice.failed"),
       )
     }
-  }, [recorder])
+  }, [recorder, t])
 
   const startStreaming = useCallback(
     async (providerId: string, modelId: string, kind: SttProviderKind) => {
@@ -224,18 +241,30 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
           })
         })
       } catch (e) {
-        const m = e instanceof Error ? e.message : String(e)
+        const error = normalizeAudioCaptureError(e)
         logger.error(
           "voice",
           "useVoiceInput::start",
-          `streaming start failed raw=${m}`,
+          `streaming start failed name=${error.name} raw=${error.message}`,
         )
+        const openedSessionId = sessionIdRef.current
         teardownSession()
-        setMode(null)
-        setErrorMessage(t("voice.failed"))
+        if (openedSessionId) {
+          await cancelSessionBestEffort(openedSessionId, "capture-start-failed")
+        }
+        setErrorMessage(
+          isAudioCapturePermissionError(error) ? t("voice.permissionDenied") : t("voice.failed"),
+        )
       }
     },
-    [streamer, subscribeSessionEvents, teardownSession, t, currentSessionId],
+    [
+      streamer,
+      subscribeSessionEvents,
+      cancelSessionBestEffort,
+      teardownSession,
+      t,
+      currentSessionId,
+    ],
   )
 
   const start = useCallback(async () => {
@@ -251,11 +280,7 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
       active = meta.active
       kind = meta.kind
       if (!active) {
-        logger.warn(
-          "voice",
-          "useVoiceInput::start",
-          "preflight: no active STT model configured",
-        )
+        logger.warn("voice", "useVoiceInput::start", "preflight: no active STT model configured")
         setErrorMessage(t("voice.noProvider"))
         return
       }
@@ -275,6 +300,20 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
     }
   }, [t, startStreaming, startBatch])
 
+  useEffect(() => {
+    if (mode !== "streaming" || streamer.state !== "error") return
+    const sessionId = sessionIdRef.current
+    if (!sessionId) return
+    teardownSession()
+    void cancelSessionBestEffort(sessionId, "capture-runtime-failed")
+    const error = streamer.error
+    setErrorMessage(
+      error && isAudioCapturePermissionError(error)
+        ? t("voice.permissionDenied")
+        : t("voice.failed"),
+    )
+  }, [mode, streamer.state, streamer.error, cancelSessionBestEffort, teardownSession, t])
+
   const finalizeStreaming = useCallback(async (): Promise<string> => {
     const sessionId = sessionIdRef.current
     if (!sessionId) return ""
@@ -285,10 +324,9 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
       // actually land on the server side. Errors already swallowed
       // inside the chain — settling is the only guarantee we need.
       await pushChainRef.current
-      const transcript = await getTransport().call<Transcript>(
-        "stt_finalize_session",
-        { sessionId },
-      )
+      const transcript = await getTransport().call<Transcript>("stt_finalize_session", {
+        sessionId,
+      })
       setTranscribing(false)
       logger.info(
         "voice",
@@ -395,11 +433,7 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
       const sessionId = sessionIdRef.current
       streamer.cancel()
       if (sessionId) {
-        void getTransport()
-          .call("stt_cancel_session", { sessionId })
-          .catch(() => {
-            // best-effort; backend GC will reap idle sessions anyway
-          })
+        void cancelSessionBestEffort(sessionId, "user-cancel")
       }
       teardownSession()
       setMode(null)
@@ -407,7 +441,7 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
       recorder.cancel()
       setMode(null)
     }
-  }, [mode, streamer, recorder, teardownSession])
+  }, [mode, streamer, recorder, cancelSessionBestEffort, teardownSession])
 
   const clearError = useCallback(() => setErrorMessage(null), [])
 
@@ -432,10 +466,7 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
       : baseState
 
   // Surface getUserMedia denial via i18n.
-  const surfacedError =
-    mode === "streaming"
-      ? streamer.error
-      : recorder.error
+  const surfacedError = mode === "streaming" ? streamer.error : recorder.error
   const surfacedErrorMessage =
     surfacedError && !errorMessage
       ? (() => {
@@ -451,9 +482,11 @@ export function useVoiceInput(currentSessionId?: string | null): UseVoiceInputRe
   // doesn't keep firing into a dead component.
   useEffect(() => {
     return () => {
+      const sessionId = sessionIdRef.current
+      if (sessionId) void cancelSessionBestEffort(sessionId, "unmount")
       teardownSession()
     }
-  }, [teardownSession])
+  }, [cancelSessionBestEffort, teardownSession])
 
   const durationMs = mode === "streaming" ? streamer.durationMs : recorder.durationMs
   const audioLevel = mode === "streaming" ? streamer.audioLevel : recorder.audioLevel

--- a/src/hooks/audioCaptureError.ts
+++ b/src/hooks/audioCaptureError.ts
@@ -1,0 +1,17 @@
+export function normalizeAudioCaptureError(value: unknown): Error {
+  if (value instanceof Error) return value
+
+  if (value && typeof value === "object") {
+    const record = value as { name?: unknown; message?: unknown }
+    const message = typeof record.message === "string" ? record.message : String(value)
+    const error = new Error(message)
+    if (typeof record.name === "string" && record.name) error.name = record.name
+    return error
+  }
+
+  return new Error(String(value))
+}
+
+export function isAudioCapturePermissionError(error: Error): boolean {
+  return error.name === "NotAllowedError" || error.name === "SecurityError"
+}

--- a/src/hooks/audioCaptureHooks.test.tsx
+++ b/src/hooks/audioCaptureHooks.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useAudioRecorder } from "./useAudioRecorder"
+import { usePcm16Streamer } from "./usePcm16Streamer"
+
+const mocks = vi.hoisted(() => ({
+  loggerError: vi.fn(),
+  startLevels: vi.fn(),
+  stopLevels: vi.fn(),
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: mocks.loggerError },
+}))
+
+vi.mock("./useAnalyserLevels", () => ({
+  useAnalyserLevels: () => ({
+    audioLevel: 0,
+    levels: [],
+    start: mocks.startLevels,
+    stop: mocks.stopLevels,
+  }),
+}))
+
+function setMediaDevices(getUserMedia: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia },
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  Reflect.deleteProperty(navigator, "mediaDevices")
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("audio capture start failures", () => {
+  it("loads the PCM worklet from a same-origin asset and rejects when loading fails", async () => {
+    const stopTrack = vi.fn()
+    setMediaDevices(
+      vi.fn().mockResolvedValue({
+        getTracks: () => [{ stop: stopTrack }],
+      }),
+    )
+
+    const workletError = new DOMException("Unable to load the worklet module", "AbortError")
+    const addModule = vi.fn().mockRejectedValue(workletError)
+    const close = vi.fn().mockResolvedValue(undefined)
+    const audioContext = {
+      state: "running",
+      audioWorklet: { addModule },
+      close,
+    }
+    function AudioContextMock() {
+      return audioContext
+    }
+    vi.stubGlobal("AudioContext", AudioContextMock)
+
+    const { result } = renderHook(() => usePcm16Streamer())
+    let rejected: unknown
+    await act(async () => {
+      try {
+        await result.current.start(vi.fn())
+      } catch (error) {
+        rejected = error
+      }
+    })
+
+    expect(addModule).toHaveBeenCalledWith("/pcm16-downsampler.worklet.js")
+    expect(rejected).toMatchObject({ name: "AbortError" })
+    await waitFor(() => expect(result.current.state).toBe("error"))
+    expect(result.current.error).toMatchObject({ name: "AbortError" })
+    expect(stopTrack).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "voice",
+      "usePcm16Streamer::start",
+      expect.stringContaining("name=AbortError"),
+    )
+  })
+
+  it("makes batch recorder setup failures observable to its caller", async () => {
+    const permissionError = new DOMException("Permission denied", "NotAllowedError")
+    setMediaDevices(vi.fn().mockRejectedValue(permissionError))
+
+    const { result } = renderHook(() => useAudioRecorder())
+    let rejected: unknown
+    await act(async () => {
+      try {
+        await result.current.start()
+      } catch (error) {
+        rejected = error
+      }
+    })
+
+    expect(rejected).toMatchObject({ name: "NotAllowedError" })
+    await waitFor(() => expect(result.current.state).toBe("error"))
+    expect(result.current.error).toMatchObject({ name: "NotAllowedError" })
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "voice",
+      "useAudioRecorder::start",
+      expect.stringContaining("name=NotAllowedError"),
+    )
+  })
+
+  it("surfaces and cleans up AudioWorklet processor failures after startup", async () => {
+    const stopTrack = vi.fn()
+    setMediaDevices(
+      vi.fn().mockResolvedValue({
+        getTracks: () => [{ stop: stopTrack }],
+      }),
+    )
+
+    const source = { connect: vi.fn(), disconnect: vi.fn() }
+    const analyser = { fftSize: 0, disconnect: vi.fn() }
+    const audioContext = {
+      state: "running",
+      audioWorklet: { addModule: vi.fn().mockResolvedValue(undefined) },
+      createMediaStreamSource: vi.fn(() => source),
+      createAnalyser: vi.fn(() => analyser),
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+    function AudioContextMock() {
+      return audioContext
+    }
+    const worklet = {
+      port: { onmessage: null, close: vi.fn() },
+      onprocessorerror: null as (() => void) | null,
+      disconnect: vi.fn(),
+    }
+    function AudioWorkletNodeMock() {
+      return worklet
+    }
+    vi.stubGlobal("AudioContext", AudioContextMock)
+    vi.stubGlobal("AudioWorkletNode", AudioWorkletNodeMock)
+
+    const { result } = renderHook(() => usePcm16Streamer())
+    await act(async () => {
+      await result.current.start(vi.fn())
+    })
+    expect(result.current.state).toBe("streaming")
+
+    act(() => worklet.onprocessorerror?.())
+
+    await waitFor(() => expect(result.current.state).toBe("error"))
+    expect(result.current.error).toMatchObject({ name: "AudioWorkletProcessorError" })
+    expect(stopTrack).toHaveBeenCalledOnce()
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "voice",
+      "usePcm16Streamer::processor",
+      expect.stringContaining("name=AudioWorkletProcessorError"),
+    )
+  })
+
+  it("logs and cleans up MediaRecorder runtime failures", async () => {
+    const stopTrack = vi.fn()
+    setMediaDevices(
+      vi.fn().mockResolvedValue({
+        getTracks: () => [{ stop: stopTrack }],
+      }),
+    )
+
+    const recorder = {
+      state: "inactive",
+      mimeType: "audio/webm",
+      ondataavailable: null,
+      onstop: null,
+      onerror: null as ((event: { error: Error }) => void) | null,
+      start: vi.fn(() => {
+        recorder.state = "recording"
+      }),
+      stop: vi.fn(),
+    }
+    function MediaRecorderMock() {
+      return recorder
+    }
+    MediaRecorderMock.isTypeSupported = vi.fn(() => true)
+    vi.stubGlobal("MediaRecorder", MediaRecorderMock)
+
+    const { result } = renderHook(() => useAudioRecorder())
+    await act(async () => {
+      await result.current.start()
+    })
+    expect(result.current.state).toBe("recording")
+
+    act(() => recorder.onerror?.({ error: new Error("device disconnected") }))
+
+    await waitFor(() => expect(result.current.state).toBe("error"))
+    expect(stopTrack).toHaveBeenCalledOnce()
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "voice",
+      "useAudioRecorder::recording",
+      expect.stringContaining("device disconnected"),
+    )
+  })
+})

--- a/src/hooks/useAudioRecorder.ts
+++ b/src/hooks/useAudioRecorder.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
+import { logger } from "@/lib/logger"
+import { normalizeAudioCaptureError } from "./audioCaptureError"
 import { useAnalyserLevels } from "./useAnalyserLevels"
 
 /**
@@ -10,12 +12,7 @@ import { useAnalyserLevels } from "./useAnalyserLevels"
  * with the final Blob so the caller can ship it to STT. `audioLevel`
  * (0-1 RMS) feeds the on-screen waveform / red-dot pulse.
  */
-export type RecorderState =
-  | "idle"
-  | "requesting-permission"
-  | "recording"
-  | "stopped"
-  | "error"
+export type RecorderState = "idle" | "requesting-permission" | "recording" | "stopped" | "error"
 
 export interface UseAudioRecorderResult {
   state: RecorderState
@@ -25,7 +22,7 @@ export interface UseAudioRecorderResult {
    * Oldest first; newest at the end. Zero-padded when not recording. */
   levels: number[]
   error: Error | null
-  /** Begin a new recording. Throws via `error` state if permission is denied. */
+  /** Begin a new recording. Rejects after updating `error` state on failure. */
   start: () => Promise<void>
   /** Stop and return the recorded Blob. */
   stop: () => Promise<{ blob: Blob; mimeType: string; durationMs: number }>
@@ -63,8 +60,12 @@ export function useAudioRecorder(): UseAudioRecorderResult {
   const streamRef = useRef<MediaStream | null>(null)
   const audioCtxRef = useRef<AudioContext | null>(null)
   const analyserRef = useRef<AnalyserNode | null>(null)
-  const { audioLevel, levels, start: startLevels, stop: stopLevels } =
-    useAnalyserLevels(analyserRef)
+  const {
+    audioLevel,
+    levels,
+    start: startLevels,
+    stop: stopLevels,
+  } = useAnalyserLevels(analyserRef)
   const startedAtRef = useRef<number>(0)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const cancelledRef = useRef<boolean>(false)
@@ -145,11 +146,18 @@ export function useAudioRecorder(): UseAudioRecorderResult {
         }
       }
       recorder.onerror = (e) => {
-        const err = (e as ErrorEvent).error ?? new Error("MediaRecorder error")
-        setError(err instanceof Error ? err : new Error(String(err)))
+        const recorderError = normalizeAudioCaptureError(
+          (e as ErrorEvent).error ?? new Error("MediaRecorder error"),
+        )
+        setError(recorderError)
         cleanup()
         setState("error")
-        stopPromiseRef.current?.reject(err instanceof Error ? err : new Error(String(err)))
+        logger.error(
+          "voice",
+          "useAudioRecorder::recording",
+          `capture runtime failed name=${recorderError.name} raw=${recorderError.message}`,
+        )
+        stopPromiseRef.current?.reject(recorderError)
         stopPromiseRef.current = null
       }
 
@@ -179,32 +187,37 @@ export function useAudioRecorder(): UseAudioRecorderResult {
       }, 100)
       setState("recording")
     } catch (e) {
+      const captureError = normalizeAudioCaptureError(e)
       cleanup()
-      setError(e instanceof Error ? e : new Error(String(e)))
+      setError(captureError)
       setState("error")
+      logger.error(
+        "voice",
+        "useAudioRecorder::start",
+        `capture setup failed name=${captureError.name} raw=${captureError.message}`,
+      )
+      throw captureError
     }
   }, [state, cleanup, startLevels])
 
   const stop = useCallback(() => {
-    return new Promise<{ blob: Blob; mimeType: string; durationMs: number }>(
-      (resolve, reject) => {
-        // Watchdog (MAX_RECORD_MS) may have already stopped the recorder
-        // and cached its result. Drain that first so the audio isn't lost.
-        if (lastResultRef.current) {
-          const cached = lastResultRef.current
-          lastResultRef.current = null
-          resolve(cached)
-          return
-        }
-        const recorder = recorderRef.current
-        if (!recorder || recorder.state === "inactive") {
-          reject(new Error("Not recording"))
-          return
-        }
-        stopPromiseRef.current = { resolve, reject }
-        recorder.stop()
-      },
-    )
+    return new Promise<{ blob: Blob; mimeType: string; durationMs: number }>((resolve, reject) => {
+      // Watchdog (MAX_RECORD_MS) may have already stopped the recorder
+      // and cached its result. Drain that first so the audio isn't lost.
+      if (lastResultRef.current) {
+        const cached = lastResultRef.current
+        lastResultRef.current = null
+        resolve(cached)
+        return
+      }
+      const recorder = recorderRef.current
+      if (!recorder || recorder.state === "inactive") {
+        reject(new Error("Not recording"))
+        return
+      }
+      stopPromiseRef.current = { resolve, reject }
+      recorder.stop()
+    })
   }, [])
 
   const cancel = useCallback(() => {

--- a/src/hooks/usePcm16Streamer.ts
+++ b/src/hooks/usePcm16Streamer.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
+import { logger } from "@/lib/logger"
+import { normalizeAudioCaptureError } from "./audioCaptureError"
 import { useAnalyserLevels } from "./useAnalyserLevels"
 
 /**
@@ -41,48 +43,10 @@ export interface UsePcm16StreamerResult {
   cancel: () => void
 }
 
-
-// 16 kHz target rate / 1600 sample-per-frame contract is hard-coded into
-// the worklet processor (sample rates are immutable once the AudioContext
-// is created, so there's no reason to template these on the TS side).
 const MAX_RECORD_MS = 5 * 60 * 1000
-
-// AudioWorklet processor that downsamples to 16 kHz mono and emits PCM16
-// frames of `FRAME_SAMPLES` samples each. Lives in a separate global scope
-// (worklet thread) — `sampleRate` and `registerProcessor` are worklet
-// globals so we ship this as a string and load via Blob URL.
-const WORKLET_SOURCE = `
-class Pcm16Downsampler extends AudioWorkletProcessor {
-  constructor() {
-    super()
-    this.targetRate = 16000
-    this.frameSamples = 1600
-    this.buffer = new Int16Array(this.frameSamples)
-    this.write = 0
-    this.sourceCursor = 0
-    this.step = sampleRate / this.targetRate
-  }
-  process(inputs) {
-    const input = inputs[0]
-    if (!input || !input[0]) return true
-    const ch = input[0]
-    for (let i = 0; i < ch.length; i++) {
-      this.sourceCursor += 1
-      if (this.sourceCursor >= this.step) {
-        this.sourceCursor -= this.step
-        const f = Math.max(-1, Math.min(1, ch[i]))
-        this.buffer[this.write++] = f < 0 ? f * 0x8000 : f * 0x7FFF
-        if (this.write >= this.frameSamples) {
-          this.port.postMessage(this.buffer.slice(0))
-          this.write = 0
-        }
-      }
-    }
-    return true
-  }
-}
-registerProcessor("pcm16-downsampler", Pcm16Downsampler)
-`
+// Keep executable worklet code in a same-origin static asset. Loading it from
+// a Blob URL would require widening Tauri's `script-src` to include `blob:`.
+const WORKLET_MODULE_PATH = "/pcm16-downsampler.worklet.js"
 
 export function usePcm16Streamer(): UsePcm16StreamerResult {
   const [state, setState] = useState<Pcm16StreamerState>("idle")
@@ -94,11 +58,14 @@ export function usePcm16Streamer(): UsePcm16StreamerResult {
   const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null)
   const workletRef = useRef<AudioWorkletNode | null>(null)
   const analyserRef = useRef<AnalyserNode | null>(null)
-  const { audioLevel, levels, start: startLevels, stop: stopLevels } =
-    useAnalyserLevels(analyserRef)
+  const {
+    audioLevel,
+    levels,
+    start: startLevels,
+    stop: stopLevels,
+  } = useAnalyserLevels(analyserRef)
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const startedAtRef = useRef<number>(0)
-  const workletBlobUrlRef = useRef<string | null>(null)
 
   const cleanup = useCallback(() => {
     if (intervalRef.current !== null) clearInterval(intervalRef.current)
@@ -129,10 +96,6 @@ export function usePcm16Streamer(): UsePcm16StreamerResult {
     audioCtxRef.current = null
     streamRef.current?.getTracks().forEach((t) => t.stop())
     streamRef.current = null
-    if (workletBlobUrlRef.current) {
-      URL.revokeObjectURL(workletBlobUrlRef.current)
-      workletBlobUrlRef.current = null
-    }
   }, [stopLevels])
 
   const start = useCallback(
@@ -157,10 +120,7 @@ export function usePcm16Streamer(): UsePcm16StreamerResult {
         const ctx = new AudioCtxCtor()
         audioCtxRef.current = ctx
 
-        const workletBlob = new Blob([WORKLET_SOURCE], { type: "application/javascript" })
-        const workletUrl = URL.createObjectURL(workletBlob)
-        workletBlobUrlRef.current = workletUrl
-        await ctx.audioWorklet.addModule(workletUrl)
+        await ctx.audioWorklet.addModule(WORKLET_MODULE_PATH)
 
         const source = ctx.createMediaStreamSource(stream)
         sourceRef.current = source
@@ -170,12 +130,24 @@ export function usePcm16Streamer(): UsePcm16StreamerResult {
         analyserRef.current = analyser
 
         const worklet = new AudioWorkletNode(ctx, "pcm16-downsampler")
+        workletRef.current = worklet
         worklet.port.onmessage = (e) => {
           // Worklet posts Int16Array slices; pass straight through.
           const data = e.data as Int16Array | undefined
           if (data && data.length > 0) onChunk(data)
         }
-        workletRef.current = worklet
+        worklet.onprocessorerror = () => {
+          const processorError = new Error("AudioWorklet processor failed")
+          processorError.name = "AudioWorkletProcessorError"
+          cleanup()
+          setError(processorError)
+          setState("error")
+          logger.error(
+            "voice",
+            "usePcm16Streamer::processor",
+            `capture runtime failed name=${processorError.name} raw=${processorError.message}`,
+          )
+        }
 
         // Source feeds both the analyser (level meter, no downsample) and
         // the worklet (downsamples + emits PCM16). Worklet output is NOT
@@ -202,9 +174,16 @@ export function usePcm16Streamer(): UsePcm16StreamerResult {
         startLevels()
         setState("streaming")
       } catch (e) {
+        const captureError = normalizeAudioCaptureError(e)
         cleanup()
-        setError(e instanceof Error ? e : new Error(String(e)))
+        setError(captureError)
         setState("error")
+        logger.error(
+          "voice",
+          "usePcm16Streamer::start",
+          `capture setup failed name=${captureError.name} raw=${captureError.message}`,
+        )
+        throw captureError
       }
     },
     [state, cleanup, startLevels],


### PR DESCRIPTION
## Summary

- load the PCM16 AudioWorklet from a same-origin static asset so Tauri's strict CSP remains unchanged
- surface and log batch/streaming capture startup and runtime failures consistently
- cancel backend STT sessions after setup failure, runtime failure, user cancellation, and component unmount
- add regression coverage and document the fix in the changelog

## Root cause

Desktop streaming STT created the AudioWorklet module from a Blob URL. Tauri's CSP correctly rejects that module because `script-src` does not allow `blob:`. The hook then swallowed the rejection after the backend session had already opened, leaving the UI with a generic failure and the backend session alive until idle cleanup.

## Impact

Restores desktop streaming speech capture for streaming STT providers without broadening the application CSP.

Fixes #576

## Validation

- `pnpm typecheck`
- targeted ESLint on the affected files
- targeted Vitest: 2 files, 8 tests
- `pnpm exec vite build` and verified the worklet asset is copied unchanged
- pre-push gate: typecheck, full ESLint, updater key verification, and full Vitest (225 files / 1157 tests)