### PR TITLE
feat(release): 安装包与自动更新新增 Cloudflare R2 镜像

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,6 +44,14 @@ jobs:
       - name: Updater pubkey sync check
         run: node scripts/verify-updater-pubkey.mjs
 
+      # Same class of two-place contract as the pubkey above, for the manifest
+      # endpoints: tauri.conf.json (desktop), manifest.rs (headless), and the
+      # mirror workflow's PUBLIC_BASE must name the same URLs in the same
+      # order. Drift means one update path silently stops working, or every
+      # client asks a host nothing is published to.
+      - name: Updater endpoints sync check
+        run: node scripts/verify-updater-endpoints.mjs
+
       # Catch release.yml / update-*.yml path bugs at PR time instead of
       # at tag-push time. Covers the workspace target/ vs src-tauri/target/
       # mismatch that took down v0.2.0 release three times in a row, plus

--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -1,0 +1,404 @@
+name: Mirror Release to R2
+
+# Mirror every published Release's assets to the Cloudflare R2 bucket served
+# at https://repo.hopeagent.ai/, then publish an R2-hosted `latest.json`
+# whose download URLs point at the mirror.
+#
+# WHY: a real population of users cannot reach github.com at all. For them
+# this is not a latency optimization — it is whether the app can be
+# installed or updated. apt/dnf users have been served from R2 since the
+# Linux repo moved there; DMG / setup.exe / AppImage / tar.gz users and the
+# in-app updater were still GitHub-only. This closes that gap.
+#
+# ORDERING IS THE SAFETY PROPERTY. Assets go up first, every URL the
+# manifest references is fetched back over the PUBLIC domain and size-checked,
+# and only then is `download/latest.json` written. So the mutable manifest
+# never advertises bytes that aren't there. If verification fails the job
+# fails with the previous manifest untouched — meaning a stale R2 manifest
+# always describes a real, fully-mirrored release, never a broken one.
+#
+# RESIDUAL RISK (documented, accepted): `endpoints` is first-success-wins in
+# both tauri-plugin-updater and ha_core::updater, so a stale-but-200 R2
+# manifest reports "no update" without falling through to GitHub. Mitigated
+# by the short Cache-Control on latest.json (below) and by this job failing
+# loudly. If it fails, re-run it — `gh workflow run mirror-release-r2.yml
+# -f tag=vX.Y.Z` — and the staleness window closes. Uploads are idempotent.
+#
+# SECURITY: signatures in the manifest are copied verbatim, never
+# recomputed, and are verified client-side against the Minisign public key
+# compiled into the binary. A tampered mirror cannot install a malicious
+# build — worst case is denial of service or a stale version advertisement.
+# See docs/architecture/self-update.md.
+#
+# Triggers:
+#   - release.published — auto-fires after a draft Release is manually
+#     published (see docs/release-process.md §1.4).
+#   - workflow_dispatch — manual re-run against a tag (idempotent).
+#
+# Required repo secrets: R2_ACCOUNT_ID / R2_ACCESS_KEY_ID /
+# R2_SECRET_ACCESS_KEY / R2_BUCKET. Cloudflare-side setup (bucket, custom
+# domain, API token) is documented in linux-repo/README.md — this workflow
+# reuses that same bucket and domain.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to mirror (for example v0.26.0)
+        required: true
+        type: string
+
+concurrency:
+  # Separate from update-linux-repo: the two write disjoint prefixes
+  # (download/ vs apt/ + rpm/) so they are safe to run at the same time.
+  group: mirror-release-r2
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  # Public base URL served by the R2 bucket's custom domain. Keep in lockstep
+  # with update-linux-repo.yml, README.md / README.en.md,
+  # linux-repo/rpm/hope-agent.repo, and the R2 entry in
+  # src-tauri/tauri.conf.json#plugins.updater.endpoints — that last one is
+  # enforced by scripts/verify-updater-endpoints.mjs.
+  PUBLIC_BASE: https://repo.hopeagent.ai
+  # rclone remote "r2" configured entirely from env (no rclone.conf file).
+  RCLONE_CONFIG_R2_TYPE: s3
+  RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+  RCLONE_CONFIG_R2_REGION: auto
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+  # RCLONE_CONFIG_R2_ENDPOINT is derived by scripts/r2-endpoint.sh.
+
+jobs:
+  mirror-release-r2:
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+
+    steps:
+      - name: Resolve version from tag
+        run: |
+          set -euo pipefail
+          tag="${TAG}"
+          version="${tag#v}"
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::tag '$tag' does not look like a release tag (expected vX.Y.Z[-pre])"
+            exit 1
+          fi
+          echo "VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Checkout source repo
+        # DEFAULT BRANCH, deliberately not `ref: $TAG`. Two reasons:
+        #
+        #  - Backfill has to work. Checking out the tag would run the tag's
+        #    copy of the mirror scripts, so any release tagged BEFORE this
+        #    workflow landed could never be mirrored — its tree has no
+        #    scripts/mirror-*.mjs at all. The whole existing back catalogue
+        #    would be permanently unmirrorable, and README's download/latest/
+        #    links would 404 until the next release shipped.
+        #  - Tooling should be current. A bug fixed in the rewriter should
+        #    apply the next time any tag is re-mirrored, not stay frozen at
+        #    whatever shipped with that release.
+        #
+        # The DOCS we mirror still come from the tag — fetched explicitly
+        # below — because those must be what the release actually shipped.
+        uses: actions/checkout@v6
+
+      - name: Fetch the release's docs from its tag
+        run: |
+          set -euo pipefail
+          # Shallow single-tag fetch: cheap, and keeps the working tree on the
+          # default branch so the scripts above stay current.
+          # Leading `+` forces the update: on a re-run the local tag ref may
+          # already exist, and a non-forced fetch refuses to clobber it.
+          git fetch --depth=1 origin "+refs/tags/${TAG}:refs/tags/${TAG}"
+          mkdir -p docs-upload
+          # Always mirror both release-note languages plus the CHANGELOG: the
+          # notes body links to the sibling language, so mirroring only the
+          # linked one leaves the language switch a dead end.
+          #
+          # This list is the mirror's public doc surface — the "Stage docs"
+          # step below fails closed if the notes link anything outside it.
+          {
+            echo "CHANGELOG.md"
+            echo "docs/release-notes/${TAG}.md"
+            echo "docs/release-notes/${TAG}.en.md"
+          } > allowed-docs.txt
+          while IFS= read -r p; do
+            if ! git cat-file -e "${TAG}:${p}" 2>/dev/null; then
+              echo "::error::${TAG} does not contain ${p} — a release must ship its own notes (see docs/release-process.md §1.1a)"
+              exit 1
+            fi
+            mkdir -p "docs-upload/$(dirname "$p")"
+            git show "${TAG}:${p}" > "docs-upload/${p}"
+          done < allowed-docs.txt
+          echo "--- docs fetched from ${TAG} ---"
+          find docs-upload -type f | sort
+
+      - name: Preflight — required R2 secrets present
+        run: |
+          set -euo pipefail
+          missing=()
+          [[ -n "${{ secrets.R2_ACCOUNT_ID }}"        ]] || missing+=(R2_ACCOUNT_ID)
+          [[ -n "${{ secrets.R2_ACCESS_KEY_ID }}"     ]] || missing+=(R2_ACCESS_KEY_ID)
+          [[ -n "${{ secrets.R2_SECRET_ACCESS_KEY }}" ]] || missing+=(R2_SECRET_ACCESS_KEY)
+          [[ -n "${{ secrets.R2_BUCKET }}"            ]] || missing+=(R2_BUCKET)
+          if (( ${#missing[@]} )); then
+            echo "::error::missing required R2 secret(s): ${missing[*]} — see linux-repo/README.md"
+            exit 1
+          fi
+
+      - name: Resolve R2 endpoint from account id
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+        # Shared with update-linux-repo.yml — see that workflow's note.
+        run: bash scripts/r2-endpoint.sh
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install rclone
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq rclone jq
+
+      - name: Download release assets + manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p assets manifest
+          gh release download "$TAG" --repo "${{ github.repository }}" --dir assets
+          # latest.json is handled separately: the mirror's copy lives at the
+          # stable, mutable download/latest.json — not inside the immutable
+          # per-version prefix — so move it out of the asset set.
+          test -f assets/latest.json || { echo "::error::release $TAG has no latest.json"; exit 1; }
+          mv assets/latest.json manifest/latest.json
+          echo "--- assets to mirror ---"
+          ls -la assets/
+          count=$(find assets -type f | wc -l | tr -d ' ')
+          echo "asset count: $count"
+          # A release with almost nothing in it means tauri-action failed or
+          # the operator published an empty draft; mirroring that would
+          # advertise a mostly-404 tree.
+          if (( count < 20 )); then
+            echo "::error::only $count assets found (expected 25+ across 4 platforms) — refusing to mirror an incomplete release"
+            exit 1
+          fi
+
+      - name: Rewrite manifest for the mirror
+        run: |
+          set -euo pipefail
+          mkdir -p upload
+          node scripts/rewrite-manifest-for-mirror.mjs \
+            manifest/latest.json "$TAG" "$PUBLIC_BASE" \
+            --out=upload/latest.json --docs-out=upload/notes-docs.txt
+
+      - name: Assert the notes link only mirrored docs
+        run: |
+          set -euo pipefail
+          # Fail closed if a release note grew a link to something outside the
+          # mirrored set — better a failed mirror than a published dead link
+          # for the users who cannot fall back to github.com.
+          while IFS= read -r linked; do
+            [[ -z "$linked" ]] && continue
+            if ! grep -qxF "$linked" allowed-docs.txt; then
+              echo "::error::notes link an un-mirrored doc: $linked — add it to allowed-docs.txt in the 'Fetch the release's docs' step (and confirm it should be public)"
+              exit 1
+            fi
+          done < upload/notes-docs.txt
+          echo "notes link only mirrored docs"
+
+      - name: Stage version-less latest/ aliases
+        run: |
+          set -euo pipefail
+          # README cannot hardcode a version, so every documented download
+          # link points at download/latest/<version-less name>. Staged here,
+          # verified by the same gate below, published only after it passes.
+          node scripts/mirror-latest-aliases.mjs assets "$VERSION" latest-upload
+
+      - name: Upload assets (immutable)
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          # Immutable per-version prefix, so a long edge TTL is correct and
+          # every historical download link keeps working forever.
+          rclone copy assets "r2:${R2_BUCKET}/download/${TAG}" \
+            --header-upload "Cache-Control: public, max-age=31536000, immutable" \
+            --transfers=8 --checkers=16 --stats=30s --stats-one-line 2>&1 | tail -10
+          # Raw markdown as text/plain so a browser DISPLAYS it instead of
+          # downloading an opaque .md — these are read, not installed.
+          rclone copy docs-upload "r2:${R2_BUCKET}/download/${TAG}" \
+            --header-upload "Cache-Control: public, max-age=31536000, immutable" \
+            --header-upload "Content-Type: text/plain; charset=utf-8" \
+            --transfers=4 --stats=0 2>&1 | tail -5
+          echo "Uploaded to r2:${R2_BUCKET}/download/${TAG}"
+
+      - name: Upload latest/ aliases (mutable, short TTL)
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          # These names are reused every release, so they must NOT carry the
+          # immutable header the pinned copies get — an installer pinned for a
+          # year at the edge would hand out an old build forever. 5 minutes is
+          # long enough to absorb a download burst, short enough that a new
+          # release is picked up promptly.
+          #
+          # --ignore-times is deliberate. rclone's default skip is size +
+          # modtime, and these destination names are REUSED every release. An
+          # asset that happens to land on the same byte size as the previous
+          # release's same-named alias could be skipped, leaving
+          # download/latest/ serving the OLD installer while latest.json
+          # advertises the new version — a silent, hard-to-spot mismatch.
+          # Re-uploading ~25 objects per release costs nothing worth saving.
+          rclone copy latest-upload "r2:${R2_BUCKET}/download/latest" \
+            --header-upload "Cache-Control: public, max-age=300, must-revalidate" \
+            --ignore-times \
+            --transfers=8 --checkers=16 --stats=30s --stats-one-line 2>&1 | tail -10
+          echo "Uploaded to r2:${R2_BUCKET}/download/latest"
+
+      - name: Verify every mirrored URL is live with the right size
+        run: |
+          set -euo pipefail
+          # HARD GATE before latest.json is written. Fetch back over the
+          # PUBLIC custom-domain URL users actually hit, and compare
+          # Content-Length to the local file — a 200 alone would pass a
+          # truncated or zero-length object.
+          fail=0
+
+          head_len() {
+            local url="$1" attempt hdr len
+            for attempt in 1 2 3 4 5; do
+              if hdr=$(curl -fsSL -I --max-time 30 "$url" 2>/dev/null); then
+                len=$(grep -i '^content-length:' <<<"$hdr" | tail -1 | tr -dc '0-9')
+                if [[ -n "$len" ]]; then printf '%s' "$len"; return 0; fi
+              fi
+              sleep $((attempt * 5))
+            done
+            return 1
+          }
+
+          check_one() {
+            local url="$1" local_file="$2" expect actual
+            expect=$(stat -c%s "$local_file")
+            if ! actual=$(head_len "$url"); then
+              echo "  FAIL (unreachable)  $url"
+              fail=1; return
+            fi
+            if [[ "$actual" != "$expect" ]]; then
+              echo "  FAIL (size $actual != $expect)  $url"
+              fail=1; return
+            fi
+            echo "  ok  ${actual}B  $url"
+          }
+
+          prefix="${PUBLIC_BASE}/download/${TAG}/"
+
+          # ── (a) structural: every manifest URL must point into this
+          # mirror prefix AND have a local counterpart. Derived from the
+          # manifest itself, never a hardcoded platform list, so a new
+          # platform key is covered the day it appears. No network yet.
+          #
+          # `while read` over process substitution (not a pipeline) so the
+          # loop runs in THIS shell and `fail` survives; and no `mapfile`, so
+          # the gate does not depend on a bash-4-only builtin.
+          n=0
+          while IFS= read -r url; do
+            [[ -z "$url" ]] && continue
+            n=$((n + 1))
+            case "$url" in
+              "$prefix"*) ;;
+              *) echo "  FAIL (not a mirror URL)  $url"; fail=1; continue ;;
+            esac
+            f="assets/${url#"$prefix"}"
+            [[ -f "$f" ]] || { echo "  FAIL (manifest references a file this release did not ship)  $url"; fail=1; }
+          done < <(jq -r '[.platforms[].url] + [.bare_binary.platforms[]?.url] | unique | .[]' upload/latest.json)
+          echo "manifest references $n download URL(s), all inside the mirror prefix"
+          # Zero URLs would sail through every check above and publish a
+          # manifest nobody verified.
+          if (( n == 0 )); then
+            echo "::error::manifest yielded no download URLs to verify"
+            exit 1
+          fi
+
+          # ── (b) live: HEAD every object we uploaded — not just the ones the
+          # manifest names. The macOS DMG is deliberately absent from the
+          # manifest (updates ship as .app.tar.gz) but README links it
+          # directly, so a manifest-only gate would leave the most-clicked
+          # download unverified.
+          echo "checking every uploaded object"
+          while IFS= read -r p; do
+            check_one "${prefix}${p}" "assets/${p}"
+          done < <(find assets -type f -printf '%P\n' | sort)
+          while IFS= read -r p; do
+            check_one "${prefix}${p}" "docs-upload/${p}"
+          done < <(find docs-upload -type f -printf '%P\n' | sort)
+          # The version-less aliases README links — same gate, because a 404
+          # here is a broken install page for exactly the users the mirror
+          # exists to serve.
+          while IFS= read -r p; do
+            check_one "${PUBLIC_BASE}/download/latest/${p}" "latest-upload/${p}"
+          done < <(find latest-upload -type f -printf '%P\n' | sort)
+
+          if (( fail )); then
+            echo "::error::mirror verification failed — NOT publishing download/latest.json. R2's existing manifest is untouched (it still describes the last fully-mirrored release). Fix and re-run: gh workflow run mirror-release-r2.yml -f tag=$TAG"
+            exit 1
+          fi
+          echo "All mirrored URLs verified live at ${PUBLIC_BASE}"
+
+      - name: Publish download/latest.json (short TTL)
+        env:
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          # The ONE mutable object in the tree, and written last. Short TTL is
+          # load-bearing, not tuning: with a long TTL Cloudflare's edge would
+          # pin an old manifest for hours and every user behind that PoP would
+          # be told "you're up to date" after a release shipped.
+          # --ignore-times for the same reason as the aliases above: this is a
+          # fixed destination name, and a corrected manifest that happens to
+          # be the same size as the one already up there must not be skipped.
+          rclone copyto upload/latest.json "r2:${R2_BUCKET}/download/latest.json" \
+            --header-upload "Cache-Control: public, max-age=60, must-revalidate" \
+            --ignore-times \
+            --stats=0
+          echo "Published r2:${R2_BUCKET}/download/latest.json"
+
+      - name: Verify the published manifest serves this release
+        run: |
+          set -euo pipefail
+          url="${PUBLIC_BASE}/download/latest.json"
+          for attempt in 1 2 3 4 5 6; do
+            if body=$(curl -fsSL --max-time 20 "$url" 2>/dev/null); then
+              got=$(jq -r '.version' <<<"$body")
+              if [[ "$got" == "$VERSION" ]]; then
+                echo "OK   $url serves version $got"
+                # Spot-check that a URL inside the served manifest resolves,
+                # so a manifest that is itself fine but points at a prefix
+                # that isn't cannot pass.
+                spot=$(jq -r '.platforms | to_entries | .[0].value.url' <<<"$body")
+                curl -fsSL -I --max-time 30 "$spot" >/dev/null
+                echo "OK   spot-checked $spot"
+                cc=$(curl -fsSI --max-time 20 "$url" | grep -i '^cache-control:' | tr -d '\r')
+                echo "     $cc"
+                exit 0
+              fi
+              echo "…retry $attempt  served version '$got', want '$VERSION'"
+            else
+              echo "…retry $attempt  $url unreachable"
+            fi
+            sleep $((attempt * 10))
+          done
+          echo "::error::published manifest at $url did not settle on version $VERSION"
+          exit 1

--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -17,6 +17,14 @@ name: Mirror Release to R2
 # fails with the previous manifest untouched — meaning a stale R2 manifest
 # always describes a real, fully-mirrored release, never a broken one.
 #
+# THE MUTABLE SURFACE IS GATED. `download/latest/` and `download/latest.json`
+# are global and shared; writing them for anything but the current stable
+# release is a downgrade broadcast, because R2 is endpoint[0] and
+# first-success-wins. Backfilling an old tag by hand and publishing a
+# prerelease both reach this workflow, so promotion is conditional on
+# `PROMOTE` (see the step that computes it). Everything else always mirrors
+# to its own immutable `download/<tag>/` prefix, which harms nothing.
+#
 # RESIDUAL RISK (documented, accepted): `endpoints` is first-success-wins in
 # both tauri-plugin-updater and ha_core::updater, so a stale-but-200 R2
 # manifest reports "no update" without falling through to GitHub. Mitigated
@@ -92,22 +100,77 @@ jobs:
           fi
           echo "VERSION=$version" >> "$GITHUB_ENV"
 
+      - name: Decide whether this tag owns the mutable surface
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # The tree has two kinds of object and only one of them is safe to
+          # write unconditionally:
+          #
+          #   download/<tag>/   immutable, always written — a backfill of an
+          #                     old release belongs here and harms nothing.
+          #   download/latest/  + download/latest.json — MUTABLE and global.
+          #
+          # Writing the mutable pair for anything other than the current
+          # stable release is a downgrade broadcast: R2 is endpoint[0] and
+          # first-success-wins, so clients would be told the older version is
+          # current and would stop seeing the real latest release. That is
+          # reachable two ordinary ways — backfilling an old tag by hand
+          # (documented in release-process §1.10), and a published
+          # PRERELEASE, which also fires release.published.
+          #
+          # So: promote only when this tag is exactly what GitHub itself
+          # considers the latest release, and is not a prerelease. Anything
+          # else mirrors to its immutable prefix and stops there.
+          promote=false
+          reason=""
+          is_pre=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isPrerelease --jq .isPrerelease 2>/dev/null || echo "unknown")
+          # `releases/latest` is GitHub's own definition: newest non-draft,
+          # non-prerelease release — the exact thing the GitHub updater
+          # endpoint resolves to, so the mirror stays consistent with it.
+          latest_tag=$(gh api "repos/${{ github.repository }}/releases/latest" --jq .tag_name 2>/dev/null || echo "")
+          if [[ "$is_pre" == "true" ]]; then
+            reason="$TAG is a prerelease"
+          elif [[ "$is_pre" == "unknown" ]]; then
+            reason="could not read release metadata for $TAG"
+          elif [[ -z "$latest_tag" ]]; then
+            reason="could not resolve the repository's latest release"
+          elif [[ "$latest_tag" != "$TAG" ]]; then
+            reason="the current latest release is $latest_tag, not $TAG"
+          else
+            promote=true
+          fi
+          echo "PROMOTE=$promote" >> "$GITHUB_ENV"
+          if [[ "$promote" == "true" ]]; then
+            echo "$TAG is the current stable release — will publish download/latest/ and download/latest.json"
+          else
+            # A notice, not a failure: mirroring an old tag to its immutable
+            # prefix is a legitimate, useful operation on its own.
+            echo "::notice::Mirroring $TAG to its immutable prefix only — NOT touching download/latest/ or download/latest.json ($reason)."
+          fi
+
       - name: Checkout source repo
