### PR TITLE
docs+ci: 补 v0.27.0 发版实测出的三条，下游 workflow 加 run-name

### DIFF
--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -51,6 +51,12 @@ name: Mirror Release to R2
 # domain, API token) is documented in linux-repo/README.md — this workflow
 # reuses that same bucket and domain.
 
+# run-name puts the tag in the run's display title. Without it every run
+# is called "Mirror Release to R2" and `gh run list` cannot tell which release a run
+# belongs to — a manual re-run for an older tag looks identical to this
+# release's own run. See docs/release-process.md §1.4.
+run-name: Mirror ${{ inputs.tag || github.event.release.tag_name }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/update-aur.yml
+++ b/.github/workflows/update-aur.yml
@@ -16,6 +16,12 @@ name: Update AUR
 #                         registered on the maintainer's AUR account.
 #                         Setup steps live in aur/README.md.
 
+# run-name puts the tag in the run's display title. Without it every run
+# is called "Update AUR" and `gh run list` cannot tell which release a run
+# belongs to — a manual re-run for an older tag looks identical to this
+# release's own run. See docs/release-process.md §1.4.
+run-name: AUR ${{ inputs.tag || github.event.release.tag_name }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -15,6 +15,12 @@ name: Update Homebrew Tap
 #   HOMEBREW_TAP_TOKEN — fine-grained PAT with `Contents: Read and write`
 #                       on shiwenwen/homebrew-hope-agent only.
 
+# run-name puts the tag in the run's display title. Without it every run
+# is called "Update Homebrew Tap" and `gh run list` cannot tell which release a run
+# belongs to — a manual re-run for an older tag looks identical to this
+# release's own run. See docs/release-process.md §1.4.
+run-name: Homebrew tap ${{ inputs.tag || github.event.release.tag_name }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/update-linux-repo.yml
+++ b/.github/workflows/update-linux-repo.yml
@@ -32,6 +32,12 @@ name: Update Linux Repo
 # First-time / rotation setup on the Cloudflare side (bucket, custom domain
 # repo.hopeagent.ai, API token) is documented in linux-repo/README.md.
 
+# run-name puts the tag in the run's display title. Without it every run
+# is called "Update Linux Repo" and `gh run list` cannot tell which release a run
+# belongs to — a manual re-run for an older tag looks identical to this
+# release's own run. See docs/release-process.md §1.4.
+run-name: Linux repo ${{ inputs.tag || github.event.release.tag_name }}
+
 on:
   release:
     types: [published]

--- a/.github/workflows/update-scoop-bucket.yml
+++ b/.github/workflows/update-scoop-bucket.yml
@@ -15,6 +15,12 @@ name: Update Scoop Bucket
 #   SCOOP_BUCKET_TOKEN — fine-grained PAT with `Contents: Read and write`
 #                        on shiwenwen/scoop-hope-agent only.
 
+# run-name puts the tag in the run's display title. Without it every run
+# is called "Update Scoop Bucket" and `gh run list` cannot tell which release a run
+# belongs to — a manual re-run for an older tag looks identical to this
+# release's own run. See docs/release-process.md §1.4.
+run-name: Scoop bucket ${{ inputs.tag || github.event.release.tag_name }}
+
 on:
   release:
     types: [published]

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -155,6 +155,18 @@ Releases 页找到 `Hope Agent v0.1.2` draft，确认：
 
 确认后点 **Publish release**。draft 状态 updater 抓不到 `latest.json`，不 publish 等于没发。publish 会同时触发 §1.6~§1.10 五条下游渠道。
 
+**publish 之后必须逐条确认五条渠道都 success**，不要默认它们成了：
+
+```bash
+for wf in update-homebrew-tap update-aur update-scoop-bucket update-linux-repo mirror-release-r2; do
+  printf '%-24s ' "$wf"
+  gh run list --workflow="$wf.yml" --limit 1 --json status,conclusion,databaseId \
+    --jq '.[0] | "\(.status)/\(.conclusion // "-")  \(.databaseId)"'
+done
+```
+
+`mirror-release-r2` 失败最常见，两种成因与补救见 §1.10（多数情况是 `-f force=true` 重跑）。它失败时 `download/latest.json` 保持旧版本——由于端点是首个成功者胜，**全体客户端会一直被告知「已是最新」**，所以这条不能放着不管。
+
 ### 1.5 backport 到 main
 
 见 [§3 backport 策略](#3-backport-策略)。
@@ -231,13 +243,19 @@ download/
 
 **可变面有 `PROMOTE` 门控**。`download/latest/` 与 `download/latest.json` 全局共享，给非当前稳定版写它们就是一次降级广播——R2 是 endpoint[0] 且首个成功者胜，全体客户端会被告知那个旧版本是最新。两条日常路径会踩到：手动回填旧 tag、发布 prerelease（同样触发 `release.published`）。所以只有该 tag 恰好是 GitHub 认定的 latest release 且非 prerelease 时才推进可变面；其余情况只写自己的不可变前缀然后停下（给 `::notice::`，不算失败）。
 
-**`actions/checkout` 的 `ref:` 必须显式指默认分支**。`release.published` 下 `github.ref` 就是 `refs/tags/vX.Y.Z`，不写 `ref:` 会静默取那个 tag，两个后果：① 本 workflow 落地**之前**发布的 tag 永远无法镜像（那些树里没有 `scripts/mirror-*.mjs`），整个历史目录不可镜像；② 改写器里修掉的 bug 会冻结在 tag 发布时的样子。文档则相反——必须是该版本实际发布的那一份，所以单独 `git fetch --depth=1` 该 tag 再 `git show <tag>:<path>` 取。
+**改了 `mirror-release-r2.yml`，本次发版用不上，要下一次才生效**。`release.published` 触发的 run 用的是 **tag 那棵树的 workflow YAML**（`headSha` = 被打 tag 的 commit，`headBranch` = tag 名），哪怕修复早已合进 main。所以：
+
+- 想让修复对**当前这次**发版生效，publish 之后手动补跑一次 `gh workflow run mirror-release-r2.yml --ref main -f tag=vX.Y.Z`——dispatch 用的是 `--ref` 指定分支的 YAML。补跑是幂等的，且此时该 tag 已是 `releases/latest`，`PROMOTE` 会算 true、可变面照常推进。
+- 顺序反过来也不行：先合修复再打 tag 才能让 `release.published` 那一轮就带上修复。
+
+**`actions/checkout` 的 `ref:` 是另一回事，必须显式指默认分支**。它决定的是 `scripts/*.mjs` 从哪来，与上面 YAML 的来源无关。`release.published` 下 `github.ref` 就是 `refs/tags/vX.Y.Z`，不写 `ref:` 会静默取那个 tag，两个后果：① 本 workflow 落地**之前**发布的 tag 永远无法镜像（那些树里没有 `scripts/mirror-*.mjs`），整个历史目录不可镜像；② 改写器里修掉的 bug 会冻结在 tag 发布时的样子。文档则相反——必须是该版本实际发布的那一份，所以单独 `git fetch --depth=1` 该 tag 再 `git show <tag>:<path>` 取。
 
 **其余规则**：
 
 - **Cache-Control 用 `--metadata-set` 随 PUT 写入，禁用 `--header-upload`**。`--header-upload` 是 PUT 成功之后的另一次调用，R2 对它返回 501，结果是对象字节正确、Cache-Control 缺失。三档值单一定义在 workflow 的 `CC_IMMUTABLE` / `CC_LATEST` / `CC_MANIFEST`。
-- **排查 `max-age=14400`：看指令，不看数字**。别用"是否全体对象都不对"判因，两种成因都只命中一部分对象。
-  - 裸 `max-age=14400`（无 `public`、无 `must-revalidate`）＝ 头没写上。用 `workflow_dispatch` 的 `force` 强制重传补写（`--checksum` 因内容一致不会自己重传）。
+- **`--metadata-set` 只是降低概率，不保证头一定落地**。v0.27.0 那批就有一部分对象仍然缺 Cache-Control。**所以「校验报头缺失 → 带 `force` 重跑一次」是常规补救，不是一次性修复**：`gh workflow run mirror-release-r2.yml --ref main -f tag=vX.Y.Z -f force=true`。普通重跑没用——`--checksum` 看内容一致就跳过，metadata 根本不会被重写。
+- **排查 Cache-Control 异常：看指令，不看数字**。别用"是否全体对象都不对"判因，几种成因都只命中一部分对象。
+  - **无 Cache-Control**，或裸 `max-age=14400`（无 `public`、无 `must-revalidate`）＝ 头没写上，走上一条的 `force` 重传。两种表现取决于 Cloudflare 那时是否在替源站补默认值，同一个问题。
   - `public, max-age=14400, must-revalidate` ＝ 对象正常，是 Cloudflare Browser Cache TTL 抬高了值。只命中 CF 默认缓存的扩展名（`.dmg` `.exe` `.zip` `.tar.gz`；`.deb` `.rpm` `.AppImage` `.sig` `.json` 走 `DYNAMIC` 不中），且只上调不下调（`download/<tag>/` 的 31536000 不受影响）。要让 `latest/` 的 300s 到达浏览器，Caching → Configuration → Browser Cache TTL 改成 **Respect Existing Headers**。
   - 校验只断言 `immutable` / `must-revalidate` 是否存在，不断言 TTL 数值；TTL 低于设定值才算错误。边缘设置 CI 控制不了，不该卡住发版。
 - **rclone 退出码不代表成败，以本 workflow 的回抓校验为准**。R2 会在 PUT 成功之后的某次调用上返回 `501 NotImplemented`，rclone 因此把已经写好的对象报成 `Failed to copy`（实测：报错对象经公开域名 HEAD 全部 200、`Content-Length` 与源文件逐字节一致）。用 `--checksum`，禁用 `--ignore-times`——`--checksum` 发现哈希一致就跳过、整轮自愈；`--ignore-times` 每次强制重传因而每次重报失败，会烧完 10 次重试变成永久失败。

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -158,14 +158,26 @@ Releases 页找到 `Hope Agent v0.1.2` draft，确认：
 **publish 之后必须逐条确认五条渠道都 success**，不要默认它们成了：
 
 ```bash
+TAG=v0.1.2
 for wf in update-homebrew-tap update-aur update-scoop-bucket update-linux-repo mirror-release-r2; do
-  printf '%-24s ' "$wf"
-  gh run list --workflow="$wf.yml" --limit 1 --json status,conclusion,databaseId \
-    --jq '.[0] | "\(.status)/\(.conclusion // "-")  \(.databaseId)"'
+  printf '%-22s ' "$wf"
+  gh run list --workflow="$wf.yml" --limit 20 \
+    --json displayTitle,conclusion,status,databaseId \
+  | jq -r --arg tag "$TAG" '
+      [.[] | select(.displayTitle | endswith(" " + $tag))] as $mine
+      | ($mine | map(select(.conclusion == "success"))) as $ok
+      | if   ($mine | length) == 0 then "本 tag 尚无 run（刚 publish 的话等几秒重查）"
+        elif ($ok   | length) >  0 then "OK  run \($ok[0].databaseId)"
+        else "未成功  \($mine[0].status)/\($mine[0].conclusion // "-")  run \($mine[0].databaseId)"
+        end'
 done
 ```
 
-`mirror-release-r2` 失败最常见，两种成因与补救见 §1.10（多数情况是 `-f force=true` 重跑）。它失败时 `download/latest.json` 保持旧版本——由于端点是首个成功者胜，**全体客户端会一直被告知「已是最新」**，所以这条不能放着不管。
+**必须按 tag 认 run，不能用 `--limit 1`**：那条可能是上一版的 run（本版的还没出现），也可能是某次与本版无关的手动补跑，两种情况都会让清单显示绿而本版根本没跑。五个 workflow 都设了 `run-name: <渠道> <tag>`，所以 `displayTitle` 结尾就是 tag，可以直接匹配。
+
+判定口径是「**本 tag 存在一条 success 的 run**」，不是「最新那条 success」——publish 触发的那条失败、随后手动补跑成功，是正常且完整的结果（v0.27.0 就是这样）。
+
+`mirror-release-r2` 失败最常见，成因与补救见 §1.10（多数情况是 `-f force=true` 重跑）。它失败时 `download/latest.json` 保持旧版本——由于端点是首个成功者胜，**全体客户端会一直被告知「已是最新」**，所以这条不能放着不管。
 
 ### 1.5 backport 到 main
 


### PR DESCRIPTION
v0.27.0 发版过程中实测出三条与文档不符的事实，都会让下一次发版重复踩。

## 1. `release` 事件的 workflow YAML 跟着 tag 走，不是默认分支

```
run 30649914521   headSha = e61e4d5b5   headBranch = v0.27.0
#596（校验修复）合并进 main   15:50:59Z
Release publish               17:07:13Z
```

#596 的 Cache-Control 校验修复早已在 main 上，但 `release.published` 那一轮仍然跑了 tag 那棵树里的旧校验，报的是旧格式错误 `FAIL (cache-control max-age=14400, want 300)`。

原文里「`actions/checkout` 的 `ref:` 必须显式指默认分支」那段容易被读成「整个 workflow 都取默认分支」。实际那条只决定 `scripts/*.mjs` 从哪来，YAML 本身另一回事。已拆成两段分别写清，并给出两条可行做法：先合修复再打 tag，或 publish 后 `gh workflow run <wf>.yml --ref main -f tag=vX.Y.Z` 补跑。

## 2. `--metadata-set` 不保证 Cache-Control 落地，`force` 重传是常规手段

原文写「根因已定位：改用 `--metadata-set` 后 header 随 PUT 一次写入」，并把 `force` 描述成"修好之前落地的对象"的一次性修复。

实测 v0.27.0 那批仍有一部分对象缺 Cache-Control（校验报 `cache-control 'none' is missing 'immutable'`），带 `-f force=true` 重传后全部通过。所以这是概率问题、不是已解决的历史问题。同时写明普通重跑无效——`--checksum` 看内容一致就跳过，metadata 根本不会被重写。

排查那条也补上：**无 Cache-Control** 与**裸 `max-age=14400`** 是同一个问题的两种表现，取决于 Cloudflare 当时是否在替源站补默认值。

## 3. 下游 workflow 的 run 认不出属于哪个 tag（新增 `run-name`）

publish 后确认渠道状态时，`gh run list --limit 1` 拿到的可能是上一版的 run（本版还没出现），也可能是与本版无关的手动补跑——两种情况都会让清单显示绿而本版根本没跑。

v0.27.0 的实际数据把问题暴露得更彻底：

```
event=workflow_dispatch  conclusion=success  title=[Mirror Release to R2]
event=release            conclusion=failure  title=[Hope Agent v0.27.0]
```

- `--limit 1` 拿到那条 success，但看不出它跑的是哪一版
- `--branch v0.27.0` 只命中 release 事件那条 failure，把真正修好本版的补跑滤掉了

**两种过滤方式都给不出正确答案**，因为 run 的显示名不带 tag：`release` 事件那条恰好叫 `Hope Agent v0.27.0`（Release 的名字），`workflow_dispatch` 那条叫 `Mirror Release to R2`——能认出的恰好是失败那条，认不出的恰好是修好它的那条。

改动：

- 五个下游 workflow 全部加 `run-name: <渠道> ${{ inputs.tag || github.event.release.tag_name }}`，两类触发都带 tag
- §1.4 加 publish 后的确认脚本，按 `displayTitle` 结尾匹配 tag，判定口径是「**本 tag 存在一条 success 的 run**」而非「最新那条 success」——publish 触发的失败、随后补跑成功是正常且完整的结果
- 无匹配时明确报「本 tag 尚无 run（刚 publish 的话等几秒重查）」

并写明 `mirror-release-r2` 失败时 `download/latest.json` 停在旧版本，配合 endpoint 首个成功者胜，**全体客户端会一直被告知「已是最新」**，所以不能放着不管。本次就是这个状态，直到 force 重跑才恢复。

## 验证

- jq 判定逻辑本地跑了 5 种场景：有成功 / 只有失败 / 全是别版的 run / 本版还在跑 / `v0.27.0` 不误命中 `v0.27.0-rc1`
- 顺带修掉一个我自己写错的：`gh` 的 `--jq` 不支持 `--arg`（报 `unknown command "tag"`），改成管道给真 jq
- 五个 workflow YAML 均可解析，`run-name` 字段正确
- `docs/release-process.md` 43 个相对链接全部命中，标题未动