### PR TITLE
fix(chat): prevent panel badge clipping

### DIFF
--- a/src/components/chat/ChatTitleBar.tsx
+++ b/src/components/chat/ChatTitleBar.tsx
@@ -404,7 +404,7 @@ export default function ChatTitleBar({
   const rightPanelControls = rightPanels.length > 0 ? (
     <div className="ml-1 flex items-center gap-0.5 border-l border-border-soft pl-1">
       <div
-        className="flex h-8 max-w-[248px] items-center gap-0.5 overflow-x-auto p-0.5"
+        className="flex h-9 max-w-[248px] items-center gap-0.5 overflow-x-auto pb-0.5 pl-0.5 pr-1.5 pt-1.5"
         role="toolbar"
         aria-label={t("chat.rightPanel.dock")}
       >


### PR DESCRIPTION
## Summary

- reserve top and right space inside the title-bar panel dock
- keep the existing panel button alignment while allowing status badges to render fully

## Root cause

The horizontally scrollable panel dock clipped the negative top/right badge offsets at its overflow boundary.

## User impact

Running-count badges for Background Tasks and the Agent panel are no longer visibly cropped.

## Validation

- `pnpm typecheck`
- `git diff --check`