-        # DEFAULT BRANCH, deliberately not `ref: $TAG`. Two reasons:
+        # `ref` is EXPLICIT and must stay that way. On a `release.published`
+        # event `github.ref` is `refs/tags/vX.Y.Z`, so a bare checkout would
+        # silently take the TAG, not the default branch. Two things break if
+        # it does:
         #
-        #  - Backfill has to work. Checking out the tag would run the tag's
-        #    copy of the mirror scripts, so any release tagged BEFORE this
-        #    workflow landed could never be mirrored — its tree has no
-        #    scripts/mirror-*.mjs at all. The whole existing back catalogue
-        #    would be permanently unmirrorable, and README's download/latest/
-        #    links would 404 until the next release shipped.
-        #  - Tooling should be current. A bug fixed in the rewriter should
-        #    apply the next time any tag is re-mirrored, not stay frozen at
-        #    whatever shipped with that release.
+        #  - Backfill stops working. The tag's tree would supply the mirror
+        #    scripts, so any release tagged BEFORE this workflow landed could
+        #    never be mirrored — those trees have no scripts/mirror-*.mjs at
+        #    all. The whole back catalogue becomes permanently unmirrorable
+        #    and README's download/latest/ links stay 404 until the next
+        #    release ships.
+        #  - Tooling freezes. A bug fixed in the rewriter would only apply to
+        #    releases tagged after the fix, never to a re-mirror of an older
+        #    one.
         #
         # The DOCS we mirror still come from the tag — fetched explicitly
         # below — because those must be what the release actually shipped.
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Fetch the release's docs from its tag
         run: |
@@ -219,6 +282,7 @@ jobs:
           echo "notes link only mirrored docs"
 
       - name: Stage version-less latest/ aliases
+        if: env.PROMOTE == 'true'
         run: |
           set -euo pipefail
           # README cannot hardcode a version, so every documented download
@@ -245,6 +309,7 @@ jobs:
           echo "Uploaded to r2:${R2_BUCKET}/download/${TAG}"
 
       - name: Upload latest/ aliases (mutable, short TTL)
+        if: env.PROMOTE == 'true'
         env:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
@@ -346,10 +411,17 @@ jobs:
           done < <(find docs-upload -type f -printf '%P\n' | sort)
           # The version-less aliases README links — same gate, because a 404
           # here is a broken install page for exactly the users the mirror
-          # exists to serve.
-          while IFS= read -r p; do
-            check_one "${PUBLIC_BASE}/download/latest/${p}" "latest-upload/${p}"
-          done < <(find latest-upload -type f -printf '%P\n' | sort)
+          # exists to serve. Only present when this tag owns the mutable
+          # surface; a backfill of an older tag skips staging them entirely,
+          # and must NOT assert against whatever the current release left
+          # there.
+          if [[ "$PROMOTE" == "true" ]]; then
+            while IFS= read -r p; do
+              check_one "${PUBLIC_BASE}/download/latest/${p}" "latest-upload/${p}"
+            done < <(find latest-upload -type f -printf '%P\n' | sort)
+          else
+            echo "  (skipping download/latest/ — this tag does not own the mutable surface)"
+          fi
 
           if (( fail )); then
             echo "::error::mirror verification failed — NOT publishing download/latest.json. R2's existing manifest is untouched (it still describes the last fully-mirrored release). Fix and re-run: gh workflow run mirror-release-r2.yml -f tag=$TAG"
@@ -358,6 +430,7 @@ jobs:
           echo "All mirrored URLs verified live at ${PUBLIC_BASE}"
 
       - name: Publish download/latest.json (short TTL)
+        if: env.PROMOTE == 'true'
         env:
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
         run: |
@@ -376,6 +449,7 @@ jobs:
           echo "Published r2:${R2_BUCKET}/download/latest.json"
 
       - name: Verify the published manifest serves this release
