### PR TITLE
Lighten skill mention styling

### DIFF
--- a/src/components/chat/input/MentionComposerInput.tsx
+++ b/src/components/chat/input/MentionComposerInput.tsx
@@ -36,6 +36,7 @@ import { parseAgentMentions } from "../agent-mention/agentTokens"
 import { parseMentions, parseNoteRefs } from "../file-mention/mentionTokens"
 import { joinAbs } from "../file-mention/types"
 import { SkillMentionIcon } from "../skill-mention/SkillMentionIcon"
+import { skillMentionToneClass } from "../skill-mention/skillMentionStyles"
 import {
   isSkillMentionName,
   parseSkillMentions,
@@ -91,7 +92,7 @@ const FILE_CHIP_CLASS =
 const NOTE_CHIP_CLASS =
   "cm-mention-chip cm-mention-note mx-0.5 inline-flex h-6 max-w-[16rem] align-baseline items-center rounded-md border border-violet-500/20 bg-violet-500/10 px-1.5 text-sm font-medium text-violet-600 shadow-sm dark:border-violet-300/20 dark:bg-violet-300/15 dark:text-violet-200"
 const SKILL_CHIP_CLASS =
-  "cm-mention-chip cm-mention-skill mx-0.5 inline-flex h-6 max-w-[16rem] align-baseline items-center gap-1 rounded-md border border-rose-500/20 bg-rose-500/10 px-1.5 text-sm font-medium text-rose-600 shadow-sm dark:border-rose-300/20 dark:bg-rose-300/15 dark:text-rose-200"
+  "cm-mention-chip cm-mention-skill mx-0.5 inline-flex h-6 max-w-[16rem] items-center gap-1 whitespace-nowrap align-baseline text-sm font-normal"
 const AGENT_CHIP_CLASS =
   "cm-mention-chip cm-mention-agent mx-0.5 inline-flex h-6 max-w-[16rem] align-baseline items-center gap-1 rounded-md border border-teal-500/20 bg-teal-500/10 px-1.5 text-sm font-medium text-teal-700 shadow-sm dark:border-teal-300/20 dark:bg-teal-300/15 dark:text-teal-200"
 const CHIP_ICON_CLASS = "h-4 w-4 shrink-0"
@@ -234,7 +235,10 @@ class MentionWidget extends WidgetType {
 
     if (this.span.kind === "skill") {
       const meta = skillMentionMeta(this.span.name)
-      root.className = SKILL_CHIP_CLASS
+      root.className = cn(
+        SKILL_CHIP_CLASS,
+        meta ? skillMentionToneClass(meta.iconKind) : "text-foreground/85",
+      )
       root.title = this.span.raw
       if (meta) {
         appendIcon(

--- a/src/components/chat/skill-mention/SkillMentionChip.tsx
+++ b/src/components/chat/skill-mention/SkillMentionChip.tsx
@@ -1,7 +1,7 @@
 /**
- * Inline rose chip for a `@skill` mention rendered inside message markdown.
+ * Lightweight inline treatment for a `@skill` mention in message markdown.
  * `MarkdownLink` (common/MarkdownRenderer) dispatches `[@label](#skill:<name>)`
- * links here so the **history bubble shows the same styled chip as the
+ * links here so the **history bubble shows the same styled mention as the
  * composer** instead of the raw `[@…](#skill:…)` link text. Label + icon are
  * resolved from the catalog by id (current UI language), so it stays localized.
  */
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next"
 
 import { cn } from "@/lib/utils"
 import { SkillMentionIcon } from "./SkillMentionIcon"
+import { skillMentionToneClass } from "./skillMentionStyles"
 import { skillMentionMeta } from "./skillTokens"
 
 export function SkillMentionChip({ name }: { name: string }) {
@@ -22,10 +23,9 @@ export function SkillMentionChip({ name }: { name: string }) {
       data-skill-mention={name}
       data-ha-title-tip={label}
       className={cn(
-        "mx-0.5 inline-flex items-center gap-1 rounded-md border px-1.5 align-baseline",
-        "text-[0.95em] font-medium leading-snug",
-        "border-rose-500/20 bg-rose-500/10 text-rose-600",
-        "dark:border-rose-300/20 dark:bg-rose-300/15 dark:text-rose-200",
+        "mx-0.5 inline-flex max-w-[16rem] items-center gap-1 whitespace-nowrap align-baseline",
+        "text-[0.95em] font-normal leading-snug",
+        skillMentionToneClass(meta.iconKind),
       )}
     >
       <SkillMentionIcon kind={meta.iconKind} className="h-3.5 w-3.5 shrink-0" />

--- a/src/components/chat/skill-mention/skillMentionStyles.ts
+++ b/src/components/chat/skill-mention/skillMentionStyles.ts
@@ -1,0 +1,23 @@
+import type { SkillIconKind } from "./skillTokens"
+
+/**
+ * Keep skill mentions visually close to surrounding prose: the icon carries
+ * most of the identity, while the label gets a restrained brand-adjacent tone.
+ * Composer widgets and rendered messages both consume this helper so they do
+ * not drift back into separate chip styles.
+ */
+export function skillMentionToneClass(kind: SkillIconKind): string {
+  switch (kind) {
+    case "docx":
+      return "text-blue-600 dark:text-blue-400"
+    case "pptx":
+      return "text-orange-600 dark:text-orange-400"
+    case "xlsx":
+      return "text-emerald-700 dark:text-emerald-400"
+    case "analytics":
+      return "text-sky-600 dark:text-sky-400"
+    case "browser":
+    case "mac":
+      return "text-foreground/85"
+  }
+}

--- a/src/components/chat/skill-mention/skillMentionStyles.ts
+++ b/src/components/chat/skill-mention/skillMentionStyles.ts
@@ -11,11 +11,11 @@ export function skillMentionToneClass(kind: SkillIconKind): string {
     case "docx":
       return "text-blue-600 dark:text-blue-400"
     case "pptx":
-      return "text-orange-600 dark:text-orange-400"
+      return "text-orange-700 dark:text-orange-400"
     case "xlsx":
       return "text-emerald-700 dark:text-emerald-400"
     case "analytics":
-      return "text-sky-600 dark:text-sky-400"
+      return "text-sky-700 dark:text-sky-400"
     case "browser":
     case "mac":
       return "text-foreground/85"

--- a/src/components/common/MarkdownRenderer.tsx
+++ b/src/components/common/MarkdownRenderer.tsx
@@ -419,8 +419,9 @@ export function MarkdownLink({
   ...rest
 }: MarkdownAnchorProps) {
   const isIncomplete = href === "streamdown:incomplete-link"
-  // `@skill` mentions are `[@label](#skill:<name>)` links — render the same rose
-  // chip the composer shows, not the raw link. Fragment href survives sanitize.
+  // `@skill` mentions are `[@label](#skill:<name>)` links — render the same
+  // lightweight inline treatment as the composer, not the raw link. Fragment
+  // href survives sanitize.
   const skillName = isIncomplete ? null : skillNameFromHref(href)
   if (skillName && isSkillMentionName(skillName)) {
     return <SkillMentionChip name={skillName} />


### PR DESCRIPTION
## What changed

- Remove the tinted background, border, rounded chip shape, shadow, and extra horizontal padding from `@skill` mentions.
- Use lightweight inline typography with restrained per-skill label colors.
- Share the tone mapping between the composer and rendered message history.

## Why

Skill mentions were visually heavier than the surrounding prose in both the composer and sent messages. This aligns them with a lighter icon-and-label treatment while preserving recognition and localization.

## Validation

- `pnpm typecheck`
- Prettier check for changed files
- `git diff --check`