### PR TITLE
fix(ci): 辅助变量避开 rclone 的 RCLONE_* flag 命名空间

### DIFF
--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -58,7 +58,7 @@ on:
         required: true
         type: string
       force:
-        description: "Re-upload objects even when their content already matches. Needed once to repair objects that landed WITHOUT their Cache-Control (see the RCLONE_FLAGS note); --checksum alone skips them because the bytes are already correct."
+        description: "Re-upload objects even when their content already matches. Needed once to repair objects that landed WITHOUT their Cache-Control (see the R2_UPLOAD_FLAGS note); --checksum alone skips them because the bytes are already correct."
         required: false
         type: boolean
         default: false
@@ -94,6 +94,13 @@ env:
   RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
   # RCLONE_CONFIG_R2_ENDPOINT is derived by scripts/r2-endpoint.sh.
   #
+  # NAMING TRAP: rclone reads ANY `RCLONE_<FLAG>` environment variable as a
+  # value for the flag of that name. The `RCLONE_CONFIG_R2_*` vars above are
+  # the documented remote-config form and are fine, but a helper variable
+  # named RCLONE_FORCE becomes `--force`, RCLONE_VERSION becomes `--version`,
+  # and rclone dies on the first invocation with a bool-parse error. Hence the
+  # `R2_` prefix on everything below — do NOT rename them back.
+  #
   # Shared robustness flags for every upload. R2 answers `501 NotImplemented`
   # on the call rclone made to apply `--header-upload` headers AFTER a
   # successful PUT. Measured consequence: the object landed byte-correct but
@@ -109,7 +116,7 @@ env:
   #     managed out of band (linux-repo/README.md).
   #   --transfers/--checkers: lower concurrency, less pressure per burst.
   # Expanded UNQUOTED at each call site — word splitting is the point.
-  RCLONE_FLAGS: >-
+  R2_UPLOAD_FLAGS: >-
     --retries 10
     --low-level-retries 20
     --s3-no-check-bucket
@@ -140,10 +147,10 @@ jobs:
           # normal runs must NOT set it, since re-uploading every object each
           # release is pure waste.
           if [[ "${{ github.event.inputs.force }}" == "true" ]]; then
-            echo "RCLONE_FORCE=--ignore-times" >> "$GITHUB_ENV"
+            echo "R2_FORCE_FLAG=--ignore-times" >> "$GITHUB_ENV"
             echo "force: re-uploading even content-identical objects"
           else
-            echo "RCLONE_FORCE=" >> "$GITHUB_ENV"
+            echo "R2_FORCE_FLAG=" >> "$GITHUB_ENV"
           fi
           work="${RUNNER_TEMP}/mirror"
           # Start from empty: a leftover from an earlier run on a warm runner
@@ -300,16 +307,16 @@ jobs:
           # flags this workflow depends on would silently change with the
           # image. A release-critical publish path must not inherit its tool
           # version from the base image.
-          RCLONE_VERSION: v1.74.4
+          R2_RCLONE_PIN: v1.74.4
         run: |
           set -euo pipefail
           sudo apt-get update -qq
           sudo apt-get install -y -qq jq unzip
           tmp="$(mktemp -d)"
           curl -fsSL -o "$tmp/rclone.zip" \
-            "https://downloads.rclone.org/${RCLONE_VERSION}/rclone-${RCLONE_VERSION}-linux-amd64.zip"
+            "https://downloads.rclone.org/${R2_RCLONE_PIN}/rclone-${R2_RCLONE_PIN}-linux-amd64.zip"
           unzip -q "$tmp/rclone.zip" -d "$tmp"
-          sudo install -m 755 "$tmp/rclone-${RCLONE_VERSION}-linux-amd64/rclone" /usr/local/bin/rclone
+          sudo install -m 755 "$tmp/rclone-${R2_RCLONE_PIN}-linux-amd64/rclone" /usr/local/bin/rclone
           rm -rf "$tmp"
           rclone version | head -1
 
@@ -317,13 +324,13 @@ jobs:
           # this, an unsupported flag surfaces as an opaque failure partway
           # through the first upload; here it is one clear line before any
           # bytes move. --metadata-set is what applies Cache-Control during the