+        if: env.PROMOTE == 'true'
         run: |
           set -euo pipefail
           url="${PUBLIC_BASE}/download/latest.json"

--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -102,49 +102,11 @@ jobs:
         env:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-        run: |
-          set -euo pipefail
-          # Accept either the bare 32-hex Cloudflare account id OR a pasted
-          # full S3 endpoint (host or URL, incl. jurisdiction variants like
-          # <id>.eu.r2.cloudflarestorage.com). Strip whitespace + scheme, then:
-          #   - if it already names the R2 endpoint host, use it verbatim
-          #     (preserves any .eu. jurisdiction label);
-          #   - otherwise treat it as a bare account id and build the host,
-          #     validating it is 32 lowercase hex first.
-          # This turns the common "pasted the whole endpoint URL" mistake —
-          # which otherwise surfaces as an opaque `tls: handshake failure` —
-          # into either a correct endpoint or a clear, actionable error.
-          raw="$(printf '%s' "$R2_ACCOUNT_ID" | tr -d '[:space:]')"
-          raw="${raw#http://}"; raw="${raw#https://}"
-          # Cloudflare's bucket "S3 API" panel shows the endpoint WITH the
-          # bucket path (…r2.cloudflarestorage.com/<bucket>). Strip any path
-          # so pasting that whole string resolves to the endpoint host.
-          raw="${raw%%/*}"
-          if [[ "$raw" == *".r2.cloudflarestorage.com" ]]; then
-            host="$raw"
-          else
-            id="$raw"
-            if [[ ! "$id" =~ ^[0-9a-f]{32}$ ]]; then
-              echo "::error::R2_ACCOUNT_ID must be the 32-char hex Cloudflare account id (or the full S3 endpoint host). Got something that normalizes to length ${#id}. Do NOT paste the whole 'https://<id>.r2.cloudflarestorage.com' URL — paste only the account id shown on the R2 overview page. See linux-repo/README.md."
-              exit 1
-            fi
-            # Common mixup: the R2 API token's Access Key ID is ALSO 32 hex and
-            # sits right next to the Account ID on the token screen. If someone
-            # pasted the Access Key ID into R2_ACCOUNT_ID, the endpoint host is
-            # wrong and Cloudflare rejects it at TLS (handshake failure), not
-            # with a 403. Catch the identical-value case with a clear message.
-            akid="$(printf '%s' "$R2_ACCESS_KEY_ID" | tr -d '[:space:]')"
-            if [[ -n "$akid" && "$id" == "$akid" ]]; then
-              echo "::error::R2_ACCOUNT_ID equals R2_ACCESS_KEY_ID — you pasted the API token's Access Key ID into R2_ACCOUNT_ID. They are DIFFERENT values: the Account ID is the 32-hex id in the dashboard URL dash.cloudflare.com/<ACCOUNT_ID> and in https://<ACCOUNT_ID>.r2.cloudflarestorage.com. Re-set R2_ACCOUNT_ID to the account id. See linux-repo/README.md."
-              exit 1
-            fi
-            host="${id}.r2.cloudflarestorage.com"
-          fi
-          echo "RCLONE_CONFIG_R2_ENDPOINT=https://${host}" >> "$GITHUB_ENV"
-          # Bare 32-hex account id (first label of the host) for Wrangler's
-          # CLOUDFLARE_ACCOUNT_ID on the bridge path.
-          echo "CF_ACCOUNT_ID=${host%%.*}" >> "$GITHUB_ENV"
-          echo "R2 endpoint host: ${host}"
+        # Shared with mirror-release-r2.yml — the validation exists to turn
+        # Cloudflare's opaque `tls: handshake failure` into an actionable
+        # message, and two copies drift into two different sets of half-right
+        # hints. Writes RCLONE_CONFIG_R2_ENDPOINT + CF_ACCOUNT_ID to $GITHUB_ENV.
+        run: bash scripts/r2-endpoint.sh
 
       - name: Resolve version from tag
         id: ver
@@ -231,7 +193,16 @@ jobs:
             # first seed run — reprepro/createrepo then build from scratch.
             # `copy` (never `sync`) so a transient partial download can never
             # delete anything; egress from R2 is free.
+            #
+            # --include is LOAD-BEARING, not an optimization: the same bucket
+            # also holds mirror-release-r2.yml's `download/` tree (~1.5 GB of
+            # installers per release, kept forever). Without the filter this
+            # pull drags every historical installer down on every Linux-repo
+            # publish, growing without bound until the job times out. Only
+            # apt/ + rpm/ + pubkey.gpg are inputs to the index rebuild.
+            # Adding a new top-level path this job owns? Add it here too.
             rclone copy "r2:${{ secrets.R2_BUCKET }}" bucket \
+              --include "/apt/**" --include "/rpm/**" --include "/pubkey.gpg" \
               --fast-list --transfers=16 --checkers=32 --stats=0 2>&1 | tail -5
             echo "--- pulled state ---"
             find bucket -maxdepth 3 -type d | sort | head -30

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -57,6 +57,9 @@ pnpm lint
 echo "[pre-push] verify-updater-pubkey (tauri.conf.json ↔ ha-core)"
 node scripts/verify-updater-pubkey.mjs
 
+echo "[pre-push] verify-updater-endpoints (tauri.conf.json ↔ ha-core ↔ mirror PUBLIC_BASE)"
+node scripts/verify-updater-endpoints.mjs
+
 echo "[pre-push] vitest run"
 pnpm test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,7 +256,8 @@ Tauri 命令 → `invoke_handler!`；HTTP 端点 → `build_router_with_cors`；
 - **下载产物必须验签**：更新下载走 `updater::download::download_to`，落地 / swap 前必过 Minisign `signature::verify_bytes`
 - **pubkey 两处必须相等**：`updater::keys::MINISIGN_PUBKEY_BASE64` ↔ `tauri.conf.json#plugins.updater.pubkey`（启动 panic / CI / pre-push 三重校验）
 - **manifest endpoints 两处逐项逐序相等**：`manifest::UPDATE_MANIFEST_URLS` ↔ `tauri.conf.json#plugins.updater.endpoints`（`verify-updater-endpoints.mjs`，CI + pre-push，另校验镜像域名 ↔ `mirror-release-r2.yml` 的 `PUBLIC_BASE`）。R2 镜像恒排第一——**是可达性不是延迟**（部分用户访问不了 github.com）；**刻意维持「首个成功者胜」**、不做比版本取新，否则桌面与 headless 会对「当前哪个版本」分歧
-- **镜像 manifest 是派生物、GitHub 那份权威**：`mirror-release-r2.yml` 只改 URL 与 `notes` 链接，`signature` 原样复制**绝不重算**（验签用编译期嵌入 pubkey，故污染镜像装不进恶意二进制，最坏只能拒服务/谎报版本）；必须**先回抓校验全部对象再写 `latest.json`**，顺序反了可变 manifest 就会指向不存在的字节。`latest/` 别名**禁带 immutable 头**（文件名每版复用）；`update-linux-repo.yml` 整桶 pull 的 `--include` 过滤是 load-bearing，新增本 job 顶层路径须同步
+- **镜像 manifest 是派生物、GitHub 那份权威**：`mirror-release-r2.yml` 只改 URL 与 `notes` 链接，`signature` 原样复制**绝不重算**（验签用编译期嵌入 pubkey，故污染镜像装不进恶意二进制，最坏只能拒服务/谎报版本）；必须**先回抓校验全部对象再写 `latest.json`**，顺序反了可变 manifest 就会指向不存在的字节
+- **可变面只许当前稳定版写（红线）**：`download/latest/` 与 `download/latest.json` 全局共享，给非 latest / prerelease 写＝降级广播（R2 是 endpoint[0] 且首个成功者胜，全体客户端从此看不到真新版）——回填旧 tag 与发 prerelease 都会触发本 workflow，故推进可变面须过 `PROMOTE` 门控；不可变 `download/<tag>/` 永远照写。`latest/` 别名**禁带 immutable 头**（文件名每版复用）、可变上传须 `--ignore-times`（同名同大小会被静默跳过）；`checkout` 的 `ref:` **必须显式**指默认分支（`release.published` 下 `github.ref` 是 tag，裸 checkout 会取 tag，历史版本从此不可回填）；`update-linux-repo.yml` 整桶 pull 的 `--include` 过滤是 load-bearing，新增本 job 顶层路径须同步
 - **换 binary 只走 `platform::atomic_replace_binary`**（禁 `fs::write` 覆盖运行中 binary）；swap 后冷烟自检失败自动回滚
 - **安装 / 重启必经用户确认**：`auto_update` 后台只检查 + 预下载 staging，`app_update` 的 `install` / `rollback` 弹 `ask_user_question`，**桌面绝不无条件 relaunch**
 - **ha-core 不依赖 tauri-plugin-updater**，桌面路径经 `updater::UpdaterBridge` 反向注册

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,6 +255,8 @@ Tauri 命令 → `invoke_handler!`；HTTP 端点 → `build_router_with_cors`；
 
 - **下载产物必须验签**：更新下载走 `updater::download::download_to`，落地 / swap 前必过 Minisign `signature::verify_bytes`
 - **pubkey 两处必须相等**：`updater::keys::MINISIGN_PUBKEY_BASE64` ↔ `tauri.conf.json#plugins.updater.pubkey`（启动 panic / CI / pre-push 三重校验）
