### PR TITLE
fix(ci): R2 上传加重试余量，停止截断 rclone 错误输出

### DIFF
--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -81,6 +81,27 @@ env:
   RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
   RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
   # RCLONE_CONFIG_R2_ENDPOINT is derived by scripts/r2-endpoint.sh.
+  #
+  # Shared robustness flags for every upload. R2 intermittently answers
+  # `501 NotImplemented` mid-transfer: the first backfill run saw attempt 1
+  # fail wholesale on all three upload steps, two of them recovering on
+  # attempt 2 and the third exhausting rclone's default 3 retries. Root cause
+  # is NOT established yet — the long-stable update-linux-repo.yml writes the
+  # same bucket without trouble, and the one flag it does not use is
+  # --header-upload. Until that is pinned down, give transfers real retry
+  # headroom and stop swallowing the errors that would identify it.
+  #   --retries / --low-level-retries: headroom over the defaults (3 / 10).
+  #   --s3-no-check-bucket: skips the bucket-existence probe, one of the calls
+  #     R2 is known to answer NotImplemented for. The bucket is created and
+  #     managed out of band (linux-repo/README.md).
+  #   --transfers/--checkers: lower concurrency, less pressure per burst.
+  # Expanded UNQUOTED at each call site — word splitting is the point.
+  RCLONE_FLAGS: >-
+    --retries 10
+    --low-level-retries 20
+    --s3-no-check-bucket
+    --transfers=4
+    --checkers=8
 
 jobs:
   mirror-release-r2:
@@ -297,15 +318,18 @@ jobs:
           set -euo pipefail
           # Immutable per-version prefix, so a long edge TTL is correct and
           # every historical download link keeps working forever.
+          # stderr is NOT piped through `tail`: the first backfill run was
+          # diagnosable only from the per-object error lines, and truncating
+          # them threw away exactly what was needed.
           rclone copy assets "r2:${R2_BUCKET}/download/${TAG}" \
             --header-upload "Cache-Control: public, max-age=31536000, immutable" \
-            --transfers=8 --checkers=16 --stats=30s --stats-one-line 2>&1 | tail -10
+            $RCLONE_FLAGS --stats=30s --stats-one-line
           # Raw markdown as text/plain so a browser DISPLAYS it instead of
           # downloading an opaque .md — these are read, not installed.
           rclone copy docs-upload "r2:${R2_BUCKET}/download/${TAG}" \
             --header-upload "Cache-Control: public, max-age=31536000, immutable" \
             --header-upload "Content-Type: text/plain; charset=utf-8" \
-            --transfers=4 --stats=0 2>&1 | tail -5
+            $RCLONE_FLAGS --stats=0
           echo "Uploaded to r2:${R2_BUCKET}/download/${TAG}"
 
       - name: Upload latest/ aliases (mutable, short TTL)
@@ -330,7 +354,7 @@ jobs:
           rclone copy latest-upload "r2:${R2_BUCKET}/download/latest" \
             --header-upload "Cache-Control: public, max-age=300, must-revalidate" \
             --ignore-times \
-            --transfers=8 --checkers=16 --stats=30s --stats-one-line 2>&1 | tail -10
+            $RCLONE_FLAGS --stats=30s --stats-one-line
           echo "Uploaded to r2:${R2_BUCKET}/download/latest"
 
       - name: Verify every mirrored URL is live with the right size
@@ -445,7 +469,7 @@ jobs:
           rclone copyto upload/latest.json "r2:${R2_BUCKET}/download/latest.json" \
             --header-upload "Cache-Control: public, max-age=60, must-revalidate" \
             --ignore-times \
