### PR TITLE
fix(ci): 不可变前缀的 rclone copy 补 --checksum，普通重跑不再抹掉 Cache-Control

### DIFF
--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -418,11 +418,24 @@ jobs:
           set -euo pipefail
           # Immutable per-version prefix, so a long edge TTL is correct and
           # every historical download link keeps working forever.
+          #
+          # --checksum IS LOAD-BEARING, not an optimization. Without it rclone
+          # compares size+modtime, decides the already-correct object needs its
+          # metadata refreshed, and does a metadata-only server-side copy — and
+          # that copy lands WITHOUT Cache-Control. Measured on v0.27.0: a force
+          # run wrote the header on all 28 objects and verification passed; the
+          # next ordinary re-run "uploaded" in 3 seconds (no bytes moved) and
+          # every immutable object came back with no Cache-Control at all. So
+          # each ordinary re-run was undoing the previous repair. The
+          # latest/ upload below always had --checksum, which is exactly why
+          # its objects kept their header through the same re-runs.
+          #
           # stderr is NOT piped through `tail`: the first backfill run was
           # diagnosable only from the per-object error lines, and truncating
           # them threw away exactly what was needed.
           rclone copy "$WORK/assets" "r2:${R2_BUCKET}/download/${TAG}" \
             --metadata --metadata-set "cache-control=${CC_IMMUTABLE}" \
+            --checksum \
             $R2_UPLOAD_FLAGS $R2_FORCE_FLAG --stats=30s --stats-one-line
           # Raw markdown as text/plain so a browser DISPLAYS it instead of
           # downloading an opaque .md — these are read, not installed.
@@ -430,6 +443,7 @@ jobs:
             --metadata \
             --metadata-set "cache-control=${CC_IMMUTABLE}" \
             --metadata-set "content-type=text/plain; charset=utf-8" \
+            --checksum \
             $R2_UPLOAD_FLAGS $R2_FORCE_FLAG --stats=0
           echo "Uploaded to r2:${R2_BUCKET}/download/${TAG}"
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -265,7 +265,8 @@ download/
 **其余规则**：
 
 - **Cache-Control 用 `--metadata-set` 随 PUT 写入，禁用 `--header-upload`**。`--header-upload` 是 PUT 成功之后的另一次调用，R2 对它返回 501，结果是对象字节正确、Cache-Control 缺失。三档值单一定义在 workflow 的 `CC_IMMUTABLE` / `CC_LATEST` / `CC_MANIFEST`。
-- **`--metadata-set` 只是降低概率，不保证头一定落地**。v0.27.0 那批就有一部分对象仍然缺 Cache-Control。**所以「校验报头缺失 → 带 `force` 重跑一次」是常规补救，不是一次性修复**：`gh workflow run mirror-release-r2.yml --ref main -f tag=vX.Y.Z -f force=true`。普通重跑没用——`--checksum` 看内容一致就跳过，metadata 根本不会被重写。
+- **三条 `rclone copy` 都必须带 `--checksum`，这是正确性不是优化**。少了它 rclone 按 size+modtime 比对，认为已经正确的对象需要刷新 metadata，于是做一次纯 metadata 的服务端 copy——**而那次 copy 落地时没有 Cache-Control**。v0.27.0 实测：force 跑给 28 个对象写上头、校验通过；紧接着一次普通重跑「上传」只花 3 秒（没搬字节），所有不可变对象的 Cache-Control 全部消失。也就是**每次普通重跑都在撤销上一次的修复**。`download/latest/` 那条一直带 `--checksum`，所以它的头在同样的重跑里毫发无损——这个不对称就是判据。
+- **头已经丢了要用 `force` 补**：`gh workflow run mirror-release-r2.yml --ref main -f tag=vX.Y.Z -f force=true`。普通重跑修不回来——`--checksum` 看哈希一致就整个跳过，不会重写 metadata。
 - **排查 Cache-Control 异常：看指令，不看数字**。别用"是否全体对象都不对"判因，几种成因都只命中一部分对象。
   - **无 Cache-Control**，或裸 `max-age=14400`（无 `public`、无 `must-revalidate`）＝ 头没写上，走上一条的 `force` 重传。两种表现取决于 Cloudflare 那时是否在替源站补默认值，同一个问题。
   - `public, max-age=14400, must-revalidate` ＝ 对象正常，是 Cloudflare Browser Cache TTL 抬高了值。只命中 CF 默认缓存的扩展名（`.dmg` `.exe` `.zip` `.tar.gz`；`.deb` `.rpm` `.AppImage` `.sig` `.json` 走 `DYNAMIC` 不中），且只上调不下调（`download/<tag>/` 的 31536000 不受影响）。要让 `latest/` 的 300s 到达浏览器，Caching → Configuration → Browser Cache TTL 改成 **Respect Existing Headers**。


