### PR TITLE
fix(ci): 镜像临时目录移出 checkout，--ignore-times 换 --checksum

### DIFF
--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -108,8 +108,29 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.event.release.tag_name }}
+      # WORK (the scratch root) is set by the first step from $RUNNER_TEMP.
+      # It cannot be defined here: the `runner` context is not available in a
+      # job-level `env:` block, so `${{ runner.temp }}` would not resolve.
 
     steps:
+      - name: Prepare a clean scratch tree
+        run: |
+          set -euo pipefail
+          # Every scratch dir lives OUTSIDE the checkout, under the runner's
+          # own temp. `assets/` used to be a bare relative path, so it silently
+          # merged with the repo's top-level assets/ directory and mirrored
+          # alpha-logo.png + transparency-logo.png as if they were release
+          # artifacts. Any bare name can collide with a future repo directory;
+          # $RUNNER_TEMP cannot.
+          work="${RUNNER_TEMP}/mirror"
+          # Start from empty: a leftover from an earlier run on a warm runner
+          # would be mirrored as a release artifact too — same failure mode,
+          # different source.
+          rm -rf "$work"
+          mkdir -p "$work"
+          echo "WORK=$work" >> "$GITHUB_ENV"
+          echo "scratch: $work"
+
       - name: Resolve version from tag
         run: |
           set -euo pipefail
@@ -201,7 +222,7 @@ jobs:
           # Leading `+` forces the update: on a re-run the local tag ref may
           # already exist, and a non-forced fetch refuses to clobber it.
           git fetch --depth=1 origin "+refs/tags/${TAG}:refs/tags/${TAG}"
-          mkdir -p docs-upload
+          mkdir -p "$WORK/docs"
           # Always mirror both release-note languages plus the CHANGELOG: the
           # notes body links to the sibling language, so mirroring only the
           # linked one leaves the language switch a dead end.
@@ -212,17 +233,17 @@ jobs:
             echo "CHANGELOG.md"
             echo "docs/release-notes/${TAG}.md"
             echo "docs/release-notes/${TAG}.en.md"
-          } > allowed-docs.txt
+          } > "$WORK/allowed-docs.txt"
           while IFS= read -r p; do
             if ! git cat-file -e "${TAG}:${p}" 2>/dev/null; then
               echo "::error::${TAG} does not contain ${p} — a release must ship its own notes (see docs/release-process.md §1.1a)"
               exit 1
             fi
-            mkdir -p "docs-upload/$(dirname "$p")"
-            git show "${TAG}:${p}" > "docs-upload/${p}"
-          done < allowed-docs.txt
+            mkdir -p "$WORK/docs/$(dirname "$p")"
+            git show "${TAG}:${p}" > "$WORK/docs/${p}"
+          done < "$WORK/allowed-docs.txt"
           echo "--- docs fetched from ${TAG} ---"
-          find docs-upload -type f | sort
+          find "$WORK/docs" -type f | sort
 
       - name: Preflight — required R2 secrets present
         run: |
@@ -260,16 +281,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          mkdir -p assets manifest
-          gh release download "$TAG" --repo "${{ github.repository }}" --dir assets
+          mkdir -p "$WORK/assets" "$WORK/manifest"
+          gh release download "$TAG" --repo "${{ github.repository }}" --dir "$WORK/assets"
           # latest.json is handled separately: the mirror's copy lives at the
           # stable, mutable download/latest.json — not inside the immutable
           # per-version prefix — so move it out of the asset set.
-          test -f assets/latest.json || { echo "::error::release $TAG has no latest.json"; exit 1; }
-          mv assets/latest.json manifest/latest.json
+          test -f "$WORK/assets/latest.json" || { echo "::error::release $TAG has no latest.json"; exit 1; }
+          mv "$WORK/assets/latest.json" "$WORK/manifest/latest.json"
           echo "--- assets to mirror ---"
-          ls -la assets/
-          count=$(find assets -type f | wc -l | tr -d ' ')
+          ls -la "$WORK/assets/"
+          count=$(find "$WORK/assets" -type f | wc -l | tr -d ' ')
           echo "asset count: $count"
           # A release with almost nothing in it means tauri-action failed or
           # the operator published an empty draft; mirroring that would
