### PR TITLE
fix(ci): 镜像 Cache-Control 校验改断言指令集 + release-process 文档重排

### DIFF
--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -101,15 +101,14 @@ env:
   # and rclone dies on the first invocation with a bool-parse error. Hence the
   # `R2_` prefix on everything below — do NOT rename them back.
   #
-  # Shared robustness flags for every upload. R2 answers `501 NotImplemented`
-  # on the call rclone made to apply `--header-upload` headers AFTER a
-  # successful PUT. Measured consequence: the object landed byte-correct but
-  # WITHOUT its Cache-Control, so Cloudflare served its own 4h default — and
-  # it hit only some objects, which is what made it look like a Cloudflare
-  # override rather than our bug. Headers are now set with --metadata-set,
-  # which applies them as part of the upload instead of a follow-up call, and
-  # the verify step below asserts the served Cache-Control so a silent
-  # regression cannot happen again. Retry headroom is kept as a backstop.
+  # Shared robustness flags for every upload. Set Cache-Control with
+  # --metadata-set, never --header-upload: R2 answers 501 on the separate
+  # post-PUT call --header-upload makes, leaving the object byte-correct but
+  # header-less. Retry headroom is a backstop.
+  #
+  # Two things produce `max-age=14400`: a missing header (bare value, no
+  # directives) and Cloudflare's Browser Cache TTL (keeps our directives,
+  # raises the value). Tell them apart by the directives, not the number.
   #   --retries / --low-level-retries: headroom over the defaults (3 / 10).
   #   --s3-no-check-bucket: skips the bucket-existence probe, one of the calls
   #     R2 is known to answer NotImplemented for. The bucket is created and
@@ -481,13 +480,21 @@ jobs:
             return 1
           }
 