### PR DESCRIPTION
## 症状

`download/<tag>/` 下的对象反复丢失 `Cache-Control`，校验报 `cache-control 'none' is missing 'immutable'`。`force` 重传能修好，但过一阵又没了。

## 根因

四条 rclone 调用里，只有 `download/<tag>/` 的两条漏了 `--checksum`：

| 目标 | `--checksum` |
| --- | --- |
| `download/<tag>/` assets | ❌ |
| `download/<tag>/` docs | ❌ |
| `download/latest/` | ✅ |
| `download/latest.json` | ✅ |

少了它，rclone 按 size+modtime 比对，认为已经正确的对象需要刷新 metadata，于是做一次**纯 metadata 的服务端 copy**——而那次 copy 落地时没有 `Cache-Control`。

## 实测链路（v0.27.0）

```
17:07  release 事件跑（旧校验只比 max-age）  通过
17:11  普通重跑                             报 none  ✗
17:19  force 重跑（真重传 21s，28 个全过）   通过    ✓
20:26  普通重跑（"上传" 3s，没搬字节）        报 none  ✗
20:36  force 重跑                           ok=53 FAIL=0 ✓
```

中间没有任何其他写入。`Upload assets (immutable)` 步骤耗时 3 秒即证明没有搬字节——那 3 秒就是在做 metadata-only copy。

**判据是那个不对称**：带 `--checksum` 的 `download/latest/` 对象在同样的重跑里毫发无损，至今保留 `must-revalidate`。

也就是说**每次普通重跑都在撤销上一次 force 的修复**。

## 为什么现在才暴露

Cloudflare 的 Browser Cache TTL 之前在替源站合成 `Cache-Control`，把「对象上根本没写头」这件事遮住了。改成 Respect Existing Headers 之后，`cf-cache-status: DYNAMIC` 的响应直接透传源站，真相才露出来。

对照可以确认不是 Cloudflare 在剥头：

```
v0.26.0/…deb   cc=public, max-age=31536000, immutable   cf=DYNAMIC   ← 有
v0.27.0/…deb   cc=<无>                                  cf=DYNAMIC   ← 无
```

同前缀、同为 DYNAMIC，差别只在对象本身。

## 改动

- 两条 immutable `rclone copy` 补 `--checksum`，四条调用统一
- 注释写明这是正确性不是优化，附实测数据
- 改掉 #597 里我写错的一句：「`--metadata-set` 只是降低概率」——真正原因是这个不对称，不是概率问题

## 验证

修复后线上实况：

```
download/v0.27.0/*     max-age=31536000, immutable
download/latest/*      max-age=300, must-revalidate
download/latest.json   max-age=60, must-revalidate
```

最近一次 force 跑 [30663418831](https://github.com/shiwenwen/hope-agent/actions/runs/30663418831)：ok=53、FAIL=0。

本 PR 合并后需要再跑一次不带 `force` 的镜像 workflow，确认头不再被抹掉——那是这个修复的真正验收。