@@ -282,10 +303,10 @@ jobs:
       - name: Rewrite manifest for the mirror
         run: |
           set -euo pipefail
-          mkdir -p upload
+          mkdir -p "$WORK/out"
           node scripts/rewrite-manifest-for-mirror.mjs \
-            manifest/latest.json "$TAG" "$PUBLIC_BASE" \
-            --out=upload/latest.json --docs-out=upload/notes-docs.txt
+            "$WORK/manifest/latest.json" "$TAG" "$PUBLIC_BASE" \
+            --out="$WORK/out/latest.json" --docs-out="$WORK/out/notes-docs.txt"
 
       - name: Assert the notes link only mirrored docs
         run: |
@@ -295,11 +316,11 @@ jobs:
           # for the users who cannot fall back to github.com.
           while IFS= read -r linked; do
             [[ -z "$linked" ]] && continue
-            if ! grep -qxF "$linked" allowed-docs.txt; then
+            if ! grep -qxF "$linked" "$WORK/allowed-docs.txt"; then
               echo "::error::notes link an un-mirrored doc: $linked — add it to allowed-docs.txt in the 'Fetch the release's docs' step (and confirm it should be public)"
               exit 1
             fi
-          done < upload/notes-docs.txt
+          done < "$WORK/out/notes-docs.txt"
           echo "notes link only mirrored docs"
 
       - name: Stage version-less latest/ aliases
@@ -309,7 +330,7 @@ jobs:
           # README cannot hardcode a version, so every documented download
           # link points at download/latest/<version-less name>. Staged here,
           # verified by the same gate below, published only after it passes.
-          node scripts/mirror-latest-aliases.mjs assets "$VERSION" latest-upload
+          node scripts/mirror-latest-aliases.mjs "$WORK/assets" "$VERSION" "$WORK/latest"
 
       - name: Upload assets (immutable)
         env:
@@ -321,12 +342,12 @@ jobs:
           # stderr is NOT piped through `tail`: the first backfill run was
           # diagnosable only from the per-object error lines, and truncating
           # them threw away exactly what was needed.
-          rclone copy assets "r2:${R2_BUCKET}/download/${TAG}" \
+          rclone copy "$WORK/assets" "r2:${R2_BUCKET}/download/${TAG}" \
             --header-upload "Cache-Control: public, max-age=31536000, immutable" \
             $RCLONE_FLAGS --stats=30s --stats-one-line
           # Raw markdown as text/plain so a browser DISPLAYS it instead of
           # downloading an opaque .md — these are read, not installed.
-          rclone copy docs-upload "r2:${R2_BUCKET}/download/${TAG}" \
+          rclone copy "$WORK/docs" "r2:${R2_BUCKET}/download/${TAG}" \
             --header-upload "Cache-Control: public, max-age=31536000, immutable" \
             --header-upload "Content-Type: text/plain; charset=utf-8" \
             $RCLONE_FLAGS --stats=0
@@ -344,16 +365,24 @@ jobs:
           # long enough to absorb a download burst, short enough that a new
           # release is picked up promptly.
           #
-          # --ignore-times is deliberate. rclone's default skip is size +
-          # modtime, and these destination names are REUSED every release. An
-          # asset that happens to land on the same byte size as the previous
-          # release's same-named alias could be skipped, leaving
-          # download/latest/ serving the OLD installer while latest.json
-          # advertises the new version — a silent, hard-to-spot mismatch.
-          # Re-uploading ~25 objects per release costs nothing worth saving.
-          rclone copy latest-upload "r2:${R2_BUCKET}/download/latest" \
+          # --checksum, NOT --ignore-times. These destination names are REUSED
+          # every release, and rclone's default skip is size + modtime — an
+          # asset landing on the same byte size as the previous release's
+          # same-named alias could be skipped, leaving download/latest/
+          # serving the OLD installer while latest.json advertises the new
+          # version. Comparing content hashes closes that hole.
+          #
+          # --ignore-times would close it too, but it deadlocks against an R2
+          # quirk: R2 answers `501 NotImplemented` on a call rclone makes
+          # AFTER a successful PUT, so rclone reports "Failed to copy" for an
+          # object that did in fact land correctly (verified byte-for-byte
+          # over the public domain). With --checksum the retry sees matching
+          # hashes and skips, so the run self-heals; with --ignore-times every
+          # retry re-uploads and re-fails, forever — that is exactly how the
+          # first two backfill attempts burned all 10 retries.
+          rclone copy "$WORK/latest" "r2:${R2_BUCKET}/download/latest" \
             --header-upload "Cache-Control: public, max-age=300, must-revalidate" \
