### PR TITLE
Fix memory claims navigation loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ import ChatScreen, { type ChatInsert } from "@/components/chat/ChatScreen"
 import { subscribeChatFocus, type ChatFocusTarget } from "@/components/chat/chatFocus"
 import type { KnowledgeFocusTarget } from "@/components/knowledge/knowledgeFocus"
 import {
+  clearMemoryFocusUrl,
   parseMemoryFocusFromLocation,
   requestMemoryFocus,
 } from "@/components/settings/memory-panel/memoryFocus"
@@ -113,6 +114,16 @@ const PERSISTENT_APP_VIEWS: ReadonlySet<AppView> = new Set([
   "knowledge",
   "design",
   "artifacts",
+])
+
+const SETTINGS_APP_VIEWS: ReadonlySet<AppView> = new Set([
+  "settings",
+  "skills",
+  "profile",
+  "agents",
+  "modelConfig",
+  "memory",
+  "channels",
 ])
 
 function PersistentViewSurface({ active, children }: { active: boolean; children: ReactNode }) {
@@ -229,6 +240,7 @@ export default function App() {
   const petFocusNonceRef = useRef(0)
   const knowledgeFocusNonceRef = useRef(0)
   const lastMemoryFocusHashRef = useRef<string | null>(null)
+  const previousViewRef = useRef<AppView>(view)
   // 侧边栏工作区首次访问时才挂载；之后只隐藏顶层容器，不销毁组件树与 Effects。
   // 需要区分可见性的行为（快捷键、轮询、已读回执）由各工作区的 isViewVisible 明确门控。
   const [mountedViews, setMountedViews] = useState<Set<AppView>>(() => new Set(["chat"]))
@@ -386,6 +398,16 @@ export default function App() {
     window.addEventListener("settings:navigate", handleNavigate)
     return () => window.removeEventListener("settings:navigate", handleNavigate)
   }, [handleOpenSettings])
+
+  // Memory panels keep their current subview in the hash with replaceState.
+  // Consume that internal URL state before the view-change deep-link effect below,
+  // otherwise an intentional top-level navigation is interpreted as a fresh deep link.
+  useEffect(() => {
+    const previousView = previousViewRef.current
+    previousViewRef.current = view
+    if (previousView === view || !SETTINGS_APP_VIEWS.has(previousView)) return
+    if (clearMemoryFocusUrl()) lastMemoryFocusHashRef.current = null
+  }, [view])
 
   const handleMemoryFocusDeepLink = useCallback(() => {
     if (typeof window === "undefined") return false

--- a/src/components/settings/memory-panel/memoryFocus.navigation.test.ts
+++ b/src/components/settings/memory-panel/memoryFocus.navigation.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, test } from "vitest"
+
+import { clearMemoryFocusUrl } from "./memoryFocus"
+
+describe("memory focus URL lifecycle", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/workspace?mode=desktop")
+  })
+
+  test("clears a claims hash without changing the current page or query", () => {
+    window.history.replaceState(
+      { navigation: "settings" },
+      "",
+      "/workspace?mode=desktop#memory/claims?status=active",
+    )
+
+    expect(clearMemoryFocusUrl()).toBe(true)
+    expect(window.location.pathname).toBe("/workspace")
+    expect(window.location.search).toBe("?mode=desktop")
+    expect(window.location.hash).toBe("")
+    expect(window.history.state).toEqual({ navigation: "settings" })
+  })
+
+  test("leaves unrelated hashes untouched", () => {
+    window.history.replaceState(null, "", "/workspace#dashboard/reports")
+
+    expect(clearMemoryFocusUrl()).toBe(false)
+    expect(window.location.hash).toBe("#dashboard/reports")
+  })
+})

--- a/src/components/settings/memory-panel/memoryFocus.ts
+++ b/src/components/settings/memory-panel/memoryFocus.ts
@@ -380,6 +380,14 @@ export function parseMemoryFocusFromLocation(): MemoryFocusTarget | null {
   return parseMemoryFocusHash(window.location.hash)
 }
 
+export function clearMemoryFocusUrl(): boolean {
+  if (typeof window === "undefined" || !parseMemoryFocusFromLocation()) return false
+  const url = new URL(window.location.href)
+  url.hash = ""
+  window.history.replaceState(window.history.state, "", url)
+  return true
+}
+
 function updateMemoryFocusUrl(target: MemoryFocusTarget, replace: boolean): void {
   if (typeof window === "undefined") return
   const url = memoryFocusUrl(target)


### PR DESCRIPTION
## Summary

- clear consumed `#memory/...` URL state when leaving a SettingsView-backed top-level view
- preserve the current path, query parameters, history state, and unrelated hashes
- add regression coverage for the memory-focus URL lifecycle

## Root cause

The claims view keeps its current state in `window.location.hash`, while `App` reparses memory deep links whenever the top-level view changes. Leaving Settings therefore caused the unchanged claims hash to be interpreted as a fresh deep link and reopened Settings → Memory → Claims.

## User impact

Users can leave the memory claims page for chat, Dashboard, or another top-level view without being redirected back. Initial memory deep links continue to work.

## Validation

- `pnpm exec vitest run src/components/settings/memory-panel/memoryFocus.test.ts src/components/settings/memory-panel/memoryFocus.navigation.test.ts` — 12 passed
- `pnpm typecheck`
- targeted ESLint and Prettier checks
- `git diff --check`

Fixes #574