### PR TITLE
Align skill mention baselines

### DIFF
--- a/src/components/chat/input/MentionComposerInput.tsx
+++ b/src/components/chat/input/MentionComposerInput.tsx
@@ -92,7 +92,7 @@ const FILE_CHIP_CLASS =
 const NOTE_CHIP_CLASS =
   "cm-mention-chip cm-mention-note mx-0.5 inline-flex h-6 max-w-[16rem] align-baseline items-center rounded-md border border-violet-500/20 bg-violet-500/10 px-1.5 text-sm font-medium text-violet-600 shadow-sm dark:border-violet-300/20 dark:bg-violet-300/15 dark:text-violet-200"
 const SKILL_CHIP_CLASS =
-  "cm-mention-chip cm-mention-skill mx-0.5 inline-flex h-6 max-w-[16rem] items-center gap-1 whitespace-nowrap align-baseline text-sm font-normal"
+  "cm-mention-chip cm-mention-skill mx-0.5 inline-flex max-w-[16rem] items-baseline gap-1 whitespace-nowrap align-baseline text-sm font-normal"
 const AGENT_CHIP_CLASS =
   "cm-mention-chip cm-mention-agent mx-0.5 inline-flex h-6 max-w-[16rem] align-baseline items-center gap-1 rounded-md border border-teal-500/20 bg-teal-500/10 px-1.5 text-sm font-medium text-teal-700 shadow-sm dark:border-teal-300/20 dark:bg-teal-300/15 dark:text-teal-200"
 const CHIP_ICON_CLASS = "h-4 w-4 shrink-0"
@@ -176,9 +176,9 @@ function appendText(parent: HTMLElement, className: string, text: string) {
   parent.appendChild(el)
 }
 
-function appendIcon(parent: HTMLElement, icon: React.ReactNode) {
+function appendIcon(parent: HTMLElement, icon: React.ReactNode, className?: string) {
   const mount = document.createElement("span")
-  mount.className = "inline-flex shrink-0 items-center justify-center"
+  mount.className = cn("inline-flex shrink-0 items-center justify-center", className)
   parent.appendChild(mount)
   const root = createRoot(mount)
   root.render(icon)
@@ -244,6 +244,7 @@ class MentionWidget extends WidgetType {
         appendIcon(
           root,
           createElement(SkillMentionIcon, { kind: meta.iconKind, className: CHIP_ICON_CLASS }),
+          "self-center",
         )
       }
       appendText(root, CHIP_LABEL_CLASS, this.skillLabel(this.span.name))

--- a/src/components/chat/skill-mention/SkillMentionChip.tsx
+++ b/src/components/chat/skill-mention/SkillMentionChip.tsx
@@ -23,13 +23,13 @@ export function SkillMentionChip({ name }: { name: string }) {
       data-skill-mention={name}
       data-ha-title-tip={label}
       className={cn(
-        "mx-0.5 inline-flex max-w-[16rem] items-center gap-1 whitespace-nowrap align-baseline",
+        "mx-0.5 inline-flex max-w-[16rem] items-baseline gap-1 whitespace-nowrap align-baseline",
         "text-[0.95em] font-normal leading-snug",
         skillMentionToneClass(meta.iconKind),
       )}
     >
-      <SkillMentionIcon kind={meta.iconKind} className="h-3.5 w-3.5 shrink-0" />
-      {label}
+      <SkillMentionIcon kind={meta.iconKind} className="h-3.5 w-3.5 shrink-0 self-center" />
+      <span className="min-w-0 truncate">{label}</span>
     </span>
   )
 }

--- a/src/components/chat/skill-mention/skillMentionStyles.ts
+++ b/src/components/chat/skill-mention/skillMentionStyles.ts
@@ -17,7 +17,8 @@ export function skillMentionToneClass(kind: SkillIconKind): string {
     case "analytics":
       return "text-sky-700 dark:text-sky-400"
     case "browser":
+      return "text-blue-600 dark:text-blue-400"
     case "mac":
-      return "text-foreground/85"
+      return "text-foreground"
   }
 }


### PR DESCRIPTION
## What changed

- Align skill mentions to surrounding text using the label's real font baseline in both the composer and message history.
- Keep mention icons vertically centered without letting them define the inline-flex baseline.
- Use Chrome blue for browser control mentions and system foreground black/white for Mac control mentions.

## Why

The mention icon was the first flex item, so browsers synthesized the inline-flex baseline from the icon rather than the label. Text typed or rendered after a mention therefore appeared vertically offset. Optical pixel/em nudges only moved the mismatch in the opposite direction; making the label the baseline participant fixes the layout deterministically.

## Validation

- `pnpm typecheck`
- Pre-push ESLint (0 errors; 3 existing warnings)
- Pre-push Vitest: 229 files, 1169 tests passed
- Updater key and endpoint consistency checks
- `git diff --check`