+- **manifest endpoints 两处逐项逐序相等**：`manifest::UPDATE_MANIFEST_URLS` ↔ `tauri.conf.json#plugins.updater.endpoints`（`verify-updater-endpoints.mjs`，CI + pre-push，另校验镜像域名 ↔ `mirror-release-r2.yml` 的 `PUBLIC_BASE`）。R2 镜像恒排第一——**是可达性不是延迟**（部分用户访问不了 github.com）；**刻意维持「首个成功者胜」**、不做比版本取新，否则桌面与 headless 会对「当前哪个版本」分歧
+- **镜像 manifest 是派生物、GitHub 那份权威**：`mirror-release-r2.yml` 只改 URL 与 `notes` 链接，`signature` 原样复制**绝不重算**（验签用编译期嵌入 pubkey，故污染镜像装不进恶意二进制，最坏只能拒服务/谎报版本）；必须**先回抓校验全部对象再写 `latest.json`**，顺序反了可变 manifest 就会指向不存在的字节。`latest/` 别名**禁带 immutable 头**（文件名每版复用）；`update-linux-repo.yml` 整桶 pull 的 `--include` 过滤是 load-bearing，新增本 job 顶层路径须同步
 - **换 binary 只走 `platform::atomic_replace_binary`**（禁 `fs::write` 覆盖运行中 binary）；swap 后冷烟自检失败自动回滚
 - **安装 / 重启必经用户确认**：`auto_update` 后台只检查 + 预下载 staging，`app_update` 的 `install` / `rollback` 弹 `ask_user_question`，**桌面绝不无条件 relaunch**
 - **ha-core 不依赖 tauri-plugin-updater**，桌面路径经 `updater::UpdaterBridge` 反向注册

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **安装包与自动更新新增 Cloudflare R2 镜像，不再必须能访问 GitHub**：所有平台安装包同时发布到 `https://repo.hopeagent.ai/download/`（与 apt / dnf 软件源同域名），README 每个手动下载入口都给了固定镜像直链，历史版本按版本号长期保留。桌面自动更新改为优先读镜像、GitHub 兜底——此前访问不了 GitHub 的用户既装不上也更新不了。安装包一律经内置公钥验签，镜像与 GitHub 走完全相同的校验，镜像被篡改也装不进非官方构建。
+- **安装包与自动更新新增 Cloudflare R2 镜像，不再必须能访问 GitHub**：所有平台安装包同时发布到 `https://repo.hopeagent.ai/download/`（与 apt / dnf 软件源同域名），README 每个手动下载入口都给了固定镜像直链，历史版本按版本号长期保留。桌面自动更新改为优先读镜像、GitHub 兜底——此前访问不了 GitHub 的用户既装不上也更新不了。安装包一律经内置公钥验签，镜像与 GitHub 走完全相同的校验，镜像被篡改也装不进非官方构建。 (#580)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **安装包与自动更新新增 Cloudflare R2 镜像，不再必须能访问 GitHub**：所有平台安装包同时发布到 `https://repo.hopeagent.ai/download/`（与 apt / dnf 软件源同域名），README 每个手动下载入口都给了固定镜像直链，历史版本按版本号长期保留。桌面自动更新改为优先读镜像、GitHub 兜底——此前访问不了 GitHub 的用户既装不上也更新不了。安装包一律经内置公钥验签，镜像与 GitHub 走完全相同的校验，镜像被篡改也装不进非官方构建。
+
 ### Fixed
 
 - **修复 Markdown 外链图标需悬停后才加载站点 favicon**：网页链接进入视口附近时会自动加载站点图标，不再需要先把鼠标移到链接上或聚焦链接；屏幕外的历史消息保持懒加载，请求仍复用现有缓存、并发与数量限制，加载失败时继续显示网页占位图标。

--- a/README.en.md
+++ b/README.en.md
@@ -155,6 +155,8 @@
 ### Install Locally
 
 > 📦 Full installer list across platforms: [Releases](https://github.com/shiwenwen/hope-agent/releases)
+>
+> 🌏 **Can't reach GitHub?** Every installer is mirrored at <https://repo.hopeagent.ai/download/latest/> (Cloudflare R2, the same domain as the apt / dnf repos), and each manual-install entry below links the mirror directly. The desktop auto-updater prefers this mirror too, with GitHub as the fallback. Past versions are kept indefinitely under `https://repo.hopeagent.ai/download/v<version>/`.
 
 #### macOS
 
@@ -169,7 +171,7 @@ brew install --cask hope-agent
 
 ##### Manual install (DMG)
 
-Download `Hope.Agent_*.dmg` from [Releases](https://github.com/shiwenwen/hope-agent/releases) and drag into Applications.
+Download `Hope.Agent_*.dmg` from [Releases](https://github.com/shiwenwen/hope-agent/releases) and drag into Applications. Mirror: [Hope.Agent_aarch64.dmg](https://repo.hopeagent.ai/download/latest/Hope.Agent_aarch64.dmg).
 
 > If macOS reports "damaged" or "cannot verify the developer" on first launch, run in Terminal:
 >
@@ -197,7 +199,7 @@ scoop install hope-agent
 
 ##### Manual install (installer)
 
-Download `Hope.Agent_*-setup.exe` from [Releases](https://github.com/shiwenwen/hope-agent/releases) and double-click. **Windows is not yet fully tested** — please file issues if anything breaks.
+Download `Hope.Agent_*-setup.exe` from [Releases](https://github.com/shiwenwen/hope-agent/releases) and double-click. Mirror: [Hope.Agent_x64-setup.exe](https://repo.hopeagent.ai/download/latest/Hope.Agent_x64-setup.exe). **Windows is not yet fully tested** — please file issues if anything breaks.
 
 > If Windows reports "MSVCP140_1.dll was not found" or a similar missing `VCRUNTIME140.dll` / `MSVCP140.dll` error on launch, install the [Microsoft Visual C++ 2015–2022 Redistributable (x64)](https://aka.ms/vs/17/release/vc_redist.x64.exe) and relaunch.
 
@@ -251,9 +253,9 @@ sudo zypper install hope-agent
 
 From [Releases](https://github.com/shiwenwen/hope-agent/releases) (filenames include the arch suffix — pick `_amd64` / `_arm64` for deb/AppImage or `.x86_64` / `.aarch64` for rpm):
 
-- AppImage: `Hope.Agent_*.AppImage` — `chmod +x` and run
-- Debian / Ubuntu: `Hope.Agent_*.deb` — `sudo dpkg -i Hope.Agent_*.deb`
-- Fedora / RHEL: `Hope.Agent_*.rpm` — `sudo rpm -i Hope.Agent_*.rpm`
+- AppImage: `Hope.Agent_*.AppImage` — `chmod +x` and run. Mirror: [amd64](https://repo.hopeagent.ai/download/latest/Hope.Agent_amd64.AppImage) · [aarch64](https://repo.hopeagent.ai/download/latest/Hope.Agent_aarch64.AppImage)
+- Debian / Ubuntu: `Hope.Agent_*.deb` — `sudo dpkg -i Hope.Agent_*.deb`. Mirror: [amd64](https://repo.hopeagent.ai/download/latest/Hope.Agent_amd64.deb) · [arm64](https://repo.hopeagent.ai/download/latest/Hope.Agent_arm64.deb)
+- Fedora / RHEL: `Hope.Agent_*.rpm` — `sudo rpm -i Hope.Agent_*.rpm`. Mirror: [x86_64](https://repo.hopeagent.ai/download/latest/Hope.Agent.x86_64.rpm) · [aarch64](https://repo.hopeagent.ai/download/latest/Hope.Agent.aarch64.rpm)
 
 Both amd64 (x86_64) and arm64 (aarch64) native builds are published, covering desktops, Raspberry Pi 4/5, Apple Silicon Macs running Asahi Linux, and Graviton / Ampere cloud VMs. apt and dnf automatically pick the right arch via `dpkg --print-architecture` / `$basearch`.
 
@@ -266,7 +268,7 @@ Both amd64 (x86_64) and arm64 (aarch64) native builds are published, covering de
 #### First launch & auto-update
 
 1. First launch wizard: **pick a provider template → paste API key / sign in with Codex OAuth → chat.**
-2. Desktop builds ship with the GitHub Releases auto-updater. Go to **Settings → About** in-app to check for and install updates, or just tell the model "upgrade" / "check for updates" in chat.
+2. Desktop builds ship with a built-in auto-updater (it reads the `repo.hopeagent.ai` mirror first and falls back to GitHub Releases). Go to **Settings → About** in-app to check for and install updates, or just tell the model "upgrade" / "check for updates" in chat. Every installer is signature-verified against the built-in public key — the mirror and GitHub go through the identical check.
 3. Versions installed via Homebrew / AUR / Scoop also receive updates through the built-in updater; the package manager's recorded version stays pinned to the initial install version and does not affect functionality.
 
 > To connect from a phone or another computer, set an API key under **Settings → Server** and change the bind address to `0.0.0.0:8420`. After restarting, open `http://<IP of the device running Hope Agent>:8420`. Never expose the port to a LAN or the public internet without authentication; for public access, put it behind an HTTPS reverse proxy. See the [Docker deployment guide](docs/deployment/docker.en.md).

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@
 ### 下载安装
 
 > 📦 各平台完整安装包列表：[Releases](https://github.com/shiwenwen/hope-agent/releases)
+>
+> 🌏 **访问不了 GitHub？** 所有安装包同时镜像在 <https://repo.hopeagent.ai/download/latest/>（Cloudflare R2，与 apt / dnf 软件源同域名），下面每个手动安装入口都给了镜像直链。桌面应用的自动更新也优先走这个镜像，GitHub 作为兜底。历史版本按 `https://repo.hopeagent.ai/download/v<版本>/` 长期保留。
 
 #### macOS
 
@@ -169,7 +171,7 @@ brew install --cask hope-agent
 
 ##### 手动安装（DMG）
 
-到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载 `Hope.Agent_*.dmg`，拖到「应用程序」即可。
+到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载 `Hope.Agent_*.dmg`，拖到「应用程序」即可。镜像直链：[Hope.Agent_aarch64.dmg](https://repo.hopeagent.ai/download/latest/Hope.Agent_aarch64.dmg)。
 
 > 若启动时提示"已损坏"或"无法验证开发者"，请在终端执行：
 >
@@ -197,7 +199,7 @@ scoop install hope-agent
 
 ##### 手动安装（installer）
 
-到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载 `Hope.Agent_*-setup.exe` 双击安装。**Windows 端尚未完成充分测试**，欢迎反馈问题。
+到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载 `Hope.Agent_*-setup.exe` 双击安装。镜像直链：[Hope.Agent_x64-setup.exe](https://repo.hopeagent.ai/download/latest/Hope.Agent_x64-setup.exe)。**Windows 端尚未完成充分测试**，欢迎反馈问题。
 
 > 若启动时提示"由于找不到 MSVCP140_1.dll，无法继续执行代码"或类似缺失 `VCRUNTIME140.dll` / `MSVCP140.dll`，请安装 [Microsoft Visual C++ 2015–2022 运行库（x64）](https://aka.ms/vs/17/release/vc_redist.x64.exe)后重启应用。
 
@@ -251,9 +253,9 @@ sudo zypper install hope-agent
 
 到 [Releases](https://github.com/shiwenwen/hope-agent/releases) 下载（包名含架构后缀，按你的机器选 `_amd64` / `_arm64` 或 `.x86_64` / `.aarch64`）：
 
-- AppImage：`Hope.Agent_*.AppImage` —— `chmod +x` 后直接运行
-- Debian / Ubuntu：`Hope.Agent_*.deb` —— `sudo dpkg -i Hope.Agent_*.deb`
-- Fedora / RHEL：`Hope.Agent_*.rpm` —— `sudo rpm -i Hope.Agent_*.rpm`
+- AppImage：`Hope.Agent_*.AppImage` —— `chmod +x` 后直接运行。镜像：[amd64](https://repo.hopeagent.ai/download/latest/Hope.Agent_amd64.AppImage) · [aarch64](https://repo.hopeagent.ai/download/latest/Hope.Agent_aarch64.AppImage)
+- Debian / Ubuntu：`Hope.Agent_*.deb` —— `sudo dpkg -i Hope.Agent_*.deb`。镜像：[amd64](https://repo.hopeagent.ai/download/latest/Hope.Agent_amd64.deb) · [arm64](https://repo.hopeagent.ai/download/latest/Hope.Agent_arm64.deb)
+- Fedora / RHEL：`Hope.Agent_*.rpm` —— `sudo rpm -i Hope.Agent_*.rpm`。镜像：[x86_64](https://repo.hopeagent.ai/download/latest/Hope.Agent.x86_64.rpm) · [aarch64](https://repo.hopeagent.ai/download/latest/Hope.Agent.aarch64.rpm)
 
 提供 amd64 (x86_64) 与 arm64 (aarch64) 两种原生构建，覆盖普通 PC、树莓派 4/5、Apple Silicon 跑 Asahi Linux、Graviton / Ampere 云主机。apt 与 dnf 都会按 `dpkg --print-architecture` / `$basearch` 自动选对版本。
 
@@ -266,7 +268,7 @@ sudo zypper install hope-agent
 #### 首次启动 & 自动更新
 
 1. 首次启动向导：**选 Provider 模板 → 填 API Key / Codex OAuth 登录 → 开聊**
-2. 桌面应用内置 GitHub Releases 自动更新，应用内 **设置 → 关于** 检查更新并一键安装；或者直接在对话里说「升级」或「检查更新」
+2. 桌面应用内置自动更新（优先读 `repo.hopeagent.ai` 镜像，GitHub Releases 兜底），应用内 **设置 → 关于** 检查更新并一键安装；或者直接在对话里说「升级」或「检查更新」。安装包一律经内置公钥验签，镜像与 GitHub 走同一套校验
 3. 通过 Homebrew / AUR / Scoop 装的版本同样走应用内置 updater；包管理器视角的版本号会保持初装时的，不影响功能
 
 > 要从手机或另一台电脑访问，在「设置 → 服务器」中设置 API Key，并把监听地址改为 `0.0.0.0:8420`；重启后访问 `http://<运行 Hope Agent 的设备 IP>:8420`。不要在没有鉴权的情况下把端口暴露到局域网或公网；公网使用请前置 HTTPS 反向代理，详见 [Docker 部署指南](docs/deployment/docker.md)。

--- a/crates/ha-core/src/updater/manifest.rs
+++ b/crates/ha-core/src/updater/manifest.rs
@@ -13,10 +13,28 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-/// Endpoint matching `src-tauri/tauri.conf.json#updater.endpoints[0]` so the
-/// desktop + headless paths read the same manifest.
-pub const UPDATE_MANIFEST_URL: &str =
-    "https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json";
+/// Manifest endpoints, tried in order, mirroring
+/// `src-tauri/tauri.conf.json#plugins.updater.endpoints` so the desktop and
+/// headless paths agree on which manifest is authoritative. Drift between
+/// the two lists means one path updates and the other doesn't;
+/// `scripts/verify-updater-endpoints.mjs` refuses the PR if they diverge.
+///
+/// R2 mirror FIRST, and not as a latency tweak: a real population of users
+/// cannot reach github.com at all, and for them the manifest is the whole
+/// question — a manifest that never loads means the installer URLs inside
+/// it are never read. GitHub second so a total Cloudflare / R2 outage still
+/// resolves for everyone else.
+///
+/// First success wins, matching `tauri-plugin-updater`'s own behaviour, so
+/// the two paths cannot disagree about which release is current. The
+/// consequence — a stale-but-200 mirror manifest reports "no update"
+/// instead of falling through — is bounded by the short Cache-Control the
+/// mirror workflow sets and by that workflow writing the manifest only
+/// after every referenced URL verified. See docs/architecture/self-update.md.
+pub const UPDATE_MANIFEST_URLS: &[&str] = &[
+    "https://repo.hopeagent.ai/download/latest.json",
+    "https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json",
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Manifest {
@@ -79,7 +97,38 @@ pub enum ArchiveKind {
 const MANIFEST_FETCH_TIMEOUT_SECS: u64 = 20;
 
 pub async fn fetch_manifest() -> Result<Manifest> {
-    fetch_manifest_from(UPDATE_MANIFEST_URL).await
+    let mut last_err: Option<anyhow::Error> = None;
+    for (idx, url) in UPDATE_MANIFEST_URLS.iter().enumerate() {
+        match fetch_manifest_from(url).await {
+            Ok(manifest) => {
+                if idx > 0 {
+                    // Worth a breadcrumb: reaching the fallback means the R2
+                    // mirror is down or unreachable from this host, which is
+                    // exactly the state that leaves GitHub-blocked users with
+                    // no update path at all.
+                    app_warn!(
+                        "self_update",
+                        "manifest",
+                        "manifest served by fallback endpoint {} (index {})",
+                        url,
+                        idx
+                    );
+                }
+                return Ok(manifest);
+            }
+            Err(e) => {
+                app_warn!(
+                    "self_update",
+                    "manifest",
+                    "manifest endpoint {} failed ({}); trying next",
+                    url,
+                    e
+                );
+                last_err = Some(e);
+            }
+        }
+    }
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("no update manifest endpoints configured")))
 }
 
 pub async fn fetch_manifest_from(url: &str) -> Result<Manifest> {

--- a/docs/architecture/self-update.md
+++ b/docs/architecture/self-update.md
@@ -106,6 +106,8 @@ Manifest 结构（[`updater::manifest::Manifest`](../../crates/ha-core/src/updat
 
 **镜像不削弱签名信任根**：manifest 自身不签名，但里面的 `signature` 要用编译进二进制的 `MINISIGN_PUBKEY_BASE64` 验（见上节）。所以被污染的镜像**无法让恶意二进制装进去**，最坏只能拒绝服务或谎报版本。镜像 workflow 因此原样复制 `signature`、**绝不重算**。
 
+**「谎报版本」不只是被攻击才会发生**——正常运维就能踩到。`download/latest.json` 是全局共享的可变对象，一旦给**非当前稳定版**写它（手动回填旧 tag、或发布 prerelease，两者都会触发镜像 workflow），配合上面「首个成功者胜」，全体客户端会被告知那个旧版本才是最新，从而看不到真正的新版。因此镜像 workflow 只在该 tag 恰好是 GitHub 认定的 latest release 且非 prerelease 时才写可变面（`PROMOTE` 门控），其余情况只写自己的不可变 `download/<tag>/` 前缀。
+
 镜像的 bucket 布局与发布顺序见 [release-process §1.10](../release-process.md#110-r2-安装包镜像自动同步)。
 
 ## 用户审批契约

--- a/docs/architecture/self-update.md
+++ b/docs/architecture/self-update.md
@@ -51,6 +51,8 @@ Hope Agent 是单 binary 多形态产品（桌面 GUI / `hope-agent server` 守�
 2. CI / PR：`.github/workflows/lint.yml` 跑 `scripts/verify-updater-pubkey.mjs`。
 3. 本地 `.husky/pre-push`：同一脚本拦在 push 前。
 
+> `endpoints` 是同类的双处契约，但**校验脚本不同**（`verify-updater-endpoints.mjs`），且没有启动期 panic —— 端点写错只会拉不到 manifest，不会用错密钥验签。详见下面「Manifest 端点链」。
+
 私钥（`TAURI_SIGNING_PRIVATE_KEY` + `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`）只存 GitHub Secrets，CI release.yml 调 `pnpm tauri signer sign` 同时签桌面 installer 和 bare binary archive。私钥严禁入仓。
 
 ## 发布产物（latest.json 扩展）
@@ -87,6 +89,24 @@ Manifest 结构（[`updater::manifest::Manifest`](../../crates/ha-core/src/updat
 ```
 
 平台 key 与 tauri-action 一致：`{darwin,linux,windows}-{x86_64,aarch64}`，由 [`manifest::current_platform_key`](../../crates/ha-core/src/updater/manifest.rs) 在运行时返回当前平台串。
+
+## Manifest 端点链（R2 镜像优先，GitHub 兜底）
+
+端点列表在两处，**必须逐项逐序相等**：`src-tauri/tauri.conf.json#plugins.updater.endpoints`（桌面，`tauri-plugin-updater` 读）与 [`manifest.rs::UPDATE_MANIFEST_URLS`](../../crates/ha-core/src/updater/manifest.rs)（headless / CLI）。当前顺序：
+
+1. `https://repo.hopeagent.ai/download/latest.json` —— Cloudflare R2 镜像
+2. `https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json` —— GitHub
+
+**镜像排第一不是延迟优化，是可达性**：有一部分用户根本访问不了 `github.com`，对他们而言 manifest 拉不到就等于自动更新整条链断掉——里面的安装包 URL 连被读到的机会都没有。GitHub 排第二，保证 Cloudflare / R2 整体故障时其余用户仍能更新。
+
+**两条约束**：
+
+- **首个成功者胜**，与 `tauri-plugin-updater` 自身行为一致——刻意不做「比较版本取新者」，否则桌面与 headless 两条路径会对「当前是哪个版本」产生分歧。代价是**一份 stale-but-200 的镜像 manifest 会报「已是最新」而不会 fallback**。这条残留风险由三件事兜住：镜像 manifest 的 `Cache-Control: max-age=60`、镜像 workflow 只在全部 URL 回抓校验通过后才写 manifest（所以 stale 的那份必然描述一个真实且已完整镜像的版本，绝不会是残缺版本）、以及该 workflow 失败即报错。
+- **两处漂移会被拦**：[`scripts/verify-updater-endpoints.mjs`](../../scripts/verify-updater-endpoints.mjs) 在 CI（`lint.yml`）与 `pre-push` 双处校验，且同时校验镜像 endpoint 的域名与 [`mirror-release-r2.yml`](../../.github/workflows/mirror-release-r2.yml) 的 `PUBLIC_BASE` 一致——否则所有客户端会去问一个没有发布任何东西的主机。
+
+**镜像不削弱签名信任根**：manifest 自身不签名，但里面的 `signature` 要用编译进二进制的 `MINISIGN_PUBKEY_BASE64` 验（见上节）。所以被污染的镜像**无法让恶意二进制装进去**，最坏只能拒绝服务或谎报版本。镜像 workflow 因此原样复制 `signature`、**绝不重算**。
+
+镜像的 bucket 布局与发布顺序见 [release-process §1.10](../release-process.md#110-r2-安装包镜像自动同步)。
 
 ## 用户审批契约
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -246,9 +246,13 @@ download/
 
 所以**可变的 manifest 绝不会指向不存在的字节**。② 失败则 job 失败、`latest.json` 保持原样——意味着 R2 上一份陈旧 manifest 必然描述一个真实且已完整镜像的版本，绝不会是残缺版本。修好后重跑：`gh workflow run mirror-release-r2.yml -f tag=vX.Y.Z`（幂等）。
 
-**工具取默认分支、文档取 tag**（`actions/checkout` 不带 `ref:`，随后 `git fetch --depth=1` 单独取该 tag 再 `git show <tag>:<path>` 抽文档）。这条**刻意不写成 `ref: $TAG`**，两个理由：
+**可变面有门控**。`download/latest/` 与 `download/latest.json` 是全局共享的，给**非当前稳定版**写它们就是一次降级广播——R2 是 endpoint[0] 且首个成功者胜，全体客户端会被告知那个旧版本才是最新，从而看不到真正的新版。有两条日常路径会踩到：手动回填旧 tag（就是本节文档的那条命令），以及**发布 prerelease**（同样触发 `release.published`）。
 
-- **能回填历史版本**。用 tag 那棵树会跑 tag 自带的镜像脚本，于是本 workflow 落地**之前**发布的所有 tag 永远无法镜像（那些树里根本没有 `scripts/mirror-*.mjs`），整个历史目录就此不可镜像，README 的 `download/latest/` 链接要等到下一次发版才不是 404。取默认分支后可以直接补：`gh workflow run mirror-release-r2.yml -f tag=v0.26.0`。
+所以只有当该 tag 恰好就是 GitHub 自己认定的 latest release、且非 prerelease 时才推进可变面；其余情况只镜像到自己的不可变前缀然后停下（日志里给 `::notice::`，不算失败——回填旧版本到它自己的前缀本身是有用且无害的）。
+
+**工具取默认分支、文档取 tag**（`actions/checkout` 的 `ref:` **显式**指向默认分支，随后 `git fetch --depth=1` 单独取该 tag 再 `git show <tag>:<path>` 抽文档）。**`ref:` 必须显式写**：`release.published` 事件下 `github.ref` 就是 `refs/tags/vX.Y.Z`，不写 `ref:` 的 `actions/checkout` 会**静默取那个 tag**。取 tag 会坏两件事：
+
+- **能回填历史版本**。用 tag 那棵树会跑 tag 自带的镜像脚本，于是本 workflow 落地**之前**发布的所有 tag 永远无法镜像（那些树里根本没有 `scripts/mirror-*.mjs`），整个历史目录就此不可镜像，README 的 `download/latest/` 链接要等到下一次发版才不是 404。取默认分支后可以直接补：`gh workflow run mirror-release-r2.yml -f tag=v0.26.0`。回填旧版本时上面那道门控生效——只写它自己的不可变前缀，不会抢走 `latest`。
 - **工具应当是当前版本**。改写器里修掉的 bug 应该在下次重镜像任何 tag 时生效，而不是冻结在那个版本发布时的样子。
 
 而**文档必须是该版本实际发布的那一份**，所以单独从 tag 取，不用工作树里的。

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -218,6 +218,50 @@ Release publish 后 [`.github/workflows/update-linux-repo.yml`](../.github/workf
 
 > reprepro 的 `apt/db/` 是 incremental state（含 packages 的 sha256 索引）：CI 每次先从 R2 `copy` 下来、改完再 `copy` 回去，故历史版本记录随 R2 持久保存；`apt/conf/distributions` 每次 CI 跑覆盖渲染。R2 上传用 `copy`（非 `sync`）永不删除，一次失败的下载不会误清空。
 
+### 1.10 R2 安装包镜像自动同步
+
+与 §1.6~§1.9 同模式，Release publish 后 [`.github/workflows/mirror-release-r2.yml`](../.github/workflows/mirror-release-r2.yml) 由 `release.published` 自动触发，把**全部安装包**镜像到 §1.9 那个同一个 R2 bucket（同域名 `https://repo.hopeagent.ai/`）。
+
+**为什么要有它**：有一部分用户根本访问不了 `github.com`。apt / dnf 用户从 Linux 源迁到 R2 之后已经不受影响，但 DMG / setup.exe / AppImage / tar.gz 手动下载、以及应用内自动更新仍然只有 GitHub 一条路。这条 workflow 补掉那个缺口。
+
+**bucket 布局**（`apt/` `rpm/` `pubkey.gpg` 是 §1.9 的，互不重叠）：
+
+```
+download/
+  v0.26.0/                     ← 不可变，长 TTL，永久保留
+    Hope.Agent_0.26.0_aarch64.dmg  …（全部 25 个资产 + .sig）
+    CHANGELOG.md                   ← text/plain，供 notes 链接
+    docs/release-notes/v0.26.0.md
+    docs/release-notes/v0.26.0.en.md
+  latest/                      ← 版本无关别名，max-age=300
+    Hope.Agent_aarch64.dmg  Hope.Agent_x64-setup.exe  …
+  latest.json                  ← 唯一可变 manifest，max-age=60
+```
+
+**执行顺序即安全性质**，改这个 workflow 前必须理解：
+
+1. 资产 + 文档 + `latest/` 别名先上传
+2. **硬门禁**：把每一个上传的对象都经**公开域名**回抓，比对 `Content-Length` 与本地文件——只判 200 会让截断/零长对象过关。同时结构性断言 manifest 里每个 URL 都落在本次镜像前缀内且有本地对应文件
+3. 只有 ② 全过，才改写 `latest.json` 的 16 个 URL（12 个 `platforms` + 4 个 `bare_binary`）并发布
+
+所以**可变的 manifest 绝不会指向不存在的字节**。② 失败则 job 失败、`latest.json` 保持原样——意味着 R2 上一份陈旧 manifest 必然描述一个真实且已完整镜像的版本，绝不会是残缺版本。修好后重跑：`gh workflow run mirror-release-r2.yml -f tag=vX.Y.Z`（幂等）。
+
+**工具取默认分支、文档取 tag**（`actions/checkout` 不带 `ref:`，随后 `git fetch --depth=1` 单独取该 tag 再 `git show <tag>:<path>` 抽文档）。这条**刻意不写成 `ref: $TAG`**，两个理由：
+
+- **能回填历史版本**。用 tag 那棵树会跑 tag 自带的镜像脚本，于是本 workflow 落地**之前**发布的所有 tag 永远无法镜像（那些树里根本没有 `scripts/mirror-*.mjs`），整个历史目录就此不可镜像，README 的 `download/latest/` 链接要等到下一次发版才不是 404。取默认分支后可以直接补：`gh workflow run mirror-release-r2.yml -f tag=v0.26.0`。
+- **工具应当是当前版本**。改写器里修掉的 bug 应该在下次重镜像任何 tag 时生效，而不是冻结在那个版本发布时的样子。
+
+而**文档必须是该版本实际发布的那一份**，所以单独从 tag 取，不用工作树里的。
+
+**几条容易踩的**：
+
+- **`latest/` 别名不能带 immutable 头**。那些文件名每版复用，长 TTL 会让边缘把旧安装包钉住一年。别名由 [`scripts/mirror-latest-aliases.mjs`](../scripts/mirror-latest-aliases.mjs) 按规则剥版本号派生，但 README 实际链接的 8 个名字在 `REQUIRED_ALIASES` 里**硬登记**——规则失灵时报错，而不是发布一堆 404。两侧对齐由 `check-release-paths.mjs` 在 PR 时守。
+- **`update-linux-repo.yml` 的整桶 pull 必须带 `--include`**。它把 bucket 镜像下来重建索引；本 workflow 每版往同一个 bucket 放约 1.5 GB 且永久保留，不过滤会让那个 pull 无界增长直到超时。新增本 job 独占的顶层路径时，同步加进那个过滤列表。
+- **`notes` 里的 GitHub 链接会被改写**（改写发生在 R2 那份 manifest 上，仓库源文件不动，§1.1(a) 的「链接一律用完整 GitHub URL」规则不变）。`notes` 是应用内「发现新版」弹窗的正文且按 markdown 渲染，中英切换与 CHANGELOG 两条链接对目标用户就是死链。链到 `REQUIRED` 之外的文档时 workflow 会 fail-closed。
+- **签名原样复制、绝不重算**。理由与端点链的信任模型见 [self-update](architecture/self-update.md#manifest-端点链r2-镜像优先github-兜底)。
+
+存储成本：一版约 1.5 GB，R2 存储 $0.015/GB·月、egress 免费，按每月 3 版算一年累积约 55 GB（每月 < $1）。刻意全部保留而不做清理——现有 R2 发布路径全程只用 `copy` 不用 `sync` 就是为了「绝不删除」，加删除逻辑要单独定义失败语义。
+
 ---
 
 ## 2. 新 minor 发版差异

--- a/linux-repo/README.md
+++ b/linux-repo/README.md
@@ -24,7 +24,7 @@ See [`../docs/release-process.md`](../docs/release-process.md) §1.9 for the ful
 
 1. `gh release download` pulls every deb + rpm whose filename matches the release version — both amd64 / x86_64 and arm64 / aarch64 when present. Only the amd64 deb + x86_64 rpm are required as the minimum baseline.
 2. Import `GPG_SIGNING_KEY` into a fresh `GNUPGHOME`.
-3. **`rclone copy r2:$R2_BUCKET → ./bucket`** — mirror the currently-published tree DOWN so reprepro's `apt/db` state and createrepo_c's existing repodata are intact for an incremental update. Empty on the very first seed run.
+3. **`rclone copy r2:$R2_BUCKET → ./bucket --include /apt/** --include /rpm/** --include /pubkey.gpg`** — mirror the currently-published tree DOWN so reprepro's `apt/db` state and createrepo_c's existing repodata are intact for an incremental update. Empty on the very first seed run. The `--include` filter is **load-bearing, not tuning**: [`mirror-release-r2.yml`](../.github/workflows/mirror-release-r2.yml) shares this bucket and writes ~1.5 GB of installers per release under `download/`, kept forever — an unfiltered pull would drag every historical installer down on every Linux-repo publish and grow without bound. Adding a new top-level path this job owns? Add it to the filter too.
 4. `reprepro -b apt includedeb stable …` files each deb into the right `binary-<arch>` index and signs `InRelease` / `Release.gpg` via `SignWith:`.
 5. `createrepo_c --update rpm/stable/<arch>/` + `gpg --detach-sign --armor` on each `repodata/repomd.xml`. Per-arch subdirs (`x86_64` + `aarch64`); dnf picks via `$basearch`.
 6. Export `pubkey.gpg` from the imported key.
@@ -32,6 +32,8 @@ See [`../docs/release-process.md`](../docs/release-process.md) §1.9 for the ful
 8. **Verify** — fetch `InRelease`, `repomd.xml` and `pubkey.gpg` back over `https://repo.hopeagent.ai/…` and assert they are live and well-formed. A broken publish (or an unwired custom domain) fails the job here instead of silently leaving users on a stale source.
 
 `rpm --addsign` is **not** used — reprepro/createrepo only require *repo metadata* signatures; the rpm is trusted via repo-level `repo_gpgcheck=1`.
+
+> **This bucket has a second tenant.** [`mirror-release-r2.yml`](../.github/workflows/mirror-release-r2.yml) publishes the raw installer mirror plus the updater manifest under `download/` (`download/v<version>/`, `download/latest/`, `download/latest.json`) on the same bucket and custom domain. The two workflows write disjoint prefixes and are safe to run concurrently, but anything that touches the whole bucket — a pull, a lifecycle rule, a cleanup script — has to account for both. See [`../docs/release-process.md`](../docs/release-process.md) §1.10.
 
 ## R2 first-time setup (one-time, on the Cloudflare side)
 

--- a/scripts/check-release-paths.mjs
+++ b/scripts/check-release-paths.mjs
@@ -202,6 +202,47 @@ for (const template of ["hope-agent.rb.tmpl", "hope-agent-arm-only.rb.tmpl"]) {
   }
 }
 
+// ─── Check 7 ─────────────────────────────────────────────────────────
+// Every `download/latest/<name>` link in either README must be a name the
+// mirror actually publishes, i.e. present in REQUIRED_ALIASES — that list is
+// what mirror-release-r2.yml verifies is live before it publishes anything.
+// A README link outside the list is a documented download that nothing
+// guarantees exists, which lands as a 404 for precisely the users who cannot
+// fall back to GitHub. Checked both ways: an unused entry means the list
+// still pins a name no one links, usually a half-finished rename.
+{
+  const aliasSrc = readFileSync(
+    path.join(repoRoot, "scripts/mirror-latest-aliases.mjs"),
+    "utf8",
+  )
+  const block = aliasSrc.match(/const REQUIRED_ALIASES = \[([\s\S]*?)\]/)
+  if (!block) {
+    errors.push("scripts/mirror-latest-aliases.mjs: REQUIRED_ALIASES literal not found.")
+  } else {
+    const required = new Set([...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]))
+    const linked = new Set()
+    for (const readme of ["README.md", "README.en.md"]) {
+      const text = readFileSync(path.join(repoRoot, readme), "utf8")
+      const names = [...text.matchAll(/download\/latest\/([A-Za-z0-9._-]+)/g)].map((m) => m[1])
+      for (const n of names) {
+        linked.add(n)
+        if (!required.has(n)) {
+          errors.push(
+            `${readme}: links download/latest/${n}, which is not in REQUIRED_ALIASES (scripts/mirror-latest-aliases.mjs) — the mirror never verifies it, so the link can 404 silently.`,
+          )
+        }
+      }
+    }
+    for (const r of required) {
+      if (!linked.has(r)) {
+        errors.push(
+          `scripts/mirror-latest-aliases.mjs: REQUIRED_ALIASES pins "${r}" but neither README links it — drop it or add the link.`,
+        )
+      }
+    }
+  }
+}
+
 // ─── Report ──────────────────────────────────────────────────────────
 if (warnings.length > 0) {
   console.warn("[check-release-paths] warnings:")

--- a/scripts/mirror-latest-aliases.mjs
+++ b/scripts/mirror-latest-aliases.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+//
+// Build the version-less `download/latest/` alias set from a release's
+// assets, so README can carry download links that never go stale.
+//
+// Usage:
+//   node scripts/mirror-latest-aliases.mjs <assets-dir> <version> <out-dir>
+//
+// WHY version-less aliases exist: the mirror stores each release under an
+// immutable `download/<tag>/` prefix, which is right for permanence but
+// unusable in documentation — README cannot hardcode a version that changes
+// every release. Users who cannot reach github.com need ONE stable URL per
+// platform, so this produces `Hope.Agent_aarch64.dmg` next to the pinned
+// `download/v0.26.0/Hope.Agent_0.26.0_aarch64.dmg`.
+//
+// The rename is a RULE (strip the version token, tidy separators), not a
+// hand-maintained table, so a new artifact kind is covered automatically.
+// But rules mis-fire silently, so `REQUIRED_ALIASES` pins the names README
+// actually links: if the rule ever stops producing one of those, the mirror
+// fails instead of publishing a README full of 404s.
+
+import fs from "node:fs";
+import path from "node:path";
+
+// Exactly the filenames README.md / README.en.md link under
+// https://repo.hopeagent.ai/download/latest/. Adding a link there? Add it
+// here too, or it is not covered by the mirror's verification gate.
+//
+// Note the arch labels are NOT uniform upstream — AppImage says `aarch64`
+// where deb says `arm64`, and the rpm drops the `_` separator entirely.
+// That inconsistency is exactly why this list is pinned rather than assumed.
+const REQUIRED_ALIASES = [
+  "Hope.Agent_aarch64.dmg",
+  "Hope.Agent_x64-setup.exe",
+  "Hope.Agent_amd64.AppImage",
+  "Hope.Agent_aarch64.AppImage",
+  "Hope.Agent_amd64.deb",
+  "Hope.Agent_arm64.deb",
+  "Hope.Agent.x86_64.rpm",
+  "Hope.Agent.aarch64.rpm",
+];
+
+/**
+ * Strip the version out of a release asset filename.
+ *
+ * The four shapes tauri-action + release.yml produce:
+ *   Hope.Agent_0.26.0_aarch64.dmg        -> Hope.Agent_aarch64.dmg
+ *   Hope.Agent-0.26.0-1.x86_64.rpm       -> Hope.Agent.x86_64.rpm
+ *   hope-agent-0.26.0-linux-x86_64.tar.gz-> hope-agent-linux-x86_64.tar.gz
+ *   Hope.Agent_aarch64.app.tar.gz        -> unchanged (already version-less)
+ */
+export function aliasFor(name, version) {
+  if (!name.includes(version)) return name;
+  let out = name;
+  // The rpm carries a release number after the version (`-<v>-1.`); drop both
+  // so the alias does not pin a build revision either.
+  out = out.replace(`-${version}-1.`, ".");
+  out = out.replace(`_${version}_`, "_");
+  out = out.replace(`-${version}-`, "-");
+  out = out.replace(`_${version}`, "");
+  out = out.replace(`-${version}`, "");
+  out = out.replace(version, "");
+  // Collapse separators a removal may have doubled up, and never emit a name
+  // that starts or ends on one.
+  out = out.replace(/([._-])\1+/g, "$1").replace(/^[._-]+|[._-]+$/g, "");
+  return out;
+}
+
+function main(argv) {
+  const [assetsDir, version, outDir] = argv;
+  if (!assetsDir || !version || !outDir) {
+    console.error(
+      "Usage: node scripts/mirror-latest-aliases.mjs <assets-dir> <version> <out-dir>",
+    );
+    return 2;
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const produced = new Map(); // alias -> source name
+
+  for (const name of fs.readdirSync(assetsDir).sort()) {
+    const src = path.join(assetsDir, name);
+    if (!fs.statSync(src).isFile()) continue;
+    const alias = aliasFor(name, version);
+    const prior = produced.get(alias);
+    if (prior && prior !== name) {
+      // Two different assets collapsing onto one alias would make the alias
+      // ambiguous — whichever copied last would win, silently.
+      console.error(
+        `[mirror-latest-aliases] alias collision: "${prior}" and "${name}" both map to "${alias}"`,
+      );
+      return 1;
+    }
+    fs.copyFileSync(src, path.join(outDir, alias));
+    produced.set(alias, name);
+  }
+
+  const missing = REQUIRED_ALIASES.filter((a) => !produced.has(a));
+  if (missing.length) {
+    console.error(
+      "[mirror-latest-aliases] refusing to publish: README links these aliases but the release produced no asset for them:",
+    );
+    for (const m of missing) console.error(`  - ${m}`);
+    console.error(
+      "  Either the release is incomplete, or an artifact filename changed and REQUIRED_ALIASES / README need updating together.",
+    );
+    return 1;
+  }
+
+  console.log(
+    `[mirror-latest-aliases] ${produced.size} alias(es) staged in ${outDir} (all ${REQUIRED_ALIASES.length} README-linked names present)`,
+  );
+  for (const [alias, from] of [...produced].sort()) {
+    console.log(`  ${alias}${alias === from ? "  (unchanged)" : `  <- ${from}`}`);
+  }
+  return 0;
+}
+
+// Importable for tests; only runs the CLI when invoked directly.
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/r2-endpoint.sh
+++ b/scripts/r2-endpoint.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Resolve the Cloudflare R2 S3 endpoint from `R2_ACCOUNT_ID`, with the
+# operator-error validation that turns Cloudflare's opaque failures into
+# actionable messages.
+#
+# Shared by every workflow that talks to the R2 bucket
+# (update-linux-repo.yml, mirror-release-r2.yml). Extracted so the
+# validation lives in ONE place: it exists entirely to produce good error
+# text, and two copies drift into two different sets of half-right hints.
+#
+# Inputs (env):
+#   R2_ACCOUNT_ID      — 32-hex Cloudflare account id, OR a pasted full S3
+#                        endpoint host / URL (jurisdiction variants ok).
+#   R2_ACCESS_KEY_ID   — optional; only used to catch the account-id /
+#                        access-key-id mixup with a specific message.
+#
+# Outputs:
+#   Appends RCLONE_CONFIG_R2_ENDPOINT + CF_ACCOUNT_ID to $GITHUB_ENV when
+#   that variable is set (the CI path); otherwise prints both as
+#   `KEY=value` lines so the script is runnable and testable locally.
+#
+# Exit 0 = resolved. Exit 1 = misconfigured (message names the fix).
+
+set -euo pipefail
+
+: "${R2_ACCOUNT_ID:?R2_ACCOUNT_ID must be set}"
+
+# Accept either the bare 32-hex Cloudflare account id OR a pasted full S3
+# endpoint (host or URL, incl. jurisdiction variants like
+# <id>.eu.r2.cloudflarestorage.com). Strip whitespace + scheme, then:
+#   - if it already names the R2 endpoint host, use it verbatim
+#     (preserves any .eu. jurisdiction label);
+#   - otherwise treat it as a bare account id and build the host,
+#     validating it is 32 lowercase hex first.
+# This turns the common "pasted the whole endpoint URL" mistake — which
+# otherwise surfaces as an opaque `tls: handshake failure` — into either a
+# correct endpoint or a clear, actionable error.
+raw="$(printf '%s' "$R2_ACCOUNT_ID" | tr -d '[:space:]')"
+raw="${raw#http://}"; raw="${raw#https://}"
+# Cloudflare's bucket "S3 API" panel shows the endpoint WITH the bucket
+# path (…r2.cloudflarestorage.com/<bucket>). Strip any path so pasting
+# that whole string resolves to the endpoint host.
+raw="${raw%%/*}"
+
+if [[ "$raw" == *".r2.cloudflarestorage.com" ]]; then
+  host="$raw"
+else
+  id="$raw"
+  if [[ ! "$id" =~ ^[0-9a-f]{32}$ ]]; then
+    echo "::error::R2_ACCOUNT_ID must be the 32-char hex Cloudflare account id (or the full S3 endpoint host). Got something that normalizes to length ${#id}. Do NOT paste the whole 'https://<id>.r2.cloudflarestorage.com' URL — paste only the account id shown on the R2 overview page. See linux-repo/README.md."
+    exit 1
+  fi
+  # Common mixup: the R2 API token's Access Key ID is ALSO 32 hex and sits
+  # right next to the Account ID on the token screen. If someone pasted the
+  # Access Key ID into R2_ACCOUNT_ID, the endpoint host is wrong and
+  # Cloudflare rejects it at TLS (handshake failure), not with a 403. Catch
+  # the identical-value case with a clear message.
+  akid="$(printf '%s' "${R2_ACCESS_KEY_ID:-}" | tr -d '[:space:]')"
+  if [[ -n "$akid" && "$id" == "$akid" ]]; then
+    echo "::error::R2_ACCOUNT_ID equals R2_ACCESS_KEY_ID — you pasted the API token's Access Key ID into R2_ACCOUNT_ID. They are DIFFERENT values: the Account ID is the 32-hex id in the dashboard URL dash.cloudflare.com/<ACCOUNT_ID> and in https://<ACCOUNT_ID>.r2.cloudflarestorage.com. Re-set R2_ACCOUNT_ID to the account id. See linux-repo/README.md."
+    exit 1
+  fi
+  host="${id}.r2.cloudflarestorage.com"
+fi
+
+# Bare 32-hex account id (first label of the host) for Wrangler's
+# CLOUDFLARE_ACCOUNT_ID on the bridge path.
+out_endpoint="RCLONE_CONFIG_R2_ENDPOINT=https://${host}"
+out_account="CF_ACCOUNT_ID=${host%%.*}"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "$out_endpoint" >> "$GITHUB_ENV"
+  echo "$out_account" >> "$GITHUB_ENV"
+else
+  echo "$out_endpoint"
+  echo "$out_account"
+fi
+echo "R2 endpoint host: ${host}"

--- a/scripts/rewrite-manifest-for-mirror.mjs
+++ b/scripts/rewrite-manifest-for-mirror.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+//
+// Derive the R2-hosted copy of `latest.json` from the authoritative
+// GitHub-hosted one: repoint every download URL at the mirror, and repoint
+// the two GitHub doc links inside `notes` at the mirrored copies.
+//
+// Usage:
+//   node scripts/rewrite-manifest-for-mirror.mjs <latest.json> <tag> <public-base> [--out=<path>]
+//
+// Example:
+//   node scripts/rewrite-manifest-for-mirror.mjs manifest/latest.json v0.26.0 \
+//     https://repo.hopeagent.ai --out=upload/latest.json
+//
+// WHY this exists: a real population of users cannot reach github.com at
+// all. For them the manifest is not a latency question — it is whether
+// auto-update works, because a manifest that never loads means the
+// installer URLs inside it are never read. Mirroring the manifest without
+// rewriting its URLs would be pointless: they'd resolve the manifest and
+// then fail on the 100–190 MB download.
+//
+// The GitHub-hosted manifest stays AUTHORITATIVE and untouched. This
+// output is a derived artifact. The two deliberately diverge in exactly
+// two ways — download URLs and the `notes` doc links — and nothing else.
+// Every URL must be recognized and rewritten: an unrecognized one, or a
+// surviving `releases/download/` URL, fails the run rather than shipping a
+// manifest that sends some users back to github.com for bytes.
+//
+// SECURITY: the per-platform `signature` values are copied verbatim and
+// never recomputed. Verification happens against the Minisign public key
+// compiled into the binary (`ha_core::updater::keys::MINISIGN_PUBKEY_BASE64`),
+// so a tampered mirror cannot cause a malicious install — the worst it can
+// do is deny service or advertise a stale version. Rewriting a signature
+// here, or deriving one from mirror bytes, would break that property.
+
+import fs from "node:fs";
+
+function usage() {
+  console.error(
+    "Usage: node scripts/rewrite-manifest-for-mirror.mjs <latest.json> <tag> <public-base> [--out=<path>]",
+  );
+  process.exit(2);
+}
+
+const argv = process.argv.slice(2);
+const outFlag = argv.find((a) => a.startsWith("--out="));
+const docsOutFlag = argv.find((a) => a.startsWith("--docs-out="));
+const [manifestPath, tagRaw, publicBaseRaw] = argv.filter(
+  (a) => !a.startsWith("--"),
+);
+if (!manifestPath || !tagRaw || !publicBaseRaw) usage();
+
+const tag = tagRaw.startsWith("v") ? tagRaw : `v${tagRaw}`;
+const version = tag.slice(1);
+const publicBase = publicBaseRaw.replace(/\/+$/, "");
+const outPath = outFlag ? outFlag.slice("--out=".length) : manifestPath;
+
+// Mirror layout, mirroring GitHub's own: immutable per-version prefix. The
+// only mutable object is `download/latest.json`, written by the workflow
+// (not here) with a short Cache-Control so the edge cannot pin a stale
+// manifest — see mirror-release-r2.yml.
+const mirrorBase = `${publicBase}/download/${tag}`;
+
+// Any release asset URL on the GitHub release for THIS tag. Matching on the
+// tag (not a bare hostname) means a URL pointing at some other release —
+// which would be a bug upstream — fails the assertion below instead of
+// being silently rewritten to a file we never mirrored.
+const RELEASE_ASSET_RE = new RegExp(
+  `^https://github\\.com/shiwenwen/hope-agent/releases/download/${tag.replace(/\./g, "\\.")}/(.+)$`,
+);
+
+const problems = [];
+const rewrites = [];
+// Repo-relative doc paths the `notes` rewrite now points at. Emitted via
+// --docs-out so the workflow uploads exactly the set that got linked,
+// instead of carrying a hardcoded list that silently drifts when a release
+// note gains or loses a cross-file link.
+const mirroredDocs = new Set();
+
+function rewriteAssetUrl(where, url) {
+  const m = RELEASE_ASSET_RE.exec(url);
+  if (!m) {
+    problems.push(`${where}: not a v${version} release asset URL — ${url}`);
+    return url;
+  }
+  const next = `${mirrorBase}/${m[1]}`;
+  rewrites.push(`${where}: ${m[1]}`);
+  return next;
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+
+if (manifest.version !== version) {
+  console.error(
+    `[rewrite-manifest] manifest.version is "${manifest.version}" but tag says "${version}" — refusing to rewrite a manifest for a different release.`,
+  );
+  process.exit(1);
+}
+
+// ── platforms[] (tauri-plugin-updater) ─────────────────────────────────
+const platforms = manifest.platforms ?? {};
+if (Object.keys(platforms).length === 0) {
+  console.error("[rewrite-manifest] manifest has no `platforms` — refusing.");
+  process.exit(1);
+}
+for (const [key, entry] of Object.entries(platforms)) {
+  entry.url = rewriteAssetUrl(`platforms.${key}`, entry.url);
+}
+
+// ── bare_binary.platforms[] (headless self-update) ─────────────────────
+// Absent on manifests predating the extension; tolerated (the headless
+// path falls back to the package manager), but if present it must be
+// complete — a half-rewritten section would send headless installs to
+// GitHub for some platforms and R2 for others.
+const bare = manifest.bare_binary?.platforms ?? {};
+for (const [key, entry] of Object.entries(bare)) {
+  entry.url = rewriteAssetUrl(`bare_binary.platforms.${key}`, entry.url);
+}
+
+// ── notes: the two tag-pinned GitHub doc links ─────────────────────────
+// `notes` is the release-notes body, rendered as clickable markdown in the
+// in-app "update available" dialog (AboutPanel -> MarkdownRenderer). Its
+// language-switch and CHANGELOG links point at github.com/blob/<tag>/…,
+// which are dead ends for exactly the users the mirror exists for.
+//
+// The repo's source files keep their GitHub URLs — AGENTS.md's "release
+// notes links must be absolute tag-pinned GitHub URLs" rule is unchanged.
+// Only this derived copy is rewritten.
+let notesRewrites = 0;
+if (typeof manifest.notes === "string" && manifest.notes.length > 0) {
+  const BLOB_RE = new RegExp(
+    `https://github\\.com/shiwenwen/hope-agent/blob/${tag.replace(/\./g, "\\.")}/([^)\\s]+)`,
+    "g",
+  );
+  manifest.notes = manifest.notes.replace(BLOB_RE, (_full, docPath) => {
+    notesRewrites += 1;
+    // Strip any #anchor: the mirror serves raw markdown as text/plain, where
+    // a fragment has nothing to jump to. Dropping it lands the reader at the
+    // top of the file — and the section they want is the newest release,
+    // which is at the top of CHANGELOG.md anyway.
+    //
+    // The path is kept repo-relative under the version prefix (so
+    // `docs/release-notes/x.md` and `CHANGELOG.md` land where their repo
+    // paths say) — the workflow then uploads those same paths verbatim and
+    // there is no mapping table to drift.
+    const [cleanPath] = docPath.split("#");
+    mirroredDocs.add(cleanPath);
+    return `${mirrorBase}/${cleanPath}`;
+  });
+}
+
+// ── assertions: exactly two kinds of divergence, nothing else ──────────
+if (problems.length) {
+  console.error("[rewrite-manifest] refusing to write a partly-rewritten manifest:");
+  for (const p of problems) console.error(`  - ${p}`);
+  process.exit(1);
+}
+
+const remaining = JSON.stringify(manifest).match(
+  /https:\/\/github\.com\/shiwenwen\/hope-agent\/releases\/download\//g,
+);
+if (remaining) {
+  console.error(
+    `[rewrite-manifest] ${remaining.length} GitHub release-download URL(s) survived the rewrite — the mirror manifest must not send anyone back to github.com for bytes.`,
+  );
+  process.exit(1);
+}
+
+fs.writeFileSync(outPath, JSON.stringify(manifest, null, 2) + "\n");
+if (docsOutFlag) {
+  const docsOutPath = docsOutFlag.slice("--docs-out=".length);
+  fs.writeFileSync(
+    docsOutPath,
+    [...mirroredDocs].sort().map((p) => `${p}\n`).join(""),
+  );
+}
+console.log(
+  `[rewrite-manifest] ${rewrites.length} download URL(s) + ${notesRewrites} notes link(s) repointed at ${mirrorBase}`,
+);
+for (const r of rewrites) console.log(`  ${r}`);
+for (const d of [...mirroredDocs].sort()) console.log(`  notes doc: ${d}`);

--- a/scripts/verify-updater-endpoints.mjs
+++ b/scripts/verify-updater-endpoints.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+//
+// CI / pre-push sanity check for the updater manifest endpoints, which live
+// in THREE places that must agree:
+//
+//   1. src-tauri/tauri.conf.json#plugins.updater.endpoints  (desktop, read
+//      by tauri-plugin-updater)
+//   2. crates/ha-core/src/updater/manifest.rs::UPDATE_MANIFEST_URLS
+//      (headless / CLI self-update)
+//   3. .github/workflows/mirror-release-r2.yml env.PUBLIC_BASE — the domain
+//      the mirror actually publishes `download/latest.json` to
+//
+// Drift between 1 and 2 means the desktop and headless paths disagree about
+// which manifest is authoritative: one gets updates, the other silently
+// doesn't. Drift between the R2 entry and 3 means every client asks a
+// hostname nothing is published to — a 404 that quietly falls through to
+// GitHub, taking away exactly the reachability the mirror exists to provide.
+//
+// Order matters and is checked: these lists are first-success-wins, so
+// swapping them changes which source is preferred.
+//
+// Exit 0 = agree. Exit 1 = drift (prints all sides).
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const tauriConfPath = path.join(repoRoot, "src-tauri/tauri.conf.json");
+const manifestRsPath = path.join(
+  repoRoot,
+  "crates/ha-core/src/updater/manifest.rs",
+);
+const mirrorWorkflowPath = path.join(
+  repoRoot,
+  ".github/workflows/mirror-release-r2.yml",
+);
+
+function readEndpointsFromTauriConf() {
+  const conf = JSON.parse(fs.readFileSync(tauriConfPath, "utf8"));
+  const eps = conf?.plugins?.updater?.endpoints;
+  if (!Array.isArray(eps) || eps.length === 0) {
+    throw new Error(
+      `tauri.conf.json#plugins.updater.endpoints is missing or empty (${tauriConfPath})`,
+    );
+  }
+  return eps.map((s) => String(s).trim());
+}
+
+function readEndpointsFromManifestRs() {
+  const raw = fs.readFileSync(manifestRsPath, "utf8");
+  const block = raw.match(
+    /pub const UPDATE_MANIFEST_URLS:\s*&\[&str\]\s*=\s*&\[([\s\S]*?)\];/,
+  );
+  if (!block) {
+    throw new Error(
+      `Could not find UPDATE_MANIFEST_URLS literal in ${manifestRsPath}`,
+    );
+  }
+  const urls = [...block[1].matchAll(/"([^"]+)"/g)].map((m) => m[1].trim());
+  if (urls.length === 0) {
+    throw new Error(`UPDATE_MANIFEST_URLS is empty in ${manifestRsPath}`);
+  }
+  return urls;
+}
+
+function readPublicBaseFromMirrorWorkflow() {
+  const raw = fs.readFileSync(mirrorWorkflowPath, "utf8");
+  // Deliberately a line-anchored match on the `env:` entry rather than a YAML
+  // parse: this script runs in pre-push, where pulling in a YAML dependency
+  // for one scalar is not worth it.
+  const m = raw.match(/^\s{2}PUBLIC_BASE:\s*(\S+)\s*$/m);
+  if (!m) {
+    throw new Error(
+      `Could not find the PUBLIC_BASE env entry in ${mirrorWorkflowPath}`,
+    );
+  }
+  return m[1].replace(/\/+$/, "");
+}
+
+function main() {
+  const fromConf = readEndpointsFromTauriConf();
+  const fromRs = readEndpointsFromManifestRs();
+  const publicBase = readPublicBaseFromMirrorWorkflow();
+
+  let ok = true;
+
+  if (JSON.stringify(fromConf) !== JSON.stringify(fromRs)) {
+    ok = false;
+    console.error(
+      "[verify-updater-endpoints] DRIFT — desktop and headless updaters would read different manifests.",
+    );
+    console.error(`  tauri.conf.json#plugins.updater.endpoints:`);
+    for (const e of fromConf) console.error(`    - ${e}`);
+    console.error(`  ha-core/updater/manifest.rs UPDATE_MANIFEST_URLS:`);
+    for (const e of fromRs) console.error(`    - ${e}`);
+    console.error(
+      "  Resolve by making both lists identical, in the same order (order = preference).",
+    );
+  }
+
+  // The mirror entry, if configured, must be the domain the mirror workflow
+  // publishes to. Absence is allowed — the mirror is an addition, not a
+  // requirement — but a mismatched host is always a bug.
+  const mirrorEntries = fromConf.filter((e) => !e.includes("github.com"));
+  for (const entry of mirrorEntries) {
+    if (!entry.startsWith(`${publicBase}/`)) {
+      ok = false;
+      console.error(
+        "[verify-updater-endpoints] DRIFT — a non-GitHub updater endpoint does not match the mirror's published base.",
+      );
+      console.error(`  endpoint:                       ${entry}`);
+      console.error(`  mirror-release-r2.yml PUBLIC_BASE: ${publicBase}`);
+      console.error(
+        "  Resolve by pointing both at the same host (and remember README.md / README.en.md / update-linux-repo.yml / linux-repo/rpm/hope-agent.repo carry the same base).",
+      );
+    }
+  }
+
+  if (!ok) return 1;
+  console.log(
+    `[verify-updater-endpoints] OK — ${fromConf.length} endpoint(s) agree across tauri.conf.json, manifest.rs, and PUBLIC_BASE (${publicBase}).`,
+  );
+  return 0;
+}
+
+process.exit(main());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -105,6 +105,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDMxNjgyN0E5ODY0MzM4RDIKUldUU09FT0dxU2RvTVRGWW5IN3lkMkE2b05mRW4wUk0wak5yUHQvMjNNaTdXYVR6RjlxbmVUcC8K",
       "endpoints": [
+        "https://repo.hopeagent.ai/download/latest.json",
         "https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json"
       ],
       "windows": {


### PR DESCRIPTION
## 问题

访问不了 `github.com` 的用户此前**既装不上也更新不了**。apt / dnf 用户从 Linux 源迁到 R2 之后已经不受影响，但 DMG / setup.exe / AppImage / tar.gz 手动下载，以及应用内自动更新，仍然只有 GitHub 一条路。

自动更新走两步：先拉 16 KB 的 `latest.json`，再按里面每个 platform 的 `url` 下 100~190 MB 安装包。**清单拉不到，里面的 URL 连被读到的机会都没有**——所以这不是延迟问题，是这条链能不能工作的问题。

## 做法

新增 [`mirror-release-r2.yml`](.github/workflows/mirror-release-r2.yml)（`release.published` 触发），复用 §1.9 已有的 R2 bucket 与域名 `repo.hopeagent.ai`，无需新增任何 secret。

**执行顺序即安全性质**：

1. 资产 + 文档 + `latest/` 别名先上传
2. **硬门禁**：把每一个上传的对象经**公开域名**回抓，比对 `Content-Length` 与本地文件——只判 200 会让截断 / 零长对象过关
3. 只有 ② 全过，才改写 `latest.json` 的 16 个 URL（12 `platforms` + 4 `bare_binary`）并发布

所以**可变的 manifest 绝不会指向不存在的字节**。② 失败则 job 失败、`latest.json` 保持原样——R2 上一份陈旧 manifest 必然描述一个真实且已完整镜像的版本，绝不会是残缺版本。

**bucket 布局**（与 `apt/` `rpm/` 互不重叠）：

```
download/
  v0.26.0/     ← 不可变，max-age=31536000，永久保留
  latest/      ← 版本无关别名（README 链接用），max-age=300
  latest.json  ← 唯一可变 manifest，max-age=60
```

## 安全模型不受影响

`verify_bytes` 用的是**编译期嵌进二进制**的 `MINISIGN_PUBKEY_BASE64`。manifest 自身不签名，但里面的 `signature` 要拿那个公钥验，**伪造签名过不了**。被污染的镜像最多能拒绝服务或谎报版本，**不可能让恶意二进制装进去**。所以本 workflow 原样复制 `signature`、绝不重算。

## 权衡：刻意保持「首个成功者胜」

`endpoints` 在 `tauri-plugin-updater` 和 `ha_core::updater` 都是首个成功者胜。刻意**不做**「比较版本取新者」——否则桌面与 headless 会对「当前是哪个版本」产生分歧。

代价是**一份 stale-but-200 的镜像 manifest 会报「已是最新」而不 fallback**。由三件事兜住：`latest.json` 的 `max-age=60`、上面那条「校验全过才写」、以及 workflow 失败即报错。这条残留风险在 [self-update.md](docs/architecture/self-update.md) 与 AGENTS.md 都显式写明。

## 配套改动

- **`update-linux-repo.yml` 整桶 pull 加 `--include` 过滤**。这是 load-bearing 不是调优：同一 bucket 每版多出约 1.5 GB 且永久保留，不过滤会让那个 pull 无界增长直到超时（该 workflow 目前总共只跑 1 分钟，就是因为 bucket 还小）
- R2 endpoint 解析（含那套把 Cloudflare 的 `tls: handshake failure` 翻译成可操作报错的校验）抽成 [`scripts/r2-endpoint.sh`](scripts/r2-endpoint.sh)，两个 workflow 共用
- 新增 [`verify-updater-endpoints.mjs`](scripts/verify-updater-endpoints.mjs)：守 `tauri.conf.json` ↔ `manifest.rs` 两处**逐项逐序相等**，并校验镜像域名 ↔ `PUBLIC_BASE`（CI + pre-push，与 pubkey 同类契约）
- `check-release-paths` 新增 check 7：README 的 `download/latest/` 链接必须在 `REQUIRED_ALIASES` 内，双向校验（避免文档里出现镜像从不验证的 404 链接）
- `notes` 里两条 tag-pin 的 GitHub 文档链接会在**镜像那份 manifest** 上改写（仓库源文件不动，AGENTS.md 那条规则不变）。`notes` 是应用内「发现新版」弹窗正文且按 markdown 渲染，对目标用户就是两条死链

## 一个部署顺序上的坑（已处理）

`checkout` **刻意不写 `ref: $TAG`**。用 tag 那棵树会跑 tag 自带的镜像脚本，于是本 workflow 落地**之前**发布的所有 tag 永远无法镜像——那些树里根本没有 `scripts/mirror-*.mjs`。改成工具取默认分支、文档单独从 tag 取。

**因此合并后需要手动回填一次**，否则 README 的镜像链接要等到下次发版才不是 404：

```bash
gh workflow run mirror-release-r2.yml -f tag=v0.26.0
```

## 验证

- `scripts/r2-endpoint.sh`：6 用例（32-hex / 粘完整 URL 带 bucket 路径 / eu 辖区标签 / 长度错 / account_id==access_key_id / 未设变量）
- `rewrite-manifest-for-mirror.mjs`：对**真实的 v0.26.0 `latest.json`** 跑通——16 个 URL 全部改写，签名逐字节未变，除 `url` / `notes` 外零差异，无残留 `releases/download/` URL
- `mirror-latest-aliases.mjs`：对真实 25 个资产名全部正确（含 rpm 的 `-<v>-1.` 形状与本就无版本的 `.app.tar.gz`）。**这道断言抓出了我自己写错的一条**——AppImage 用 `aarch64` 而 deb 用 `arm64`。另测了别名碰撞与 README 链接缺失
- `verify-updater-endpoints.mjs`：3 个漂移场景（顺序颠倒 / PUBLIC_BASE 改域名 / 只改 manifest.rs）全部拦住
- `check-release-paths` check 7：正负双向
- 16 步 YAML 解析 + 14 个 run 步骤 `bash -n`（并去掉了对 bash-4-only `mapfile` 的依赖）
- `cargo check --workspace`（含不在门禁内的 `src-tauri`）、`pnpm typecheck`、docs parity、i18n、pre-push 全套

## 无法预先证明的

R2 经 Cloudflare 边缘对国内到底比 GitHub 快多少，得等第一次真跑。步骤 ② 的回抓会把每个对象的耗时打进日志，正好是这份数据。

存储成本：一版约 1.5 GB，R2 存储 $0.015/GB·月、egress 免费，按每月 3 版算一年累积约 55 GB（每月 < $1）。刻意全部保留不做清理——现有 R2 发布路径全程只用 `copy` 不用 `sync` 就是为了「绝不删除」。