### PR TITLE
fix(ci): flag 自检别把 rclone 管进 grep -q，会被 SIGPIPE 误判

### DIFF
--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -325,9 +325,21 @@ jobs:
           # through the first upload; here it is one clear line before any
           # bytes move. --metadata-set is what applies Cache-Control during the
           # PUT (see the R2_UPLOAD_FLAGS note on why --header-upload was dropped).
+          # Capture once, then match against the captured text. Do NOT pipe
+          # rclone into `grep -q`: grep exits on first match and closes the
+          # pipe, rclone dies of SIGPIPE, and `set -o pipefail` turns that
+          # into a failed pipeline — so a flag that EXISTS gets reported
+          # missing. It bites exactly the flags that appear early in the
+          # output (the global ones) while late backend flags pass, which is
+          # what made the first failure look like a version problem.
+          flags_help="$(rclone help flags 2>/dev/null || true)"
+          if [[ -z "$flags_help" ]]; then
+            echo "::error::\`rclone help flags\` produced no output — cannot verify flag support"
+            exit 1
+          fi
           missing=()
           for flag in --metadata --metadata-set --checksum --s3-no-check-bucket; do
-            rclone help flags 2>/dev/null | grep -q -- "$flag" || missing+=("$flag")
+            grep -q -- "$flag" <<<"$flags_help" || missing+=("$flag")
           done
           if (( ${#missing[@]} )); then
             echo "::error::rclone ${R2_RCLONE_PIN} does not support: ${missing[*]} — pin a version that does"

--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -318,7 +318,7 @@ jobs:
           unzip -q "$tmp/rclone.zip" -d "$tmp"
           sudo install -m 755 "$tmp/rclone-${R2_RCLONE_PIN}-linux-amd64/rclone" /usr/local/bin/rclone
           rm -rf "$tmp"
-          rclone version | head -1
+          rclone version | head -1 || true
 
           # Assert the flags this workflow depends on actually exist. Without
           # this, an unsupported flag surfaces as an opaque failure partway
@@ -493,18 +493,23 @@ jobs:
               echo "  FAIL (unreachable)  $url"
               fail=1; return
             fi
-            actual=$(grep -i '^content-length:' <<<"$HDR" | tail -1 | tr -dc '0-9')
+            # `|| true` on every extraction below: with pipefail a grep that
+            # matches nothing fails the pipeline, and `set -e` would abort the
+            # whole step instead of reaching the FAIL branch — for the very
+            # case this check exists to catch (a response with no
+            # cache-control at all, which is exactly what the R2 bug produced).
+            actual=$(grep -i '^content-length:' <<<"$HDR" | tail -1 | tr -dc '0-9' || true)
             if [[ "$actual" != "$expect" ]]; then
               echo "  FAIL (size $actual != $expect)  $url"
               fail=1; return
             fi
             if [[ -n "$want_cc" ]]; then
-              cc=$(grep -i '^cache-control:' <<<"$HDR" | tail -1 | tr -d '\r')
+              cc=$(grep -i '^cache-control:' <<<"$HDR" | tail -1 | tr -d '\r' || true)
               # Compare max-age only, not the whole string: directive order
               # and casing are not ours to control, but the TTL is the thing
               # that actually matters and the thing that silently regressed.
-              got_age=$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9')
-              want_age=$(grep -oE 'max-age=[0-9]+' <<<"$want_cc" | head -1 | tr -dc '0-9')
+              got_age=$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9' || true)
+              want_age=$(grep -oE 'max-age=[0-9]+' <<<"$want_cc" | head -1 | tr -dc '0-9' || true)
               if [[ "$got_age" != "$want_age" ]]; then
                 echo "  FAIL (cache-control max-age=${got_age:-none}, want $want_age)  $url"
                 fail=1; return
@@ -611,8 +616,8 @@ jobs:
                 echo "OK   spot-checked $spot"
                 cc=$(curl -fsSI --max-time 20 "$url" | grep -i '^cache-control:' | tr -d '\r')
                 echo "     $cc"
-                got=$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9')
-                want=$(grep -oE 'max-age=[0-9]+' <<<"$CC_MANIFEST" | head -1 | tr -dc '0-9')
+                got=$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9' || true)
+                want=$(grep -oE 'max-age=[0-9]+' <<<"$CC_MANIFEST" | head -1 | tr -dc '0-9' || true)
                 if [[ "$got" != "$want" ]]; then
                   # The manifest is the one object where a long TTL is a real
                   # problem: a pinned stale copy tells clients "no update".


### PR DESCRIPTION
`force` 回填第二次挂在 [#585](https://github.com/shiwenwen/hope-agent/pull/585) 新加的 flag 自检上：rclone v1.74.4 明明装好了（日志里 `rclone version` 打印正常），自检却报三个 flag 不支持。

```
rclone v1.74.4
##[error]rclone v1.74.4 does not support: --metadata --metadata-set --checksum
```

## 原因

```bash
rclone help flags 2>/dev/null | grep -q -- "$flag" || missing+=("$flag")
```

`grep -q` 命中即退出并关闭管道 → rclone 收到 SIGPIPE 非零退出 → `set -o pipefail` 把整条管道判为失败 → **存在的 flag 被报成缺失**。

**关键线索是「只错三个」**：`--s3-no-check-bucket` 没被误报。它是 backend flag、排在输出末尾，grep 要读完整个流才匹配，rclone 得以正常退出；而三个全局 flag 排在前面，命中早、必 SIGPIPE。正是这个形态让上一次失败看起来像版本问题——实际和版本无关。

## 改动

先把输出抓进变量，再对变量匹配；输出为空时明确报错（那才是真的读不到 flag 列表）。

## 关于上一轮的验证

**我上一轮的本地验证是无效的**：用的是不带 `set -euo pipefail` 的一次性 shell，没复现 CI 的条件，所以旧写法在本地"通过"了。

这次带 `pipefail` 精确复现：

```
--- 旧写法(管道 + grep -q) ---
  报缺失: --metadata --metadata-set --checksum     ← 与 CI 报的完全一致
--- 新写法(先抓进变量) ---
  报缺失: 无
```

同时也再次确认 v1.60.1 与 v1.74.4 都支持这四个 flag——[#585](https://github.com/shiwenwen/hope-agent/pull/585) 里那条 review 的事实判断仍然不成立，但钉版本的做法保留。