-          # $3 = expected max-age. Asserting it is not belt-and-braces: R2
-          # once answered 501 on the header-application call, so objects landed
-          # byte-correct but WITHOUT Cache-Control and Cloudflare served its own
-          # 4h default. Size checks pass right through that — only reading back
-          # the served header catches it.
+          # $3 = the Cache-Control we uploaded. Read it back: the 501 bug (see
+          # R2_UPLOAD_FLAGS) landed objects byte-correct but header-less, which
+          # a size check cannot see.
+          #
+          # Asserts the marker directive, NOT the max-age value. `immutable` /
+          # `must-revalidate` are ours, mutually exclusive across the tiers,
+          # and absent from Cloudflare's default — so a missing header and a
+          # wrong-tier header both still fail. The value is not ours to assert:
+          # Cloudflare's Browser Cache TTL raises max-age on cached responses
+          # (4h floor, hits `latest/*.dmg|exe|zip|tar.gz` as REVALIDATED,
+          # leaves DYNAMIC ones and the immutable prefix alone). Only a value
+          # BELOW what we uploaded is an error.
           check_one() {
-            local url="$1" local_file="$2" want_cc="$3" expect actual cc got_age want_age
+            local url="$1" local_file="$2" want_cc="$3"
+            local expect actual cc marker got_age want_age cf
             expect=$(stat -c%s "$local_file")
             if ! fetch_headers "$url"; then
               echo "  FAIL (unreachable)  $url"
@@ -505,14 +512,29 @@ jobs:
             fi
             if [[ -n "$want_cc" ]]; then
               cc=$(grep -i '^cache-control:' <<<"$HDR" | tail -1 | tr -d '\r' || true)
-              # Compare max-age only, not the whole string: directive order
-              # and casing are not ours to control, but the TTL is the thing
-              # that actually matters and the thing that silently regressed.
-              got_age=$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9' || true)
-              want_age=$(grep -oE 'max-age=[0-9]+' <<<"$want_cc" | head -1 | tr -dc '0-9' || true)
-              if [[ "$got_age" != "$want_age" ]]; then
-                echo "  FAIL (cache-control max-age=${got_age:-none}, want $want_age)  $url"
+              cf=$(grep -i '^cf-cache-status:' <<<"$HDR" | tail -1 | tr -d '\r' \
+                   | sed 's/^[^:]*: *//' || true)
+              if grep -qi 'immutable' <<<"$want_cc"; then marker=immutable; else marker=must-revalidate; fi
+              if ! grep -qi -- "$marker" <<<"$cc"; then
+                echo "  FAIL (cache-control '${cc:-none}' is missing '$marker' — the header we uploaded did not land)  $url"
                 fail=1; return
+              fi
+              got_age=$(grep -oiE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9' || true)
+              want_age=$(grep -oiE 'max-age=[0-9]+' <<<"$want_cc" | head -1 | tr -dc '0-9' || true)
+              if [[ -z "$got_age" ]]; then
+                echo "  FAIL (cache-control '$cc' has no max-age)  $url"
+                fail=1; return
+              fi
+              if (( got_age < want_age )); then
+                echo "  FAIL (cache-control max-age=$got_age is BELOW the $want_age we uploaded)  $url"
+                fail=1; return
+              fi
+              if (( got_age > want_age )); then
+                echo "  ok  ${actual}B  $url"
+                echo "      note: edge serves max-age=$got_age (we set $want_age, cf-cache-status=${cf:-unknown})."
+                echo "      Cloudflare Browser Cache TTL raises max-age on cached responses; set it to"
+                echo "      'Respect Existing Headers' if the shorter TTL should reach browsers."
+                return
               fi
             fi
             echo "  ok  ${actual}B  $url"
@@ -616,13 +638,26 @@ jobs:
                 echo "OK   spot-checked $spot"
                 cc=$(curl -fsSI --max-time 20 "$url" | grep -i '^cache-control:' | tr -d '\r')
                 echo "     $cc"
-                got=$(grep -oE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9' || true)
-                want=$(grep -oE 'max-age=[0-9]+' <<<"$CC_MANIFEST" | head -1 | tr -dc '0-9' || true)
-                if [[ "$got" != "$want" ]]; then
-                  # The manifest is the one object where a long TTL is a real
-                  # problem: a pinned stale copy tells clients "no update".
-                  echo "::error::manifest Cache-Control max-age=${got:-none}, want $want — the mirror manifest would be cached far longer than intended"
+                # Same reasoning as check_one: `must-revalidate` proves OUR
+                # header landed (Cloudflare's own default carries neither
+                # marker), while the max-age value can be raised by the edge's
+                # Browser Cache TTL and is not ours to assert. Too SHORT is
+                # still an error — the manifest is the one object where a long
+                # TTL genuinely hurts, since a pinned stale copy tells clients
+                # "no update", so a value above what we set is called out loudly
+                # even though it does not fail the release.
+                if ! grep -qi -- 'must-revalidate' <<<"$cc"; then
+                  echo "::error::manifest Cache-Control '${cc:-none}' is missing 'must-revalidate' — the header we uploaded did not land"
                   exit 1
+                fi
+                got=$(grep -oiE 'max-age=[0-9]+' <<<"$cc" | head -1 | tr -dc '0-9' || true)
+                want=$(grep -oiE 'max-age=[0-9]+' <<<"$CC_MANIFEST" | head -1 | tr -dc '0-9' || true)
+                if [[ -z "$got" ]] || (( got < want )); then
+                  echo "::error::manifest Cache-Control max-age=${got:-none} is below the $want we uploaded"
+                  exit 1
+                fi
+                if (( got > want )); then
+                  echo "::warning::manifest is served with max-age=$got (we set $want). Cloudflare Browser Cache TTL raises max-age on cached responses; clients may see this manifest up to $got s stale. Set Browser Cache TTL to 'Respect Existing Headers' to fix."
                 fi
                 exit 0
               fi

--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -34,8 +34,11 @@ name: Mirror Release to R2
 #
 # SECURITY: signatures in the manifest are copied verbatim, never
 # recomputed, and are verified client-side against the Minisign public key
-# compiled into the binary. A tampered mirror cannot install a malicious
-# build — worst case is denial of service or a stale version advertisement.
+# compiled into the binary. A tampered mirror therefore cannot push a
+# malicious build through the UPDATER — worst case there is denial of service
+# or a stale version advertisement. This says nothing about the manual
+# download links: those installers are run by OS tooling and never reach that
+# verifier, exactly as with manual downloads from GitHub.
 # See docs/architecture/self-update.md.
 #
 # Triggers:

--- a/docs/architecture/self-update.md
+++ b/docs/architecture/self-update.md
@@ -104,7 +104,9 @@ Manifest 结构（[`updater::manifest::Manifest`](../../crates/ha-core/src/updat
 - **首个成功者胜**，与 `tauri-plugin-updater` 自身行为一致——刻意不做「比较版本取新者」，否则桌面与 headless 两条路径会对「当前是哪个版本」产生分歧。代价是**一份 stale-but-200 的镜像 manifest 会报「已是最新」而不会 fallback**。这条残留风险由三件事兜住：镜像 manifest 的 `Cache-Control: max-age=60`、镜像 workflow 只在全部 URL 回抓校验通过后才写 manifest（所以 stale 的那份必然描述一个真实且已完整镜像的版本，绝不会是残缺版本）、以及该 workflow 失败即报错。
 - **两处漂移会被拦**：[`scripts/verify-updater-endpoints.mjs`](../../scripts/verify-updater-endpoints.mjs) 在 CI（`lint.yml`）与 `pre-push` 双处校验，且同时校验镜像 endpoint 的域名与 [`mirror-release-r2.yml`](../../.github/workflows/mirror-release-r2.yml) 的 `PUBLIC_BASE` 一致——否则所有客户端会去问一个没有发布任何东西的主机。
 
-**镜像不削弱签名信任根**：manifest 自身不签名，但里面的 `signature` 要用编译进二进制的 `MINISIGN_PUBKEY_BASE64` 验（见上节）。所以被污染的镜像**无法让恶意二进制装进去**，最坏只能拒绝服务或谎报版本。镜像 workflow 因此原样复制 `signature`、**绝不重算**。
+**镜像不削弱签名信任根**：manifest 自身不签名，但里面的 `signature` 要用编译进二进制的 `MINISIGN_PUBKEY_BASE64` 验（见上节）。所以被污染的镜像**无法通过自动更新把恶意二进制装进去**，最坏只能拒绝服务或谎报版本。镜像 workflow 因此原样复制 `signature`、**绝不重算**。
+
+**这条保证只覆盖 updater 路径**。`verify_bytes` 的调用点只有 [`self_contained.rs`](../../crates/ha-core/src/updater/self_contained.rs)；README 上的手动下载链接指向同一个镜像，但那些安装包由系统安装、不经这道验签——与从 GitHub 手动下载的情况相同。对外描述镜像安全性时不要把范围写成「安装包一律验签」。
 
 **「谎报版本」不只是被攻击才会发生**——正常运维就能踩到。`download/latest.json` 是全局共享的可变对象，一旦给**非当前稳定版**写它（手动回填旧 tag、或发布 prerelease，两者都会触发镜像 workflow），配合上面「首个成功者胜」，全体客户端会被告知那个旧版本才是最新，从而看不到真正的新版。因此镜像 workflow 只在该 tag 恰好是 GitHub 认定的 latest release 且非 prerelease 时才写可变面（`PROMOTE` 门控），其余情况只写自己的不可变 `download/<tag>/` 前缀。
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,6 +1,6 @@
 # Hope Agent 发版流程
 
-> 分支模型与跨分支红线（`main` / `release/X.Y`、只 cherry-pick 不 merge）见 [AGENTS.md "## 分支与发布"](../AGENTS.md#分支与发布)。本文档是配套实操手册，覆盖在 branch protection 启用下的完整命令流程、避坑要点与速查表。
+> 分支模型与跨分支红线（`main` / `release/X.Y`、只 cherry-pick 不 merge）见 [AGENTS.md "## 分支与发布"](../AGENTS.md#分支与发布)。本文是实操手册：命令怎么敲、什么不能做。
 
 ---
 
@@ -10,102 +10,125 @@
 
 | 角色 | 形态 | 由谁产出 |
 | --- | --- | --- |
-| 维护分支 `release/X.Y` | git branch | 新 minor 发版后由人工切出，长期存在 |
-| Tag `vX.Y.Z` | git tag | 人工在维护分支 HEAD 打，推送后触发 CI |
+| 维护分支 `release/X.Y` | git branch | 新 minor 发版后人工切出，长期存在 |
+| Tag `vX.Y.Z` | git tag | 人工在目标分支 HEAD 打，推送后触发 CI |
 | GitHub Release | GitHub 资源 | [release.yml](../.github/workflows/release.yml) 自动创建 draft，人工 publish |
-| 安装包 | 多平台二进制（DMG / NSIS / DEB / AppImage） | tauri-action 在 CI 中构建并上传到 Release |
-| `latest.json` | Tauri updater 清单 | tauri-action 自动生成并上传到 Release，客户端从此拉更新元数据 |
+| 安装包 | DMG / NSIS / DEB / RPM / AppImage | tauri-action 在 CI 构建并上传到 Release |
+| `latest.json` | Tauri updater 清单 | tauri-action 生成并上传到 Release，客户端据此拉更新 |
 
 ### 0.2 一次发版的全链路
 
 ```
-PR (含 release notes + CHANGELOG + version bump)
-  → 合并到 release/X.Y
-  → 在 release/X.Y HEAD 打 tag vX.Y.Z
-  → push tag 到 origin
-  → release.yml 构建 macOS/Windows/Linux 产物 + latest.json
-  → 自动创建 draft GitHub Release，资产齐全
+PR（release notes + CHANGELOG + version bump）
+  → 合并到目标分支
+  → 在目标分支 HEAD 打 tag vX.Y.Z 并 push
+  → release.yml 构建 4 平台产物 + latest.json
+  → 自动创建 draft GitHub Release
   → 人工审阅 → publish
-  → updater endpoint（latest published release/download/latest.json）开始对外服务
-  → 已安装客户端"检查更新"拉到新版
+  → 5 条下游渠道 workflow 由 release.published 自动触发（§1.6~§1.10）
+  → 已安装客户端「检查更新」拉到新版
 ```
 
 ### 0.3 Tauri updater 拉取链路
 
-客户端配置在 [src-tauri/tauri.conf.json](../src-tauri/tauri.conf.json) `plugins.updater.endpoints`，固定指向 `https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json`。GitHub 对 `releases/latest` 的解析规则：**只看已 published（非 draft）且非 prerelease 的最新 Release**。因此 draft 状态客户端拉不到，必须人工 publish 后才生效。
+客户端按顺序试两个 endpoint，**首个成功者胜**（不比较版本号）：
+
+1. `https://repo.hopeagent.ai/download/latest.json` — R2 镜像，由 §1.10 发布
+2. `https://github.com/shiwenwen/hope-agent/releases/latest/download/latest.json` — GitHub 兜底
+
+R2 排第一是**可达性**不是延迟：有一部分用户根本访问不了 `github.com`。
+
+两处配置必须逐项逐序相等：[`tauri.conf.json`](../src-tauri/tauri.conf.json) `plugins.updater.endpoints` ↔ [`manifest.rs`](../crates/ha-core/src/updater/manifest.rs) `UPDATE_MANIFEST_URLS`，由 [`scripts/verify-updater-endpoints.mjs`](../scripts/verify-updater-endpoints.mjs) 在 CI 与 pre-push 强制。
+
+GitHub 的 `releases/latest` 只解析**已 published 且非 prerelease** 的 Release，所以 draft 状态客户端拉不到。
 
 ### 0.4 版本号单一来源
 
-`package.json` 是版本号唯一真相源，[scripts/sync-version.mjs](../scripts/sync-version.mjs) 把它同步到 [src-tauri/Cargo.toml](../src-tauri/Cargo.toml)、[src-tauri/tauri.conf.json](../src-tauri/tauri.conf.json)、`ha-core`、`ha-server`、`ha-eval` 及 `Cargo.lock`。CI 入口 [scripts/verify-release-version.mjs](../scripts/verify-release-version.mjs) 在 tag 触发后校验所有产品版本来源一致且与 tag 名匹配。
+`package.json` 是唯一真相源，[`sync-version.mjs`](../scripts/sync-version.mjs) 同步到 `src-tauri/Cargo.toml`、`src-tauri/tauri.conf.json`、`ha-core` / `ha-server` / `ha-browser-host` / `ha-eval` 的 Cargo.toml 及 `Cargo.lock`。**禁止手改任何一处**。tag 触发后 [`verify-release-version.mjs`](../scripts/verify-release-version.mjs) 校验全部来源一致且与 tag 名匹配。
 
 ### 0.5 macOS 代码签名
 
-`release.yml` 用一个固定自签名证书签 macOS 包，让授予的系统权限（录屏 / 辅助功能等）跨自动更新不失效（ad-hoc 签名会随 cdhash 变化每次重置授权）。一次性配置（生成证书 + 4 个 GitHub Secrets）见 [macos-self-signing.md](macos-self-signing.md)。Secrets 未配时自动退回 ad-hoc，不影响发布。
+`release.yml` 用固定自签名证书签 macOS 包，让已授予的系统权限（录屏 / 辅助功能）跨自动更新不失效——ad-hoc 签名的 cdhash 每次变，授权每次重置。一次性配置（证书 + 4 个 Secrets）见 [macos-self-signing.md](macos-self-signing.md)；Secrets 未配时自动退回 ad-hoc，不阻塞发布。
 
 ---
 
 ## 1. patch 发版完整步骤
 
-以从 `release/v0.1` 发 `v0.1.2` 为例。
+以从 `release/v0.1` 发 `v0.1.2` 为例。新 minor 的差异见 §2。
 
 ### 1.1 准备发版 PR
 
-从目标维护分支切发版 PR 分支：
-
 ```bash
 git checkout release/v0.1 && git pull
-git checkout -b release/v0.1.2
+git checkout -b chore/release-v0.1.2
 ```
 
-在 PR 分支上完成三件事（必须同 PR 合并）：
+> **分支名不能用 `release/v0.1.2`**。`refs/heads/release/**` 是维护分支的受保护命名空间，推该前缀的新分支直接被 ruleset 拒（`8 of 8 required status checks are expected`，等多久都不会好）。一律用 `chore/release-<tag>`。
 
-**(a) 写双语 release notes**
+同一个 PR 里做三件事：
 
-新增两份文件：
-- [docs/release-notes/v0.1.2.md](release-notes/) — 中文
-- [docs/release-notes/v0.1.2.en.md](release-notes/) — 英文
+**(a) 双语 release notes**
 
-顶部互加 `简体中文 · English` 切换链接（AGENTS.md 强制约定）。文件名必须与 tag 严格对应（带 `v` 前缀），CI 据此填充 `latest.json#notes`。
+新增 [`docs/release-notes/v0.1.2.md`](release-notes/) 与 `v0.1.2.en.md`，顶部互加 `简体中文 · English` 切换链接。
 
-**链接一律用完整 GitHub URL（tag pin），禁止相对路径**：release notes 内所有跨文件链接必须使用 `https://github.com/shiwenwen/hope-agent/blob/v<X>.<Y>.<Z>/...` 形式的绝对 URL，不要用 `./` 或 `../`。包括中英切换链接、CHANGELOG 锚点、历史 release notes 引用。
+- **文件名必须与 tag 严格对应**（带 `v` 前缀）。CI 据此填 `latest.json#notes`，找不到就落 fallback 文字 `See CHANGELOG.md for details.`
+- **跨文件链接一律用 `https://github.com/shiwenwen/hope-agent/blob/v0.1.2/...` 绝对 URL，禁用 `./` `../`**。这些链接会进 `latest.json#notes`，在桌面应用的「发现新版」弹窗里渲染时已脱离 GitHub 上下文，相对路径必 broken。tag pin 在 release.yml 触发时已含本文件，永不漂移。
 
-原因：[release.yml](../.github/workflows/release.yml) 把 release notes 注入 GitHub Release body 与 `latest.json#notes`；前者 GitHub 会代解析相对路径，后者在桌面应用内的「发现新版」弹窗里渲染时已脱离 GitHub 上下文，相对路径必 broken。tag pin 在 release.yml 触发时（tag push 后）已含本文件，永不漂移；用 `main` 分支引用则需要等 backport 合并才生效，时序上有窗口期。
+**(b) CHANGELOG**
 
-**(b) 更新 CHANGELOG**
+[CHANGELOG.md](../CHANGELOG.md) 顶部新增 `## [0.1.2]` 段，保留空的 `## [Unreleased]` 在其上。每条 entry 单行 + `(#PR)` 引用，用户视角。规范见 AGENTS.md "## 文档维护"。
 
-[CHANGELOG.md](../CHANGELOG.md) 顶部新增 `## [0.1.2]` 段，每条 entry 单行 + `(#PR)` 引用，面向用户视角。具体规范见 AGENTS.md "## 文档维护"。
-
-**(c) 同步版本号**
+**(c) 版本号**
 
 ```bash
 pnpm version 0.1.2 --no-git-tag-version
 ```
 
-`--no-git-tag-version` 关键：只改文件、不创建 commit、不打 tag。该命令会触发 `package.json` 中的 `version` script ([sync-version.mjs](../scripts/sync-version.mjs)) 同步 `src-tauri/Cargo.toml` 与 `src-tauri/tauri.conf.json` 三处版本号。
+`--no-git-tag-version` 不能漏：不带它会直接产生 commit + tag，而 branch protection 不让把它们推上去，发版当场卡死。
 
-提交 PR：
+提交：
 
 ```bash
 git add CHANGELOG.md \
         docs/release-notes/v0.1.2.md docs/release-notes/v0.1.2.en.md \
-        package.json src-tauri/Cargo.toml src-tauri/tauri.conf.json
+        package.json Cargo.lock src-tauri/Cargo.toml src-tauri/tauri.conf.json \
+        crates/ha-core/Cargo.toml crates/ha-server/Cargo.toml \
+        crates/ha-browser-host/Cargo.toml crates/ha-eval/Cargo.toml
 git commit -m "release: v0.1.2"
-git push -u origin release/v0.1.2
+git push -u origin chore/release-v0.1.2
 gh pr create --base release/v0.1 --title "release: v0.1.2" \
   --body "release notes 见 docs/release-notes/v0.1.2.md"
 ```
 
+推送前自查（都是秒级）：
+
+```bash
+RELEASE_TAG=v0.1.2 node scripts/verify-release-version.mjs
+node scripts/sync-i18n.mjs --check
+node scripts/check-docs-parity.mjs
+node scripts/verify-updater-endpoints.mjs
+node scripts/check-release-paths.mjs
+```
+
 ### 1.2 合并 PR
 
-走完 8 项 status check（CI 必须全绿），由 reviewer 合并到 `release/v0.1`。merge / squash / rebase 任选，hash 漂移不影响后续 tag。
+9 项 status check 全绿后合并。merge / squash / rebase 任选，hash 漂移不影响打 tag。
+
+判断"全绿"要**同时校验检查数量 ≥ 9**（Rust scope、cargo fmt、clippy ×3 平台、test ×3 平台、Frontend lint+typecheck）。GitHub 是逐个创建 check run 的，只判"全部非 pending"会在只创建了 1 项时就成立。
+
+CI 全绿仍报 `mergeStateStatus: BLOCKED` 时按这个顺序查：
+
+| 现象 | 原因 | 处理 |
+| --- | --- | --- |
+| `gh pr checks` 说 no checks reported | PR 与 base 有冲突，GitHub 算不出 `refs/pull/N/merge`，`lint.yml` / `rust.yml` 一项都不会跑 | 看 `mergeStateStatus`，`DIRTY` 即是；rebase 解冲突后 CI 自动开跑 |
+| "head branch is not up to date" | base 落后（发版期间 main 常有新 PR 落地） | `git rebase origin/main` 再 force-push，重跑一轮 CI |
+| "base branch policy prohibits the merge" | 有未 resolve 的 review 线程（`chatgpt-codex-connector` bot 会自动 review，纯 .md PR 也会） | 先回复说明，再用 GraphQL `resolveReviewThread` |
+
+`gh pr merge --delete-branch` 在 worktree 里必失败（`fatal: 'main' is already used by worktree`），但**合并本身已成功**——去 `gh api -X DELETE repos/.../git/refs/heads/<branch>` 补删，别重试 merge。
 
 ### 1.3 打 tag 推 tag 触发 CI
 
-PR 合并后，本地：
-
-确认 `release/v0.1` 的 HEAD 就是准备发布的提交后直接打 tag。当前阶段 GitHub Actions 不运行 Capability Evals 或 Live Model Campaign，`release.yml` 也不读取 eval evidence，因此评测不会阻断发布。团队如需发版前回归，可在该 SHA 上通过 App 或 `hope-agent-eval` 本地显式运行；本地结果仅用于人工判断，不会上传或附加到 GitHub Release。
-
-给该 SHA 打 tag：
+确认目标分支 HEAD 就是要发布的提交，然后：
 
 ```bash
 git checkout release/v0.1 && git pull
@@ -113,178 +136,130 @@ git tag v0.1.2
 git push origin v0.1.2
 ```
 
-`git push origin v0.1.2` 推送的是 tag ref，**不在 branch protection 管辖内**（仓库未配置 tag protection rule），可直推。tag 一旦上 origin，[release.yml](../.github/workflows/release.yml) 立即触发：
+tag ref 不在 branch protection 管辖内（仓库未配 tag protection rule），可直推。tag 一上 origin，[release.yml](../.github/workflows/release.yml) 立即：
 
 1. `release:verify` 校验 `package.json` 版本与 tag 名一致
-2. `Extract release notes` 步骤读取 `docs/release-notes/v0.1.2.md`，缺失则 fallback 为 `See CHANGELOG.md for details.`
-3. `tauri-action` 在 macOS / Windows / Linux runner 上构建产物
-4. 自动创建 draft Release；安装产物与 `latest.json` 按现有发布流程生成
+2. 读 `docs/release-notes/v0.1.2.md` 填 Release body 与 `latest.json#notes`
+3. tauri-action 在 4 平台 runner 构建产物
+4. 创建 draft Release
+
+评测不阻断发版：GitHub Actions 当前不跑 Capability Evals / Live Model Campaign，`release.yml` 也不读 eval evidence。需要发版前回归就在该 SHA 上本地跑 `hope-agent-eval`，结果只供人工判断、不上传。
 
 ### 1.4 审阅 draft Release 并 publish
 
-GitHub Releases 页找到 `Hope Agent v0.1.2` draft，确认：
+Releases 页找到 `Hope Agent v0.1.2` draft，确认：
 
-- macOS x64 / arm64 DMG 齐全
-- Windows NSIS installer 齐全
-- Linux AppImage / DEB 齐全
+- macOS arm64 DMG、Windows NSIS installer、Linux AppImage / DEB / RPM 齐全
 - `latest.json` 在资产列表中
-- Release body 显示的是 v0.1.2 release notes 内容（不是 fallback 的 `See CHANGELOG.md for details.`）
+- Release body 是本版 release notes，**不是** fallback 的 `See CHANGELOG.md for details.`
 
-确认无误后点 **Publish release**。draft 状态 updater endpoint 抓不到 `latest.json`，**必须 publish 才会推送给已安装客户端**。
+确认后点 **Publish release**。draft 状态 updater 抓不到 `latest.json`，不 publish 等于没发。publish 会同时触发 §1.6~§1.10 五条下游渠道。
 
 ### 1.5 backport 到 main
 
-详见 [§3 backport 策略](#3-backport-策略)。
+见 [§3 backport 策略](#3-backport-策略)。
 
 ### 1.6 Homebrew tap 自动同步
 
-Publish Release 后 [`.github/workflows/update-homebrew-tap.yml`](../.github/workflows/update-homebrew-tap.yml) 由 `release.published` 事件自动触发：
+`release.published` 触发 [`update-homebrew-tap.yml`](../.github/workflows/update-homebrew-tap.yml)：下载本版 `Hope.Agent_<version>_aarch64.dmg`，算 sha256，渲染 [`homebrew/hope-agent.rb.tmpl`](../homebrew/hope-agent.rb.tmpl) 的 `__VERSION__` / `__SHA256__`，用 `HOMEBREW_TAP_TOKEN` push 到 tap repo。
 
-1. `gh release download` 拉本次 release 的 `Hope.Agent_<version>_aarch64.dmg`
-2. `sha256sum` 算 DMG 摘要
-3. `sed` 把 [`homebrew/hope-agent.rb.tmpl`](../homebrew/hope-agent.rb.tmpl) 的 `__VERSION__` / `__SHA256__` 占位符替换，渲染为 `Casks/hope-agent.rb`
-4. 用 `HOMEBREW_TAP_TOKEN`（fine-grained PAT，仅授 `shiwenwen/homebrew-hope-agent` 的 `Contents: Read and write`）push 到 tap repo
-
-正常路径**不需要任何人工操作**。下列情况需要手动 `gh workflow run update-homebrew-tap.yml -f tag=vX.Y.Z`：
-
-- cask 模板本身改了（如新增 caveats / zap 路径），想立即对已发布版本生效，不等下个 release
-- workflow 因为 token 过期 / tap repo 不存在等原因失败过，修复后重跑
-
-**tap repo 初始化（一次性）**：详见 [`homebrew/README.md`](../homebrew/README.md)。仓库名必须是 `homebrew-hope-agent`（Homebrew 约定 `homebrew-<tapname>`），否则 `brew tap shiwenwen/hope-agent` 找不到。
-
-**cask 模板单一真相源在主仓 [`homebrew/hope-agent.rb.tmpl`](../homebrew/hope-agent.rb.tmpl)**。不要在 tap repo 里直接改 `Casks/hope-agent.rb`——下次发版会被 CI 覆盖。
+- 手动重跑：`gh workflow run update-homebrew-tap.yml -f tag=vX.Y.Z`（改了模板想立即对已发布版本生效、或修复 token 后补跑）
+- **禁止直接改 tap repo 的 `Casks/hope-agent.rb`**，下次发版会被覆盖。单一真相源是主仓的 `.tmpl`
+- tap 仓库名必须是 `homebrew-hope-agent`（Homebrew 约定 `homebrew-<tapname>`），否则 `brew tap shiwenwen/hope-agent` 找不到
+- 一次性初始化见 [`homebrew/README.md`](../homebrew/README.md)
 
 ### 1.7 AUR 自动同步
 
-与 §1.6 Homebrew tap 同模式，Release publish 后 [`.github/workflows/update-aur.yml`](../.github/workflows/update-aur.yml) 由 `release.published` 自动触发：
+`release.published` 触发 [`update-aur.yml`](../.github/workflows/update-aur.yml)：下载本版 `Hope.Agent_<version>_amd64.deb`，算 sha256，渲染 [`PKGBUILD.tmpl`](../aur/hope-agent-bin/PKGBUILD.tmpl) + [`.SRCINFO.tmpl`](../aur/hope-agent-bin/.SRCINFO.tmpl)，用 `AUR_SSH_PRIVATE_KEY` push 到 `ssh://aur@aur.archlinux.org/hope-agent-bin.git`。
 
-1. `gh release download` 拉本次 release 的 `Hope.Agent_<version>_amd64.deb`
-2. `sha256sum` 算 deb 摘要
-3. `sed` 渲染 [`aur/hope-agent-bin/PKGBUILD.tmpl`](../aur/hope-agent-bin/PKGBUILD.tmpl) + [`.SRCINFO.tmpl`](../aur/hope-agent-bin/.SRCINFO.tmpl)
-4. 用 `AUR_SSH_PRIVATE_KEY`（专用 ed25519 deploy key，公钥已绑到 maintainer 的 AUR 账号）SSH push 到 `ssh://aur@aur.archlinux.org/hope-agent-bin.git`
-
-正常路径**不需要任何人工操作**。下列情况需要手动 `gh workflow run update-aur.yml -f tag=vX.Y.Z`：
-
-- PKGBUILD / .SRCINFO 模板本身改了（如改 deps / 改 pkgdesc），想立即对已发布版本生效
-- workflow 因为 SSH key / AUR 账号变化等原因失败过，修复后重跑
-
-**AUR 账号 + SSH key 初始化（一次性）**：详见 [`aur/README.md`](../aur/README.md)。
-
-**模板单一真相源在主仓 [`aur/hope-agent-bin/`](../aur/hope-agent-bin/)**。不要直接 push AUR 仓库——下次发版会被 CI 覆盖。**改 PKGBUILD 字段时必须同步改 .SRCINFO** 字段（两个文件结构是平行的），否则 AUR Web UI 元数据会与 PKGBUILD 不一致。
+- 手动重跑：`gh workflow run update-aur.yml -f tag=vX.Y.Z`
+- **禁止直接 push AUR 仓库**，下次发版会被覆盖。单一真相源是 [`aur/hope-agent-bin/`](../aur/hope-agent-bin/)
+- **改 PKGBUILD 字段必须同步改 .SRCINFO**（两文件结构平行），否则 AUR Web UI 元数据与 PKGBUILD 不一致
+- 一次性初始化见 [`aur/README.md`](../aur/README.md)
 
 ### 1.8 Scoop bucket 自动同步
 
-与 §1.6 / §1.7 同模式，Release publish 后 [`.github/workflows/update-scoop-bucket.yml`](../.github/workflows/update-scoop-bucket.yml) 由 `release.published` 自动触发：
+`release.published` 触发 [`update-scoop-bucket.yml`](../.github/workflows/update-scoop-bucket.yml)：下载本版 `Hope.Agent_<version>_x64-setup.exe`，算 sha256，渲染 [`scoop/hope-agent.json.tmpl`](../scoop/hope-agent.json.tmpl)，JSON 语法校验后用 `SCOOP_BUCKET_TOKEN` push 到 bucket repo。
 
-1. `gh release download` 拉本次 release 的 `Hope.Agent_<version>_x64-setup.exe`
-2. `sha256sum` 算 setup.exe 摘要
-3. `sed` 渲染 [`scoop/hope-agent.json.tmpl`](../scoop/hope-agent.json.tmpl) → `bucket/hope-agent.json`
-4. JSON 语法校验
-5. 用 `SCOOP_BUCKET_TOKEN`（fine-grained PAT，仅授 `shiwenwen/scoop-hope-agent` 的 `Contents: Read and write`）push 到 bucket repo
-
-手动重跑：`gh workflow run update-scoop-bucket.yml -f tag=vX.Y.Z`。
-
-**首次配置**：详见 [`scoop/README.md`](../scoop/README.md)。
-
-**Manifest 单一真相源在主仓 [`scoop/hope-agent.json.tmpl`](../scoop/hope-agent.json.tmpl)**。不要在 bucket repo 直接改 `bucket/hope-agent.json`——下次发版会被 CI 覆盖。
-
-> Scoop 默认对 `.exe` URL 用 7zip 解压（不跑 NSIS installer），所以 manifest 不需要 `installer.script`——`hope-agent.exe` 解压出来就是直接可用的单文件 binary。
+- 手动重跑：`gh workflow run update-scoop-bucket.yml -f tag=vX.Y.Z`
+- **禁止直接改 bucket repo 的 `bucket/hope-agent.json`**，下次发版会被覆盖
+- manifest 不需要 `installer.script`：Scoop 默认对 `.exe` URL 用 7zip 解压（不跑 NSIS installer），解出来的 `hope-agent.exe` 就是可用单文件
+- 一次性初始化见 [`scoop/README.md`](../scoop/README.md)
 
 ### 1.9 Linux apt + dnf/yum 软件源自动同步
 
-托管在 **Cloudflare R2**，用户经自定义域名 **`https://repo.hopeagent.ai/`** 访问；用户安装命令见根仓 [`README.md`](../README.md) 「普通用户 → Linux → Debian/Ubuntu」/「Fedora/RHEL/CentOS」段（dnf 与 yum 同 URL 通用，curl 下载 `.repo` 文件方式兼容 dnf4 / dnf5 / yum / zypper）。
+托管在 Cloudflare R2，用户经 `https://repo.hopeagent.ai/` 访问。安装命令见 [`README.md`](../README.md) 的 Linux 段（dnf 与 yum 同 URL 通用）。
 
-> **为何 R2 而非 GitHub Pages**：apt/dnf 索引按同一 base URL 引用包文件，故 `.deb`/`.rpm` 必须托管在该 base 下。GitHub 单文件 100MB 硬上限在包体积破百后会整体拒 push（v0.20.1 arm64 `.deb` 首次越界，v0.21.0 四个包全线越界），旧的 git-commit-to-Pages 方案结构性卡死。R2 无单文件上限、**egress 全免**，是高频下载软件源的自然托管。reprepro / createrepo_c / GPG 构建逻辑不变，只换了发布落点。
+`release.published` 触发 [`update-linux-repo.yml`](../.github/workflows/update-linux-repo.yml)：
 
-Release publish 后 [`.github/workflows/update-linux-repo.yml`](../.github/workflows/update-linux-repo.yml) 由 `release.published` 自动触发：
+1. 下载本版 `.deb` + `.rpm`（amd64/x86_64 与 arm64/aarch64）
+2. 导入 `GPG_SIGNING_KEY` 到临时 `GNUPGHOME`，解出 long fingerprint
+3. `rclone copy r2:$R2_BUCKET → ./bucket` 把已发布的树整体拉下来（R2 是单一真相源），让 reprepro `apt/db` 与 createrepo_c 既有 repodata 可增量更新
+4. 渲染 `apt/conf/distributions`（`SignWith:` 填当前 fingerprint，密钥轮换无需改模板），`reprepro includedeb` 重建索引并签 `InRelease` / `Release.gpg`
+5. `createrepo_c --update` 增量更新 yum 索引，`gpg --detach-sign --armor` 签出 `repomd.xml.asc`，供 dnf `repo_gpgcheck=1` 验签
+6. 同步 [`hope-agent.repo`](../linux-repo/rpm/hope-agent.repo) 模板，从私钥导出 `pubkey.gpg`
+7. `rclone copy ./bucket → r2:$R2_BUCKET` 上传（`copy` 不是 `sync`，绝不删除）
+8. 经公开域名回抓 `InRelease` / `repomd.xml` / `pubkey.gpg` 断言 live 且格式正确
 
-1. `gh release download` 拉本次 release 的 `Hope.Agent_<v>_amd64.deb` + `Hope.Agent-<v>-1.x86_64.rpm`（arm64/aarch64 若在则一并）
-2. `gpg --batch --import` 把 `GPG_SIGNING_KEY` secret 导入临时 `GNUPGHOME`，从 imported key 解出 long fingerprint
-3. **`rclone copy r2:$R2_BUCKET → ./bucket`** 把当前已发布的整棵树镜像下来（R2 是单一真相源），令 reprepro `apt/db` 与 createrepo_c 既有 repodata 完整、可增量更新；首次 seed 时为空、从零构建
-4. CI 动态渲染 `apt/conf/distributions`（`SignWith:` 填当前 fingerprint，密钥轮换无需改模板），`reprepro -b apt includedeb stable …` 重建 apt index 并签 `InRelease` / `Release.gpg`
-5. `createrepo_c --update rpm/stable/<arch>/` 增量更新 yum index，`gpg --detach-sign --armor` 签 `repomd.xml`（产 `repomd.xml.asc`），让 dnf `repo_gpgcheck=1` 能验签
-6. 同步 [`linux-repo/rpm/hope-agent.repo`](../linux-repo/rpm/hope-agent.repo) 模板到 `rpm/hope-agent.repo`；从私钥导出公钥到 `pubkey.gpg`（不再手动维护）
-7. **`rclone copy ./bucket → r2:$R2_BUCKET`** 非破坏上传（`copy` 非 `sync`）：重生成的索引覆盖、历史包按 checksum 跳过、绝不删除
-8. **回抓校验**：经 `https://repo.hopeagent.ai/…` 拉回 `InRelease` / `repomd.xml` / `pubkey.gpg` 断言 live 且格式正确——坏发布（或自定义域名未接好）在 CI 里失败，而非静默把用户留在陈旧源
+- 手动重跑：`gh workflow run update-linux-repo.yml -f tag=vX.Y.Z`（幂等：reprepro 先 `remove`，R2 上传非破坏）
+- **禁止直接改 R2 上的 `apt/` / `rpm/`**，下次发版 CI 会覆盖。单一真相源是 [`linux-repo/`](../linux-repo/)
+- **`pubkey.gpg` 由 CI 从 `GPG_SIGNING_KEY` 导出**，不要手动 PUT
+- **第 3 步的整桶 pull 必须带 `--include "/apt/**" --include "/rpm/**" --include "/pubkey.gpg"`**。同一个桶的 `download/` 前缀（§1.10）每版放约 1.5 GB 且永久保留，不过滤会让这个 pull 无界增长直到超时。新增本 job 独占的顶层路径时同步加进过滤列表
+- 必备 secret：`GPG_SIGNING_KEY`（专用 ed25519 私钥，与 maintainer 个人身份独立）、`R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_BUCKET`
+- 建桶 / 连自定义域名 / 密钥轮换见 [`linux-repo/README.md`](../linux-repo/README.md)
 
-手动重跑：`gh workflow run update-linux-repo.yml -f tag=vX.Y.Z`（同 tag 重跑幂等——reprepro 先 `remove`，R2 上传非破坏）。
-
-**首次配置（建桶 / 连自定义域名 / R2 API Token / GitHub secrets）+ 密钥轮换流程**：详见 [`linux-repo/README.md`](../linux-repo/README.md)。必备 secret：
-
-- `GPG_SIGNING_KEY` — ed25519 私钥（专用密钥，与 maintainer 个人身份独立）
-- `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_BUCKET` — R2 S3 兼容凭据 + 桶名（旧 `LINUX_REPO_TOKEN` 已退役）
-
-**模板单一真相源在主仓 [`linux-repo/`](../linux-repo/)**。不要直接改 R2 上的 `apt/` / `rpm/`——下次发版 CI 会覆盖。`pubkey.gpg` 现由 CI 从 `GPG_SIGNING_KEY` 导出上传，不再手动 PUT。
-
-> reprepro 的 `apt/db/` 是 incremental state（含 packages 的 sha256 索引）：CI 每次先从 R2 `copy` 下来、改完再 `copy` 回去，故历史版本记录随 R2 持久保存；`apt/conf/distributions` 每次 CI 跑覆盖渲染。R2 上传用 `copy`（非 `sync`）永不删除，一次失败的下载不会误清空。
+> **为何是 R2 而非 GitHub Pages**（别改回去）：apt/dnf 索引按同一 base URL 引用包文件，`.deb`/`.rpm` 必须托管在该 base 下。GitHub 单文件 100 MB 硬上限在包体积破百后整体拒 push（v0.20.1 arm64 `.deb` 首次越界，v0.21.0 四个包全线越界），git-commit-to-Pages 方案结构性卡死。R2 无单文件上限、egress 全免。
 
 ### 1.10 R2 安装包镜像自动同步
 
-与 §1.6~§1.9 同模式，Release publish 后 [`.github/workflows/mirror-release-r2.yml`](../.github/workflows/mirror-release-r2.yml) 由 `release.published` 自动触发，把**全部安装包**镜像到 §1.9 那个同一个 R2 bucket（同域名 `https://repo.hopeagent.ai/`）。
+`release.published` 触发 [`mirror-release-r2.yml`](../.github/workflows/mirror-release-r2.yml)，把**全部安装包**镜像到 §1.9 那个桶（同域名）。存在的理由：一部分用户根本访问不了 `github.com`，对他们这不是快慢问题而是能不能装、能不能更新。
 
-**为什么要有它**：有一部分用户根本访问不了 `github.com`。apt / dnf 用户从 Linux 源迁到 R2 之后已经不受影响，但 DMG / setup.exe / AppImage / tar.gz 手动下载、以及应用内自动更新仍然只有 GitHub 一条路。这条 workflow 补掉那个缺口。
-
-**bucket 布局**（`apt/` `rpm/` `pubkey.gpg` 是 §1.9 的，互不重叠）：
+桶布局（`apt/` `rpm/` `pubkey.gpg` 属 §1.9，互不重叠）：
 
 ```
 download/
-  v0.26.0/                     ← 不可变，长 TTL，永久保留
-    Hope.Agent_0.26.0_aarch64.dmg  …（全部 25 个资产 + .sig）
+  v0.26.0/                     ← 不可变，max-age=31536000，永久保留
+    Hope.Agent_0.26.0_aarch64.dmg  …（全部资产 + .sig）
     CHANGELOG.md                   ← text/plain，供 notes 链接
-    docs/release-notes/v0.26.0.md
-    docs/release-notes/v0.26.0.en.md
+    docs/release-notes/v0.26.0.md  docs/release-notes/v0.26.0.en.md
   latest/                      ← 版本无关别名，max-age=300
     Hope.Agent_aarch64.dmg  Hope.Agent_x64-setup.exe  …
   latest.json                  ← 唯一可变 manifest，max-age=60
 ```
 
-**执行顺序即安全性质**，改这个 workflow 前必须理解：
+**执行顺序是安全性质，改 workflow 前先读懂**：先传资产与 `latest/` 别名 → 把每个上传对象经**公开域名**回抓、比对 `Content-Length`（只判 200 会放过截断/零长对象），并断言 manifest 里每个 URL 都落在本次前缀内且有本地对应文件 → 全过之后才改写并发布 `latest.json`。所以可变 manifest 绝不会指向不存在的字节；校验失败则 job 失败、`latest.json` 保持原样，R2 上的陈旧 manifest 必然描述一个真实且完整镜像过的版本。修好后重跑：`gh workflow run mirror-release-r2.yml -f tag=vX.Y.Z`（幂等）。
 
-1. 资产 + 文档 + `latest/` 别名先上传
-2. **硬门禁**：把每一个上传的对象都经**公开域名**回抓，比对 `Content-Length` 与本地文件——只判 200 会让截断/零长对象过关。同时结构性断言 manifest 里每个 URL 都落在本次镜像前缀内且有本地对应文件
-3. 只有 ② 全过，才改写 `latest.json` 的 16 个 URL（12 个 `platforms` + 4 个 `bare_binary`）并发布
+**可变面有 `PROMOTE` 门控**。`download/latest/` 与 `download/latest.json` 全局共享，给非当前稳定版写它们就是一次降级广播——R2 是 endpoint[0] 且首个成功者胜，全体客户端会被告知那个旧版本是最新。两条日常路径会踩到：手动回填旧 tag、发布 prerelease（同样触发 `release.published`）。所以只有该 tag 恰好是 GitHub 认定的 latest release 且非 prerelease 时才推进可变面；其余情况只写自己的不可变前缀然后停下（给 `::notice::`，不算失败）。
 
-所以**可变的 manifest 绝不会指向不存在的字节**。② 失败则 job 失败、`latest.json` 保持原样——意味着 R2 上一份陈旧 manifest 必然描述一个真实且已完整镜像的版本，绝不会是残缺版本。修好后重跑：`gh workflow run mirror-release-r2.yml -f tag=vX.Y.Z`（幂等）。
+**`actions/checkout` 的 `ref:` 必须显式指默认分支**。`release.published` 下 `github.ref` 就是 `refs/tags/vX.Y.Z`，不写 `ref:` 会静默取那个 tag，两个后果：① 本 workflow 落地**之前**发布的 tag 永远无法镜像（那些树里没有 `scripts/mirror-*.mjs`），整个历史目录不可镜像；② 改写器里修掉的 bug 会冻结在 tag 发布时的样子。文档则相反——必须是该版本实际发布的那一份，所以单独 `git fetch --depth=1` 该 tag 再 `git show <tag>:<path>` 取。
 
-**可变面有门控**。`download/latest/` 与 `download/latest.json` 是全局共享的，给**非当前稳定版**写它们就是一次降级广播——R2 是 endpoint[0] 且首个成功者胜，全体客户端会被告知那个旧版本才是最新，从而看不到真正的新版。有两条日常路径会踩到：手动回填旧 tag（就是本节文档的那条命令），以及**发布 prerelease**（同样触发 `release.published`）。
+**其余规则**：
 
-所以只有当该 tag 恰好就是 GitHub 自己认定的 latest release、且非 prerelease 时才推进可变面；其余情况只镜像到自己的不可变前缀然后停下（日志里给 `::notice::`，不算失败——回填旧版本到它自己的前缀本身是有用且无害的）。
-
-**工具取默认分支、文档取 tag**（`actions/checkout` 的 `ref:` **显式**指向默认分支，随后 `git fetch --depth=1` 单独取该 tag 再 `git show <tag>:<path>` 抽文档）。**`ref:` 必须显式写**：`release.published` 事件下 `github.ref` 就是 `refs/tags/vX.Y.Z`，不写 `ref:` 的 `actions/checkout` 会**静默取那个 tag**。取 tag 会坏两件事：
-
-- **能回填历史版本**。用 tag 那棵树会跑 tag 自带的镜像脚本，于是本 workflow 落地**之前**发布的所有 tag 永远无法镜像（那些树里根本没有 `scripts/mirror-*.mjs`），整个历史目录就此不可镜像，README 的 `download/latest/` 链接要等到下一次发版才不是 404。取默认分支后可以直接补：`gh workflow run mirror-release-r2.yml -f tag=v0.26.0`。回填旧版本时上面那道门控生效——只写它自己的不可变前缀，不会抢走 `latest`。
-- **工具应当是当前版本**。改写器里修掉的 bug 应该在下次重镜像任何 tag 时生效，而不是冻结在那个版本发布时的样子。
-
-而**文档必须是该版本实际发布的那一份**，所以单独从 tag 取，不用工作树里的。
-
-**几条容易踩的**：
-
-- **Cache-Control 用 `--metadata-set` 随 PUT 写入，禁用 `--header-upload`**。`--header-upload` 是 PUT 成功之后的另一次调用，R2 对它返回 501，结果是对象字节正确、Cache-Control 缺失。三档值单一定义在 workflow 的 `CC_IMMUTABLE` / `CC_LATEST` / `CC_MANIFEST`，上传设、校验读回。
-- **排查 `max-age=14400`：看指令，不看数字**。别用「是否全体对象都不对」判因，两种成因都只命中一部分对象。
+- **Cache-Control 用 `--metadata-set` 随 PUT 写入，禁用 `--header-upload`**。`--header-upload` 是 PUT 成功之后的另一次调用，R2 对它返回 501，结果是对象字节正确、Cache-Control 缺失。三档值单一定义在 workflow 的 `CC_IMMUTABLE` / `CC_LATEST` / `CC_MANIFEST`。
+- **排查 `max-age=14400`：看指令，不看数字**。别用"是否全体对象都不对"判因，两种成因都只命中一部分对象。
   - 裸 `max-age=14400`（无 `public`、无 `must-revalidate`）＝ 头没写上。用 `workflow_dispatch` 的 `force` 强制重传补写（`--checksum` 因内容一致不会自己重传）。
   - `public, max-age=14400, must-revalidate` ＝ 对象正常，是 Cloudflare Browser Cache TTL 抬高了值。只命中 CF 默认缓存的扩展名（`.dmg` `.exe` `.zip` `.tar.gz`；`.deb` `.rpm` `.AppImage` `.sig` `.json` 走 `DYNAMIC` 不中），且只上调不下调（`download/<tag>/` 的 31536000 不受影响）。要让 `latest/` 的 300s 到达浏览器，Caching → Configuration → Browser Cache TTL 改成 **Respect Existing Headers**。
   - 校验只断言 `immutable` / `must-revalidate` 是否存在，不断言 TTL 数值；TTL 低于设定值才算错误。边缘设置 CI 控制不了，不该卡住发版。
-- **`latest/` 别名不能带 immutable 头**。那些文件名每版复用，长 TTL 会让边缘把旧安装包钉住一年。别名由 [`scripts/mirror-latest-aliases.mjs`](../scripts/mirror-latest-aliases.mjs) 按规则剥版本号派生，但 README 实际链接的 8 个名字在 `REQUIRED_ALIASES` 里**硬登记**——规则失灵时报错，而不是发布一堆 404。两侧对齐由 `check-release-paths.mjs` 在 PR 时守。
-- **`update-linux-repo.yml` 的整桶 pull 必须带 `--include`**。它把 bucket 镜像下来重建索引；本 workflow 每版往同一个 bucket 放约 1.5 GB 且永久保留，不过滤会让那个 pull 无界增长直到超时。新增本 job 独占的顶层路径时，同步加进那个过滤列表。
-- **`notes` 里的 GitHub 链接会被改写**（改写发生在 R2 那份 manifest 上，仓库源文件不动，§1.1(a) 的「链接一律用完整 GitHub URL」规则不变）。`notes` 是应用内「发现新版」弹窗的正文且按 markdown 渲染，中英切换与 CHANGELOG 两条链接对目标用户就是死链。链到 `REQUIRED` 之外的文档时 workflow 会 fail-closed。
-- **签名原样复制、绝不重算**。理由与端点链的信任模型见 [self-update](architecture/self-update.md#manifest-端点链r2-镜像优先github-兜底)。
 - **rclone 退出码不代表成败，以本 workflow 的回抓校验为准**。R2 会在 PUT 成功之后的某次调用上返回 `501 NotImplemented`，rclone 因此把已经写好的对象报成 `Failed to copy`（实测：报错对象经公开域名 HEAD 全部 200、`Content-Length` 与源文件逐字节一致）。用 `--checksum`，禁用 `--ignore-times`——`--checksum` 发现哈希一致就跳过、整轮自愈；`--ignore-times` 每次强制重传因而每次重报失败，会烧完 10 次重试变成永久失败。
-- **rclone 的 stderr 不要用 `tail` 截断**。第一次失败时能定位问题的正是那些被截掉的逐对象错误行，为了日志好看丢掉它们，代价是再跑一整轮。
-- **给 rclone 传参的辅助变量不能用 `RCLONE_` 前缀**。rclone 会把**任何** `RCLONE_<FLAG>` 环境变量当成同名 flag 的值：`RCLONE_FORCE` 变成 `--force`、`RCLONE_VERSION` 变成 `--version`，rclone 在第一次调用就以 bool 解析错误退出。`RCLONE_CONFIG_R2_*` 是文档化的 remote 配置写法，不受影响；其余一律用 `R2_` 前缀（`R2_UPLOAD_FLAGS` / `R2_FORCE_FLAG` / `R2_RCLONE_PIN`）。
-- **rclone 版本要钉住，别用 `apt-get install rclone`**。发版关键路径不该从基础镜像继承工具版本（Ubuntu 24.04 自带 1.60.1）。安装步骤同时断言所需 flag 存在，不支持时在动任何字节之前给一行明确错误。
-- **所有临时目录必须落在 `$RUNNER_TEMP` 下，不要用裸相对路径**。`assets/` 曾经就是裸路径，于是和仓库自带的 `assets/` 目录合并，把 `alpha-logo.png`、`transparency-logo.png` 当作发布产物镜像了上去。任何裸名字都可能和将来某个仓库目录撞车。
+- **rclone 的 stderr 不要用 `tail` 截断**。第一次失败时能定位问题的正是那些被截掉的逐对象错误行。
+- **给 rclone 传参的辅助变量不能用 `RCLONE_` 前缀**。rclone 把**任何** `RCLONE_<FLAG>` 环境变量当成同名 flag 的值：`RCLONE_FORCE` 变成 `--force`、`RCLONE_VERSION` 变成 `--version`，第一次调用就以 bool 解析错误退出。`RCLONE_CONFIG_R2_*` 是文档化的 remote 配置写法不受影响；其余一律 `R2_` 前缀。
+- **rclone 版本钉住，别用 `apt-get install rclone`**（Ubuntu 24.04 自带 1.60.1）。安装步骤同时断言所需 flag 存在，不支持时在动任何字节之前就报错。
+- **临时目录一律落在 `$RUNNER_TEMP` 下，禁用裸相对路径**。`assets/` 曾经是裸路径，于是和仓库自带的 `assets/` 目录合并，把 `alpha-logo.png`、`transparency-logo.png` 当作发布产物镜像了上去。
+- **`latest/` 别名不能带 immutable 头**。那些文件名每版复用，长 TTL 会让边缘把旧安装包钉住一年。别名由 [`mirror-latest-aliases.mjs`](../scripts/mirror-latest-aliases.mjs) 按规则剥版本号派生，但 README 实际链接的 8 个名字在 `REQUIRED_ALIASES` 里硬登记——规则失灵时报错，而不是发布一堆 404。两侧对齐由 `check-release-paths.mjs` 在 PR 时守。
+- **`notes` 里的 GitHub 链接会被改写成镜像域名**（只改 R2 那份 manifest，仓库源文件不动，§1.1(a) 的绝对 URL 规则不变）。`notes` 是应用内「发现新版」弹窗正文，中英切换与 CHANGELOG 两条链接对目标用户就是死链。链到 `REQUIRED` 之外的文档时 workflow fail-closed。
+- **签名原样复制、绝不重算**。信任模型见 [self-update](architecture/self-update.md#manifest-端点链r2-镜像优先github-兜底)。
 
-存储成本：一版约 1.5 GB，R2 存储 $0.015/GB·月、egress 免费，按每月 3 版算一年累积约 55 GB（每月 < $1）。刻意全部保留而不做清理——现有 R2 发布路径全程只用 `copy` 不用 `sync` 就是为了「绝不删除」，加删除逻辑要单独定义失败语义。
+> 存储成本：一版约 1.5 GB，R2 存储 $0.015/GB·月、egress 免费，按每月 3 版算一年累积约 55 GB（每月 < $1）。刻意全部保留不做清理——现有 R2 发布路径全程只用 `copy` 不用 `sync` 就是为了「绝不删除」，加删除逻辑要单独定义失败语义。
 
 ---
 
 ## 2. 新 minor 发版差异
 
-从 `main` 发 `v0.2.0` 为例，与 patch 流程的差异：
+从 `main` 发 `v0.2.0`，与 §1 的差异只有三处。
 
 ### 2.1 PR base 改为 main
 
-§1.1 的 PR base 从 `release/v0.1` 换成 `main`。
+§1.1 的 `gh pr create --base` 从 `release/v0.1` 换成 `main`。分支名仍用 `chore/release-v0.2.0`。
 
 ### 2.2 tag 在 main HEAD 打
 
@@ -292,26 +267,30 @@ download/
 
 ### 2.3 发版后切维护分支
 
-tag 推送 + Release publish 完成后，**额外**切一条新维护分支并推送：
+tag 推送 + Release publish 完成后，额外切一条维护分支：
 
 ```bash
 git branch release/v0.2 v0.2.0
 git push -u origin release/v0.2
 ```
 
-CI 触发条件 ([lint.yml](../.github/workflows/lint.yml) / [rust.yml](../.github/workflows/rust.yml) 的 `branches: [main, "release/**"]`) 与 GitHub ruleset `main-branch-protection` 的 `refs/heads/release/**` 通配符自动覆盖新分支，不需要手配。
+被 ruleset 拒（`push declined due to repository rule violations` + `N of 8 required status checks are in progress`）时不要改配置：`refs/heads/release/**` 同样受必需检查约束，而合并后 main 上那轮 push 触发的 8 项检查此时往往还没跑完。等 `gh api repos/shiwenwen/hope-agent/commits/<sha>/check-runs` 里 8 项全 completed 再重推即可。
 
-后续 `v0.2.x` 系列 patch 在 `release/v0.2` 上发，按 §1 流程走。
+> tag 推送不等这些检查，所以 tag 会先成功、切分支后失败，看起来像 tag 打错了。
+
+CI 触发条件（[lint.yml](../.github/workflows/lint.yml) / [rust.yml](../.github/workflows/rust.yml) 的 `branches: [main, "release/**"]`）与 ruleset `main-branch-protection` 的 `refs/heads/release/**` 通配符自动覆盖新分支，不需要手配。
+
+后续 `v0.2.x` 系列 patch 在 `release/v0.2` 上按 §1 发。
 
 ---
 
 ## 3. backport 策略
 
-`release/X.Y` 上的修复**必须 cherry-pick 回 main**，否则下个 minor 发版会丢失这些修复（用户感知为"修过的 bug 又出现"经典回归）。AGENTS.md 红线：**只 cherry-pick 不 merge**。
+`release/X.Y` 上的修复**必须 cherry-pick 回 main**，否则下个 minor 会丢掉它们（用户感知为"修过的 bug 又出现"）。AGENTS.md 红线：**只 cherry-pick 不 merge**。
 
 ### 3.1 推荐节奏：按版本批量
 
-每发一版 patch 后立刻批量 cherry-pick 该版本所有 commit 到 main：
+每发一版 patch 后立刻批量 cherry-pick 该版本全部 commit，N 个 fix 只开一个 PR：
 
 ```bash
 # 列出 v0.1.1 → v0.1.2 之间 release/v0.1 上的所有 commit
@@ -326,53 +305,33 @@ git cherry-pick v0.1.1..v0.1.2
 git push -u origin backport/v0.1.2-to-main
 gh pr create --base main \
   --title "backport: v0.1.2 fixes to main" \
-  --body "cherry-pick 自 release/v0.1, 含 v0.1.1..v0.1.2 全部 commit"
+  --body "cherry-pick 自 release/v0.1，含 v0.1.1..v0.1.2 全部 commit"
 ```
-
-N 个 fix 只开一个 backport PR，节奏可控。
 
 ### 3.2 跳过等价 commit
 
-某些 commit 在 main 上已经独立存在（如 CI workflow 调整两边各做一次）。`git cherry-pick` 检测到等价改动会冲突或 no-op，遇到时手动跳过：
+某些 commit 在 main 上已独立存在（如 CI workflow 调整两边各做一次），`git cherry-pick` 会冲突或 no-op。commit message 与 diff 跟 main 上某个 commit 完全等价的，`git cherry-pick --skip` 跳过。
 
-```bash
-git cherry-pick --skip
-```
-
-判断方法：commit message 与 diff 跟 main 上某个 commit 完全等价的可跳。
-
-### 3.3 评估"是否需要 backport"
-
-并非所有 patch commit 都需要回种 main：
+### 3.3 评估是否需要 backport
 
 | 情形 | 处理 |
 |---|---|
-| main 已重构掉这段代码，bug 只在老分支 | 不 backport |
 | main 与 release 都有同样代码 | 必须 backport |
-| 只 main 有（新功能引入） | 不在 release 修，只在 main 修 |
+| main 已重构掉这段代码，bug 只在老分支 | 不 backport |
+| 只 main 有（新功能引入的 bug） | 不在 release 修，只在 main 修 |
 | 文档改动只针对老版本 | 不 backport |
-
-仔细评估能砍掉相当比例的 backport 工作量。
 
 ### 3.4 cherry-pick 命令速查
 
 ```bash
-# 单个 commit
-git cherry-pick <sha>
+git cherry-pick <sha>            # 单个
+git cherry-pick A^..B            # 一段连续（含两端）
+git cherry-pick sha1 sha2 sha3   # 多个不连续
+git cherry-pick -x <sha>         # 在 message 末尾追加 (cherry picked from commit <sha>)
 
-# 一段连续 commit（含两端）
-git cherry-pick A^..B
-
-# 多个不连续 commit
-git cherry-pick sha1 sha2 sha3
-
-# 冲突中
-git cherry-pick --continue   # 解完冲突后继续
-git cherry-pick --skip       # 跳过当前
-git cherry-pick --abort      # 整段放弃
-
-# 自动在 commit message 末尾追加来源链接
-git cherry-pick -x <sha>     # 加 (cherry picked from commit <sha>)
+git cherry-pick --continue       # 解完冲突后继续
+git cherry-pick --skip           # 跳过当前
+git cherry-pick --abort          # 整段放弃
 ```
 
 ---
@@ -381,56 +340,36 @@ git cherry-pick -x <sha>     # 加 (cherry picked from commit <sha>)
 
 | 坑 | 后果 | 规避 |
 |---|---|---|
-| `pnpm version X.Y.Z` 不带 `--no-git-tag-version` | 本地直接产 commit + tag，但 branch protection 不让推到 `main` / `release/**`，发版卡死 | 一律 `--no-git-tag-version`，version commit 走 PR |
-| release notes 文件名错（如 `0.1.2.md` 缺 `v` 前缀，或拼写错误） | `latest.json#notes` 落 fallback 文字 `See CHANGELOG.md for details.`，客户端弹窗看到通用文字 | 文件名严格匹配 tag：`docs/release-notes/v<X>.<Y>.<Z>.md` |
-| release notes 用相对路径（`./` `../`） | 注入到 `latest.json#notes` 后桌面应用「发现新版」弹窗里链接全 broken（不在 GitHub 渲染上下文里） | 一律 `https://github.com/shiwenwen/hope-agent/blob/v<X>.<Y>.<Z>/...` 完整 URL（tag pin） |
-| 忘记同 PR 合双语 release notes | 中英任一缺失，AGENTS.md 文档约定违例 | 一个发版 PR 必有 4 个文件改动：CHANGELOG + 中文 notes + 英文 notes + 三个 version 文件 |
-| draft Release 不 publish | updater endpoint 抓不到，已发布版本对客户端不可见 | §1.4 必须人工 publish |
-| 在功能分支 `pnpm version` 带 commit/tag | squash merge 后本地 tag 指向不在 main 上的死 commit，需要重打 | 始终 `--no-git-tag-version`，tag 在 PR 合并后的目标分支 HEAD 上重新打 |
-| 跳过 backport 到 main | 下个 minor 丢失所有 patch 修复，回归风险高 | §3.1 每版发完立刻 backport |
-| 误用 `git merge release/X.Y → main` | 把维护分支历史污染进 main，AGENTS.md 红线违反 | 只 cherry-pick |
-| 新 minor 发版前忘了切 `release/X.Y` 分支 | patch 修复无处落，紧急修复需要回退 main 历史 | §2.3 minor 发布后立即切维护分支 |
-| 改 workflow job 名后没同步 ruleset | PR 卡在 status check 等待已不存在的 job | 见 AGENTS.md "## 分支与发布" 末尾 |
-| 改 [`release.yml`](../.github/workflows/release.yml) 但没在 PR 阶段验证 | tag push 后跑真实 release 才 fail，删 tag 重打+又一轮 CI 等待。v0.2.0 三次因此返工 | PR CI 会跑 [`scripts/check-release-paths.mjs`](../scripts/check-release-paths.mjs) 静态校验（路径/双架构/必备 platform）；进一步可手动跑 dry-run（见 §4.1） |
+| 发版 PR 分支叫 `release/vX.Y.Z` | 落进受保护命名空间，push 被 ruleset 直接拒，等多久都不会好 | 用 `chore/release-vX.Y.Z`。踩到时 `git branch -m` 改名，commit SHA 不变、pre-push 结果仍有效，可 `HA_SKIP_PREPUSH=1` 重推 |
+| `pnpm version X.Y.Z` 不带 `--no-git-tag-version` | 本地直接产 commit + tag，branch protection 不让推，发版卡死 | 一律带 `--no-git-tag-version`，version commit 走 PR |
+| release notes 文件名错（缺 `v` 前缀等） | `latest.json#notes` 落 fallback 文字，客户端弹窗看到通用文案 | 文件名严格匹配 tag：`docs/release-notes/v<X>.<Y>.<Z>.md` |
+| release notes 用相对路径 | 注入 `latest.json#notes` 后，桌面「发现新版」弹窗里链接全 broken | 一律 `https://github.com/shiwenwen/hope-agent/blob/v<X>.<Y>.<Z>/...`（tag pin） |
+| 只写了单语 release notes | 违反 AGENTS.md 双语约定 | 一个发版 PR 至少 4 类改动：CHANGELOG + 中文 notes + 英文 notes + version 文件 |
+| draft Release 不 publish | updater 抓不到，5 条下游渠道一条都不触发 | §1.4 必须人工 publish |
+| 本机 pre-push 挂在一个与本次改动无关的孤立测试上 | 误以为 main 有回归，白查一轮 | `ha-core` 部分测试读真实 `~/.hope-agent`（例：`permission/global-allowlist.json` 里的「总是允许」会让 permission engine 用例失败）。用 `HA_DATA_DIR=<空目录> git push` 复跑，等价 CI 环境 |
+| 跳过 backport 到 main | 下个 minor 丢失全部 patch 修复 | §3.1 每版发完立刻 backport |
+| `git merge release/X.Y → main` | 维护分支历史污染进 main，违反 AGENTS.md 红线 | 只 cherry-pick |
+| 新 minor 发完忘了切 `release/X.Y` | patch 修复无处落，紧急修复要回退 main 历史 | §2.3 publish 后立即切 |
+| 改 workflow job 名后没同步 ruleset | PR 卡在等一个已不存在的 job | 见 AGENTS.md "## 分支与发布" |
+| 改 `release.yml` 但没在 PR 阶段验证 | tag push 后跑真实 release 才 fail，删 tag 重打 + 又一轮 CI。v0.2.0 三次因此返工 | §4.1 |
 
 ### 4.1 修改 release.yml 时的验证流程
 
-任何动 [`release.yml`](../.github/workflows/release.yml) 或 `update-*.yml` 的 PR，按下面两层防护：
-
-**Layer 1 — 自动静态校验**（PR CI 必跑，秒级）
-
-[`.github/workflows/lint.yml`](../.github/workflows/lint.yml) 跑 `node scripts/check-release-paths.mjs`，验证：
+**Layer 1 — 静态校验**（PR CI 必跑，秒级）：[`lint.yml`](../.github/workflows/lint.yml) 跑 `node scripts/check-release-paths.mjs`，验证
 
 - 每个 platform matrix 的 `target_dir=...` 不带 `src-tauri/` 前缀（Hope Agent 是 Cargo workspace，binary 在仓库根 `./target/`）
-- Swatinem/rust-cache `workspaces:` 不指向 src-tauri 子目录
-- `update-homebrew-tap.yml` / `update-aur.yml` / `update-scoop-bucket.yml` / `update-linux-repo.yml` 引用的 release artifact 文件名模式与 [release.yml](../.github/workflows/release.yml) 实际产出对得上（缺哪个 platform 就 fail / warn）
-- matrix 包含 4 个必备 platform（`macos-arm64` / `linux-x64` / `linux-arm64` / `windows-x64`）
+- Swatinem/rust-cache 的 `workspaces:` 不指向 src-tauri 子目录
+- `update-*.yml` 引用的 artifact 文件名模式与 [release.yml](../.github/workflows/release.yml) 实际产出对得上
+- matrix 含 4 个必备 platform（`macos-arm64` / `linux-x64` / `linux-arm64` / `windows-x64`）
+- README 的 `download/latest/<name>` 链接与 `REQUIRED_ALIASES` 双向一致
 
-本地手动跑：`pnpm check:release-paths`。任何输出 `errors:` 段都会让 PR CI fail。
+本地：`pnpm check:release-paths`。任何 `errors:` 段都会让 PR CI fail。
 
-**Layer 2 — 手动 dry-run**（建议但不强制，~30~40 min）
+**Layer 2 — dry-run**（~30~40 min，下列情况必跑）：改了 `Bundle + sign bare binary` step 的 path/case 分支、改了 matrix、改了 [`tauri.conf.json`](../src-tauri/tauri.conf.json) 的 `beforeBuildCommand` / `frontendDist` / bundle config、引入新的 platform-specific build deps。单纯改 release notes 或 version bump 不用跑。
 
-不确定改动会不会 break 真实 build 时，触发一次 dry-run：
+跑法：[Actions → Release workflow](https://github.com/shiwenwen/hope-agent/actions/workflows/release.yml) → Run workflow → branch 选 PR 分支 → `tag` 填一个不存在的 sentinel 如 `v0.0.0-dryrun`（verify 步骤自动跳过）→ `dry_run` 勾 true。全平台 build 矩阵会跑（含 bare-binary path check 与 signer 验证），但跳过 draft Release 创建、bare-binary 上传、patch-manifest job。产物在 run 的 `Artifacts` 段下载。
 
-1. 打开 [Actions → Release workflow](https://github.com/shiwenwen/hope-agent/actions/workflows/release.yml)
-2. 点 "Run workflow" → branch 选 PR 分支
-3. **`tag`** 填一个 sentinel 如 `v0.0.0-dryrun`（不真存在的 tag，verify 步骤自动跳过）
-4. **`dry_run`** 勾选为 `true`
-5. 跑 → 全 5 平台的 build 矩阵会跑（含 bare-binary path check + signer sign 验证），但跳过：
-   - tauri-action 的 draft Release 创建
-   - bare-binary upload to release
-   - patch-manifest job
-6. 产物可在 workflow run 的 `Artifacts` 段下载（`bare-binary-<platform>` artifact）
-
-dry-run **不**改任何 GitHub 状态：不打 tag、不创建 Release、不污染 latest.json。失败重跑无副作用。
-
-**何时必跑 dry-run**：
-
-- 改了 [release.yml](../.github/workflows/release.yml) `Bundle + sign bare binary` step 的 path/case 分支
-- 改了 matrix 配置（platform / runner / target / args）
-- 改了 [`tauri.conf.json`](../src-tauri/tauri.conf.json) 的 `beforeBuildCommand` / `frontendDist` 或 bundle config
-- 引入新的 platform-specific build deps（apt deps / NASM / 等）
-- 单纯改 release notes / version bump：不用跑
+dry-run 不改任何 GitHub 状态：不打 tag、不建 Release、不碰 latest.json，失败重跑无副作用。
 
 ---
 
@@ -438,21 +377,23 @@ dry-run **不**改任何 GitHub 状态：不打 tag、不创建 Release、不污
 
 ### 5.1 关键脚本
 
-| 命令 | 作用 | 入口 |
-|---|---|---|
-| `pnpm version X.Y.Z --no-git-tag-version` | 同步版本号到三处文件，不创建 commit/tag | [package.json](../package.json) `scripts.version` → [scripts/sync-version.mjs](../scripts/sync-version.mjs) |
-| `pnpm sync:version` | 手动重新同步（一般不用，version 命令自动调） | 同上 |
-| `pnpm release:verify -- --tag vX.Y.Z` | 校验三处版本号一致 + 与 tag 名匹配 | [scripts/verify-release-version.mjs](../scripts/verify-release-version.mjs) |
-| `pnpm check:release-paths` | 静态校验 release.yml / update-*.yml 路径与 platform 一致性 | [scripts/check-release-paths.mjs](../scripts/check-release-paths.mjs) |
+| 命令 | 作用 |
+|---|---|
+| `pnpm version X.Y.Z --no-git-tag-version` | 同步版本号到 8 处文件 + Cargo.lock，不产 commit/tag |
+| `pnpm release:verify -- --tag vX.Y.Z` | 校验各处版本号一致且与 tag 匹配 |
+| `pnpm check:release-paths` | 静态校验 release.yml / update-*.yml 路径、platform、README 别名一致性 |
+| `node scripts/verify-updater-endpoints.mjs` | 校验 updater endpoints 在 tauri.conf.json / manifest.rs / 镜像 PUBLIC_BASE 三处逐项逐序相等 |
+| `node scripts/sync-i18n.mjs --check` | 翻译缺失 / 多余 / 插值不一致 / key 顺序漂移 |
+| `node scripts/check-docs-parity.mjs` | 用户手册中英章节对齐 |
 
 ### 5.2 关键文件
 
 | 文件 | 作用 |
 |---|---|
 | [package.json](../package.json) | 版本号单一真相源 |
-| [src-tauri/Cargo.toml](../src-tauri/Cargo.toml) | Rust crate 版本，由 sync-version 同步 |
-| [src-tauri/tauri.conf.json](../src-tauri/tauri.conf.json) | Tauri app 版本 + updater endpoint 配置 |
-| [.github/workflows/release.yml](../.github/workflows/release.yml) | tag push 触发的发版 workflow，含 release notes 提取逻辑 |
+| [src-tauri/tauri.conf.json](../src-tauri/tauri.conf.json) | Tauri app 版本 + updater endpoints + pubkey |
+| [crates/ha-core/src/updater/manifest.rs](../crates/ha-core/src/updater/manifest.rs) | headless 侧 updater endpoints，与上一行必须逐项逐序相等 |
+| [.github/workflows/release.yml](../.github/workflows/release.yml) | tag push 触发的发版 workflow，含 release notes 提取 |
 | [docs/release-notes/](release-notes/) | 双语 release notes，文件名 `vX.Y.Z[.en].md` |
 | [CHANGELOG.md](../CHANGELOG.md) | 用户视角变更日志，单行 entry + PR 引用 |
 
@@ -475,24 +416,30 @@ git branch --contains <sha>
 ### 5.4 GitHub CLI 速查
 
 ```bash
-# 看最近的 release
+# 最近的 release
 gh release list --limit 5
 
-# 看某 tag 触发的 workflow run
+# 某 workflow 的近期 run
 gh run list --workflow release.yml --limit 5
 
-# 查 latest.json 内容（验证发版后 notes 字段填得对不对）
+# 查 latest.json（验证 notes 字段填得对不对）
 gh release view v0.1.2 --json assets --jq '.assets[] | select(.name=="latest.json") | .url' \
   | xargs curl -sL | jq .
+
+# 查镜像那份 latest.json
+curl -sL https://repo.hopeagent.ai/download/latest.json | jq '.version, .platforms | keys'
+
+# 某 commit 的检查是否跑完（切维护分支前用）
+gh api repos/shiwenwen/hope-agent/commits/<sha>/check-runs --jq '.check_runs[] | "\(.status)\t\(.name)"'
 ```
 
 ---
 
 ## 附录：术语对照
 
-- **patch / minor / major**：semver 三段含义，`X.Y.Z` 中的 Z / Y / X
-- **维护分支**：`release/X.Y`，长期存在，承载该 minor 的所有 patch
-- **PR 临时分支**：每次发版用一次性的 PR 工作分支（命名随意，如 `release/v0.1.2`），合并后删除
-- **backport**：把维护分支上的修复 cherry-pick 回 main 的动作
-- **draft Release**：CI 创建但未公开的 GitHub Release，updater 不可见
-- **updater endpoint**：客户端拉 `latest.json` 的固定 URL，配置在 `tauri.conf.json`
+- **patch / minor / major**：semver `X.Y.Z` 中的 Z / Y / X
+- **维护分支**：`release/X.Y`，长期存在，承载该 minor 的所有 patch。**该前缀受 ruleset 保护**
+- **发版 PR 分支**：一次性工作分支，命名 `chore/release-vX.Y.Z`，合并后删除。**不能用 `release/` 前缀**
+- **backport**：把维护分支上的修复 cherry-pick 回 main
+- **draft Release**：CI 创建但未公开的 GitHub Release，updater 不可见，下游渠道不触发
+- **updater endpoint**：客户端拉 `latest.json` 的 URL，两个、按序试、首个成功者胜

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -259,12 +259,16 @@ download/
 
 **几条容易踩的**：
 
-- **Cache-Control 由 `--metadata-set` 随 PUT 一次写入，不要用 `--header-upload`**。后者是事后单独一次调用，而 R2 恰好对那次调用返回 501——对象本体正确落地、Cache-Control 却没写上，Cloudflare 于是按自己的默认 4 小时服。这个坑的隐蔽之处在于它**只命中一部分对象**（同一次上传里有的对、有的不对），看起来极像 Cloudflare 在覆盖源站头，实际是我们自己漏写。**判据：如果只有部分对象的 TTL 不对，那就是写入问题，不是覆盖问题**——覆盖不可能只覆盖一半。三档值在 workflow 的 `CC_IMMUTABLE` / `CC_LATEST` / `CC_MANIFEST` 单一定义，上传设、校验断言，两边不会漂。
+- **Cache-Control 用 `--metadata-set` 随 PUT 写入，禁用 `--header-upload`**。`--header-upload` 是 PUT 成功之后的另一次调用，R2 对它返回 501，结果是对象字节正确、Cache-Control 缺失。三档值单一定义在 workflow 的 `CC_IMMUTABLE` / `CC_LATEST` / `CC_MANIFEST`，上传设、校验读回。
+- **排查 `max-age=14400`：看指令，不看数字**。别用「是否全体对象都不对」判因，两种成因都只命中一部分对象。
+  - 裸 `max-age=14400`（无 `public`、无 `must-revalidate`）＝ 头没写上。用 `workflow_dispatch` 的 `force` 强制重传补写（`--checksum` 因内容一致不会自己重传）。
+  - `public, max-age=14400, must-revalidate` ＝ 对象正常，是 Cloudflare Browser Cache TTL 抬高了值。只命中 CF 默认缓存的扩展名（`.dmg` `.exe` `.zip` `.tar.gz`；`.deb` `.rpm` `.AppImage` `.sig` `.json` 走 `DYNAMIC` 不中），且只上调不下调（`download/<tag>/` 的 31536000 不受影响）。要让 `latest/` 的 300s 到达浏览器，Caching → Configuration → Browser Cache TTL 改成 **Respect Existing Headers**。
+  - 校验只断言 `immutable` / `must-revalidate` 是否存在，不断言 TTL 数值；TTL 低于设定值才算错误。边缘设置 CI 控制不了，不该卡住发版。
 - **`latest/` 别名不能带 immutable 头**。那些文件名每版复用，长 TTL 会让边缘把旧安装包钉住一年。别名由 [`scripts/mirror-latest-aliases.mjs`](../scripts/mirror-latest-aliases.mjs) 按规则剥版本号派生，但 README 实际链接的 8 个名字在 `REQUIRED_ALIASES` 里**硬登记**——规则失灵时报错，而不是发布一堆 404。两侧对齐由 `check-release-paths.mjs` 在 PR 时守。
 - **`update-linux-repo.yml` 的整桶 pull 必须带 `--include`**。它把 bucket 镜像下来重建索引；本 workflow 每版往同一个 bucket 放约 1.5 GB 且永久保留，不过滤会让那个 pull 无界增长直到超时。新增本 job 独占的顶层路径时，同步加进那个过滤列表。
 - **`notes` 里的 GitHub 链接会被改写**（改写发生在 R2 那份 manifest 上，仓库源文件不动，§1.1(a) 的「链接一律用完整 GitHub URL」规则不变）。`notes` 是应用内「发现新版」弹窗的正文且按 markdown 渲染，中英切换与 CHANGELOG 两条链接对目标用户就是死链。链到 `REQUIRED` 之外的文档时 workflow 会 fail-closed。
 - **签名原样复制、绝不重算**。理由与端点链的信任模型见 [self-update](architecture/self-update.md#manifest-端点链r2-镜像优先github-兜底)。
-- **rclone 报的 `501 NotImplemented` 是假失败——对象其实已经正确落地**。R2 在 rclone 于 PUT **成功之后**发出的某个调用上返回 501，于是 rclone 把一个已经写好的对象报成 `Failed to copy`。实测确认：报错的那批对象经公开域名 HEAD 全部 200 且 `Content-Length` 与源文件逐字节一致。**所以判断成败要看本 workflow 自己的回抓校验，不要只看 rclone 退出码。** 用 `--checksum` 而非 `--ignore-times`：前者在重试时发现哈希一致就跳过，整轮能自愈；后者每次强制重传、每次重报失败，会把这个噪声变成永久失败（前两次回填就是这么烧完 10 次重试的）。**根因已定位**：501 出在 `--header-upload` 那次事后调用上，改用 `--metadata-set` 后 header 随 PUT 一次写入（见上一条）。修好之前落地的对象缺 header，`--checksum` 因内容一致不会重传，需用 `workflow_dispatch` 的 `force` 开关强制重传一次补上。
+- **rclone 退出码不代表成败，以本 workflow 的回抓校验为准**。R2 会在 PUT 成功之后的某次调用上返回 `501 NotImplemented`，rclone 因此把已经写好的对象报成 `Failed to copy`（实测：报错对象经公开域名 HEAD 全部 200、`Content-Length` 与源文件逐字节一致）。用 `--checksum`，禁用 `--ignore-times`——`--checksum` 发现哈希一致就跳过、整轮自愈；`--ignore-times` 每次强制重传因而每次重报失败，会烧完 10 次重试变成永久失败。
 - **rclone 的 stderr 不要用 `tail` 截断**。第一次失败时能定位问题的正是那些被截掉的逐对象错误行，为了日志好看丢掉它们，代价是再跑一整轮。
 - **给 rclone 传参的辅助变量不能用 `RCLONE_` 前缀**。rclone 会把**任何** `RCLONE_<FLAG>` 环境变量当成同名 flag 的值：`RCLONE_FORCE` 变成 `--force`、`RCLONE_VERSION` 变成 `--version`，rclone 在第一次调用就以 bool 解析错误退出。`RCLONE_CONFIG_R2_*` 是文档化的 remote 配置写法，不受影响；其余一律用 `R2_` 前缀（`R2_UPLOAD_FLAGS` / `R2_FORCE_FLAG` / `R2_RCLONE_PIN`）。
 - **rclone 版本要钉住，别用 `apt-get install rclone`**。发版关键路径不该从基础镜像继承工具版本（Ubuntu 24.04 自带 1.60.1）。安装步骤同时断言所需 flag 存在，不支持时在动任何字节之前给一行明确错误。


### PR DESCRIPTION
两个独立 commit。

---

## 1/2 `fix(ci)` 镜像 Cache-Control 校验改断言指令集

### 问题

校验步骤断言「served 的 `max-age` 必须等于我们上传的值」。这条断言会失败，而校验失败即不发布 `download/latest.json` —— 镜像上就看不到新版本。

失败原因是 Cloudflare 的 **Browser Cache TTL**（Caching → Configuration，默认 4h）：它抬高由 CF 缓存服务的响应的 `max-age`，保留我们其余的指令。

实测（v0.26.0，`repo.hopeagent.ai`）：

| 对象 | served Cache-Control | cf-cache-status |
| --- | --- | --- |
| `latest/Hope.Agent_amd64.deb` | `public, max-age=300, must-revalidate` | DYNAMIC |
| `latest/Hope.Agent_aarch64.dmg` | `public, max-age=14400, must-revalidate` | REVALIDATED |
| `v0.26.0/…_aarch64.dmg` | `public, max-age=31536000, immutable` | HIT |
| `latest.json` | `public, max-age=60, must-revalidate` | DYNAMIC |

命中面 = CF 默认缓存的扩展名（`.dmg` `.exe` `.zip` `.tar.gz`；`.deb` `.rpm` `.AppImage` `.sig` `.json` 走 DYNAMIC），且只上调不下调（`download/<tag>/` 的 31536000 高于 4h 不受影响）。`latest.json` 是 DYNAMIC，**自动更新不受影响**。

上一轮 `workflow_dispatch` 因此在 7 个对象上 FAIL（[run 30609222832](https://github.com/shiwenwen/hope-agent/actions/runs/30609222832)），其余全部 ok。

### 改动

断言**指令**而非 TTL 数值：`immutable` / `must-revalidate` 是我方写入、分档互斥，且 Cloudflare 的默认应答两个都不带。

| 场景 | 新行为 |
| --- | --- |
| 我方头原样 | ok |
| 边缘抬高 300 → 14400 | ok + 打印说明 |
| 裸 `max-age=14400`（头没落上） | FAIL |
| 完全无 Cache-Control | FAIL |
| 上错档（immutable 头进 latest / 反之） | FAIL |
| TTL 低于设定值 | FAIL |

顺带修掉 `max-age` 提取的大小写敏感（旧代码同样有，本地验证时发现）。

### 验证

把 `check_one` 从 workflow 里逐字抽出，在 `set -euo pipefail` 下跑 12 组场景（上表 6 组 + 大小写混杂 / 有指令无 max-age / 大小不符 / 不可达 / immutable 正确 / 我方头原样）：**12 passed, 0 wrong**。YAML 解析 18 steps。

### 不做的事

不改 Cloudflare 设置。要让 `latest/` 的 300s 真正到达浏览器，需要把 Browser Cache TTL 改成 Respect Existing Headers —— 那是 dashboard 操作，且不影响发版与自动更新，文档里已写明。

---

## 2/2 `docs(release-process)` 按「怎么做 / 避免什么」重排

原文有大量背景叙事和有状态措辞（「上一条那个」「后者」「与 §1.6 同模式」），读者必须先读完前文才能用某一条。改为每条自包含：命令 → 规则 → 后果。498 → 445 行。

**顺带修掉两处已经错了的内容**：

- **§0.3** 还写着 endpoint「固定指向 `https://github.com/…/releases/latest/download/latest.json`」。R2 镜像上线后已是两个 endpoint、R2 在前、首个成功者胜。
- **附录**写「PR 临时分支（命名随意，如 `release/v0.1.2`）」。照做会被 ruleset 直接拒——`refs/heads/release/**` 是维护分支的受保护命名空间。已改成明确禁止并给出 `chore/release-vX.Y.Z`。

**其他**：

- §1.1 的 `git add` 列表原本只列 3 个 version 文件，实际 `sync-version.mjs` 改 8 个 + `Cargo.lock`，照抄会漏提交
- §1.2 补上 CI 全绿仍 `BLOCKED` 的三种原因与处理
- §1.6~§1.8 三节原本是近乎逐字重复的流水账，压成「触发 → 手动重跑 → 禁止事项」
- §2.3 补上被 ruleset 拒时的处理（等 8 项检查跑完，不要改配置）
- §4 避坑表新增两行：发版 PR 分支命名；本机 pre-push 挂在无关测试上时先用 `HA_DATA_DIR` 空目录复跑（`ha-core` 部分测试读真实 `~/.hope-agent`）

**兼容性**：35 个标题一字未动——6 个 workflow 与 4 个 README 按 §编号引用本文，`docs/architecture/self-update.md` 引 `#110-r2-安装包镜像自动同步` 锚点。43 个相对链接全部命中。