-            --stats=0
+            $RCLONE_FLAGS --stats=0
           echo "Published r2:${R2_BUCKET}/download/latest.json"
 
       - name: Verify the published manifest serves this release

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -263,6 +263,7 @@ download/
 - **`update-linux-repo.yml` 的整桶 pull 必须带 `--include`**。它把 bucket 镜像下来重建索引；本 workflow 每版往同一个 bucket 放约 1.5 GB 且永久保留，不过滤会让那个 pull 无界增长直到超时。新增本 job 独占的顶层路径时，同步加进那个过滤列表。
 - **`notes` 里的 GitHub 链接会被改写**（改写发生在 R2 那份 manifest 上，仓库源文件不动，§1.1(a) 的「链接一律用完整 GitHub URL」规则不变）。`notes` 是应用内「发现新版」弹窗的正文且按 markdown 渲染，中英切换与 CHANGELOG 两条链接对目标用户就是死链。链到 `REQUIRED` 之外的文档时 workflow 会 fail-closed。
 - **签名原样复制、绝不重算**。理由与端点链的信任模型见 [self-update](architecture/self-update.md#manifest-端点链r2-镜像优先github-兜底)。
+- **R2 会间歇性返回 `501 NotImplemented`**。首次回填时三个上传步骤的 attempt 1 全部大面积失败，两个在 attempt 2 自愈、第三个耗尽 rclone 默认的 3 次重试而告败。**根因尚未定位**——长期稳定的 `update-linux-repo.yml` 往同一个 bucket 传同量级文件从不出这个，而它与这三步唯一的差别是没有 `--header-upload`。当前对策是给足重试余量并跳过 R2 已知会 501 的 bucket 探测（见 `RCLONE_FLAGS`）。**rclone 的 stderr 不要再用 `tail` 截断**——首次失败时正是被截掉的逐对象错误行才能定位问题，别再为了日志好看把它们丢掉。
 
 存储成本：一版约 1.5 GB，R2 存储 $0.015/GB·月、egress 免费，按每月 3 版算一年累积约 55 GB（每月 < $1）。刻意全部保留而不做清理——现有 R2 发布路径全程只用 `copy` 不用 `sync` 就是为了「绝不删除」，加删除逻辑要单独定义失败语义。
 


### PR DESCRIPTION
## 背景

[#580](https://github.com/shiwenwen/hope-agent/pull/580) 合并后跑了首次回填 [run 30556569618](https://github.com/shiwenwen/hope-agent/actions/runs/30556569618)。链路走通了，但 R2 间歇性返回 `501 NotImplemented`：

| 步骤 | 结果 |
| --- | --- |
| 不可变资产（25 个） | attempt 1 失败 **31 errors** → attempt 2 成功 |
| 文档（3 个） | attempt 1 失败 **3 errors**（全失败）→ attempt 2 成功 |
| `latest/` 别名（25 个） | **3 次全失败**，最后 27 errors |

模式是「第一次几乎全挂、第二次就好」，rclone 默认的 3 次重试对最后一步不够。

**安全设计按预期生效**：上传失败 → 校验步骤跳过 → `latest.json` 未被写入。R2 上没有半成品状态，`download/v0.26.0/` 的不可变资产已完整（那两步自愈了），缺的只是 `latest/` 别名与 manifest。

## 根因未定位

**不假装定位了。** 现有事实：长期稳定的 `update-linux-repo.yml` 往**同一个 bucket**、用同一个 rclone、在同一种 runner 上传同量级文件，从 v0.20.1 到 v0.26.0 从未出过这个；它与失败的这三步唯一的差别是**没有 `--header-upload`**。这是线索，不是结论——所以本 PR 不去动 `--header-upload`（Cache-Control 的分档是正确性要求，`latest/` 若带上 immutable 头会让边缘把旧安装包钉住一年）。

## 改动

1. **给足重试余量**：`--retries 10 --low-level-retries 20`（默认 3 / 10），并降低并发到 `--transfers=4 --checkers=8`
2. **`--s3-no-check-bucket`**：跳过 bucket 存在性探测，那是 R2 已知会答 NotImplemented 的调用之一。bucket 本就在带外创建管理（`linux-repo/README.md`）
3. **去掉 `2>&1 | tail -10`**

第 3 条比前两条更要紧。首次失败时能定位问题的正是那些被截掉的逐对象错误行——为了日志好看丢掉它们，代价是下次还得再跑一整轮才能看到。`docs/release-process.md` 里也写明了这条教训，避免有人日后又把它加回去。

## 后续

合并后重跑 `gh workflow run mirror-release-r2.yml -f tag=v0.26.0`。无论成败都会有完整错误输出：成功则镜像上线，失败则拿到定位 501 所需的全部信息，再针对性处理（届时 `--header-upload` 那条线索就有数据可验证了）。