### PR TITLE
fix(ui): slow shimmer animation

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -581,7 +581,7 @@ html[data-focus-indicators="enhanced"]
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent !important;
-  animation: text-shimmer 2.5s ease-in-out infinite;
+  animation: text-shimmer 4s ease-in-out infinite;
 }
 
 @keyframes tool-count-number-change {


### PR DESCRIPTION
## Summary

- slow the shared text shimmer cycle from 2.5 seconds to 4 seconds
- keep Pet bubbles and running states in the conversation list visually consistent

## Why

The existing sweep moved too quickly and felt distracting. The shared animation timing was the root cause across both surfaces.

## User impact

Running-state shimmer is calmer and easier to read without changing content or interaction behavior.

## Validation

- `pnpm typecheck`
- `git diff --check`