### PR TITLE
fix(ci): 镜像 Cache-Control 随 PUT 写入并加断言（根因已定位）

### DIFF
--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -57,6 +57,11 @@ on:
         description: Release tag to mirror (for example v0.26.0)
         required: true
         type: string
+      force:
+        description: "Re-upload objects even when their content already matches. Needed once to repair objects that landed WITHOUT their Cache-Control (see the RCLONE_FLAGS note); --checksum alone skips them because the bytes are already correct."
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   # Separate from update-linux-repo: the two write disjoint prefixes
@@ -74,6 +79,13 @@ env:
   # src-tauri/tauri.conf.json#plugins.updater.endpoints — that last one is
   # enforced by scripts/verify-updater-endpoints.mjs.
   PUBLIC_BASE: https://repo.hopeagent.ai
+  # The three Cache-Control tiers, defined ONCE: the upload steps set them and
+  # the verify step asserts the served value's max-age against them. Two
+  # copies would drift, and drift here is invisible — the bytes stay correct
+  # while the caching behaviour silently becomes something else.
+  CC_IMMUTABLE: "public, max-age=31536000, immutable"
+  CC_LATEST: "public, max-age=300, must-revalidate"
+  CC_MANIFEST: "public, max-age=60, must-revalidate"
   # rclone remote "r2" configured entirely from env (no rclone.conf file).
   RCLONE_CONFIG_R2_TYPE: s3
   RCLONE_CONFIG_R2_PROVIDER: Cloudflare
@@ -82,14 +94,15 @@ env:
   RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
   # RCLONE_CONFIG_R2_ENDPOINT is derived by scripts/r2-endpoint.sh.
   #
-  # Shared robustness flags for every upload. R2 intermittently answers
-  # `501 NotImplemented` mid-transfer: the first backfill run saw attempt 1
-  # fail wholesale on all three upload steps, two of them recovering on
-  # attempt 2 and the third exhausting rclone's default 3 retries. Root cause
-  # is NOT established yet — the long-stable update-linux-repo.yml writes the
-  # same bucket without trouble, and the one flag it does not use is
-  # --header-upload. Until that is pinned down, give transfers real retry
-  # headroom and stop swallowing the errors that would identify it.
+  # Shared robustness flags for every upload. R2 answers `501 NotImplemented`
+  # on the call rclone made to apply `--header-upload` headers AFTER a
+  # successful PUT. Measured consequence: the object landed byte-correct but
+  # WITHOUT its Cache-Control, so Cloudflare served its own 4h default — and
+  # it hit only some objects, which is what made it look like a Cloudflare
+  # override rather than our bug. Headers are now set with --metadata-set,
+  # which applies them as part of the upload instead of a follow-up call, and
+  # the verify step below asserts the served Cache-Control so a silent
+  # regression cannot happen again. Retry headroom is kept as a backstop.
   #   --retries / --low-level-retries: headroom over the defaults (3 / 10).
   #   --s3-no-check-bucket: skips the bucket-existence probe, one of the calls
   #     R2 is known to answer NotImplemented for. The bucket is created and
@@ -122,6 +135,16 @@ jobs:
           # alpha-logo.png + transparency-logo.png as if they were release
           # artifacts. Any bare name can collide with a future repo directory;
           # $RUNNER_TEMP cannot.
+          # `force` re-uploads content-identical objects. Only needed to
+          # repair metadata (Cache-Control) on objects already in place —
+          # normal runs must NOT set it, since re-uploading every object each
+          # release is pure waste.
+          if [[ "${{ github.event.inputs.force }}" == "true" ]]; then
+            echo "RCLONE_FORCE=--ignore-times" >> "$GITHUB_ENV"
+            echo "force: re-uploading even content-identical objects"
+          else
+            echo "RCLONE_FORCE=" >> "$GITHUB_ENV"
+          fi
           work="${RUNNER_TEMP}/mirror"
           # Start from empty: a leftover from an earlier run on a warm runner
           # would be mirrored as a release artifact too — same failure mode,
@@ -343,14 +366,15 @@ jobs:
           # diagnosable only from the per-object error lines, and truncating
           # them threw away exactly what was needed.
           rclone copy "$WORK/assets" "r2:${R2_BUCKET}/download/${TAG}" \