-            --ignore-times \
+            --checksum \
             $RCLONE_FLAGS --stats=30s --stats-one-line
           echo "Uploaded to r2:${R2_BUCKET}/download/latest"
 
@@ -410,9 +439,9 @@ jobs:
               "$prefix"*) ;;
               *) echo "  FAIL (not a mirror URL)  $url"; fail=1; continue ;;
             esac
-            f="assets/${url#"$prefix"}"
+            f="$WORK/assets/${url#"$prefix"}"
             [[ -f "$f" ]] || { echo "  FAIL (manifest references a file this release did not ship)  $url"; fail=1; }
-          done < <(jq -r '[.platforms[].url] + [.bare_binary.platforms[]?.url] | unique | .[]' upload/latest.json)
+          done < <(jq -r '[.platforms[].url] + [.bare_binary.platforms[]?.url] | unique | .[]' "$WORK/out/latest.json")
           echo "manifest references $n download URL(s), all inside the mirror prefix"
           # Zero URLs would sail through every check above and publish a
           # manifest nobody verified.
@@ -428,11 +457,11 @@ jobs:
           # download unverified.
           echo "checking every uploaded object"
           while IFS= read -r p; do
-            check_one "${prefix}${p}" "assets/${p}"
-          done < <(find assets -type f -printf '%P\n' | sort)
+            check_one "${prefix}${p}" "$WORK/assets/${p}"
+          done < <(find "$WORK/assets" -type f -printf '%P\n' | sort)
           while IFS= read -r p; do
-            check_one "${prefix}${p}" "docs-upload/${p}"
-          done < <(find docs-upload -type f -printf '%P\n' | sort)
+            check_one "${prefix}${p}" "$WORK/docs/${p}"
+          done < <(find "$WORK/docs" -type f -printf '%P\n' | sort)
           # The version-less aliases README links — same gate, because a 404
           # here is a broken install page for exactly the users the mirror
           # exists to serve. Only present when this tag owns the mutable
@@ -441,8 +470,8 @@ jobs:
           # there.
           if [[ "$PROMOTE" == "true" ]]; then
             while IFS= read -r p; do
-              check_one "${PUBLIC_BASE}/download/latest/${p}" "latest-upload/${p}"
-            done < <(find latest-upload -type f -printf '%P\n' | sort)
+              check_one "${PUBLIC_BASE}/download/latest/${p}" "$WORK/latest/${p}"
+            done < <(find "$WORK/latest" -type f -printf '%P\n' | sort)
           else
             echo "  (skipping download/latest/ — this tag does not own the mutable surface)"
           fi
@@ -463,12 +492,12 @@ jobs:
           # load-bearing, not tuning: with a long TTL Cloudflare's edge would
           # pin an old manifest for hours and every user behind that PoP would
           # be told "you're up to date" after a release shipped.
-          # --ignore-times for the same reason as the aliases above: this is a
+          # --checksum for the same reason as the aliases above: this is a
           # fixed destination name, and a corrected manifest that happens to
           # be the same size as the one already up there must not be skipped.
-          rclone copyto upload/latest.json "r2:${R2_BUCKET}/download/latest.json" \
+          rclone copyto "$WORK/out/latest.json" "r2:${R2_BUCKET}/download/latest.json" \
             --header-upload "Cache-Control: public, max-age=60, must-revalidate" \
-            --ignore-times \
+            --checksum \
             $RCLONE_FLAGS --stats=0
           echo "Published r2:${R2_BUCKET}/download/latest.json"
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -259,11 +259,14 @@ download/
 
 **几条容易踩的**：
 
