### PR TITLE
docs(linux-repo): R2 S3 端点证书问题降级为历史说明

### DIFF
--- a/linux-repo/README.md
+++ b/linux-repo/README.md
@@ -58,28 +58,40 @@ All of this is done in the Cloudflare dashboard + `gh` CLI; none of it is in cod
    ```
    The verify step confirms `https://repo.hopeagent.ai/apt/dists/stable/InRelease` etc. are live. From then on it auto-fires on every `release.published`.
 
-> **New-account gotcha — `tls: handshake failure` on the first seed.** Cloudflare
-> provisions the **per-account TLS certificate for the S3 API endpoint**
-> (`<account_id>.r2.cloudflarestorage.com`) with a delay on **brand-new R2
-> accounts** — often ~20 minutes, sometimes a few hours (Cloudflare-side, see
+> **Resolved for this account (2026-07-31).** The S3 API endpoint's certificate
+> is provisioned and every workflow now talks to it directly over rclone. The
+> note below applies only to a **brand-new Cloudflare account**; nothing here
+> needs doing on the current one.
+>
+> <details>
+> <summary><b>New-account gotcha — <code>tls: handshake failure</code> on the first seed</b></summary>
+>
+> Cloudflare provisions the **per-account TLS certificate for the S3 API
+> endpoint** (`<account_id>.r2.cloudflarestorage.com`) with a delay on brand-new
+> R2 accounts — often ~20 minutes, sometimes a few hours (Cloudflare-side, see
 > cloudflare/cloudflare-docs#6252). Until it lands, rclone/aws-cli/curl all fail
 > at the TLS handshake (`alert 40`, no peer certificate) **even though the
 > account id, keys, bucket, and custom domain are all correct** — the custom
 > domain works immediately because it uses a different (Universal SSL) cert
-> path. This is not a misconfiguration: **wait and re-run the seed.** A quick way
-> to check readiness from a clean network: `curl -sS -o /dev/null -w '%{http_code}\n'
-> https://<account_id>.r2.cloudflarestorage.com/` — once it returns an HTTP status
-> (e.g. 400) instead of an SSL error, the endpoint is ready.
+> path. This is not a misconfiguration: **wait and re-run the seed.** Readiness
+> check: `curl -sS -o /dev/null -w '%{http_code}\n'
+> https://<account_id>.r2.cloudflarestorage.com/` — an HTTP status (e.g. 400)
+> instead of an SSL error means the endpoint is ready.
 >
-> **Can't wait? Seed via the Wrangler bridge.** The workflow accepts a
-> `via` input: `gh workflow run update-linux-repo.yml -f tag=vX.Y.Z -f via=wrangler`.
-> This uploads the built tree through the **Cloudflare API** (`api.cloudflare.com`,
-> which has a valid cert) with `wrangler r2 object put` instead of the S3
-> endpoint, bypassing the unprovisioned cert entirely. It is **seed-only** (a
-> fresh/empty bucket, no pull) and needs a `CLOUDFLARE_API_TOKEN` secret — an API
-> token with **Account → Workers R2 Storage → Edit**. Once the S3-endpoint cert
-> provisions, drop the flag; normal releases go back to the default rclone path
-> (which does the efficient incremental pull+push the bridge can't).
+> **Can't wait? Seed via the Wrangler bridge.** `gh workflow run
+> update-linux-repo.yml -f tag=vX.Y.Z -f via=wrangler` uploads the built tree
+> through the **Cloudflare API** (`api.cloudflare.com`, which has a valid cert)
+> with `wrangler r2 object put` instead of the S3 endpoint. It is **seed-only**
+> (fresh/empty bucket, no pull) and needs a `CLOUDFLARE_API_TOKEN` secret — an
+> API token with **Account → Workers R2 Storage → Edit**. Once the cert
+> provisions, drop the flag; normal releases use the default rclone path, which
+> does the incremental pull+push the bridge can't.
+>
+> The bridge is kept as a standby for that scenario. **A new bucket in the
+> existing account does not need it** — the certificate is per-account, not
+> per-bucket. `CLOUDFLARE_API_TOKEN` is currently unused; it can be deleted and
+> re-created if the bridge is ever needed again.
+> </details>
 
 ### Signing key info
 


### PR DESCRIPTION
## 背景

`linux-repo/README.md` 正文里有一整段讲 R2 的 S3 API 端点证书未签发导致 `tls: handshake failure`，以及绕过用的 `via=wrangler` 桥。写在正文里读起来像**当前仍然存在的问题**，会让人以为还得等证书、或者还得走那个桥。

## 现状：已解决

```
$ curl -sS -o /dev/null -w '%{http_code}\n' https://<account_id>.r2.cloudflarestorage.com/
400

subject: CN=<account_id>.r2.cloudflarestorage.com
issuer:  C=US; O=Google Trust Services; CN=WE1
expire:  Oct 20 03:34:37 2026 GMT
```

按 README 自己给的判据（返回 HTTP 状态而非 SSL 错误）就是就绪。而且今天镜像与 Linux 源的全部 workflow 都是 rclone 直连该端点跑的，上传、force 重传、校验全部正常。

## 改动

- 段首点明「Resolved for this account (2026-07-31)」，正文收进 `<details>` 折叠块，只对**全新 Cloudflare 账户**适用
- 补两条容易误解的：
  - **现有账户里新建桶不需要这个桥** —— 证书是按账户签发不是按桶
  - **`CLOUDFLARE_API_TOKEN` 目前完全不用**，可以删掉、需要时重建

## 保留的

`via=wrangler` 桥的代码不动。它是惰性的、不占运行成本，且真换 Cloudflare 账户时仍然是唯一的绕法。