-            --header-upload "Cache-Control: public, max-age=31536000, immutable" \
-            $RCLONE_FLAGS --stats=30s --stats-one-line
+            --metadata --metadata-set "cache-control=${CC_IMMUTABLE}" \
+            $RCLONE_FLAGS $RCLONE_FORCE --stats=30s --stats-one-line
           # Raw markdown as text/plain so a browser DISPLAYS it instead of
           # downloading an opaque .md — these are read, not installed.
           rclone copy "$WORK/docs" "r2:${R2_BUCKET}/download/${TAG}" \
-            --header-upload "Cache-Control: public, max-age=31536000, immutable" \
-            --header-upload "Content-Type: text/plain; charset=utf-8" \
-            $RCLONE_FLAGS --stats=0
+            --metadata \
+            --metadata-set "cache-control=${CC_IMMUTABLE}" \
+            --metadata-set "content-type=text/plain; charset=utf-8" \
+            $RCLONE_FLAGS $RCLONE_FORCE --stats=0
           echo "Uploaded to r2:${R2_BUCKET}/download/${TAG}"
 
       - name: Upload latest/ aliases (mutable, short TTL)
@@ -381,9 +405,9 @@ jobs:
           # retry re-uploads and re-fails, forever — that is exactly how the
           # first two backfill attempts burned all 10 retries.
           rclone copy "$WORK/latest" "r2:${R2_BUCKET}/download/latest" \
-            --header-upload "Cache-Control: public, max-age=300, must-revalidate" \
+            --metadata --metadata-set "cache-control=${CC_LATEST}" \
             --checksum \
-            $RCLONE_FLAGS --stats=30s --stats-one-line
+            $RCLONE_FLAGS $RCLONE_FORCE --stats=30s --stats-one-line
           echo "Uploaded to r2:${R2_BUCKET}/download/latest"
 
       - name: Verify every mirrored URL is live with the right size
@@ -395,28 +419,48 @@ jobs:
           # truncated or zero-length object.
           fail=0
 