+- **Cache-Control 分档需要 Cloudflare 侧配合，否则不生效**。实测 `latest/` 与 `v0.26.0/` 都被服成 `max-age=14400`（4 小时），而不是 workflow 设的 300 / 31536000——这是该域名 **Browser Cache TTL** 的默认值在覆盖源站头。要让分档真正生效，需在 Cloudflare 面板把它改成 **Respect Existing Headers**。未改之前：`latest.json` 最多被边缘缓存 4 小时，即发版后部分用户最多 4 小时才看到新版（GitHub 那条 endpoint 不受影响，所以不会完全收不到更新）。
 - **`latest/` 别名不能带 immutable 头**。那些文件名每版复用，长 TTL 会让边缘把旧安装包钉住一年。别名由 [`scripts/mirror-latest-aliases.mjs`](../scripts/mirror-latest-aliases.mjs) 按规则剥版本号派生，但 README 实际链接的 8 个名字在 `REQUIRED_ALIASES` 里**硬登记**——规则失灵时报错，而不是发布一堆 404。两侧对齐由 `check-release-paths.mjs` 在 PR 时守。
 - **`update-linux-repo.yml` 的整桶 pull 必须带 `--include`**。它把 bucket 镜像下来重建索引；本 workflow 每版往同一个 bucket 放约 1.5 GB 且永久保留，不过滤会让那个 pull 无界增长直到超时。新增本 job 独占的顶层路径时，同步加进那个过滤列表。
 - **`notes` 里的 GitHub 链接会被改写**（改写发生在 R2 那份 manifest 上，仓库源文件不动，§1.1(a) 的「链接一律用完整 GitHub URL」规则不变）。`notes` 是应用内「发现新版」弹窗的正文且按 markdown 渲染，中英切换与 CHANGELOG 两条链接对目标用户就是死链。链到 `REQUIRED` 之外的文档时 workflow 会 fail-closed。
 - **签名原样复制、绝不重算**。理由与端点链的信任模型见 [self-update](architecture/self-update.md#manifest-端点链r2-镜像优先github-兜底)。
-- **R2 会间歇性返回 `501 NotImplemented`**。首次回填时三个上传步骤的 attempt 1 全部大面积失败，两个在 attempt 2 自愈、第三个耗尽 rclone 默认的 3 次重试而告败。**根因尚未定位**——长期稳定的 `update-linux-repo.yml` 往同一个 bucket 传同量级文件从不出这个，而它与这三步唯一的差别是没有 `--header-upload`。当前对策是给足重试余量并跳过 R2 已知会 501 的 bucket 探测（见 `RCLONE_FLAGS`）。**rclone 的 stderr 不要再用 `tail` 截断**——首次失败时正是被截掉的逐对象错误行才能定位问题，别再为了日志好看把它们丢掉。
+- **rclone 报的 `501 NotImplemented` 是假失败——对象其实已经正确落地**。R2 在 rclone 于 PUT **成功之后**发出的某个调用上返回 501，于是 rclone 把一个已经写好的对象报成 `Failed to copy`。实测确认：报错的那批对象经公开域名 HEAD 全部 200 且 `Content-Length` 与源文件逐字节一致。**所以判断成败要看本 workflow 自己的回抓校验，不要只看 rclone 退出码。** 用 `--checksum` 而非 `--ignore-times`：前者在重试时发现哈希一致就跳过，整轮能自愈；后者每次强制重传、每次重报失败，会把这个噪声变成永久失败（前两次回填就是这么烧完 10 次重试的）。根因未最终隔离，最强线索是 `--header-upload`（长期稳定的 `update-linux-repo.yml` 唯独没有它）。
+- **rclone 的 stderr 不要用 `tail` 截断**。第一次失败时能定位问题的正是那些被截掉的逐对象错误行，为了日志好看丢掉它们，代价是再跑一整轮。
+- **所有临时目录必须落在 `$RUNNER_TEMP` 下，不要用裸相对路径**。`assets/` 曾经就是裸路径，于是和仓库自带的 `assets/` 目录合并，把 `alpha-logo.png`、`transparency-logo.png` 当作发布产物镜像了上去。任何裸名字都可能和将来某个仓库目录撞车。
 
 存储成本：一版约 1.5 GB，R2 存储 $0.015/GB·月、egress 免费，按每月 3 版算一年累积约 55 GB（每月 < $1）。刻意全部保留而不做清理——现有 R2 发布路径全程只用 `copy` 不用 `sync` 就是为了「绝不删除」，加删除逻辑要单独定义失败语义。
 


### PR DESCRIPTION
接 [#580](https://github.com/shiwenwen/hope-agent/pull/580) / [#583](https://github.com/shiwenwen/hope-agent/pull/583)。三处问题都由首次回填的实跑暴露，不是推演出来的。

## 1. 临时目录名与仓库目录撞车

workflow 用了裸相对路径 `assets/` 作工作目录，而**仓库根目录本来就有 `assets/`**（装着 logo）。`gh release download --dir assets` 于是与仓库内容合并，`alpha-logo.png` 和 `transparency-logo.png` 被当作发布产物镜像上去（已确认在 R2 上）。

改法不是改个名字了事——任何裸名字都可能和将来某个仓库目录撞车。全部临时目录挪到 `$RUNNER_TEMP` 下，并在开跑前 `rm -rf` 清空（热 runner 的残留物同样会被当成产物）。

> 顺带：`${{ runner.temp }}` **不能**写在 job 级 `env:` 里（`runner` context 在那里不可用，静默不解析）。所以 `WORK` 由首个步骤从 `$RUNNER_TEMP` 写进 `$GITHUB_ENV`。

## 2. `501 NotImplemented` 是假失败

**实测结论，改了此前的判断**：R2 在 rclone 于 PUT **成功之后**发出的某个调用上返回 501，对象其实已经正确落地。报错的那批经公开域名 HEAD 全部 200，`Content-Length` 与源文件逐字节一致：

```
200  118686307  download/latest/Hope.Agent_aarch64.dmg      (= release 资产大小)
200  113442339  download/latest/Hope.Agent_x64-setup.exe    (= release 资产大小)
200  119731292  download/latest/Hope.Agent_amd64.deb        (= release 资产大小)
```

README 链接的 8 个文件 8/8 存在且大小一致。也就是说**镜像的下载面早已在工作**，只有 `latest.json` 因为这一步"失败"而没被发布。

而这个假失败之所以变成硬失败，是我自己引入的 `--ignore-times`：不带它时，重试发现对象已在、大小匹配就跳过 → 报成功（#580 的不可变上传就是这么自愈的）；带上它则每次强制重传、每次重报失败，把噪声变成永久失败——前两次回填就是这么烧完 10 次重试的。

改用 `--checksum`：重试时哈希一致即跳过（整轮自愈），内容不同仍必传（我加 `--ignore-times` 想堵的静默跳过洞仍然堵着）。

根因未最终隔离。最强线索仍是 `--header-upload`——长期稳定的 `update-linux-repo.yml` 往同一个 bucket 传同量级文件从不出这个，而它唯独没有这个参数。

## 3. 文档

§1.10 记下三条教训：

- **判成败看本 workflow 的回抓校验，不要只看 rclone 退出码**
- **rclone 的 stderr 不要用 `tail` 截断**——第一次失败时能定位问题的正是被截掉的逐对象错误行
- **临时目录必须落在 `$RUNNER_TEMP`**

外加一条实测发现的**运维前置条件**：Cache-Control 分档目前**不生效**。两个前缀都被服成 `max-age=14400`（4 小时），而非设定的 300 / 31536000——是该域名 Browser Cache TTL 的默认值在覆盖源站头，需在 Cloudflare 面板改成 **Respect Existing Headers**。未改之前 `latest.json` 最多被边缘缓存 4 小时（GitHub endpoint 不受影响，不会完全收不到更新）。这条只能在 Cloudflare 侧改，已在文档写明。

## 遗留（有意不做）

误传的 4 个 logo 对象仍在 R2 上。现有 R2 发布路径全程只用 `copy` 不用 `sync`，就是为了「绝不删除」——不为两个小 PNG 给 workflow 引入删除逻辑与失败语义。手动在 Cloudflare 面板删掉即可。

## 后续

合并后重跑 `gh workflow run mirror-release-r2.yml -f tag=v0.26.0` 补上 `latest.json`。