-          # PUT (see the RCLONE_FLAGS note on why --header-upload was dropped).
+          # PUT (see the R2_UPLOAD_FLAGS note on why --header-upload was dropped).
           missing=()
           for flag in --metadata --metadata-set --checksum --s3-no-check-bucket; do
             rclone help flags 2>/dev/null | grep -q -- "$flag" || missing+=("$flag")
           done
           if (( ${#missing[@]} )); then
-            echo "::error::rclone ${RCLONE_VERSION} does not support: ${missing[*]} — pin a version that does"
+            echo "::error::rclone ${R2_RCLONE_PIN} does not support: ${missing[*]} — pin a version that does"
             exit 1
           fi
           echo "rclone flag support OK: --metadata --metadata-set --checksum --s3-no-check-bucket"
@@ -396,14 +403,14 @@ jobs:
           # them threw away exactly what was needed.
           rclone copy "$WORK/assets" "r2:${R2_BUCKET}/download/${TAG}" \
             --metadata --metadata-set "cache-control=${CC_IMMUTABLE}" \
-            $RCLONE_FLAGS $RCLONE_FORCE --stats=30s --stats-one-line
+            $R2_UPLOAD_FLAGS $R2_FORCE_FLAG --stats=30s --stats-one-line
           # Raw markdown as text/plain so a browser DISPLAYS it instead of
           # downloading an opaque .md — these are read, not installed.
           rclone copy "$WORK/docs" "r2:${R2_BUCKET}/download/${TAG}" \
             --metadata \
             --metadata-set "cache-control=${CC_IMMUTABLE}" \
             --metadata-set "content-type=text/plain; charset=utf-8" \
-            $RCLONE_FLAGS $RCLONE_FORCE --stats=0
+            $R2_UPLOAD_FLAGS $R2_FORCE_FLAG --stats=0
           echo "Uploaded to r2:${R2_BUCKET}/download/${TAG}"
 
       - name: Upload latest/ aliases (mutable, short TTL)
@@ -436,7 +443,7 @@ jobs:
           rclone copy "$WORK/latest" "r2:${R2_BUCKET}/download/latest" \
             --metadata --metadata-set "cache-control=${CC_LATEST}" \
             --checksum \
-            $RCLONE_FLAGS $RCLONE_FORCE --stats=30s --stats-one-line
+            $R2_UPLOAD_FLAGS $R2_FORCE_FLAG --stats=30s --stats-one-line
           echo "Uploaded to r2:${R2_BUCKET}/download/latest"
 
       - name: Verify every mirrored URL is live with the right size
@@ -571,7 +578,7 @@ jobs:
           rclone copyto "$WORK/out/latest.json" "r2:${R2_BUCKET}/download/latest.json" \
             --metadata --metadata-set "cache-control=${CC_MANIFEST}" \
             --checksum \
-            $RCLONE_FLAGS $RCLONE_FORCE --stats=0
+            $R2_UPLOAD_FLAGS $R2_FORCE_FLAG --stats=0
           echo "Published r2:${R2_BUCKET}/download/latest.json"
 
       - name: Verify the published manifest serves this release

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -266,6 +266,8 @@ download/
 - **签名原样复制、绝不重算**。理由与端点链的信任模型见 [self-update](architecture/self-update.md#manifest-端点链r2-镜像优先github-兜底)。
 - **rclone 报的 `501 NotImplemented` 是假失败——对象其实已经正确落地**。R2 在 rclone 于 PUT **成功之后**发出的某个调用上返回 501，于是 rclone 把一个已经写好的对象报成 `Failed to copy`。实测确认：报错的那批对象经公开域名 HEAD 全部 200 且 `Content-Length` 与源文件逐字节一致。**所以判断成败要看本 workflow 自己的回抓校验，不要只看 rclone 退出码。** 用 `--checksum` 而非 `--ignore-times`：前者在重试时发现哈希一致就跳过，整轮能自愈；后者每次强制重传、每次重报失败，会把这个噪声变成永久失败（前两次回填就是这么烧完 10 次重试的）。**根因已定位**：501 出在 `--header-upload` 那次事后调用上，改用 `--metadata-set` 后 header 随 PUT 一次写入（见上一条）。修好之前落地的对象缺 header，`--checksum` 因内容一致不会重传，需用 `workflow_dispatch` 的 `force` 开关强制重传一次补上。
 - **rclone 的 stderr 不要用 `tail` 截断**。第一次失败时能定位问题的正是那些被截掉的逐对象错误行，为了日志好看丢掉它们，代价是再跑一整轮。
+- **给 rclone 传参的辅助变量不能用 `RCLONE_` 前缀**。rclone 会把**任何** `RCLONE_<FLAG>` 环境变量当成同名 flag 的值：`RCLONE_FORCE` 变成 `--force`、`RCLONE_VERSION` 变成 `--version`，rclone 在第一次调用就以 bool 解析错误退出。`RCLONE_CONFIG_R2_*` 是文档化的 remote 配置写法，不受影响；其余一律用 `R2_` 前缀（`R2_UPLOAD_FLAGS` / `R2_FORCE_FLAG` / `R2_RCLONE_PIN`）。
+- **rclone 版本要钉住，别用 `apt-get install rclone`**。发版关键路径不该从基础镜像继承工具版本（Ubuntu 24.04 自带 1.60.1）。安装步骤同时断言所需 flag 存在，不支持时在动任何字节之前给一行明确错误。
 - **所有临时目录必须落在 `$RUNNER_TEMP` 下，不要用裸相对路径**。`assets/` 曾经就是裸路径，于是和仓库自带的 `assets/` 目录合并，把 `alpha-logo.png`、`transparency-logo.png` 当作发布产物镜像了上去。任何裸名字都可能和将来某个仓库目录撞车。
 
 存储成本：一版约 1.5 GB，R2 存储 $0.015/GB·月、egress 免费，按每月 3 版算一年累积约 55 GB（每月 < $1）。刻意全部保留而不做清理——现有 R2 发布路径全程只用 `copy` 不用 `sync` 就是为了「绝不删除」，加删除逻辑要单独定义失败语义。


### PR DESCRIPTION
[#585](https://github.com/shiwenwen/hope-agent/pull/585) 合并后跑 `force` 回填，第一次 rclone 调用就挂了：

```
CRITICAL: Invalid value when setting --force from environment variable
RCLONE_FORCE="--ignore-times": invalid argument "--ignore-times" for "--force" flag:
strconv.ParseBool: parsing "--ignore-times": invalid syntax
```

## 原因

**rclone 会把任何 `RCLONE_<FLAG>` 环境变量当成同名 flag 的值。** 我在 #585 加的辅助变量 `RCLONE_FORCE` 于是被解释成 `--force`；`RCLONE_VERSION` 同理会撞 `--version`。两个都不是布尔值，rclone 在第一次调用就退出。

`RCLONE_CONFIG_R2_*` 是文档化的 remote 配置写法（`RCLONE_CONFIG_<REMOTE>_<KEY>`），不在此列，保持不变。

## 改动

三个辅助变量改用 `R2_` 前缀：

| 旧 | 新 |
| --- | --- |
| `RCLONE_FLAGS` | `R2_UPLOAD_FLAGS` |
| `RCLONE_FORCE` | `R2_FORCE_FLAG` |
| `RCLONE_VERSION` | `R2_RCLONE_PIN` |

并在 workflow `env` 块与 `docs/release-process.md` §1.10 写明这个陷阱——不写下来必然复发。

## 核查

把 workflow 里**全部** env 定义（workflow / job / step 三级）加上所有写进 `$GITHUB_ENV` 的变量名都过了一遍，`RCLONE_` 开头且非 `RCLONE_CONFIG_` 的：**零**。

## 一个正面结果

挂点是安装步骤里那句 `rclone version`——也就是 #585 新加的「动任何字节之前先自检」把问题挡在了上传之前，而不是传到一半炸掉留下半个状态。这正是加那个断言的目的。