-          head_len() {
-            local url="$1" attempt hdr len
+          # Fetch headers once per object into HDR; retries absorb edge
+          # propagation.
+          fetch_headers() {
+            local url="$1" attempt
             for attempt in 1 2 3 4 5; do
-              if hdr=$(curl -fsSL -I --max-time 30 "$url" 2>/dev/null); then
-                len=$(grep -i '^content-length:' <<<"$hdr" | tail -1 | tr -dc '0-9')
-                if [[ -n "$len" ]]; then printf '%s' "$len"; return 0; fi
+              if HDR=$(curl -fsSL -I --max-time 30 "$url" 2>/dev/null) \
+                 && grep -qi '^content-length:' <<<"$HDR"; then
+                return 0
               fi
               sleep $((attempt * 5))
             done
             return 1
           }
 
+          # $3 = expected max-age. Asserting it is not belt-and-braces: R2
+          # once answered 501 on the header-application call, so objects landed
+          # byte-correct but WITHOUT Cache-Control and Cloudflare served its own
+          # 4h default. Size checks pass right through that — only reading back
+          # the served header catches it.
           check_one() {
-            local url="$1" local_file="$2" expect actual
+            local url="$1" local_file="$2" want_cc="$3" expect actual cc got_age want_age
             expect=$(stat -c%s "$local_file")
-            if ! actual=$(head_len "$url"); then
+            if ! fetch_headers "$url"; then
               echo "  FAIL (unreachable)  $url"
               fail=1; return
             fi
+            actual=$(grep -i '^content-length:' <<<"$HDR" | tail -1 | tr -dc '0-9')
             if [[ "$actual" != "$expect" ]]; then
               echo "  FAIL (size $actual != $expect)  $url"
               fail=1; return
+            fi
+            if [[ -n "$want_cc" ]]; then
+              cc=$(grep -i '^cache-control:' <<<"$HDR" | tail -1 | tr -d '\r')
+              # Compare max-age only, not the whole string: directive order
+              # and casing are not ours to control, but the TTL is the thing
+              # that actually matters and the thing that silently regressed.
+              got_age=$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9')
+              want_age=$(grep -oE 'max-age=[0-9]+' <<<"$want_cc" | head -1 | tr -dc '0-9')
+              if [[ "$got_age" != "$want_age" ]]; then
+                echo "  FAIL (cache-control max-age=${got_age:-none}, want $want_age)  $url"
+                fail=1; return
+              fi
             fi
             echo "  ok  ${actual}B  $url"
           }
@@ -457,10 +501,10 @@ jobs:
           # download unverified.
           echo "checking every uploaded object"
           while IFS= read -r p; do
-            check_one "${prefix}${p}" "$WORK/assets/${p}"
+            check_one "${prefix}${p}" "$WORK/assets/${p}" "$CC_IMMUTABLE"
           done < <(find "$WORK/assets" -type f -printf '%P\n' | sort)
           while IFS= read -r p; do
-            check_one "${prefix}${p}" "$WORK/docs/${p}"
+            check_one "${prefix}${p}" "$WORK/docs/${p}" "$CC_IMMUTABLE"
           done < <(find "$WORK/docs" -type f -printf '%P\n' | sort)
           # The version-less aliases README links — same gate, because a 404
           # here is a broken install page for exactly the users the mirror
@@ -470,7 +514,7 @@ jobs:
           # there.
           if [[ "$PROMOTE" == "true" ]]; then
             while IFS= read -r p; do
-              check_one "${PUBLIC_BASE}/download/latest/${p}" "$WORK/latest/${p}"
+              check_one "${PUBLIC_BASE}/download/latest/${p}" "$WORK/latest/${p}" "$CC_LATEST"
             done < <(find "$WORK/latest" -type f -printf '%P\n' | sort)
           else
             echo "  (skipping download/latest/ — this tag does not own the mutable surface)"
@@ -496,9 +540,9 @@ jobs:
           # fixed destination name, and a corrected manifest that happens to
           # be the same size as the one already up there must not be skipped.
           rclone copyto "$WORK/out/latest.json" "r2:${R2_BUCKET}/download/latest.json" \
-            --header-upload "Cache-Control: public, max-age=60, must-revalidate" \
+            --metadata --metadata-set "cache-control=${CC_MANIFEST}" \
             --checksum \
-            $RCLONE_FLAGS --stats=0
+            $RCLONE_FLAGS $RCLONE_FORCE --stats=0
           echo "Published r2:${R2_BUCKET}/download/latest.json"
 
       - name: Verify the published manifest serves this release
@@ -519,6 +563,14 @@ jobs:
                 echo "OK   spot-checked $spot"
                 cc=$(curl -fsSI --max-time 20 "$url" | grep -i '^cache-control:' | tr -d '\r')
                 echo "     $cc"
+                got=$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9')
+                want=$(grep -oE 'max-age=[0-9]+' <<<"$CC_MANIFEST" | head -1 | tr -dc '0-9')
+                if [[ "$got" != "$want" ]]; then
+                  # The manifest is the one object where a long TTL is a real
+                  # problem: a pinned stale copy tells clients "no update".
+                  echo "::error::manifest Cache-Control max-age=${got:-none}, want $want — the mirror manifest would be cached far longer than intended"
+                  exit 1
+                fi
                 exit 0
               fi
               echo "…retry $attempt  served version '$got', want '$VERSION'"

--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -293,11 +293,40 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install rclone
+      - name: Install rclone (pinned) + jq
+        env:
+          # Pinned deliberately. `apt-get install rclone` gives whatever the
+          # runner image's distro ships — Ubuntu 24.04 is on 1.60.1 — so the
+          # flags this workflow depends on would silently change with the
+          # image. A release-critical publish path must not inherit its tool
+          # version from the base image.
+          RCLONE_VERSION: v1.74.4
         run: |
           set -euo pipefail
           sudo apt-get update -qq
-          sudo apt-get install -y -qq rclone jq
+          sudo apt-get install -y -qq jq unzip
+          tmp="$(mktemp -d)"
+          curl -fsSL -o "$tmp/rclone.zip" \
+            "https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-amd64.zip"
+          unzip -q "$tmp/rclone.zip" -d "$tmp"
+          sudo install -m 755 "$tmp/rclone-${RCLONE_VERSION}-linux-amd64/rclone" /usr/local/bin/rclone
+          rm -rf "$tmp"
+          rclone version | head -1
+
+          # Assert the flags this workflow depends on actually exist. Without
+          # this, an unsupported flag surfaces as an opaque failure partway
+          # through the first upload; here it is one clear line before any
+          # bytes move. --metadata-set is what applies Cache-Control during the
+          # PUT (see the RCLONE_FLAGS note on why --header-upload was dropped).
+          missing=()
+          for flag in --metadata --metadata-set --checksum --s3-no-check-bucket; do
+            rclone help flags 2>/dev/null | grep -q -- "$flag" || missing+=("$flag")
+          done
+          if (( ${#missing[@]} )); then
+            echo "::error::rclone ${RCLONE_VERSION} does not support: ${missing[*]} — pin a version that does"
+            exit 1
+          fi
+          echo "rclone flag support OK: --metadata --metadata-set --checksum --s3-no-check-bucket"
 
       - name: Download release assets + manifest
         env:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -259,12 +259,12 @@ download/
 
 **几条容易踩的**：
 
-- **Cache-Control 分档需要 Cloudflare 侧配合，否则不生效**。实测 `latest/` 与 `v0.26.0/` 都被服成 `max-age=14400`（4 小时），而不是 workflow 设的 300 / 31536000——这是该域名 **Browser Cache TTL** 的默认值在覆盖源站头。要让分档真正生效，需在 Cloudflare 面板把它改成 **Respect Existing Headers**。未改之前：`latest.json` 最多被边缘缓存 4 小时，即发版后部分用户最多 4 小时才看到新版（GitHub 那条 endpoint 不受影响，所以不会完全收不到更新）。
+- **Cache-Control 由 `--metadata-set` 随 PUT 一次写入，不要用 `--header-upload`**。后者是事后单独一次调用，而 R2 恰好对那次调用返回 501——对象本体正确落地、Cache-Control 却没写上，Cloudflare 于是按自己的默认 4 小时服。这个坑的隐蔽之处在于它**只命中一部分对象**（同一次上传里有的对、有的不对），看起来极像 Cloudflare 在覆盖源站头，实际是我们自己漏写。**判据：如果只有部分对象的 TTL 不对，那就是写入问题，不是覆盖问题**——覆盖不可能只覆盖一半。三档值在 workflow 的 `CC_IMMUTABLE` / `CC_LATEST` / `CC_MANIFEST` 单一定义，上传设、校验断言，两边不会漂。
 - **`latest/` 别名不能带 immutable 头**。那些文件名每版复用，长 TTL 会让边缘把旧安装包钉住一年。别名由 [`scripts/mirror-latest-aliases.mjs`](../scripts/mirror-latest-aliases.mjs) 按规则剥版本号派生，但 README 实际链接的 8 个名字在 `REQUIRED_ALIASES` 里**硬登记**——规则失灵时报错，而不是发布一堆 404。两侧对齐由 `check-release-paths.mjs` 在 PR 时守。
 - **`update-linux-repo.yml` 的整桶 pull 必须带 `--include`**。它把 bucket 镜像下来重建索引；本 workflow 每版往同一个 bucket 放约 1.5 GB 且永久保留，不过滤会让那个 pull 无界增长直到超时。新增本 job 独占的顶层路径时，同步加进那个过滤列表。
 - **`notes` 里的 GitHub 链接会被改写**（改写发生在 R2 那份 manifest 上，仓库源文件不动，§1.1(a) 的「链接一律用完整 GitHub URL」规则不变）。`notes` 是应用内「发现新版」弹窗的正文且按 markdown 渲染，中英切换与 CHANGELOG 两条链接对目标用户就是死链。链到 `REQUIRED` 之外的文档时 workflow 会 fail-closed。
 - **签名原样复制、绝不重算**。理由与端点链的信任模型见 [self-update](architecture/self-update.md#manifest-端点链r2-镜像优先github-兜底)。
-- **rclone 报的 `501 NotImplemented` 是假失败——对象其实已经正确落地**。R2 在 rclone 于 PUT **成功之后**发出的某个调用上返回 501，于是 rclone 把一个已经写好的对象报成 `Failed to copy`。实测确认：报错的那批对象经公开域名 HEAD 全部 200 且 `Content-Length` 与源文件逐字节一致。**所以判断成败要看本 workflow 自己的回抓校验，不要只看 rclone 退出码。** 用 `--checksum` 而非 `--ignore-times`：前者在重试时发现哈希一致就跳过，整轮能自愈；后者每次强制重传、每次重报失败，会把这个噪声变成永久失败（前两次回填就是这么烧完 10 次重试的）。根因未最终隔离，最强线索是 `--header-upload`（长期稳定的 `update-linux-repo.yml` 唯独没有它）。
+- **rclone 报的 `501 NotImplemented` 是假失败——对象其实已经正确落地**。R2 在 rclone 于 PUT **成功之后**发出的某个调用上返回 501，于是 rclone 把一个已经写好的对象报成 `Failed to copy`。实测确认：报错的那批对象经公开域名 HEAD 全部 200 且 `Content-Length` 与源文件逐字节一致。**所以判断成败要看本 workflow 自己的回抓校验，不要只看 rclone 退出码。** 用 `--checksum` 而非 `--ignore-times`：前者在重试时发现哈希一致就跳过，整轮能自愈；后者每次强制重传、每次重报失败，会把这个噪声变成永久失败（前两次回填就是这么烧完 10 次重试的）。**根因已定位**：501 出在 `--header-upload` 那次事后调用上，改用 `--metadata-set` 后 header 随 PUT 一次写入（见上一条）。修好之前落地的对象缺 header，`--checksum` 因内容一致不会重传，需用 `workflow_dispatch` 的 `force` 开关强制重传一次补上。
 - **rclone 的 stderr 不要用 `tail` 截断**。第一次失败时能定位问题的正是那些被截掉的逐对象错误行，为了日志好看丢掉它们，代价是再跑一整轮。
 - **所有临时目录必须落在 `$RUNNER_TEMP` 下，不要用裸相对路径**。`assets/` 曾经就是裸路径，于是和仓库自带的 `assets/` 目录合并，把 `alpha-logo.png`、`transparency-logo.png` 当作发布产物镜像了上去。任何裸名字都可能和将来某个仓库目录撞车。
 


### PR DESCRIPTION
接 [#580](https://github.com/shiwenwen/hope-agent/pull/580) / [#583](https://github.com/shiwenwen/hope-agent/pull/583) / [#584](https://github.com/shiwenwen/hope-agent/pull/584)。上一轮遗留的「Cache-Control 未生效」定位清楚了——**而且我此前把它归因于 Cloudflare 是错的，面板无需改动。**

## 判据

同一次上传里，结果是**混合**的：

```
latest/Hope.Agent_amd64.deb      public, max-age=300, must-revalidate   ← 设定值，对
latest/Hope.Agent_aarch64.dmg    max-age=14400                           ← 错
v0.26.0/....dmg                  max-age=14400                           ← 错
v0.26.0/CHANGELOG.md             (完全没有 cache-control)                ← 错
latest.json                      public, max-age=60, must-revalidate     ← 设定值，对
```

**如果是 Cloudflare 的 Browser Cache TTL 在覆盖源站头，不可能只覆盖一部分。** 这条判据直接排除了外部原因。

## 真因

`--header-upload` 是 PUT 成功**之后**单独的一次调用，R2 恰好对那次调用返回 `501 NotImplemented`。于是对象本体正确落地、`Cache-Control` 没写上，Cloudflare 按自己的默认 4 小时服。`max-age=14400` 是**缺失的后果，不是覆盖的结果**。

这同时坐实了 #583 / #584 里那个「501 假失败」的根因——两者是同一件事。

## 改动

1. **四处上传改用 `--metadata-set`**，header 作为 PUT 的一部分写入，不再有事后调用。
2. **三档值提成 `CC_IMMUTABLE` / `CC_LATEST` / `CC_MANIFEST`**（workflow `env`）：上传设、校验断言，单一来源不会漂。两份拷贝在这里尤其危险——漂了之后字节仍然正确，只有缓存行为悄悄变成别的样子。
3. **回抓校验增加 Cache-Control 断言**。只比 `max-age`，不比整串：指令顺序与大小写不由我们控制，TTL 才是会静默劣化的那个。manifest 那步单独断言并给出明确错误（它是唯一一个长 TTL 会真造成问题的对象——被钉住的旧清单会告诉客户端「已是最新」）。
4. **`workflow_dispatch` 增加 `force` 开关**：`--checksum` 因内容一致不会重传，补不了已落地但缺 header 的旧对象，需要强制重传一次。

## 验证

断言逻辑拿**线上真实对象**跑过（现在 R2 上正好一半对一半错，是天然测试集）：

```
应 PASS  max-age=300    Hope.Agent_amd64.deb        PASS
应 PASS  max-age=60     latest.json                 PASS
应 FAIL  max-age=14400  Hope.Agent_aarch64.dmg      FAIL (want=300)
应 FAIL  max-age=14400  Hope.Agent_0.26.0_...dmg    FAIL (want=31536000)
应 FAIL  max-age=none   CHANGELOG.md                FAIL (want=31536000)
```

外加 18 步 YAML 解析 + 16 个 run 步骤 `bash -n`、docs parity、updater endpoints、release paths 全绿。

## 后续

1. 合并后跑一次 `gh workflow run mirror-release-r2.yml -f tag=v0.26.0 -f force=true`，把已落地但缺 header 的对象补齐
2. 随即开 v0.27.0 发版 PR——发布时 `release.published` 会自动触发镜像，正好用一次真实发版端到端验证整条链