### PR TITLE
🦭 fix(chat): harden session stop lifecycle

### DIFF
--- a/crates/ha-core/src/acp/agent.rs
+++ b/crates/ha-core/src/acp/agent.rs
@@ -3,8 +3,10 @@
 //! Implements all ACP Agent interface methods by translating between
 //! ACP protocol and the existing Hope Agent AssistantAgent + SessionDB.
 
+use std::collections::{HashMap, HashSet};
+use std::io::BufRead;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{mpsc, Arc, Mutex, MutexGuard};
 
 use anyhow::Result;
 use serde_json::Value;
@@ -22,6 +24,306 @@ use crate::turn_durability::{FlushReason, TurnDurabilitySink};
 
 /// ACP protocol version we advertise
 const ACP_PROTOCOL_VERSION: &str = "0.2";
+const ACP_CANCEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(25);
+const ACP_CANCEL_COOPERATIVE_GRACE: std::time::Duration = std::time::Duration::from_secs(6);
+const ACP_INBOUND_QUEUE_CAPACITY: usize = 256;
+
+type AcpCancelStates = Arc<Mutex<HashMap<String, Arc<AcpCancelState>>>>;
+
+struct AcpCancelState {
+    inner: Mutex<AcpCancelStateInner>,
+}
+
+struct AcpCancelStateInner {
+    internal_session_id: Option<String>,
+    cancel: Arc<AtomicBool>,
+    armed: bool,
+    cleanup_started: bool,
+}
+
+impl AcpCancelState {
+    fn new(internal_session_id: Option<String>, cancel: Arc<AtomicBool>) -> Self {
+        Self {
+            inner: Mutex::new(AcpCancelStateInner {
+                internal_session_id,
+                cancel,
+                armed: false,
+                cleanup_started: false,
+            }),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, AcpCancelStateInner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Arm a fresh, turn-owned token before the prompt is handed to the
+    /// synchronous request dispatcher. Keeping tokens per turn prevents a
+    /// late old future from being revived when the next prompt starts.
+    fn prepare_prompt(&self) -> Arc<AtomicBool> {
+        let mut inner = self.lock();
+        if !inner.armed {
+            inner.cancel = Arc::new(AtomicBool::new(false));
+            inner.armed = true;
+            inner.cleanup_started = false;
+        }
+        inner.cancel.clone()
+    }
+
+    fn attach(&self, internal_session_id: String) -> Option<String> {
+        let mut inner = self.lock();
+        inner.internal_session_id = Some(internal_session_id.clone());
+        let should_start_cleanup =
+            inner.armed && inner.cancel.load(Ordering::Acquire) && !inner.cleanup_started;
+        if should_start_cleanup {
+            inner.cleanup_started = true;
+            Some(internal_session_id)
+        } else {
+            None
+        }
+    }
+
+    fn request_cancel(&self) -> Option<String> {
+        let mut inner = self.lock();
+        if !inner.armed {
+            return None;
+        }
+        inner.cancel.store(true, Ordering::SeqCst);
+        if inner.cleanup_started {
+            return None;
+        }
+        let internal_session_id = inner.internal_session_id.clone()?;
+        inner.cleanup_started = true;
+        Some(internal_session_id)
+    }
+
+    fn finish_prompt(&self) {
+        let mut inner = self.lock();
+        inner.armed = false;
+        inner.cleanup_started = false;
+        // Deliberately retain the old token and its value. A cancellation-
+        // unaware future may still be unwinding after the ACP response; only
+        // prepare_prompt installs a distinct token for the next turn.
+    }
+
+    /// Linearization point between a natural/error completion and a Stop.
+    /// Once completion claims the state, a later notification belongs after
+    /// this prompt and must not rewrite its terminal result.
+    fn claim_non_cancelled_completion(&self) -> bool {
+        let mut inner = self.lock();
+        if inner.cancel.load(Ordering::Acquire) {
+            return false;
+        }
+        inner.armed = false;
+        inner.cleanup_started = false;
+        true
+    }
+
+    fn force_cancel(&self) -> Option<String> {
+        let mut inner = self.lock();
+        inner.cancel.store(true, Ordering::SeqCst);
+        if inner.cleanup_started {
+            return None;
+        }
+        let internal_session_id = inner.internal_session_id.clone()?;
+        inner.cleanup_started = true;
+        Some(internal_session_id)
+    }
+}
+
+struct AcpPromptStateGuard {
+    state: Arc<AcpCancelState>,
+}
+
+impl Drop for AcpPromptStateGuard {
+    fn drop(&mut self) {
+        self.state.finish_prompt();
+    }
+}
+
+enum AcpInbound {
+    Message(JsonRpcMessage),
+    ParseError(String),
+    IoError(String),
+    Eof,
+}
+
+fn lock_cancel_states(
+    states: &AcpCancelStates,
+) -> MutexGuard<'_, HashMap<String, Arc<AcpCancelState>>> {
+    states
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn observe_acp_control_message(msg: &JsonRpcMessage, states: &AcpCancelStates) -> Option<String> {
+    let method = msg.method.as_deref()?;
+    let session_id = msg
+        .params
+        .as_ref()
+        .and_then(|params| params.get("sessionId"))
+        .and_then(Value::as_str)?;
+    match method {
+        "session/prompt" => {
+            if let Some(state) = lock_cancel_states(states).get(session_id).cloned() {
+                state.prepare_prompt();
+            }
+            None
+        }
+        "session/cancel" => lock_cancel_states(states)
+            .get(session_id)
+            .cloned()
+            .and_then(|state| state.request_cancel()),
+        _ => None,
+    }
+}
+
+fn spawn_acp_stop_cleanup(db: Arc<SessionDB>, internal_session_id: String) {
+    let session_for_log = internal_session_id.clone();
+    if let Err(error) = std::thread::Builder::new()
+        .name("ha-acp-stop".to_string())
+        .spawn(move || {
+            let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            else {
+                crate::app_warn!(
+                    "acp",
+                    "stop",
+                    "failed to create ACP Stop cleanup runtime for session {}",
+                    internal_session_id
+                );
+                return;
+            };
+            let _ = runtime.block_on(crate::chat_engine::stop::stop_session(
+                db,
+                &internal_session_id,
+                None,
+                true,
+            ));
+        })
+    {
+        crate::app_warn!(
+            "acp",
+            "stop",
+            "failed to start ACP Stop cleanup thread for session {}: {}",
+            session_for_log,
+            error
+        );
+    }
+}
+
+async fn wait_for_acp_cancel(cancel: Arc<AtomicBool>) {
+    while !cancel.load(Ordering::Acquire) {
+        tokio::time::sleep(ACP_CANCEL_POLL_INTERVAL).await;
+    }
+}
+
+fn finalize_acp_user_stop(
+    runtime: &tokio::runtime::Runtime,
+    db: &Arc<SessionDB>,
+    durability: &Arc<crate::chat_engine::durability::StreamCoordinator>,
+    session_id: &str,
+) -> Result<()> {
+    let durable_seq = match runtime.block_on(durability.flush(FlushReason::Stop)) {
+        Ok(seq) => seq,
+        Err(error) => {
+            crate::app_warn!(
+                "acp",
+                "stop",
+                "failed to flush stopped ACP turn for session {}: {}",
+                session_id,
+                error
+            );
+            durability.snapshot().durable_seq
+        }
+    };
+    if let Err(error) = runtime.block_on(durability.reconcile_spool_to_sqlite()) {
+        crate::app_warn!(
+            "acp",
+            "stop",
+            "failed to reconcile stopped ACP turn for session {}: {}",
+            session_id,
+            error
+        );
+    }
+
+    let (attempt_no, final_seq, visible_events, provider_kind) = if durability.is_persistent() {
+        let snapshot = db
+            .stream_run_snapshot(durability.persistence_run_id())?
+            .ok_or_else(|| anyhow::anyhow!("ACP persistence run disappeared during Stop"))?;
+        let (attempt_no, final_seq, events, _) =
+            session::select_recoverable_attempt_prefix(&snapshot);
+        let provider_kind = snapshot
+            .attempts
+            .iter()
+            .find(|attempt| attempt.attempt_no == attempt_no)
+            .and_then(|attempt| attempt.provider_shape.as_deref())
+            .or(snapshot.run.provider_shape.as_deref())
+            .and_then(crate::chat_engine::finalize::ProviderApiKind::from_shape);
+        (attempt_no, final_seq, events, provider_kind)
+    } else {
+        let snapshot = durability.snapshot();
+        (
+            durability.current_attempt_no(),
+            durable_seq,
+            snapshot.events,
+            durability
+                .current_provider_shape()
+                .as_deref()
+                .and_then(crate::chat_engine::finalize::ProviderApiKind::from_shape),
+        )
+    };
+    let trailing = session::trailing_text_from_journal_events(&visible_events);
+    let (stored_context, context_checkpoint_seq, context_revision) = if durability.is_persistent() {
+        db.recovery_context_for_prefix(durability.persistence_run_id(), attempt_no, final_seq)?
+    } else {
+        let (context, revision) = db
+            .load_context_with_revision(session_id)
+            .unwrap_or((None, durability.context_revision()));
+        (context, 0, revision)
+    };
+    let mut history: Vec<serde_json::Value> = stored_context
+        .as_deref()
+        .and_then(|json| serde_json::from_str(json).ok())
+        .unwrap_or_default();
+    crate::chat_engine::finalize::rebuild::append_journal_suffix_to_history(
+        &mut history,
+        &visible_events,
+        context_checkpoint_seq,
+        provider_kind,
+    )?;
+    history.push(serde_json::json!({
+        "role": "assistant",
+        "content": crate::chat_engine::finalize::copy::model_marker(
+            &crate::chat_engine::finalize::TerminationReason::UserStop,
+        ),
+    }));
+    let assistant = session::journal_events_have_assistant_output(&visible_events).then(|| {
+        session::NewMessage::assistant(&trailing).with_source(crate::chat_engine::ChatSource::Acp)
+    });
+    let commit = session::CommitInterruptedTurn {
+        run_id: durability
+            .is_persistent()
+            .then(|| durability.persistence_run_id().to_string()),
+        attempt_no,
+        session_id: session_id.to_string(),
+        assistant,
+        context_json: serde_json::to_string(&history)?,
+        expected_context_revision: context_revision,
+        turn_id: None,
+        final_seq,
+        status: session::ChatTurnStatus::Interrupted,
+        interrupt_reason: Some("user_stop".to_string()),
+        error: None,
+        recovery_event: None,
+    };
+    db.commit_interrupted_turn(&commit)?;
+    durability.mark_interrupted("interrupted");
+    Ok(())
+}
 
 /// ACP's live transport is fed by the coordinator's post-durability output
 /// hook. Writing from the model callback would expose bytes before the journal
@@ -55,6 +357,7 @@ pub struct AcpAgent {
     pub verbose: bool,
     /// Default agent ID (from CLI flag)
     pub default_agent_id: String,
+    cancel_states: AcpCancelStates,
 }
 
 fn persist_acp_ide_context(db: &Arc<SessionDB>, session_id: &str, meta: &Option<Value>) {
@@ -98,15 +401,171 @@ impl AcpAgent {
             initialized: false,
             verbose,
             default_agent_id,
+            cancel_states: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    fn reconcile_cancel_states(&self) {
+        let live: Vec<(String, String, Arc<AtomicBool>)> = self
+            .sessions
+            .list()
+            .into_iter()
+            .map(|session| {
+                (
+                    session.session_id.clone(),
+                    session.internal_session_id.clone(),
+                    session.cancel.clone(),
+                )
+            })
+            .collect();
+        let live_ids: HashSet<String> = live
+            .iter()
+            .map(|(session_id, _, _)| session_id.clone())
+            .collect();
+        let mut cleanup_sessions = Vec::new();
+        {
+            let mut states = lock_cancel_states(&self.cancel_states);
+            states.retain(|session_id, _| live_ids.contains(session_id));
+            for (session_id, internal_session_id, cancel) in live {
+                let state = states
+                    .entry(session_id)
+                    .or_insert_with(|| {
+                        Arc::new(AcpCancelState::new(
+                            Some(internal_session_id.clone()),
+                            cancel,
+                        ))
+                    })
+                    .clone();
+                if let Some(session_id) = state.attach(internal_session_id) {
+                    cleanup_sessions.push(session_id);
+                }
+            }
+        }
+        for session_id in cleanup_sessions {
+            spawn_acp_stop_cleanup(self.session_db.clone(), session_id);
+        }
+    }
+
+    fn cancel_state(&self, session_id: &str) -> Option<Arc<AcpCancelState>> {
+        lock_cancel_states(&self.cancel_states)
+            .get(session_id)
+            .cloned()
     }
 
     /// Main loop: read messages from stdin, dispatch, respond
     pub fn run(&mut self) -> Result<()> {
+        // Prompt handling is intentionally synchronous, but cancellation is a
+        // notification on the same stdin stream. A dedicated reader must arm
+        // and flip the turn token before queueing messages, otherwise the main
+        // loop cannot even observe `session/cancel` until the prompt finishes.
+        // Ordinary JSON-RPC work is bounded so a client cannot buffer an
+        // unbounded number of requests behind one synchronous model prompt.
+        // `session/cancel` never enters this queue: the reader handles it on
+        // the control path below, so backpressure cannot starve Stop.
+        let (inbound_tx, inbound_rx) = mpsc::sync_channel(ACP_INBOUND_QUEUE_CAPACITY);
+        let inbound_overloaded = Arc::new(AtomicBool::new(false));
+        let overloaded_for_reader = inbound_overloaded.clone();
+        let cancel_states = self.cancel_states.clone();
+        let db = self.session_db.clone();
+        std::thread::Builder::new()
+            .name("ha-acp-input".to_string())
+            .spawn(move || {
+                let stdin = std::io::stdin();
+                let mut reader = std::io::BufReader::new(stdin);
+                let mut line = String::new();
+                loop {
+                    line.clear();
+                    match reader.read_line(&mut line) {
+                        Ok(0) => {
+                            let _ = inbound_tx.try_send(AcpInbound::Eof);
+                            return;
+                        }
+                        Ok(_) if line.trim().is_empty() => continue,
+                        Ok(_) => match serde_json::from_str::<JsonRpcMessage>(line.trim()) {
+                            Ok(msg) => {
+                                if msg.method.as_deref() == Some("session/cancel") {
+                                    if let Some(session_id) =
+                                        observe_acp_control_message(&msg, &cancel_states)
+                                    {
+                                        spawn_acp_stop_cleanup(db.clone(), session_id);
+                                    }
+                                    // Cancellation is a notification and has
+                                    // no response; its complete behavior ran on
+                                    // the out-of-band path above.
+                                    continue;
+                                }
+                                if overloaded_for_reader.load(Ordering::Acquire) {
+                                    continue;
+                                }
+                                let prompt_session_id = (msg.method.as_deref()
+                                    == Some("session/prompt"))
+                                .then(|| {
+                                    msg.params
+                                        .as_ref()
+                                        .and_then(|params| params.get("sessionId"))
+                                        .and_then(Value::as_str)
+                                        .map(str::to_string)
+                                })
+                                .flatten();
+                                match inbound_tx.try_send(AcpInbound::Message(msg)) {
+                                    Ok(()) => {
+                                        if let Some(session_id) = prompt_session_id.as_deref() {
+                                            if let Some(state) = lock_cancel_states(&cancel_states)
+                                                .get(session_id)
+                                                .cloned()
+                                            {
+                                                state.prepare_prompt();
+                                            }
+                                        }
+                                    }
+                                    Err(mpsc::TrySendError::Full(_)) => {
+                                        overloaded_for_reader.store(true, Ordering::Release);
+                                    }
+                                    Err(mpsc::TrySendError::Disconnected(_)) => return,
+                                }
+                            }
+                            Err(error) => {
+                                if overloaded_for_reader.load(Ordering::Acquire) {
+                                    continue;
+                                }
+                                match inbound_tx.try_send(AcpInbound::ParseError(error.to_string()))
+                                {
+                                    Ok(()) => {}
+                                    Err(mpsc::TrySendError::Full(_)) => {
+                                        overloaded_for_reader.store(true, Ordering::Release);
+                                    }
+                                    Err(mpsc::TrySendError::Disconnected(_)) => return,
+                                }
+                            }
+                        },
+                        Err(error) => {
+                            let _ = inbound_tx.try_send(AcpInbound::IoError(error.to_string()));
+                            return;
+                        }
+                    }
+                }
+            })?;
+
         loop {
-            let msg = match self.transport.read_message()? {
-                Some(m) => m,
-                None => {
+            if inbound_overloaded.load(Ordering::Acquire) {
+                anyhow::bail!(
+                    "ACP inbound queue exceeded {} messages; closing connection",
+                    ACP_INBOUND_QUEUE_CAPACITY
+                );
+            }
+            let msg = match inbound_rx.recv() {
+                Ok(AcpInbound::Message(message)) => message,
+                Ok(AcpInbound::ParseError(error)) => {
+                    let response = JsonRpcResponse::error(
+                        Value::Null,
+                        ERROR_PARSE,
+                        format!("Parse error: {error}"),
+                    );
+                    self.transport.write_response(&response)?;
+                    continue;
+                }
+                Ok(AcpInbound::IoError(error)) => anyhow::bail!("ACP stdin read failed: {error}"),
+                Ok(AcpInbound::Eof) | Err(_) => {
                     if self.verbose {
                         eprintln!("[acp] stdin closed, shutting down");
                     }
@@ -290,6 +749,7 @@ impl AcpAgent {
         if let Err(e) = self.sessions.insert(acp_session) {
             return JsonRpcResponse::error(id.clone(), ERROR_INTERNAL, e.to_string());
         }
+        self.reconcile_cancel_states();
 
         let modes = self.build_modes(&agent_id);
         let config_options = self.build_config_options(&agent_id);
@@ -351,6 +811,7 @@ impl AcpAgent {
         if let Err(e) = self.sessions.insert(acp_session) {
             return JsonRpcResponse::error(id.clone(), ERROR_INTERNAL, e.to_string());
         }
+        self.reconcile_cancel_states();
 
         // Replay session history
         self.replay_session_history(&req.session_id);
@@ -372,33 +833,58 @@ impl AcpAgent {
         let req: PromptRequest = match serde_json::from_value(params.clone()) {
             Ok(r) => r,
             Err(e) => {
-                return JsonRpcResponse::error(id.clone(), ERROR_INVALID_PARAMS, e.to_string())
+                if let Some(session_id) = params.get("sessionId").and_then(Value::as_str) {
+                    if let Some(state) = self.cancel_state(session_id) {
+                        state.finish_prompt();
+                    }
+                }
+                return JsonRpcResponse::error(id.clone(), ERROR_INVALID_PARAMS, e.to_string());
             }
         };
 
         let session_id = req.session_id.clone();
 
-        // Validate session
-        {
-            let session = match self.sessions.get_mut(&session_id) {
-                Some(s) => s,
-                None => {
-                    return JsonRpcResponse::error(
-                        id.clone(),
-                        ERROR_INVALID_PARAMS,
-                        "Session not found",
-                    )
-                }
-            };
-            if session.active_prompt {
+        let (internal_session_id, previous_cancel) = match self.sessions.get(&session_id) {
+            Some(session) if session.active_prompt => {
                 return JsonRpcResponse::error(
                     id.clone(),
                     ERROR_INVALID_REQUEST,
                     "A prompt is already active",
-                );
+                )
             }
+            Some(session) => (session.internal_session_id.clone(), session.cancel.clone()),
+            None => {
+                return JsonRpcResponse::error(
+                    id.clone(),
+                    ERROR_INVALID_PARAMS,
+                    "Session not found",
+                )
+            }
+        };
+        let cancel_state = {
+            let mut states = lock_cancel_states(&self.cancel_states);
+            states
+                .entry(session_id.clone())
+                .or_insert_with(|| {
+                    Arc::new(AcpCancelState::new(
+                        Some(internal_session_id),
+                        previous_cancel,
+                    ))
+                })
+                .clone()
+        };
+        let turn_cancel = cancel_state.prepare_prompt();
+        let _prompt_state_guard = AcpPromptStateGuard {
+            state: cancel_state,
+        };
+
+        {
+            let session = self
+                .sessions
+                .get_mut(&session_id)
+                .expect("ACP session was validated before prompt setup");
             session.active_prompt = true;
-            session.cancel.store(false, Ordering::SeqCst);
+            session.cancel = turn_cancel.clone();
         }
         self.sessions.touch(&session_id);
         persist_acp_ide_context(&self.session_db, &session_id, &req.meta);
@@ -431,18 +917,19 @@ impl AcpAgent {
             .enable_all()
             .build()
         {
-            Ok(rt) => match rt.block_on(crate::agent::preflight::user_prompt_preflight(
+            Ok(rt) => match rt.block_on(crate::agent::preflight::user_prompt_preflight_cancellable(
                 crate::agent::preflight::PreflightArgs {
                     session_id: &session_id,
                     agent_id: None,
                     raw_prompt: &text,
                     turn_id: &turn_id,
                 },
+                turn_cancel.as_ref(),
             )) {
-                crate::agent::preflight::PreflightOutcome::Proceed { effective_prompt } => {
+                Some(crate::agent::preflight::PreflightOutcome::Proceed { effective_prompt }) => {
                     effective_prompt
                 }
-                crate::agent::preflight::PreflightOutcome::Block { reason } => {
+                Some(crate::agent::preflight::PreflightOutcome::Block { reason }) => {
                     // A UserPromptSubmit hook blocked the prompt: record a
                     // UI-only event marker (excluded from LLM context), surface
                     // the reason as an agent message, and return without
@@ -473,7 +960,31 @@ impl AcpAgent {
                         serde_json::to_value(&response).unwrap(),
                     );
                 }
+                None => {
+                    if let Some(s) = self.sessions.get_mut(&session_id) {
+                        s.active_prompt = false;
+                    }
+                    let response = PromptResponse {
+                        stop_reason: "cancelled".to_string(),
+                    };
+                    return JsonRpcResponse::success(
+                        id.clone(),
+                        serde_json::to_value(&response).unwrap(),
+                    );
+                }
             },
+            Err(_) if turn_cancel.load(Ordering::Acquire) => {
+                if let Some(s) = self.sessions.get_mut(&session_id) {
+                    s.active_prompt = false;
+                }
+                let response = PromptResponse {
+                    stop_reason: "cancelled".to_string(),
+                };
+                return JsonRpcResponse::success(
+                    id.clone(),
+                    serde_json::to_value(&response).unwrap(),
+                );
+            }
             Err(_) => text.clone(),
         };
 
@@ -536,8 +1047,11 @@ impl AcpAgent {
     // ── session/cancel ──────────────────────────────────────────
 
     fn handle_cancel(&mut self, cancel: &CancelNotification) {
-        if let Some(session) = self.sessions.get_mut(&cancel.session_id) {
-            session.cancel.store(true, Ordering::SeqCst);
+        if let Some(session_id) = self
+            .cancel_state(&cancel.session_id)
+            .and_then(|state| state.request_cancel())
+        {
+            spawn_acp_stop_cleanup(self.session_db.clone(), session_id);
         }
     }
 
@@ -659,10 +1173,14 @@ impl AcpAgent {
             }
         };
 
-        if let Some(session) = self.sessions.get(&req.session_id) {
-            session.cancel.store(true, Ordering::SeqCst);
+        if let Some(session_id) = self
+            .cancel_state(&req.session_id)
+            .and_then(|state| state.force_cancel())
+        {
+            spawn_acp_stop_cleanup(self.session_db.clone(), session_id);
         }
         self.sessions.remove(&req.session_id);
+        self.reconcile_cancel_states();
 
         JsonRpcResponse::success(
             id.clone(),
@@ -780,6 +1298,7 @@ impl AcpAgent {
             Some(s) => s.cancel.clone(),
             None => return Err(anyhow::anyhow!("Session not found")),
         };
+        let cancel_state = self.cancel_state(session_id);
 
         let session_id_owned = session_id.to_string();
         let db_clone = self.session_db.clone();
@@ -834,6 +1353,7 @@ impl AcpAgent {
 
         let mut last_error = String::new();
         let mut stop_all_models = false;
+        let mut cancelled = false;
 
         // Build CompactionProvider once, reuse across retries
         let compaction_provider: Option<
@@ -845,32 +1365,6 @@ impl AcpAgent {
                 crate::agent::build_compaction_provider(&mr, &store.providers, &session_id_owned)
                     .map(|cp| std::sync::Arc::new(cp) as _)
             });
-
-        // SessionStart hook (startup/resume). ACP runs `AssistantAgent::chat`
-        // directly rather than `run_chat_engine`, so the engine's SessionStart
-        // embed never fires here — we invoke the shared observation helper
-        // ourselves. Fired once before the failover loop (`claim_session_start`
-        // only releases once); the resulting additionalContext is re-applied to
-        // each rebuilt agent so it survives retries, mirroring how the engine
-        // threads it through `extra_system_context`.
-        let mut session_start_ctx = rt.block_on(crate::hooks::fire_session_start_observation(
-            &session_id_owned,
-            &agent_id,
-            model_chain
-                .first()
-                .map(|m| m.model_id.as_str())
-                .unwrap_or_default(),
-        ));
-        // Fold in any UserPromptSubmit hook context the preflight chokepoint
-        // stashed for this turn, so the ACP entry injects it identically to
-        // `run_chat_engine`. Drained once; re-applied to each rebuilt agent
-        // below alongside the SessionStart context.
-        if let Some(extra) = crate::hooks::take_user_prompt_context(&session_id_owned) {
-            session_start_ctx = Some(match session_start_ctx.take() {
-                Some(e) => format!("{e}\n\n{extra}"),
-                None => extra,
-            });
-        }
 
         let durability = rt.block_on(crate::chat_engine::durability::StreamCoordinator::create(
             db_clone.clone(),
@@ -884,7 +1378,60 @@ impl AcpAgent {
             cancel.clone(),
         ))?;
 
+        // SessionStart hook (startup/resume). ACP runs `AssistantAgent::chat`
+        // directly rather than `run_chat_engine`, so the engine's SessionStart
+        // embed never fires here — we invoke the shared observation helper
+        // ourselves. Fired once before the failover loop (`claim_session_start`
+        // only releases once); the resulting additionalContext is re-applied to
+        // each rebuilt agent so it survives retries, mirroring how the engine
+        // threads it through `extra_system_context`.
+        let session_start_ctx = rt.block_on(async {
+            tokio::select! {
+                biased;
+                _ = wait_for_acp_cancel(cancel.clone()) => None,
+                context = crate::hooks::fire_session_start_observation(
+                    &session_id_owned,
+                    &agent_id,
+                    model_chain
+                        .first()
+                        .map(|m| m.model_id.as_str())
+                        .unwrap_or_default(),
+                ) => Some(context),
+            }
+        });
+        let mut session_start_ctx = match session_start_ctx {
+            Some(context) => context,
+            None => {
+                if let Err(error) =
+                    finalize_acp_user_stop(&rt, &db_clone, &durability, &session_id_owned)
+                {
+                    crate::app_error!(
+                        "acp",
+                        "stop",
+                        "failed to finalize ACP Stop during session-start hook for {}: {}",
+                        session_id_owned,
+                        error
+                    );
+                }
+                return Ok("cancelled".to_string());
+            }
+        };
+        // Fold in any UserPromptSubmit hook context the preflight chokepoint
+        // stashed for this turn, so the ACP entry injects it identically to
+        // `run_chat_engine`. Drained once; re-applied to each rebuilt agent
+        // below alongside the SessionStart context.
+        if let Some(extra) = crate::hooks::take_user_prompt_context(&session_id_owned) {
+            session_start_ctx = Some(match session_start_ctx.take() {
+                Some(e) => format!("{e}\n\n{extra}"),
+                None => extra,
+            });
+        }
+
         for model_ref in &model_chain {
+            if cancel.load(Ordering::Acquire) {
+                cancelled = true;
+                break;
+            }
             let prov = match provider::find_provider(&store.providers, &model_ref.provider_id) {
                 Some(p) => p,
                 None => continue,
@@ -892,6 +1439,10 @@ impl AcpAgent {
 
             let mut retry_count: u32 = 0;
             loop {
+                if cancel.load(Ordering::Acquire) {
+                    cancelled = true;
+                    break;
+                }
                 let provider_shape = match &prov.api_type {
                     crate::provider::ApiType::Anthropic => "anthropic",
                     crate::provider::ApiType::OpenaiChat => "openai_chat",
@@ -903,14 +1454,26 @@ impl AcpAgent {
                     Some(&model_ref.model_id),
                     Some(provider_shape),
                 ))?;
-                let build_result = rt.block_on(AssistantAgent::try_new_from_provider(
-                    prov,
-                    &model_ref.model_id,
-                ));
+                let build_result = rt.block_on(async {
+                    tokio::select! {
+                        biased;
+                        _ = wait_for_acp_cancel(cancel.clone()) => {
+                            Err(anyhow::anyhow!("ACP prompt cancelled"))
+                        }
+                        result = AssistantAgent::try_new_from_provider(
+                            prov,
+                            &model_ref.model_id,
+                        ) => result,
+                    }
+                });
                 let mut agent = match build_result {
                     Ok(a) => a.with_failover_context(prov),
                     Err(e) => {
                         last_error = e.to_string();
+                        if cancel.load(Ordering::Acquire) {
+                            cancelled = true;
+                            break;
+                        }
                         let reason = failover::classify_error(&last_error);
                         if reason.is_retryable() && retry_count < MAX_RETRIES {
                             retry_count += 1;
@@ -919,9 +1482,17 @@ impl AcpAgent {
                                 RETRY_BASE_MS,
                                 RETRY_MAX_MS,
                             );
-                            rt.block_on(tokio::time::sleep(std::time::Duration::from_millis(
-                                delay,
-                            )));
+                            let completed_delay = rt.block_on(async {
+                                tokio::select! {
+                                    biased;
+                                    _ = wait_for_acp_cancel(cancel.clone()) => false,
+                                    _ = tokio::time::sleep(std::time::Duration::from_millis(delay)) => true,
+                                }
+                            });
+                            if !completed_delay {
+                                cancelled = true;
+                                break;
+                            }
                             continue;
                         }
                         app_warn!(
@@ -958,28 +1529,59 @@ impl AcpAgent {
                 let durability_for_cb = durability.clone();
 
                 let result = rt.block_on(async {
-                    agent
-                        .chat(
-                            &text_owned,
-                            &attachments_owned,
-                            None,
-                            cancel_clone,
-                            move |delta| {
-                                if let Err(error) = durability_for_cb.accept_event(delta) {
-                                    app_error!(
-                                        "acp",
-                                        "stream_durability",
-                                        "failed to accept ACP stream event: {}",
-                                        error
-                                    );
-                                }
-                            },
-                        )
-                        .await
+                    let chat = agent.chat(
+                        &text_owned,
+                        &attachments_owned,
+                        None,
+                        cancel_clone.clone(),
+                        move |delta| {
+                            if let Err(error) = durability_for_cb.accept_event(delta) {
+                                app_error!(
+                                    "acp",
+                                    "stream_durability",
+                                    "failed to accept ACP stream event: {}",
+                                    error
+                                );
+                            }
+                        },
+                    );
+                    tokio::pin!(chat);
+                    tokio::select! {
+                        biased;
+                        _ = wait_for_acp_cancel(cancel_clone) => {
+                            match tokio::time::timeout(
+                                ACP_CANCEL_COOPERATIVE_GRACE,
+                                &mut chat,
+                            ).await {
+                                Ok(result) => result,
+                                Err(_) => Err(anyhow::anyhow!(
+                                    "ACP chat cancellation grace timed out"
+                                )),
+                            }
+                        }
+                        result = &mut chat => result,
+                    }
                 });
 
                 match result {
                     Ok((response, _thinking)) => {
+                        if cancel.load(Ordering::Acquire) {
+                            if let Err(error) = finalize_acp_user_stop(
+                                &rt,
+                                &db_clone,
+                                &durability,
+                                &session_id_owned,
+                            ) {
+                                crate::app_error!(
+                                    "acp",
+                                    "stop",
+                                    "failed to finalize stopped ACP turn for {}: {}",
+                                    session_id_owned,
+                                    error
+                                );
+                            }
+                            return Ok("cancelled".to_string());
+                        }
                         let final_seq = rt.block_on(durability.flush(FlushReason::FinalEnd))?;
                         rt.block_on(durability.reconcile_spool_to_sqlite())?;
                         let trailing = {
@@ -1028,43 +1630,43 @@ impl AcpAgent {
                         usage_event.agent_id = Some(agent_id.clone());
                         let context_json =
                             serde_json::to_string(&agent.get_conversation_history())?;
-                        if cancel.load(Ordering::SeqCst) {
-                            let commit = session::CommitInterruptedTurn {
-                                run_id: durability
-                                    .is_persistent()
-                                    .then(|| durability.persistence_run_id().to_string()),
-                                attempt_no: durability.current_attempt_no(),
-                                session_id: session_id_owned.clone(),
-                                assistant: Some(assistant_msg),
-                                context_json,
-                                expected_context_revision: durability.context_revision(),
-                                turn_id: None,
-                                final_seq,
-                                status: session::ChatTurnStatus::Interrupted,
-                                interrupt_reason: Some("user_stop".to_string()),
-                                error: None,
-                                recovery_event: None,
-                            };
-                            db_clone.commit_interrupted_turn(&commit)?;
-                            durability.mark_interrupted("interrupted");
-                        } else {
-                            let commit = session::CommitAssistantTurn {
-                                run_id: durability
-                                    .is_persistent()
-                                    .then(|| durability.persistence_run_id().to_string()),
-                                attempt_no: durability.current_attempt_no(),
-                                session_id: session_id_owned.clone(),
-                                assistant: assistant_msg,
-                                trailing_placeholder_id: None,
-                                context_json,
-                                expected_context_revision: durability.context_revision(),
-                                turn_id: None,
-                                usage: Some(usage_event),
-                                final_seq,
-                            };
-                            let committed = db_clone.commit_assistant_turn(&commit)?;
-                            durability.mark_committed(committed.committed_seq);
+                        let completion_claimed = cancel_state
+                            .as_ref()
+                            .map(|state| state.claim_non_cancelled_completion())
+                            .unwrap_or_else(|| !cancel.load(Ordering::Acquire));
+                        if !completion_claimed {
+                            if let Err(error) = finalize_acp_user_stop(
+                                &rt,
+                                &db_clone,
+                                &durability,
+                                &session_id_owned,
+                            ) {
+                                crate::app_error!(
+                                    "acp",
+                                    "stop",
+                                    "failed to finalize late ACP Stop for {}: {}",
+                                    session_id_owned,
+                                    error
+                                );
+                            }
+                            return Ok("cancelled".to_string());
                         }
+                        let commit = session::CommitAssistantTurn {
+                            run_id: durability
+                                .is_persistent()
+                                .then(|| durability.persistence_run_id().to_string()),
+                            attempt_no: durability.current_attempt_no(),
+                            session_id: session_id_owned.clone(),
+                            assistant: assistant_msg,
+                            trailing_placeholder_id: None,
+                            context_json,
+                            expected_context_revision: durability.context_revision(),
+                            turn_id: None,
+                            usage: Some(usage_event),
+                            final_seq,
+                        };
+                        let committed = db_clone.commit_assistant_turn(&commit)?;
+                        durability.mark_committed(committed.committed_seq);
                         crate::session_title::maybe_schedule_after_success(
                             db_clone.clone(),
                             session_id_owned.clone(),
@@ -1072,15 +1674,14 @@ impl AcpAgent {
                             model_ref.clone(),
                         );
 
-                        let stop = if cancel.load(Ordering::SeqCst) {
-                            "cancelled"
-                        } else {
-                            "end_turn"
-                        };
-                        return Ok(stop.to_string());
+                        return Ok("end_turn".to_string());
                     }
                     Err(e) => {
                         last_error = e.to_string();
+                        if cancel.load(Ordering::Acquire) {
+                            cancelled = true;
+                            break;
+                        }
                         let reason = failover::classify_error(&last_error);
 
                         if reason.is_terminal() {
@@ -1095,18 +1696,41 @@ impl AcpAgent {
                                 RETRY_BASE_MS,
                                 RETRY_MAX_MS,
                             );
-                            rt.block_on(tokio::time::sleep(std::time::Duration::from_millis(
-                                delay,
-                            )));
+                            let completed_delay = rt.block_on(async {
+                                tokio::select! {
+                                    biased;
+                                    _ = wait_for_acp_cancel(cancel.clone()) => false,
+                                    _ = tokio::time::sleep(std::time::Duration::from_millis(delay)) => true,
+                                }
+                            });
+                            if !completed_delay {
+                                cancelled = true;
+                                break;
+                            }
                             continue;
                         }
                         break;
                     }
                 }
             }
-            if stop_all_models {
+            if stop_all_models || cancelled {
                 break;
             }
+        }
+
+        if cancelled || cancel.load(Ordering::Acquire) {
+            if let Err(error) =
+                finalize_acp_user_stop(&rt, &db_clone, &durability, &session_id_owned)
+            {
+                crate::app_error!(
+                    "acp",
+                    "stop",
+                    "failed to finalize stopped ACP turn for {}: {}",
+                    session_id_owned,
+                    error
+                );
+            }
+            return Ok("cancelled".to_string());
         }
 
         // Converge provider/build failures through the same durable protocol;
@@ -1213,6 +1837,24 @@ impl AcpAgent {
                     .with_source(crate::chat_engine::ChatSource::Acp),
             ),
         };
+        let completion_claimed = cancel_state
+            .as_ref()
+            .map(|state| state.claim_non_cancelled_completion())
+            .unwrap_or_else(|| !cancel.load(Ordering::Acquire));
+        if !completion_claimed {
+            if let Err(error) =
+                finalize_acp_user_stop(&rt, &db_clone, &durability, &session_id_owned)
+            {
+                crate::app_error!(
+                    "acp",
+                    "stop",
+                    "failed to finalize ACP Stop racing terminal failure for {}: {}",
+                    session_id_owned,
+                    error
+                );
+            }
+            return Ok("cancelled".to_string());
+        }
         if let Err(error) = db_clone.commit_interrupted_turn(&commit) {
             app_error!(
                 "acp",
@@ -1368,5 +2010,74 @@ fn restore_agent_context(db: &Arc<SessionDB>, session_id: &str, agent: &Assistan
                 agent.set_conversation_history(history);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inbound(method: &str, session_id: &str) -> JsonRpcMessage {
+        JsonRpcMessage {
+            jsonrpc: "2.0".to_string(),
+            id: (method == "session/prompt").then(|| serde_json::json!(1)),
+            method: Some(method.to_string()),
+            params: Some(serde_json::json!({ "sessionId": session_id })),
+            result: None,
+            error: None,
+        }
+    }
+
+    #[test]
+    fn queued_acp_prompt_observes_cancel_before_dispatch() {
+        let states = Arc::new(Mutex::new(HashMap::new()));
+        let initial = Arc::new(AtomicBool::new(false));
+        let state = Arc::new(AcpCancelState::new(
+            Some("internal-session".to_string()),
+            initial,
+        ));
+        lock_cancel_states(&states).insert("acp-session".to_string(), state.clone());
+
+        assert_eq!(
+            observe_acp_control_message(&inbound("session/prompt", "acp-session"), &states),
+            None
+        );
+        let turn_cancel = state.prepare_prompt();
+        assert!(!turn_cancel.load(Ordering::Acquire));
+        assert_eq!(
+            observe_acp_control_message(&inbound("session/cancel", "acp-session"), &states),
+            Some("internal-session".to_string())
+        );
+        assert!(turn_cancel.load(Ordering::Acquire));
+        assert_eq!(
+            observe_acp_control_message(&inbound("session/cancel", "acp-session"), &states),
+            None,
+            "repeated Stop must not start duplicate cleanup"
+        );
+        assert!(!state.claim_non_cancelled_completion());
+    }
+
+    #[test]
+    fn completed_acp_prompt_ignores_late_cancel_and_next_turn_gets_fresh_token() {
+        let states = Arc::new(Mutex::new(HashMap::new()));
+        let state = Arc::new(AcpCancelState::new(
+            Some("internal-session".to_string()),
+            Arc::new(AtomicBool::new(false)),
+        ));
+        lock_cancel_states(&states).insert("acp-session".to_string(), state.clone());
+
+        observe_acp_control_message(&inbound("session/prompt", "acp-session"), &states);
+        let first = state.prepare_prompt();
+        assert!(state.claim_non_cancelled_completion());
+        assert_eq!(
+            observe_acp_control_message(&inbound("session/cancel", "acp-session"), &states),
+            None
+        );
+        assert!(!first.load(Ordering::Acquire));
+
+        observe_acp_control_message(&inbound("session/prompt", "acp-session"), &states);
+        let second = state.prepare_prompt();
+        assert!(!Arc::ptr_eq(&first, &second));
+        assert!(!second.load(Ordering::Acquire));
     }
 }

--- a/crates/ha-core/src/acp/agent.rs
+++ b/crates/ha-core/src/acp/agent.rs
@@ -65,11 +65,32 @@ impl AcpCancelState {
     fn prepare_prompt(&self) -> Arc<AtomicBool> {
         let mut inner = self.lock();
         if !inner.armed {
-            inner.cancel = Arc::new(AtomicBool::new(false));
-            inner.armed = true;
-            inner.cleanup_started = false;
+            Self::arm_fresh_prompt(&mut inner);
         }
         inner.cancel.clone()
+    }
+
+    fn prepare_prompt_for_enqueue(&self) -> Option<Arc<AtomicBool>> {
+        let mut inner = self.lock();
+        if inner.armed {
+            return None;
+        }
+        Self::arm_fresh_prompt(&mut inner);
+        Some(inner.cancel.clone())
+    }
+
+    fn arm_fresh_prompt(inner: &mut AcpCancelStateInner) {
+        inner.cancel = Arc::new(AtomicBool::new(false));
+        inner.armed = true;
+        inner.cleanup_started = false;
+    }
+
+    fn rollback_prompt_enqueue(&self, prepared_cancel: &Arc<AtomicBool>) {
+        let mut inner = self.lock();
+        if inner.armed && Arc::ptr_eq(&inner.cancel, prepared_cancel) {
+            inner.armed = false;
+            inner.cleanup_started = false;
+        }
     }
 
     fn attach(&self, internal_session_id: String) -> Option<String> {
@@ -140,6 +161,42 @@ struct AcpPromptStateGuard {
 impl Drop for AcpPromptStateGuard {
     fn drop(&mut self) {
         self.state.finish_prompt();
+    }
+}
+
+struct AcpPromptEnqueueGuard {
+    state: Arc<AcpCancelState>,
+    prepared_cancel: Option<Arc<AtomicBool>>,
+}
+
+impl AcpPromptEnqueueGuard {
+    fn prepare(msg: &JsonRpcMessage, states: &AcpCancelStates) -> Option<Self> {
+        if msg.method.as_deref() != Some("session/prompt") {
+            return None;
+        }
+        let session_id = msg
+            .params
+            .as_ref()
+            .and_then(|params| params.get("sessionId"))
+            .and_then(Value::as_str)?;
+        let state = lock_cancel_states(states).get(session_id).cloned()?;
+        let prepared_cancel = state.prepare_prompt_for_enqueue()?;
+        Some(Self {
+            state,
+            prepared_cancel: Some(prepared_cancel),
+        })
+    }
+
+    fn commit(mut self) {
+        self.prepared_cancel = None;
+    }
+}
+
+impl Drop for AcpPromptEnqueueGuard {
+    fn drop(&mut self) {
+        if let Some(prepared_cancel) = self.prepared_cancel.as_ref() {
+            self.state.rollback_prompt_enqueue(prepared_cancel);
+        }
     }
 }
 
@@ -497,25 +554,19 @@ impl AcpAgent {
                                 if overloaded_for_reader.load(Ordering::Acquire) {
                                     continue;
                                 }
-                                let prompt_session_id = (msg.method.as_deref()
-                                    == Some("session/prompt"))
-                                .then(|| {
-                                    msg.params
-                                        .as_ref()
-                                        .and_then(|params| params.get("sessionId"))
-                                        .and_then(Value::as_str)
-                                        .map(str::to_string)
-                                })
-                                .flatten();
+                                // Arm the prompt before publishing it. The
+                                // dispatcher may receive and finish a fast
+                                // prompt before `try_send` returns, so doing
+                                // this after the send can revive a completed
+                                // generation. A failed send drops the guard
+                                // and rolls back only the generation armed by
+                                // this enqueue attempt.
+                                let prompt_enqueue =
+                                    AcpPromptEnqueueGuard::prepare(&msg, &cancel_states);
                                 match inbound_tx.try_send(AcpInbound::Message(msg)) {
                                     Ok(()) => {
-                                        if let Some(session_id) = prompt_session_id.as_deref() {
-                                            if let Some(state) = lock_cancel_states(&cancel_states)
-                                                .get(session_id)
-                                                .cloned()
-                                            {
-                                                state.prepare_prompt();
-                                            }
+                                        if let Some(prompt_enqueue) = prompt_enqueue {
+                                            prompt_enqueue.commit();
                                         }
                                     }
                                     Err(mpsc::TrySendError::Full(_)) => {
@@ -2079,5 +2130,59 @@ mod tests {
         let second = state.prepare_prompt();
         assert!(!Arc::ptr_eq(&first, &second));
         assert!(!second.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn prompt_enqueue_commit_cannot_rearm_a_generation_completed_by_dispatch() {
+        let states = Arc::new(Mutex::new(HashMap::new()));
+        let state = Arc::new(AcpCancelState::new(
+            Some("internal-session".to_string()),
+            Arc::new(AtomicBool::new(false)),
+        ));
+        lock_cancel_states(&states).insert("acp-session".to_string(), state.clone());
+
+        let enqueue =
+            AcpPromptEnqueueGuard::prepare(&inbound("session/prompt", "acp-session"), &states)
+                .expect("prompt must be armed before it is published");
+        let completed = state.prepare_prompt();
+
+        // Model the dispatcher receiving and completing the prompt before
+        // try_send returns to the reader and commits its enqueue guard.
+        assert!(state.claim_non_cancelled_completion());
+        enqueue.commit();
+        assert_eq!(
+            observe_acp_control_message(&inbound("session/cancel", "acp-session"), &states),
+            None,
+            "a late cancel must not target the completed generation"
+        );
+
+        let next = state.prepare_prompt();
+        assert!(!Arc::ptr_eq(&completed, &next));
+        assert!(!next.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn failed_prompt_enqueue_rolls_back_only_its_new_generation() {
+        let states = Arc::new(Mutex::new(HashMap::new()));
+        let state = Arc::new(AcpCancelState::new(
+            Some("internal-session".to_string()),
+            Arc::new(AtomicBool::new(false)),
+        ));
+        lock_cancel_states(&states).insert("acp-session".to_string(), state.clone());
+
+        let failed_enqueue =
+            AcpPromptEnqueueGuard::prepare(&inbound("session/prompt", "acp-session"), &states)
+                .expect("prompt must be armed before enqueue");
+        let rejected = state.prepare_prompt();
+        drop(failed_enqueue);
+        assert_eq!(
+            observe_acp_control_message(&inbound("session/cancel", "acp-session"), &states),
+            None,
+            "a prompt rejected by the inbound queue must not remain cancellable"
+        );
+
+        let next = state.prepare_prompt();
+        assert!(!Arc::ptr_eq(&rejected, &next));
+        assert!(!next.load(Ordering::Acquire));
     }
 }

--- a/crates/ha-core/src/acp/agent.rs
+++ b/crates/ha-core/src/acp/agent.rs
@@ -142,6 +142,18 @@ impl AcpCancelState {
         true
     }
 
+    /// Ordering point between `session/cancel` and durable prompt submission.
+    /// The claim is short and contains no SQLite I/O: cancellation before it
+    /// suppresses persistence, while cancellation after it belongs to a prompt
+    /// that has already been accepted for persistence.
+    fn claim_non_cancelled_persistence(&self) -> bool {
+        let inner = self.lock();
+        if inner.cancel.load(Ordering::Acquire) || !inner.armed {
+            return false;
+        }
+        true
+    }
+
     fn force_cancel(&self) -> Option<String> {
         let mut inner = self.lock();
         inner.cancel.store(true, Ordering::SeqCst);
@@ -965,7 +977,7 @@ impl AcpAgent {
         };
         let turn_cancel = cancel_state.prepare_prompt();
         let _prompt_state_guard = AcpPromptStateGuard {
-            state: cancel_state,
+            state: cancel_state.clone(),
         };
 
         {
@@ -1077,6 +1089,17 @@ impl AcpAgent {
             }
             Err(_) => text.clone(),
         };
+
+        if !cancel_state.claim_non_cancelled_persistence() {
+            crate::hooks::set_user_prompt_context(&session_id, None);
+            if let Some(s) = self.sessions.get_mut(&session_id) {
+                s.active_prompt = false;
+            }
+            let response = PromptResponse {
+                stop_reason: "cancelled".to_string(),
+            };
+            return JsonRpcResponse::success(id.clone(), serde_json::to_value(&response).unwrap());
+        }
 
         // A model turn must never start without its triggering user message
         // being durable. Otherwise a successful assistant commit could leave
@@ -2145,6 +2168,20 @@ mod tests {
             "repeated Stop must not start duplicate cleanup"
         );
         assert!(!state.claim_non_cancelled_completion());
+        assert!(!state.claim_non_cancelled_persistence());
+    }
+
+    #[test]
+    fn acp_persistence_claim_orders_prompt_before_later_cancel() {
+        let state = Arc::new(AcpCancelState::new(
+            Some("internal-session".to_string()),
+            Arc::new(AtomicBool::new(false)),
+        ));
+        let turn_cancel = state.prepare_prompt();
+
+        assert!(state.claim_non_cancelled_persistence());
+        assert_eq!(state.request_cancel(), Some("internal-session".to_string()));
+        assert!(turn_cancel.load(Ordering::Acquire));
     }
 
     #[test]

--- a/crates/ha-core/src/acp/agent.rs
+++ b/crates/ha-core/src/acp/agent.rs
@@ -169,22 +169,35 @@ struct AcpPromptEnqueueGuard {
     prepared_cancel: Option<Arc<AtomicBool>>,
 }
 
+enum AcpPromptEnqueueDecision {
+    NotPrompt,
+    Prepared(AcpPromptEnqueueGuard),
+    RejectActive,
+}
+
 impl AcpPromptEnqueueGuard {
-    fn prepare(msg: &JsonRpcMessage, states: &AcpCancelStates) -> Option<Self> {
-        if msg.method.as_deref() != Some("session/prompt") {
-            return None;
+    fn prepare(msg: &JsonRpcMessage, states: &AcpCancelStates) -> AcpPromptEnqueueDecision {
+        if msg.method.as_deref() != Some("session/prompt") || msg.id.is_none() {
+            return AcpPromptEnqueueDecision::NotPrompt;
         }
-        let session_id = msg
+        let Some(session_id) = msg
             .params
             .as_ref()
             .and_then(|params| params.get("sessionId"))
-            .and_then(Value::as_str)?;
-        let state = lock_cancel_states(states).get(session_id).cloned()?;
-        let prepared_cancel = state.prepare_prompt_for_enqueue()?;
-        Some(Self {
-            state,
-            prepared_cancel: Some(prepared_cancel),
-        })
+            .and_then(Value::as_str)
+        else {
+            return AcpPromptEnqueueDecision::NotPrompt;
+        };
+        let Some(state) = lock_cancel_states(states).get(session_id).cloned() else {
+            return AcpPromptEnqueueDecision::NotPrompt;
+        };
+        match state.prepare_prompt_for_enqueue() {
+            Some(prepared_cancel) => AcpPromptEnqueueDecision::Prepared(AcpPromptEnqueueGuard {
+                state,
+                prepared_cancel: Some(prepared_cancel),
+            }),
+            None => AcpPromptEnqueueDecision::RejectActive,
+        }
     }
 
     fn commit(mut self) {
@@ -202,6 +215,7 @@ impl Drop for AcpPromptEnqueueGuard {
 
 enum AcpInbound {
     Message(JsonRpcMessage),
+    Response(JsonRpcResponse),
     ParseError(String),
     IoError(String),
     Eof,
@@ -562,7 +576,28 @@ impl AcpAgent {
                                 // and rolls back only the generation armed by
                                 // this enqueue attempt.
                                 let prompt_enqueue =
-                                    AcpPromptEnqueueGuard::prepare(&msg, &cancel_states);
+                                    match AcpPromptEnqueueGuard::prepare(&msg, &cancel_states) {
+                                        AcpPromptEnqueueDecision::NotPrompt => None,
+                                        AcpPromptEnqueueDecision::Prepared(guard) => Some(guard),
+                                        AcpPromptEnqueueDecision::RejectActive => {
+                                            let response = JsonRpcResponse::error(
+                                                msg.id.clone().unwrap_or(Value::Null),
+                                                ERROR_INVALID_REQUEST,
+                                                "A prompt is already active",
+                                            );
+                                            match inbound_tx
+                                                .try_send(AcpInbound::Response(response))
+                                            {
+                                                Ok(()) => {}
+                                                Err(mpsc::TrySendError::Full(_)) => {
+                                                    overloaded_for_reader
+                                                        .store(true, Ordering::Release);
+                                                }
+                                                Err(mpsc::TrySendError::Disconnected(_)) => return,
+                                            }
+                                            continue;
+                                        }
+                                    };
                                 match inbound_tx.try_send(AcpInbound::Message(msg)) {
                                     Ok(()) => {
                                         if let Some(prompt_enqueue) = prompt_enqueue {
@@ -606,6 +641,10 @@ impl AcpAgent {
             }
             let msg = match inbound_rx.recv() {
                 Ok(AcpInbound::Message(message)) => message,
+                Ok(AcpInbound::Response(response)) => {
+                    self.transport.write_response(&response)?;
+                    continue;
+                }
                 Ok(AcpInbound::ParseError(error)) => {
                     let response = JsonRpcResponse::error(
                         Value::Null,
@@ -2141,9 +2180,13 @@ mod tests {
         ));
         lock_cancel_states(&states).insert("acp-session".to_string(), state.clone());
 
-        let enqueue =
-            AcpPromptEnqueueGuard::prepare(&inbound("session/prompt", "acp-session"), &states)
-                .expect("prompt must be armed before it is published");
+        let enqueue = match AcpPromptEnqueueGuard::prepare(
+            &inbound("session/prompt", "acp-session"),
+            &states,
+        ) {
+            AcpPromptEnqueueDecision::Prepared(guard) => guard,
+            _ => panic!("prompt must be armed before it is published"),
+        };
         let completed = state.prepare_prompt();
 
         // Model the dispatcher receiving and completing the prompt before
@@ -2170,9 +2213,13 @@ mod tests {
         ));
         lock_cancel_states(&states).insert("acp-session".to_string(), state.clone());
 
-        let failed_enqueue =
-            AcpPromptEnqueueGuard::prepare(&inbound("session/prompt", "acp-session"), &states)
-                .expect("prompt must be armed before enqueue");
+        let failed_enqueue = match AcpPromptEnqueueGuard::prepare(
+            &inbound("session/prompt", "acp-session"),
+            &states,
+        ) {
+            AcpPromptEnqueueDecision::Prepared(guard) => guard,
+            _ => panic!("prompt must be armed before enqueue"),
+        };
         let rejected = state.prepare_prompt();
         drop(failed_enqueue);
         assert_eq!(
@@ -2184,5 +2231,38 @@ mod tests {
         let next = state.prepare_prompt();
         assert!(!Arc::ptr_eq(&rejected, &next));
         assert!(!next.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn concurrent_prompt_is_rejected_before_inbound_queueing() {
+        let states = Arc::new(Mutex::new(HashMap::new()));
+        let state = Arc::new(AcpCancelState::new(
+            Some("internal-session".to_string()),
+            Arc::new(AtomicBool::new(false)),
+        ));
+        lock_cancel_states(&states).insert("acp-session".to_string(), state.clone());
+
+        let first = match AcpPromptEnqueueGuard::prepare(
+            &inbound("session/prompt", "acp-session"),
+            &states,
+        ) {
+            AcpPromptEnqueueDecision::Prepared(guard) => guard,
+            _ => panic!("first prompt must be accepted"),
+        };
+        first.commit();
+
+        assert!(matches!(
+            AcpPromptEnqueueGuard::prepare(&inbound("session/prompt", "acp-session"), &states),
+            AcpPromptEnqueueDecision::RejectActive
+        ));
+        let first_cancel = state.prepare_prompt();
+        assert_eq!(state.request_cancel(), Some("internal-session".to_string()));
+        assert!(first_cancel.load(Ordering::Acquire));
+
+        state.finish_prompt();
+        assert!(matches!(
+            AcpPromptEnqueueGuard::prepare(&inbound("session/prompt", "acp-session"), &states),
+            AcpPromptEnqueueDecision::Prepared(_)
+        ));
     }
 }

--- a/crates/ha-core/src/acp/agent.rs
+++ b/crates/ha-core/src/acp/agent.rs
@@ -475,6 +475,10 @@ fn persist_acp_ide_context(db: &Arc<SessionDB>, session_id: &str, meta: &Option<
     }
 }
 
+fn acp_prompt_blocked_by_stop_cleanup(internal_session_id: &str) -> bool {
+    crate::chat_engine::active_turn::stop_cleanup_active(internal_session_id)
+}
+
 impl AcpAgent {
     pub fn new(session_db: Arc<SessionDB>, default_agent_id: String, verbose: bool) -> Self {
         Self {
@@ -963,6 +967,24 @@ impl AcpAgent {
                 )
             }
         };
+        if acp_prompt_blocked_by_stop_cleanup(&internal_session_id) {
+            // The stdin reader armed this generation before enqueueing it.
+            // Disarm it here so a prompt rejected by a late runtime snapshot
+            // cannot make the next legitimate prompt look concurrently active.
+            if let Some(state) = self.cancel_state(&session_id) {
+                state.finish_prompt();
+            }
+            crate::app_info!(
+                "acp",
+                "stop_gate",
+                "Rejected replacement ACP prompt while Stop cleanup is active: session={}",
+                internal_session_id
+            );
+            let response = PromptResponse {
+                stop_reason: "cancelled".to_string(),
+            };
+            return JsonRpcResponse::success(id.clone(), serde_json::to_value(&response).unwrap());
+        }
         let cancel_state = {
             let mut states = lock_cancel_states(&self.cancel_states);
             states
@@ -2182,6 +2204,15 @@ mod tests {
         assert!(state.claim_non_cancelled_persistence());
         assert_eq!(state.request_cancel(), Some("internal-session".to_string()));
         assert!(turn_cancel.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn replacement_acp_prompt_observes_deferred_stop_gate() {
+        let session_id = format!("acp-deferred-stop-{}", uuid::Uuid::new_v4());
+        let gate = crate::chat_engine::active_turn::begin_stop_cleanup(&session_id);
+
+        assert!(acp_prompt_blocked_by_stop_cleanup(&session_id));
+        drop(gate);
     }
 
     #[test]

--- a/crates/ha-core/src/agent/preflight.rs
+++ b/crates/ha-core/src/agent/preflight.rs
@@ -10,6 +10,11 @@
 //! place — the call sites only branch on `Block`.
 
 use crate::hooks::HookDecision;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Stable error marker used by transport shells when an explicitly stopped
+/// turn is cancelled before its user message has been persisted.
+pub const CHAT_CANCELLED_DURING_PREFLIGHT_CODE: &str = "chat_cancelled_during_preflight";
 
 /// What an entry point should do after preflight.
 #[derive(Debug, Clone)]
@@ -92,9 +97,40 @@ pub async fn user_prompt_preflight(args: PreflightArgs<'_>) -> PreflightOutcome 
     }
 }
 
+/// Cancellation-aware wrapper for foreground chat entry points.
+///
+/// `UserPromptSubmit` handlers can legitimately wait on a command, network
+/// request, model, or sub-agent. The active-turn cancel flag is acquired
+/// before preflight, so Stop must be able to drop that work instead of waiting
+/// for the handler's potentially minutes-long timeout. `None` means the caller
+/// must not persist or execute the prompt.
+pub async fn user_prompt_preflight_cancellable(
+    args: PreflightArgs<'_>,
+    cancel: &AtomicBool,
+) -> Option<PreflightOutcome> {
+    if cancel.load(Ordering::Acquire) {
+        crate::hooks::set_user_prompt_context(args.session_id, None);
+        return None;
+    }
+
+    tokio::select! {
+        biased;
+        _ = async {
+            while !cancel.load(Ordering::Acquire) {
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+        } => {
+            crate::hooks::set_user_prompt_context(args.session_id, None);
+            None
+        }
+        outcome = user_prompt_preflight(args) => Some(outcome),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicBool;
 
     #[tokio::test]
     async fn pass_through_returns_input_unchanged() {
@@ -114,5 +150,23 @@ mod tests {
         }
         // No context configured → slot cleared.
         assert!(crate::hooks::take_user_prompt_context("preflight-test-s1").is_none());
+    }
+
+    #[tokio::test]
+    async fn cancelled_preflight_never_proceeds() {
+        let cancel = AtomicBool::new(true);
+        let out = user_prompt_preflight_cancellable(
+            PreflightArgs {
+                session_id: "preflight-cancelled-s1",
+                agent_id: None,
+                raw_prompt: "must not persist",
+                turn_id: "preflight-cancelled-turn-1",
+            },
+            &cancel,
+        )
+        .await;
+
+        assert!(out.is_none());
+        assert!(crate::hooks::take_user_prompt_context("preflight-cancelled-s1").is_none());
     }
 }

--- a/crates/ha-core/src/agent/preflight.rs
+++ b/crates/ha-core/src/agent/preflight.rs
@@ -108,7 +108,7 @@ pub async fn user_prompt_preflight_cancellable(
     args: PreflightArgs<'_>,
     cancel: &AtomicBool,
 ) -> Option<PreflightOutcome> {
-    if cancel.load(Ordering::Acquire) {
+    if cancel.load(Ordering::SeqCst) {
         crate::hooks::set_user_prompt_context(args.session_id, None);
         return None;
     }
@@ -116,14 +116,32 @@ pub async fn user_prompt_preflight_cancellable(
     tokio::select! {
         biased;
         _ = async {
-            while !cancel.load(Ordering::Acquire) {
+            while !cancel.load(Ordering::SeqCst) {
                 tokio::time::sleep(std::time::Duration::from_millis(25)).await;
             }
         } => {
             crate::hooks::set_user_prompt_context(args.session_id, None);
             None
         }
-        outcome = user_prompt_preflight(args) => Some(outcome),
+        outcome = user_prompt_preflight(args) => {
+            finish_cancellable_preflight(args.session_id, cancel, outcome)
+        },
+    }
+}
+
+/// Close the final race between the cancellation poll and hook completion.
+/// `user_prompt_preflight` may already have stashed additional context, so a
+/// late Stop must also clear that slot before the shell can persist the prompt.
+fn finish_cancellable_preflight(
+    session_id: &str,
+    cancel: &AtomicBool,
+    outcome: PreflightOutcome,
+) -> Option<PreflightOutcome> {
+    if cancel.load(Ordering::SeqCst) {
+        crate::hooks::set_user_prompt_context(session_id, None);
+        None
+    } else {
+        Some(outcome)
     }
 }
 
@@ -168,5 +186,23 @@ mod tests {
 
         assert!(out.is_none());
         assert!(crate::hooks::take_user_prompt_context("preflight-cancelled-s1").is_none());
+    }
+
+    #[test]
+    fn cancellation_after_hook_completion_discards_outcome_and_context() {
+        let session_id = "preflight-cancelled-after-hook-s1";
+        crate::hooks::set_user_prompt_context(session_id, Some("hook context".into()));
+        let cancel = AtomicBool::new(true);
+
+        let out = finish_cancellable_preflight(
+            session_id,
+            &cancel,
+            PreflightOutcome::Proceed {
+                effective_prompt: "must not persist".into(),
+            },
+        );
+
+        assert!(out.is_none());
+        assert!(crate::hooks::take_user_prompt_context(session_id).is_none());
     }
 }

--- a/crates/ha-core/src/agent/streaming_loop.rs
+++ b/crates/ha-core/src/agent/streaming_loop.rs
@@ -531,6 +531,23 @@ async fn execute_tool_with_cancel(
     let cancellation_token = tokio_util::sync::CancellationToken::new();
     local_ctx.cancellation_token = Some(cancellation_token.clone());
     let tool_start = std::time::Instant::now();
+    // A concurrent-safe batch can leave calls waiting on its semaphore while
+    // earlier tools wind down.  Re-check before constructing/polling dispatch
+    // so those queued calls cannot begin side effects after the user pressed
+    // Stop.
+    if cancel.load(Ordering::SeqCst) {
+        let rendered = tools::ToolRejection::cancelled(name).to_tool_result();
+        crate::eval_context::record_tool_result_with_digest(
+            ctx.session_id.as_deref(),
+            name,
+            call_id,
+            &eval_tool_arguments_digest(args),
+            Some(&eval_tool_result_digest(&rendered)),
+            crate::eval_context::EvalToolOutcome::Cancelled,
+            0,
+        );
+        return Ok((rendered, 0, Default::default()));
+    }
     if let Err(error) = crate::eval_context::ensure_tool_budget(ctx.session_id.as_deref()) {
         let elapsed_ms = tool_start.elapsed().as_millis() as u64;
         let rendered = tools::ToolRejection::render_error(&error);
@@ -575,6 +592,38 @@ async fn execute_tool_with_cancel(
     let result = loop {
         tokio::select! {
             biased;
+            _ = wait_for_cancel(&cancel_clone) => {
+                cancellation_token.cancel();
+                // Grace window: let the dispatch wind down. If the user approved a
+                // background-capable tool (exec / web_search / …) inside this
+                // window, the dispatch returns a synthetic `{job_id,status:"started"}`
+                // and has ALREADY detached a runner with its own fresh cancel token —
+                // the turn cancel never reaches it, so the job would run on as an
+                // orphan while the model is told "cancelled" (MISC-2). Capture that
+                // result and cancel the freshly-spawned job so the verdict stays
+                // truthful. (Sync inline tools that don't finish in time are dropped
+                // here as before; their exec process group is reaped by
+                // `ProcessGroupGuard::drop`.)
+                if let Ok(Ok(grace_result)) =
+                    tokio::time::timeout(TOOL_CANCEL_CLEANUP_GRACE, &mut dispatch).await
+                {
+                    if let Some(job_id) = extract_started_job_id(&grace_result) {
+                        app_info!(
+                            "async_jobs",
+                            "cancel",
+                            "Reaping job {} spawned by tool '{}' inside the turn-cancel grace window",
+                            job_id,
+                            name
+                        );
+                        let _ = crate::blocking::run_blocking(move || {
+                            crate::async_jobs::JobManager::cancel(&job_id)
+                        })
+                        .await;
+                    }
+                }
+                eval_outcome = crate::eval_context::EvalToolOutcome::Cancelled;
+                break tools::ToolRejection::cancelled(name).to_tool_result();
+            }
             update = effective_args_sink.next() => {
                 let patched = update.value.to_string();
                 emit_tool_call_args_rewritten(on_delta, call_id, &patched);
@@ -606,40 +655,6 @@ async fn execute_tool_with_cancel(
                         tools::ToolRejection::render_error(&e)
                     }
                 };
-            }
-            _ = async {
-                loop {
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                    if cancel_clone.load(Ordering::SeqCst) { break; }
-                }
-            } => {
-                cancellation_token.cancel();
-                // Grace window: let the dispatch wind down. If the user approved a
-                // background-capable tool (exec / web_search / …) inside this
-                // window, the dispatch returns a synthetic `{job_id,status:"started"}`
-                // and has ALREADY detached a runner with its own fresh cancel token —
-                // the turn cancel never reaches it, so the job would run on as an
-                // orphan while the model is told "cancelled" (MISC-2). Capture that
-                // result and cancel the freshly-spawned job so the verdict stays
-                // truthful. (Sync inline tools that don't finish in time are dropped
-                // here as before; their exec process group is reaped by
-                // `ProcessGroupGuard::drop`.)
-                if let Ok(Ok(grace_result)) =
-                    tokio::time::timeout(TOOL_CANCEL_CLEANUP_GRACE, &mut dispatch).await
-                {
-                    if let Some(job_id) = extract_started_job_id(&grace_result) {
-                        app_info!(
-                            "async_jobs",
-                            "cancel",
-                            "Reaping job {} spawned by tool '{}' inside the turn-cancel grace window",
-                            job_id,
-                            name
-                        );
-                        let _ = crate::async_jobs::JobManager::cancel(&job_id);
-                    }
-                }
-                eval_outcome = crate::eval_context::EvalToolOutcome::Cancelled;
-                break tools::ToolRejection::cancelled(name).to_tool_result();
             }
         }
     };

--- a/crates/ha-core/src/channel/cancel.rs
+++ b/crates/ha-core/src/channel/cancel.rs
@@ -7,7 +7,16 @@ use std::sync::{Arc, Mutex};
 /// In-memory registry for active channel stream cancel flags, keyed by session ID.
 /// Follows the same pattern as `SubagentCancelRegistry`.
 pub struct ChannelCancelRegistry {
-    flags: Mutex<HashMap<String, Arc<AtomicBool>>>,
+    /// More than one inbound may be preparing for the same session while an
+    /// earlier turn is active. Keep each request's flag so `/stop` cancels all
+    /// preflight/persistence/engine phases without one registration replacing
+    /// another.
+    flags: Mutex<HashMap<String, HashMap<String, Arc<AtomicBool>>>>,
+}
+
+pub struct ChannelCancelRegistration {
+    pub id: String,
+    pub cancel: Arc<AtomicBool>,
 }
 
 impl ChannelCancelRegistry {
@@ -17,30 +26,62 @@ impl ChannelCancelRegistry {
         }
     }
 
-    /// Register a cancel flag for a session, returning the Arc<AtomicBool>.
-    pub fn register(&self, session_id: &str) -> Arc<AtomicBool> {
+    fn lock_flags(
+        &self,
+    ) -> std::sync::MutexGuard<'_, HashMap<String, HashMap<String, Arc<AtomicBool>>>> {
+        self.flags
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Register one cancellable inbound request for a session.
+    pub fn register(&self, session_id: &str) -> ChannelCancelRegistration {
+        let id = uuid::Uuid::new_v4().to_string();
         let flag = Arc::new(AtomicBool::new(false));
-        if let Ok(mut map) = self.flags.lock() {
-            map.insert(session_id.to_string(), flag.clone());
-        }
-        flag
+        self.lock_flags()
+            .entry(session_id.to_string())
+            .or_default()
+            .insert(id.clone(), flag.clone());
+        ChannelCancelRegistration { id, cancel: flag }
     }
 
     /// Signal cancellation for a specific session's active stream.
     pub fn cancel(&self, session_id: &str) -> bool {
-        if let Ok(map) = self.flags.lock() {
-            if let Some(flag) = map.get(session_id) {
+        let map = self.lock_flags();
+        if let Some(flags) = map.get(session_id) {
+            for flag in flags.values() {
                 flag.store(true, Ordering::SeqCst);
-                return true;
             }
+            return !flags.is_empty();
         }
         false
     }
 
-    /// Remove a completed session from the registry.
-    pub fn remove(&self, session_id: &str) {
-        if let Ok(mut map) = self.flags.lock() {
-            map.remove(session_id);
+    /// Signal every active Channel inbound and return the affected sessions.
+    /// Used only by the legacy/emergency global Stop fallback.
+    pub fn cancel_all(&self) -> Vec<String> {
+        let map = self.lock_flags();
+        map.iter()
+            .filter_map(|(session_id, flags)| {
+                if flags.is_empty() {
+                    return None;
+                }
+                for flag in flags.values() {
+                    flag.store(true, Ordering::SeqCst);
+                }
+                Some(session_id.clone())
+            })
+            .collect()
+    }
+
+    /// Remove exactly one completed inbound registration.
+    pub fn remove(&self, session_id: &str, registration_id: &str) {
+        let mut map = self.lock_flags();
+        if let Some(flags) = map.get_mut(session_id) {
+            flags.remove(registration_id);
+            if flags.is_empty() {
+                map.remove(session_id);
+            }
         }
     }
 
@@ -48,9 +89,34 @@ impl ChannelCancelRegistry {
     /// channel-driven turn is in flight. Used by attach catch-up to decide
     /// whether to append the "reply is being generated" hint.
     pub fn is_active(&self, session_id: &str) -> bool {
-        match self.flags.lock() {
-            Ok(map) => map.contains_key(session_id),
-            Err(_) => false,
-        }
+        self.lock_flags()
+            .get(session_id)
+            .is_some_and(|flags| !flags.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stop_cancels_every_inbound_registered_for_the_session() {
+        let registry = ChannelCancelRegistry::new();
+        let first = registry.register("session-1");
+        let second = registry.register("session-1");
+        let other = registry.register("session-2");
+
+        assert!(registry.cancel("session-1"));
+        assert!(first.cancel.load(Ordering::SeqCst));
+        assert!(second.cancel.load(Ordering::SeqCst));
+        assert!(!other.cancel.load(Ordering::SeqCst));
+
+        registry.remove("session-1", &first.id);
+        assert!(registry.is_active("session-1"));
+        registry.remove("session-1", &second.id);
+        assert!(!registry.is_active("session-1"));
+
+        assert_eq!(registry.cancel_all(), vec!["session-2".to_string()]);
+        assert!(other.cancel.load(Ordering::SeqCst));
     }
 }

--- a/crates/ha-core/src/channel/worker/approval.rs
+++ b/crates/ha-core/src/channel/worker/approval.rs
@@ -43,6 +43,18 @@ fn get_text_pending() -> &'static Mutex<HashMap<(String, String), Vec<PendingTex
     TEXT_PENDING.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// Hold the IM text-approval registry lock so approval cleanup tests can prove
+/// terminal events are published before this secondary cleanup can block.
+#[cfg(test)]
+pub(crate) async fn hold_text_pending_lock_for_test(
+    acquired: tokio::sync::oneshot::Sender<()>,
+    release: tokio::sync::oneshot::Receiver<()>,
+) {
+    let _pending = get_text_pending().lock().await;
+    let _ = acquired.send(());
+    let _ = release.await;
+}
+
 /// Throttle for the "you have N pending approvals" hint — one nudge per
 /// (account, chat) per the configured interval (see
 /// `permission.imApprovalHintThrottleSecs`, default 60s). Backed by

--- a/crates/ha-core/src/channel/worker/dispatcher.rs
+++ b/crates/ha-core/src/channel/worker/dispatcher.rs
@@ -18,6 +18,8 @@ use super::streaming::{append_preview_round_text, PreviewHandle, CARD_ELEMENT_MA
 /// Prevents resource exhaustion (DB lock contention, API rate limits) during message bursts.
 const MAX_CONCURRENT_INBOUND: usize = 20;
 const CONTROL_DELIVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+const CANCELLED_MESSAGE_RETRY_MIN: std::time::Duration = std::time::Duration::from_millis(250);
+const CANCELLED_MESSAGE_RETRY_MAX: std::time::Duration = std::time::Duration::from_secs(5);
 
 async fn wait_for_channel_cancel(cancel: &AtomicBool) {
     while !cancel.load(Ordering::Acquire) {
@@ -44,6 +46,62 @@ impl Drop for ChannelCancelHandleGuard {
 fn is_stop_command(text: Option<&str>) -> bool {
     text.and_then(|text| crate::slash_commands::parser::parse(text).ok())
         .is_some_and(|(name, _)| name == "stop")
+}
+
+fn spawn_cancelled_channel_message_rollback(
+    session_db: Arc<crate::session::SessionDB>,
+    session_id: String,
+    message_id: i64,
+) -> tokio::task::JoinHandle<()> {
+    // Install the replacement gate synchronously while the cancelled active
+    // turn still owns admission, then transfer it to retry cleanup. A transient
+    // SQLite failure must never expose the stale prompt to a later inbound.
+    let cleanup_gate = crate::chat_engine::active_turn::begin_stop_cleanup(&session_id);
+    tokio::spawn(async move {
+        let mut retry_delay = CANCELLED_MESSAGE_RETRY_MIN;
+        let mut attempt = 0_u64;
+        loop {
+            attempt = attempt.saturating_add(1);
+            let result = session_db
+                .run(move |db| db.delete_message_by_id(message_id))
+                .await;
+            match result {
+                Ok(()) => {
+                    if attempt > 1 {
+                        crate::app_info!(
+                            "channel",
+                            "cancelled_message_rollback",
+                            "Rolled back cancelled Channel message after retry: session={} message_id={} attempts={}",
+                            session_id,
+                            message_id,
+                            attempt
+                        );
+                    }
+                    emit_channel_update(&session_id);
+                    drop(cleanup_gate);
+                    return;
+                }
+                Err(error) => {
+                    if attempt == 1 || attempt.is_power_of_two() {
+                        let message = crate::logging::redact_sensitive(&error.to_string());
+                        crate::app_warn!(
+                            "channel",
+                            "cancelled_message_rollback",
+                            "Failed to roll back cancelled Channel message; retaining Stop gate and retrying: session={} message_id={} attempt={} error={}",
+                            session_id,
+                            message_id,
+                            attempt,
+                            message
+                        );
+                    }
+                    tokio::time::sleep(retry_delay).await;
+                    retry_delay = retry_delay
+                        .saturating_mul(2)
+                        .min(CANCELLED_MESSAGE_RETRY_MAX);
+                }
+            }
+        }
+    })
 }
 
 /// Notify the frontend that a channel session has new messages.
@@ -802,10 +860,11 @@ async fn handle_inbound_message(
         Ok(crate::chat_engine::active_turn::PersistenceTargetOutcome::CommittedAfterCancel(
             message_id,
         )) => {
-            let _ = session_db
-                .run(move |db| db.delete_message_by_id(message_id))
-                .await;
-            emit_channel_update(&session_id);
+            spawn_cancelled_channel_message_rollback(
+                session_db.clone(),
+                session_id.clone(),
+                message_id,
+            );
             return Ok(());
         }
         Ok(crate::chat_engine::active_turn::PersistenceTargetOutcome::CancelledBeforeCommit) => {
@@ -1882,6 +1941,50 @@ mod tests {
         assert!(!is_stop_command(Some("stop")));
         assert!(!is_stop_command(Some("/status")));
         assert!(!is_stop_command(None));
+    }
+
+    #[tokio::test]
+    async fn cancelled_channel_message_retry_holds_gate_until_delete_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db_path = dir.path().join("sessions.db");
+        let db = Arc::new(
+            crate::session::SessionDB::open_ephemeral_for_test(&db_path).expect("open session db"),
+        );
+        let session = db.create_session("ha-main").expect("create session");
+        let message_id = db
+            .append_message(
+                &session.id,
+                &crate::session::NewMessage::user("cancelled inbound"),
+            )
+            .expect("append message");
+        db.conn
+            .lock()
+            .expect("writer lock")
+            .execute_batch(
+                "CREATE TRIGGER block_cancelled_message_delete
+                 BEFORE DELETE ON messages
+                 BEGIN SELECT RAISE(FAIL, 'delete blocked'); END;",
+            )
+            .expect("install delete blocker");
+
+        let cleanup =
+            spawn_cancelled_channel_message_rollback(db.clone(), session.id.clone(), message_id);
+        assert!(crate::chat_engine::active_turn::stop_cleanup_active(
+            &session.id
+        ));
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(db.get_message(message_id).expect("read message").is_some());
+
+        db.conn
+            .lock()
+            .expect("writer lock")
+            .execute_batch("DROP TRIGGER block_cancelled_message_delete;")
+            .expect("remove delete blocker");
+        tokio::time::timeout(std::time::Duration::from_secs(2), cleanup)
+            .await
+            .expect("cleanup retry should settle")
+            .expect("cleanup task should not panic");
+        assert!(db.get_message(message_id).expect("read message").is_none());
     }
 
     fn mk_item(name: &str, mime: &str, kind: MediaKind) -> MediaItem {

--- a/crates/ha-core/src/channel/worker/dispatcher.rs
+++ b/crates/ha-core/src/channel/worker/dispatcher.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Semaphore};
 
@@ -9,7 +9,7 @@ use crate::channel::types::*;
 
 use super::media::{convert_inbound_media_to_attachments, transcribe_inbound_voice_attachments};
 use super::pipeline::{
-    await_stream_pipeline, deliver_rounds, spawn_stream_pipeline, DeliveryTarget,
+    await_stream_pipeline_until_cancel, deliver_rounds, spawn_stream_pipeline, DeliveryTarget,
 };
 use super::slash::{dispatch_slash_for_channel, ChannelSlashOutcome};
 use super::streaming::{append_preview_round_text, PreviewHandle, CARD_ELEMENT_MAX_CHARS};
@@ -17,6 +17,34 @@ use super::streaming::{append_preview_round_text, PreviewHandle, CARD_ELEMENT_MA
 /// Maximum number of inbound messages processed concurrently.
 /// Prevents resource exhaustion (DB lock contention, API rate limits) during message bursts.
 const MAX_CONCURRENT_INBOUND: usize = 20;
+const CONTROL_DELIVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+async fn wait_for_channel_cancel(cancel: &AtomicBool) {
+    while !cancel.load(Ordering::Acquire) {
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
+struct ChannelCancelHandleGuard {
+    session_id: String,
+    registration_id: Option<String>,
+}
+
+impl Drop for ChannelCancelHandleGuard {
+    fn drop(&mut self) {
+        if let (Some(registry), Some(registration_id)) = (
+            crate::globals::get_channel_cancels(),
+            self.registration_id.as_deref(),
+        ) {
+            registry.remove(&self.session_id, registration_id);
+        }
+    }
+}
+
+fn is_stop_command(text: Option<&str>) -> bool {
+    text.and_then(|text| crate::slash_commands::parser::parse(text).ok())
+        .is_some_and(|(name, _)| name == "stop")
+}
 
 /// Notify the frontend that a channel session has new messages.
 pub(super) fn emit_channel_update(session_id: &str) {
@@ -216,8 +244,13 @@ async fn handle_inbound_message(
         crate::truncate_utf8(msg.text.as_deref().unwrap_or("(media)"), 100)
     );
 
+    // `/stop` is control-plane input, never an approval answer or a custom
+    // ask_user response. In particular, a free-form question used to consume
+    // the literal "/stop" as its answer and leave the turn running.
+    let is_stop_command = is_stop_command(msg.text.as_deref());
+
     // 0. Check if this message is a text-reply to a pending approval prompt
-    if super::approval::try_handle_approval_reply(&msg).await {
+    if !is_stop_command && super::approval::try_handle_approval_reply(&msg).await {
         app_info!(
             "channel",
             "worker",
@@ -230,10 +263,12 @@ async fn handle_inbound_message(
     // 0a. Not an approval reply, but a text-mode approval is still pending in
     // this chat — nudge the user once per minute so they don't accidentally
     // start a side conversation while the prompt is still open.
-    super::approval::maybe_send_pending_hint(&msg, registry).await;
+    if !is_stop_command {
+        super::approval::maybe_send_pending_hint(&msg, registry).await;
+    }
 
     // 0b. Check if this message is a text-reply to a pending ask_user_question
-    if super::ask_user::try_handle_ask_user_reply(&msg).await {
+    if !is_stop_command && super::ask_user::try_handle_ask_user_reply(&msg).await {
         app_info!(
             "channel",
             "worker",
@@ -320,23 +355,6 @@ async fn handle_inbound_message(
         }
     }
 
-    // 2d. Hydrate any deferred-download attachments now that gating has
-    //     cleared. Channels that download eagerly (Telegram, Slack, etc.)
-    //     leave the trait method as a no-op; Feishu uses this hook so the
-    //     gateway ack isn't blocked on attachment downloads. Failures are
-    //     non-fatal — the surrounding text still reaches the agent.
-    if let Err(e) = plugin.materialize_pending_media(&account, &mut msg).await {
-        app_warn!(
-            "channel",
-            "worker",
-            "[{}] Failed to materialize pending media for {} in {}: {}",
-            channel_id_str,
-            msg.message_id,
-            msg.chat_id,
-            e
-        );
-    }
-
     // 3. Resolve agent_id via the central resolver — the precedence chain
     //    (project > topic > group > channel-override > channel-account >
     //    global > hardcoded) lives in `agent::resolver` so /status, IM
@@ -401,21 +419,39 @@ async fn handle_inbound_message(
     let session_db =
         crate::get_session_db().ok_or_else(|| anyhow::anyhow!("SessionDB not initialized"))?;
 
-    let user_text = msg.text.as_deref().unwrap_or("(media message)");
+    let user_text = msg
+        .text
+        .clone()
+        .unwrap_or_else(|| "(media message)".to_string());
 
-    // 5. Send typing indicator
-    let _ = plugin.send_typing(&account.id, &msg.chat_id).await;
+    // Register before slash dispatch: commands such as /compact can execute
+    // long-running work before the chat engine exists. `/stop` deliberately
+    // does not register itself; it cancels every other registration owned by
+    // the attached session through the shared Stop service.
+    let channel_cancel_registration = if is_stop_command {
+        None
+    } else {
+        crate::globals::get_channel_cancels().map(|registry| registry.register(&session_id))
+    };
+    let cancel = channel_cancel_registration
+        .as_ref()
+        .map(|registration| registration.cancel.clone())
+        .unwrap_or_else(|| Arc::new(AtomicBool::new(false)));
+    let _cancel_handle_guard = ChannelCancelHandleGuard {
+        session_id: session_id.clone(),
+        registration_id: channel_cancel_registration.map(|registration| registration.id),
+    };
 
     // 5a. Intercept slash commands — dispatch and send reply directly, skip LLM.
     // For PassThrough commands (e.g. skill invocations), use the transformed message as the
     // engine input so the LLM receives the skill instruction rather than the raw "/" text.
     let engine_message: String;
-    if crate::slash_commands::parser::is_command(user_text) {
+    if crate::slash_commands::parser::is_command(&user_text) {
         // Channels without inline-button support get the handler's verbose
         // no-arg text response instead of the (un-tappable) `Select an
         // option for /xxx:` shortcut.
         let supports_buttons = plugin.capabilities().supports_buttons;
-        match dispatch_slash_for_channel(
+        let slash_dispatch = dispatch_slash_for_channel(
             channel_db,
             &plugin,
             &account,
@@ -426,12 +462,17 @@ async fn handle_inbound_message(
             &msg.chat_type,
             &session_id,
             &agent_id,
-            user_text,
+            &user_text,
             &msg.sender_id,
             supports_buttons,
-        )
-        .await
-        {
+        );
+        tokio::pin!(slash_dispatch);
+        let slash_outcome = tokio::select! {
+            biased;
+            _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
+            outcome = &mut slash_dispatch => outcome,
+        };
+        match slash_outcome {
             Ok(ChannelSlashOutcome::Reply {
                 content,
                 new_session_id,
@@ -439,19 +480,41 @@ async fn handle_inbound_message(
             }) => {
                 let effective_sid = new_session_id.as_deref().unwrap_or(&session_id);
                 if new_session_id.is_none() {
-                    if let Err(e) = crate::slash_commands::append_slash_history_events(
-                        &session_db,
-                        effective_sid,
-                        user_text,
-                        Some(&content),
-                        crate::chat_engine::ChatSource::Channel,
-                    ) {
-                        app_warn!(
+                    let history_db = session_db.clone();
+                    let history_sid = effective_sid.to_string();
+                    let history_command = user_text.clone();
+                    let history_reply = content.clone();
+                    let persistence = tokio::time::timeout(
+                        std::time::Duration::from_secs(2),
+                        history_db.run(move |db| {
+                            crate::slash_commands::append_slash_history_events(
+                                db,
+                                &history_sid,
+                                &history_command,
+                                Some(&history_reply),
+                                crate::chat_engine::ChatSource::Channel,
+                            )
+                        }),
+                    );
+                    tokio::pin!(persistence);
+                    match tokio::select! {
+                        biased;
+                        _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
+                        result = &mut persistence => result,
+                    } {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(error)) => app_warn!(
                             "channel",
                             "worker",
                             "Failed to persist slash command history: {}",
-                            e
-                        );
+                            error
+                        ),
+                        Err(_) => app_warn!(
+                            "channel",
+                            "worker",
+                            "Timed out persisting slash command history for session {}",
+                            effective_sid
+                        ),
                     }
                 }
                 let slash_target = DeliveryTarget {
@@ -460,7 +523,17 @@ async fn handle_inbound_message(
                     thread_id: msg.thread_id.as_deref(),
                     reply_to_message_id: Some(&msg.message_id),
                 };
-                send_text_chunks(&plugin, &slash_target, &content, None, &buttons).await;
+                let delivery = send_text_chunks(&plugin, &slash_target, &content, None, &buttons);
+                tokio::pin!(delivery);
+                tokio::select! {
+                    biased;
+                    _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
+                    result = tokio::time::timeout(CONTROL_DELIVERY_TIMEOUT, &mut delivery) => {
+                        if result.is_err() {
+                            app_warn!("channel", "worker", "Timed out delivering slash reply for session {}", effective_sid);
+                        }
+                    }
+                }
                 emit_channel_update(effective_sid);
                 return Ok(());
             }
@@ -476,12 +549,63 @@ async fn handle_inbound_message(
                     thread_id: msg.thread_id.as_deref(),
                     reply_to_message_id: Some(&msg.message_id),
                 };
-                send_text_chunks(&plugin, &err_target, &error_reply, None, &[]).await;
+                let delivery = send_text_chunks(&plugin, &err_target, &error_reply, None, &[]);
+                tokio::pin!(delivery);
+                tokio::select! {
+                    biased;
+                    _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
+                    result = tokio::time::timeout(CONTROL_DELIVERY_TIMEOUT, &mut delivery) => {
+                        if result.is_err() {
+                            app_warn!("channel", "worker", "Timed out delivering slash error for session {}", session_id);
+                        }
+                    }
+                }
                 return Ok(());
             }
         }
     } else {
-        engine_message = user_text.to_string();
+        engine_message = user_text.clone();
+    }
+
+    if cancel.load(Ordering::Acquire) {
+        return Ok(());
+    }
+
+    // Typing and deferred media hydration are network-facing preparation, so
+    // they must be inside the same cancellable lifetime as preflight/engine.
+    // `/stop` itself returns above before either wait.
+    {
+        let typing = plugin.send_typing(&account.id, &msg.chat_id);
+        tokio::pin!(typing);
+        tokio::select! {
+            biased;
+            _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
+            _ = &mut typing => {}
+        }
+    }
+
+    // Hydrate deferred-download attachments only after slash interception and
+    // cancel registration. Channels that download eagerly leave this as a
+    // no-op; failures remain non-fatal so surrounding text can still run.
+    let media_result = {
+        let hydration = plugin.materialize_pending_media(&account, &mut msg);
+        tokio::pin!(hydration);
+        tokio::select! {
+            biased;
+            _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
+            result = &mut hydration => result,
+        }
+    };
+    if let Err(e) = media_result {
+        app_warn!(
+            "channel",
+            "worker",
+            "[{}] Failed to materialize pending media for {} in {}: {}",
+            channel_id_str,
+            msg.message_id,
+            msg.chat_id,
+            e
+        );
     }
 
     // 5b. Persist only messages that will enter the chat engine. Reply-only
@@ -493,25 +617,30 @@ async fn handle_inbound_message(
     // consistent with what lands in history.
     //
     // The turn id is minted here rather than at the `try_acquire` in 5c below
-    // purely so the hook can carry it as `prompt_id`: IM deliberately runs the
-    // preflight *before* the single-flight gate (see 5c), so without hoisting
-    // the id, `UserPromptSubmit` and the rest of the turn would report two
-    // different ids. This is a hoist, not a reorder — the acquire stays exactly
-    // where it is. A prompt that is later deferred at 5c therefore emits a
-    // `UserPromptSubmit` for a turn that never runs; correlating scripts must
-    // tolerate a `UserPromptSubmit` with no following `Stop` (already true
-    // before the id existed).
+    // so the hook and engine use the same `prompt_id`. The Channel cancel
+    // registration above deliberately starts before preflight: `/stop` and the
+    // GUI button are the same operation even while a hook is still running.
     let turn_id = uuid::Uuid::new_v4().to_string();
-    let effective_prompt = match crate::agent::preflight::user_prompt_preflight(
+    let preflight = crate::agent::preflight::user_prompt_preflight_cancellable(
         crate::agent::preflight::PreflightArgs {
             session_id: &session_id,
             agent_id: Some(agent_id.as_str()),
-            raw_prompt: user_text,
+            raw_prompt: &user_text,
             turn_id: &turn_id,
         },
+        cancel.as_ref(),
     )
-    .await
-    {
+    .await;
+    let Some(preflight) = preflight else {
+        app_info!(
+            "channel",
+            "stop",
+            "Stopped channel prompt during preflight for session {}",
+            session_id
+        );
+        return Ok(());
+    };
+    let effective_prompt = match preflight {
         crate::agent::preflight::PreflightOutcome::Proceed { effective_prompt } => effective_prompt,
         crate::agent::preflight::PreflightOutcome::Block { reason } => {
             // A UserPromptSubmit hook blocked the prompt: reply to the chat and
@@ -520,12 +649,24 @@ async fn handle_inbound_message(
             let notice = format!("🚫 {reason}");
             let _ =
                 session_db.append_message(&session_id, &crate::session::NewMessage::event(&notice));
-            let _ = plugin
-                .send_message(&account.id, &msg.chat_id, &ReplyPayload::text(&notice))
-                .await;
+            let notice_payload = ReplyPayload::text(&notice);
+            let delivery = plugin.send_message(&account.id, &msg.chat_id, &notice_payload);
+            tokio::pin!(delivery);
+            tokio::select! {
+                biased;
+                _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
+                result = tokio::time::timeout(CONTROL_DELIVERY_TIMEOUT, &mut delivery) => {
+                    if result.is_err() {
+                        app_warn!("channel", "worker", "Timed out delivering hook-block notice for session {}", session_id);
+                    }
+                }
+            }
             return Ok(());
         }
     };
+    if cancel.load(Ordering::Acquire) {
+        return Ok(());
+    }
     let mut attachments = convert_inbound_media_to_attachments(&msg.media, &session_id);
     let user_attachments_meta =
         match crate::attachments::persist_chat_user_attachments_meta(&session_id, &mut attachments)
@@ -543,6 +684,9 @@ async fn handle_inbound_message(
                 None
             }
         };
+    if cancel.load(Ordering::Acquire) {
+        return Ok(());
+    }
     let mut attachments_meta = serde_json::json!({
         "channel_inbound": {
             "channelId": channel_id_str,
@@ -619,6 +763,11 @@ async fn handle_inbound_message(
         );
     }
 
+    if cancel.load(Ordering::Acquire) {
+        emit_channel_update(&session_id);
+        return Ok(());
+    }
+
     // NOTE: We don't emit channel:message_update here because channel:stream_start
     // will handle frontend state. Emitting here would race with the stream placeholder.
 
@@ -634,23 +783,6 @@ async fn handle_inbound_message(
     // and only the *engine run* is single-flighted (a deferred message rides
     // the next turn's context; there is no auto-dequeue). The guard + cancel
     // handle are held by RAII for the whole turn including delivery.
-    let cancel = match crate::globals::get_channel_cancels() {
-        Some(reg) => reg.register(&session_id),
-        None => Arc::new(AtomicBool::new(false)),
-    };
-    // RAII removal so the channel cancel handle never leaks on an early bail
-    // (e.g. empty model chain below) — it used to be removed only on the
-    // run_chat_engine-reached path.
-    struct CancelHandleGuard(String);
-    impl Drop for CancelHandleGuard {
-        fn drop(&mut self) {
-            if let Some(reg) = crate::globals::get_channel_cancels() {
-                reg.remove(&self.0);
-            }
-        }
-    }
-    let _cancel_handle_guard = CancelHandleGuard(session_id.clone());
-
     // The synthetic turn id only keys the single-flight registry entry; the
     // engine keeps `turn_id: None` (IM streams on the `channel:*` bus, not the
     // `chat:*` seq-tracked bus, so giving it a tracked turn id would change
@@ -681,17 +813,30 @@ async fn handle_inbound_message(
                 thread_id: msg.thread_id.as_deref(),
                 reply_to_message_id: Some(&msg.message_id),
             };
-            send_text_chunks(
+            let delivery = send_text_chunks(
                 &plugin,
                 &busy_target,
                 "⏳ I'm still finishing your previous message; I'll get to this one shortly.",
                 None,
                 &[],
-            )
-            .await;
+            );
+            tokio::pin!(delivery);
+            tokio::select! {
+                biased;
+                _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
+                result = tokio::time::timeout(CONTROL_DELIVERY_TIMEOUT, &mut delivery) => {
+                    if result.is_err() {
+                        app_warn!("channel", "worker", "Timed out delivering busy notice for session {}", session_id);
+                    }
+                }
+            }
             return Ok(());
         }
     };
+    if cancel.load(Ordering::Acquire) {
+        emit_channel_update(&session_id);
+        return Ok(());
+    }
 
     // 6. Build channel context for prompt injection
     let chat_type_label = match msg.chat_type {
@@ -769,9 +914,34 @@ async fn handle_inbound_message(
 
     let resolved_temperature = runtime_defaults.temperature;
 
-    // 8. Spawn the shared streaming pipeline (preview task + sink). The
-    // chat engine writes events into `pipeline.event_sink`; we await the
-    // stream task and deliver rounds after `run_chat_engine` returns.
+    // 8a. Auto-transcribe voice / audio attachments when the account opts
+    // in. The prefix gets prepended to the engine message so the LLM sees
+    // a text version of the spoken content; the original audio is kept as
+    // an attachment so multimodal models (or downstream re-transcribe)
+    // can still fall back to listening. Failure is non-blocking — logged
+    // and dropped.
+    let engine_message = if account.auto_transcribe_voice() {
+        let transcription = transcribe_inbound_voice_attachments(&attachments, &store.language);
+        tokio::pin!(transcription);
+        let prefix = tokio::select! {
+            biased;
+            _ = wait_for_channel_cancel(cancel.as_ref()) => {
+                emit_channel_update(&session_id);
+                return Ok(());
+            }
+            prefix = &mut transcription => prefix,
+        };
+        match prefix {
+            Some(prefix) => format!("{}{}", prefix, engine_message),
+            None => engine_message,
+        }
+    } else {
+        engine_message
+    };
+
+    // 8. Spawn the shared streaming pipeline (preview task + sink) only after
+    // cancellable preparation finishes. The engine writes events into
+    // `pipeline.event_sink`; we await it and deliver rounds after the engine.
     let target = DeliveryTarget {
         account_id: &account.id,
         chat_id: &msg.chat_id,
@@ -789,21 +959,6 @@ async fn handle_inbound_message(
         true,
     );
     let event_sink = pipeline.event_sink.clone();
-
-    // 8a. Auto-transcribe voice / audio attachments when the account opts
-    // in. The prefix gets prepended to the engine message so the LLM sees
-    // a text version of the spoken content; the original audio is kept as
-    // an attachment so multimodal models (or downstream re-transcribe)
-    // can still fall back to listening. Failure is non-blocking — logged
-    // and dropped.
-    let engine_message = if account.auto_transcribe_voice() {
-        match transcribe_inbound_voice_attachments(&attachments, &store.language).await {
-            Some(prefix) => format!("{}{}", prefix, engine_message),
-            None => engine_message,
-        }
-    } else {
-        engine_message
-    };
     let reasoning_effort = Some(runtime_defaults.reasoning_effort);
 
     // Snapshot whether the *entire* fallback chain is Codex before
@@ -883,11 +1038,35 @@ async fn handle_inbound_message(
 
     // Late async tool completions arriving after this drain are deferred to
     // a future turn — a stale attachment from turn N must not leak into N+1.
-    let outcome = await_stream_pipeline(pipeline).await;
+    let Some(outcome) = await_stream_pipeline_until_cancel(pipeline, cancel.as_ref()).await else {
+        app_info!(
+            "channel",
+            "stop",
+            "Stopped channel preview finalization for session {}",
+            session_id
+        );
+        emit_stream_lifecycle("channel:stream_end", &session_id);
+        return Ok(());
+    };
 
     match result {
         Ok(engine_result) => {
-            let metrics = deliver_rounds(&plugin, &target, &outcome, &engine_result.response).await;
+            let delivery = deliver_rounds(&plugin, &target, &outcome, &engine_result.response);
+            tokio::pin!(delivery);
+            let metrics = tokio::select! {
+                biased;
+                _ = wait_for_channel_cancel(cancel.as_ref()) => {
+                    app_info!(
+                        "channel",
+                        "stop",
+                        "Stopped channel final delivery for session {}",
+                        session_id
+                    );
+                    emit_stream_lifecycle("channel:stream_end", &session_id);
+                    return Ok(());
+                }
+                metrics = &mut delivery => metrics,
+            };
 
             app_info!(
                 "channel",
@@ -933,13 +1112,27 @@ async fn handle_inbound_message(
                 thread_id: msg.thread_id.as_deref(),
                 reply_to_message_id: Some(&msg.message_id),
             };
-            send_error_reply(
+            let error_delivery = send_error_reply(
                 &plugin,
                 &err_target,
                 outcome.stream_outcome.preview.as_ref(),
                 &body,
-            )
-            .await;
+            );
+            tokio::pin!(error_delivery);
+            tokio::select! {
+                biased;
+                _ = wait_for_channel_cancel(cancel.as_ref()) => {
+                    app_info!(
+                        "channel",
+                        "stop",
+                        "Stopped channel error delivery for session {}",
+                        session_id
+                    );
+                    emit_stream_lifecycle("channel:stream_end", &session_id);
+                    return Ok(());
+                }
+                _ = &mut error_delivery => {}
+            }
         }
     }
 
@@ -1649,6 +1842,15 @@ pub(crate) async fn deliver_media_to_chat(
 mod tests {
     use super::*;
     use crate::attachments::{MediaItem, MediaKind};
+
+    #[test]
+    fn stop_command_is_reserved_from_interactive_reply_parsing() {
+        assert!(is_stop_command(Some("/stop")));
+        assert!(is_stop_command(Some("  /STOP  ")));
+        assert!(!is_stop_command(Some("stop")));
+        assert!(!is_stop_command(Some("/status")));
+        assert!(!is_stop_command(None));
+    }
 
     fn mk_item(name: &str, mime: &str, kind: MediaKind) -> MediaItem {
         MediaItem {

--- a/crates/ha-core/src/channel/worker/dispatcher.rs
+++ b/crates/ha-core/src/channel/worker/dispatcher.rs
@@ -228,6 +228,11 @@ async fn handle_inbound_message(
     channel_db: &ChannelDB,
     mut msg: MsgContext,
 ) -> anyhow::Result<()> {
+    // Capture before approval/ask-user routing performs its first await. A
+    // process-wide Stop that runs during those preludes must still reject this
+    // inbound if it later reaches active-turn registration after the bounded
+    // global cleanup gate has already closed.
+    let foreground_admission = crate::chat_engine::active_turn::begin_foreground_request();
     let channel_id_str = msg.channel_id.to_string();
     let sender_label = msg
         .sender_name
@@ -791,14 +796,27 @@ async fn handle_inbound_message(
     // hooks. The shared `cancel` Arc is reused by `engine_params` below so a
     // cross-surface cancel (session delete / GUI stop walking `active_turn`)
     // actually aborts this engine run.
-    let _active_turn_guard = match crate::chat_engine::active_turn::try_acquire(
+    let _active_turn_guard = match crate::chat_engine::active_turn::try_acquire_foreground_request(
+        foreground_admission,
         &session_id,
         crate::chat_engine::stream_seq::ChatSource::Channel,
         turn_id.clone(),
+        None,
         cancel.clone(),
     ) {
         Ok(guard) => guard,
         Err(e) => {
+            if e.cancelled_by_global_stop() {
+                app_info!(
+                    "channel",
+                    "stop",
+                    "[{}] discarded inbound for session {} because it predated global Stop",
+                    channel_id_str,
+                    session_id
+                );
+                emit_channel_update(&session_id);
+                return Ok(());
+            }
             app_info!(
                 "channel",
                 "worker",

--- a/crates/ha-core/src/channel/worker/dispatcher.rs
+++ b/crates/ha-core/src/channel/worker/dispatcher.rs
@@ -672,6 +672,70 @@ async fn handle_inbound_message(
     if cancel.load(Ordering::Acquire) {
         return Ok(());
     }
+
+    // Acquire before the user message becomes durable. Besides enforcing
+    // single-flight, this is the generation check that prevents an inbound
+    // which predates global Stop from leaking into the next turn's context.
+    let _active_turn_guard = match crate::chat_engine::active_turn::try_acquire_foreground_request(
+        foreground_admission,
+        &session_id,
+        crate::chat_engine::stream_seq::ChatSource::Channel,
+        turn_id.clone(),
+        None,
+        cancel.clone(),
+    ) {
+        Ok(guard) => guard,
+        Err(e) => {
+            if e.cancelled_by_global_stop() {
+                app_info!(
+                    "channel",
+                    "stop",
+                    "[{}] discarded inbound for session {} because it predated global Stop",
+                    channel_id_str,
+                    session_id
+                );
+                emit_channel_update(&session_id);
+                return Ok(());
+            }
+            app_info!(
+                "channel",
+                "worker",
+                "[{}] inbound for session {} rejected: a turn is already active ({})",
+                channel_id_str,
+                session_id,
+                e
+            );
+            let busy_target = DeliveryTarget {
+                account_id: &account.id,
+                chat_id: &msg.chat_id,
+                thread_id: msg.thread_id.as_deref(),
+                reply_to_message_id: Some(&msg.message_id),
+            };
+            let delivery = send_text_chunks(
+                &plugin,
+                &busy_target,
+                "⏳ I'm still finishing your previous message. Please send this again shortly.",
+                None,
+                &[],
+            );
+            tokio::pin!(delivery);
+            tokio::select! {
+                biased;
+                _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
+                result = tokio::time::timeout(CONTROL_DELIVERY_TIMEOUT, &mut delivery) => {
+                    if result.is_err() {
+                        app_warn!("channel", "worker", "Timed out delivering busy notice for session {}", session_id);
+                    }
+                }
+            }
+            return Ok(());
+        }
+    };
+    if cancel.load(Ordering::Acquire) {
+        emit_channel_update(&session_id);
+        return Ok(());
+    }
+
     let mut attachments = convert_inbound_media_to_attachments(&msg.media, &session_id);
     let user_attachments_meta =
         match crate::attachments::persist_chat_user_attachments_meta(&session_id, &mut attachments)
@@ -718,34 +782,64 @@ async fn handle_inbound_message(
     // Keep all synchronous SessionDB work off this async dispatcher's Tokio
     // workers and preserve restore-before-append ordering in one blocking task.
     let persist_session_id = session_id.clone();
-    let title_prompt = effective_prompt.clone();
-    let title_attachments_meta = attachments_meta_json.clone();
+    let persist_turn_id = turn_id.clone();
     let persist_result = session_db
-        .run(move |db| -> anyhow::Result<()> {
-            db.set_session_archived(&persist_session_id, false)?;
-            db.append_message(&persist_session_id, &user_msg)?;
-            // Auto-generate fallback title from the first real message (same
-            // logic as normal chat).
-            let _ = crate::session::ensure_first_message_title(
-                db,
+        .run(move |db| {
+            crate::chat_engine::active_turn::with_persistence_target(
                 &persist_session_id,
-                &title_prompt,
-                Some(&title_attachments_meta),
-            )?;
-            Ok(())
+                &persist_turn_id,
+                || -> anyhow::Result<i64> {
+                    db.set_session_archived(&persist_session_id, false)?;
+                    db.append_message(&persist_session_id, &user_msg)
+                },
+            )
         })
         .await;
-    if let Err(error) = persist_result {
-        app_warn!(
-            "channel",
-            "worker",
-            "[{}] Failed to restore/persist inbound conversation {}: {}",
-            channel_id_str,
-            session_id,
-            error
-        );
-        return Err(error);
-    }
+    let _user_message_id = match persist_result {
+        Ok(crate::chat_engine::active_turn::PersistenceTargetOutcome::Committed(message_id)) => {
+            message_id
+        }
+        Ok(crate::chat_engine::active_turn::PersistenceTargetOutcome::CommittedAfterCancel(
+            message_id,
+        )) => {
+            let _ = session_db
+                .run(move |db| db.delete_message_by_id(message_id))
+                .await;
+            emit_channel_update(&session_id);
+            return Ok(());
+        }
+        Ok(crate::chat_engine::active_turn::PersistenceTargetOutcome::CancelledBeforeCommit) => {
+            emit_channel_update(&session_id);
+            return Ok(());
+        }
+        Err(error) => {
+            app_warn!(
+                "channel",
+                "worker",
+                "[{}] Failed to restore/persist inbound conversation {}: {}",
+                channel_id_str,
+                session_id,
+                error
+            );
+            return Err(error);
+        }
+    };
+
+    // Auto-generate fallback title only after persistence has won over Stop;
+    // a cancelled stale inbound must not leave either a message or its title.
+    let title_session_id = session_id.clone();
+    let title_prompt = effective_prompt.clone();
+    let title_attachments_meta = attachments_meta_json.clone();
+    let _ = session_db
+        .run(move |db| {
+            crate::session::ensure_first_message_title(
+                db,
+                &title_session_id,
+                &title_prompt,
+                Some(&title_attachments_meta),
+            )
+        })
+        .await;
 
     // Notify the desktop / web side that a fresh user message landed on
     // this session from IM, so an attached GUI view can pull it into
@@ -775,86 +869,6 @@ async fn handle_inbound_message(
 
     // NOTE: We don't emit channel:message_update here because channel:stream_start
     // will handle frontend state. Emitting here would race with the stream placeholder.
-
-    // 5c. Single-flight gate (I8 / MISC-6). IM inbound previously had NO
-    // per-session turn guard: two rapid messages to the same session ran
-    // `run_chat_engine` concurrently, and the loser lost the
-    // `stream_seq::begin` race deep inside the engine — after the pipeline was
-    // spawned — surfacing as an "active stream" error reply. Acquire the same
-    // `active_turn` guard the GUI/HTTP entry points use so a concurrent turn
-    // (from IM, GUI, or HTTP on this 1:1-attached session) is rejected up
-    // front. We acquire AFTER persisting the user message: every inbound is
-    // captured into history + run through the `UserPromptSubmit` preflight,
-    // and only the *engine run* is single-flighted (a deferred message rides
-    // the next turn's context; there is no auto-dequeue). The guard + cancel
-    // handle are held by RAII for the whole turn including delivery.
-    // The synthetic turn id only keys the single-flight registry entry; the
-    // engine keeps `turn_id: None` (IM streams on the `channel:*` bus, not the
-    // `chat:*` seq-tracked bus, so giving it a tracked turn id would change
-    // stream acceptance/broadcast semantics). It is minted above the preflight
-    // so `UserPromptSubmit` reports the same `prompt_id` as this turn's other
-    // hooks. The shared `cancel` Arc is reused by `engine_params` below so a
-    // cross-surface cancel (session delete / GUI stop walking `active_turn`)
-    // actually aborts this engine run.
-    let _active_turn_guard = match crate::chat_engine::active_turn::try_acquire_foreground_request(
-        foreground_admission,
-        &session_id,
-        crate::chat_engine::stream_seq::ChatSource::Channel,
-        turn_id.clone(),
-        None,
-        cancel.clone(),
-    ) {
-        Ok(guard) => guard,
-        Err(e) => {
-            if e.cancelled_by_global_stop() {
-                app_info!(
-                    "channel",
-                    "stop",
-                    "[{}] discarded inbound for session {} because it predated global Stop",
-                    channel_id_str,
-                    session_id
-                );
-                emit_channel_update(&session_id);
-                return Ok(());
-            }
-            app_info!(
-                "channel",
-                "worker",
-                "[{}] inbound for session {} deferred: a turn is already active ({})",
-                channel_id_str,
-                session_id,
-                e
-            );
-            let busy_target = DeliveryTarget {
-                account_id: &account.id,
-                chat_id: &msg.chat_id,
-                thread_id: msg.thread_id.as_deref(),
-                reply_to_message_id: Some(&msg.message_id),
-            };
-            let delivery = send_text_chunks(
-                &plugin,
-                &busy_target,
-                "⏳ I'm still finishing your previous message; I'll get to this one shortly.",
-                None,
-                &[],
-            );
-            tokio::pin!(delivery);
-            tokio::select! {
-                biased;
-                _ = wait_for_channel_cancel(cancel.as_ref()) => return Ok(()),
-                result = tokio::time::timeout(CONTROL_DELIVERY_TIMEOUT, &mut delivery) => {
-                    if result.is_err() {
-                        app_warn!("channel", "worker", "Timed out delivering busy notice for session {}", session_id);
-                    }
-                }
-            }
-            return Ok(());
-        }
-    };
-    if cancel.load(Ordering::Acquire) {
-        emit_channel_update(&session_id);
-        return Ok(());
-    }
 
     // 6. Build channel context for prompt injection
     let chat_type_label = match msg.chat_type {

--- a/crates/ha-core/src/channel/worker/pipeline.rs
+++ b/crates/ha-core/src/channel/worker/pipeline.rs
@@ -278,6 +278,46 @@ pub(crate) async fn deliver_rounds(
     }
 }
 
+/// Deliver a complete final response through a pipeline that may have
+/// attached after the turn had already started. Unlike [`deliver_rounds`],
+/// this intentionally ignores `drained_rounds` for text reconstruction:
+/// those rounds only contain deltas observed after the late attach point.
+/// The preview handle is still honored, so a half-rendered IM preview is
+/// replaced with the complete final answer when possible.
+pub(crate) async fn deliver_full_response(
+    plugin: &Arc<dyn ChannelPlugin>,
+    target: &DeliveryTarget<'_>,
+    outcome: &PipelineOutcome,
+    response: &str,
+    media: &[crate::attachments::MediaItem],
+) -> DeliveryMetrics {
+    if response.trim().is_empty() {
+        deliver_media_to_chat(
+            plugin,
+            target.account_id,
+            target.chat_id,
+            target.thread_id,
+            media,
+            &outcome.capabilities,
+        )
+        .await;
+    } else {
+        send_final_reply(
+            plugin,
+            target,
+            response,
+            outcome.stream_outcome.preview.as_ref(),
+            media,
+            &outcome.capabilities,
+        )
+        .await;
+    }
+    DeliveryMetrics {
+        text_chars: response.chars().count(),
+        media_count: media.len(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -319,45 +359,5 @@ mod tests {
         .expect("cancelled pipeline must return promptly");
 
         assert!(outcome.is_none());
-    }
-}
-
-/// Deliver a complete final response through a pipeline that may have
-/// attached after the turn had already started. Unlike [`deliver_rounds`],
-/// this intentionally ignores `drained_rounds` for text reconstruction:
-/// those rounds only contain deltas observed after the late attach point.
-/// The preview handle is still honored, so a half-rendered IM preview is
-/// replaced with the complete final answer when possible.
-pub(crate) async fn deliver_full_response(
-    plugin: &Arc<dyn ChannelPlugin>,
-    target: &DeliveryTarget<'_>,
-    outcome: &PipelineOutcome,
-    response: &str,
-    media: &[crate::attachments::MediaItem],
-) -> DeliveryMetrics {
-    if response.trim().is_empty() {
-        deliver_media_to_chat(
-            plugin,
-            target.account_id,
-            target.chat_id,
-            target.thread_id,
-            media,
-            &outcome.capabilities,
-        )
-        .await;
-    } else {
-        send_final_reply(
-            plugin,
-            target,
-            response,
-            outcome.stream_outcome.preview.as_ref(),
-            media,
-            &outcome.capabilities,
-        )
-        .await;
-    }
-    DeliveryMetrics {
-        text_chars: response.chars().count(),
-        media_count: media.len(),
     }
 }

--- a/crates/ha-core/src/channel/worker/pipeline.rs
+++ b/crates/ha-core/src/channel/worker/pipeline.rs
@@ -4,6 +4,7 @@
 //! await, drain, and `ImReplyMode`-driven fan-out in one place keeps the
 //! two paths from drifting.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::mpsc;
@@ -151,7 +152,64 @@ pub(crate) async fn await_stream_pipeline(pipeline: StreamPipeline) -> PipelineO
     } = pipeline;
     drop(event_sink);
 
-    let stream_outcome = match stream_task.await {
+    pipeline_outcome(
+        stream_task.await,
+        round_texts,
+        reply_mode,
+        capabilities,
+        preview_active,
+    )
+}
+
+/// Await an inbound pipeline while the owning Channel turn remains live.
+/// A provider/tool cancellation can otherwise finish while the preview task is
+/// still blocked in an IM API request, keeping the session single-flight guard
+/// occupied indefinitely. Aborting leaves the already-rendered partial preview
+/// in place, which is the Channel visual contract for a stopped turn.
+pub(crate) async fn await_stream_pipeline_until_cancel(
+    pipeline: StreamPipeline,
+    cancel: &AtomicBool,
+) -> Option<PipelineOutcome> {
+    let StreamPipeline {
+        event_sink,
+        mut stream_task,
+        round_texts,
+        reply_mode,
+        capabilities,
+        preview_active,
+    } = pipeline;
+    drop(event_sink);
+
+    let join_result = tokio::select! {
+        biased;
+        _ = async {
+            while !cancel.load(Ordering::Acquire) {
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+        } => {
+            stream_task.abort();
+            return None;
+        }
+        result = &mut stream_task => result,
+    };
+
+    Some(pipeline_outcome(
+        join_result,
+        round_texts,
+        reply_mode,
+        capabilities,
+        preview_active,
+    ))
+}
+
+fn pipeline_outcome(
+    join_result: Result<StreamPreviewOutcome, tokio::task::JoinError>,
+    round_texts: Arc<Mutex<RoundTextAccumulator>>,
+    reply_mode: ImReplyMode,
+    capabilities: ChannelCapabilities,
+    preview_active: bool,
+) -> PipelineOutcome {
+    let stream_outcome = match join_result {
         Ok(outcome) => outcome,
         Err(e) => {
             crate::app_warn!("channel", "worker", "Streaming preview task failed: {}", e);
@@ -217,6 +275,50 @@ pub(crate) async fn deliver_rounds(
             )
             .await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cancelled_pipeline_does_not_wait_for_a_stuck_preview_task() {
+        let pipeline = StreamPipeline {
+            event_sink: Arc::new(crate::chat_engine::NoopEventSink),
+            stream_task: tokio::spawn(async {
+                std::future::pending::<()>().await;
+                StreamPreviewOutcome::default()
+            }),
+            round_texts: Arc::new(Mutex::new(RoundTextAccumulator::default())),
+            reply_mode: ImReplyMode::Final,
+            capabilities: ChannelCapabilities {
+                chat_types: Vec::new(),
+                supports_polls: false,
+                supports_reactions: false,
+                supports_draft: false,
+                supports_edit: false,
+                supports_unsend: false,
+                supports_reply: false,
+                supports_threads: false,
+                supports_media: Vec::new(),
+                supports_typing: false,
+                supports_buttons: false,
+                streaming_preview_max_bytes: None,
+                supports_card_stream: false,
+            },
+            preview_active: false,
+        };
+        let cancel = AtomicBool::new(true);
+
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            await_stream_pipeline_until_cancel(pipeline, &cancel),
+        )
+        .await
+        .expect("cancelled pipeline must return promptly");
+
+        assert!(outcome.is_none());
     }
 }
 

--- a/crates/ha-core/src/channel/worker/slash.rs
+++ b/crates/ha-core/src/channel/worker/slash.rs
@@ -251,11 +251,24 @@ pub(super) async fn dispatch_slash_for_channel(
             })
         }
 
-        // ── Stop stream — cancel via registry ──
+        // ── Stop stream — same session-stop orchestration as GUI / HTTP ──
         Some(CommandAction::StopStream) => {
-            let cancelled = crate::globals::get_channel_cancels()
-                .map(|reg| reg.cancel(session_id))
-                .unwrap_or(false);
+            // The shared service also flips Channel preflight registrations;
+            // keeping it there makes a GUI/HTTP Stop of this attached session
+            // exactly equivalent to `/stop`.
+            let stop = match crate::get_session_db() {
+                Some(db) => {
+                    crate::chat_engine::stop::stop_session(db.clone(), session_id, None, false)
+                        .await
+                }
+                None => crate::chat_engine::stop::StopSessionOutcome {
+                    stopped: crate::globals::get_channel_cancels()
+                        .map(|registry| registry.cancel(session_id))
+                        .unwrap_or(false),
+                    ..Default::default()
+                },
+            };
+            let cancelled = stop.stopped;
             let msg = if cancelled {
                 "Stopping current stream...".to_string()
             } else {

--- a/crates/ha-core/src/chat_engine/active_turn.rs
+++ b/crates/ha-core/src/chat_engine/active_turn.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use super::stream_seq::{ChatSource, ACTIVE_STREAM_ERROR_CODE};
@@ -15,6 +15,15 @@ use super::stream_seq::{ChatSource, ACTIVE_STREAM_ERROR_CODE};
 pub struct ActiveTurnError {
     pub session_id: String,
     pub existing_source: ChatSource,
+    cancelled_by_global_stop: bool,
+}
+
+impl ActiveTurnError {
+    /// The request was admitted before (or during) an emergency global Stop
+    /// and was rejected before its user message could be persisted.
+    pub fn cancelled_by_global_stop(&self) -> bool {
+        self.cancelled_by_global_stop
+    }
 }
 
 impl fmt::Display for ActiveTurnError {
@@ -51,6 +60,11 @@ static STOP_CLEANUPS: OnceLock<Mutex<HashMap<String, HashSet<String>>>> = OnceLo
 /// before runtime work is captured, otherwise global cleanup could cancel its
 /// resources without signalling its foreground token.
 static GLOBAL_STOP_CLEANUPS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+/// Monotonic emergency-Stop generation. Desktop/HTTP requests snapshot this at
+/// entry, before any project bootstrap or other pre-registration await. A Stop
+/// advances it while holding the active registry lock, so an older request can
+/// never register after the bounded global cleanup gate has been released.
+static GLOBAL_STOP_GENERATION: AtomicU64 = AtomicU64::new(0);
 /// Request-scoped stops may arrive before the shell has registered a turn.
 /// When the caller already knows the target session, retain that binding so a
 /// reused/malformed request id cannot cancel a turn in another session.
@@ -197,6 +211,7 @@ pub fn begin_stop_cleanup(session_id: &str) -> StopCleanupGuard {
 pub fn begin_global_stop_cleanup() -> GlobalStopCleanupGuard {
     let token = uuid::Uuid::new_v4().to_string();
     let _active = registry_lock();
+    GLOBAL_STOP_GENERATION.fetch_add(1, Ordering::SeqCst);
     global_stop_cleanups()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -204,6 +219,20 @@ pub fn begin_global_stop_cleanup() -> GlobalStopCleanupGuard {
     GlobalStopCleanupGuard {
         token,
         released: false,
+    }
+}
+
+/// Admission snapshot for a foreground request that may perform async work
+/// before it can register its active turn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ForegroundRequestAdmission {
+    global_stop_generation: u64,
+}
+
+/// Capture at the transport entry point, before its first await.
+pub fn begin_foreground_request() -> ForegroundRequestAdmission {
+    ForegroundRequestAdmission {
+        global_stop_generation: GLOBAL_STOP_GENERATION.load(Ordering::SeqCst),
     }
 }
 
@@ -226,12 +255,55 @@ pub fn try_acquire_with_client_request_id(
     client_request_id: Option<String>,
     cancel: Arc<AtomicBool>,
 ) -> Result<ActiveTurnGuard, ActiveTurnError> {
+    try_acquire_inner(session_id, source, turn_id, client_request_id, None, cancel)
+}
+
+/// Register a Desktop/HTTP request against the generation captured at its
+/// transport entry point. If an emergency Stop began while the request was in
+/// bootstrap or another pre-registration await, reject it even after the
+/// short-lived global cleanup gate has already been released.
+pub fn try_acquire_foreground_request(
+    admission: ForegroundRequestAdmission,
+    session_id: &str,
+    source: ChatSource,
+    turn_id: String,
+    client_request_id: Option<String>,
+    cancel: Arc<AtomicBool>,
+) -> Result<ActiveTurnGuard, ActiveTurnError> {
+    try_acquire_inner(
+        session_id,
+        source,
+        turn_id,
+        client_request_id,
+        Some(admission.global_stop_generation),
+        cancel,
+    )
+}
+
+fn try_acquire_inner(
+    session_id: &str,
+    source: ChatSource,
+    turn_id: String,
+    client_request_id: Option<String>,
+    request_global_stop_generation: Option<u64>,
+    cancel: Arc<AtomicBool>,
+) -> Result<ActiveTurnGuard, ActiveTurnError> {
     let token = uuid::Uuid::new_v4().to_string();
     let mut map = registry_lock();
     if let Some(existing) = map.get(session_id) {
         return Err(ActiveTurnError {
             session_id: session_id.to_string(),
             existing_source: existing.source,
+            cancelled_by_global_stop: false,
+        });
+    }
+    if request_global_stop_generation
+        .is_some_and(|generation| generation != GLOBAL_STOP_GENERATION.load(Ordering::SeqCst))
+    {
+        return Err(ActiveTurnError {
+            session_id: session_id.to_string(),
+            existing_source: source,
+            cancelled_by_global_stop: true,
         });
     }
     if !global_stop_cleanups()
@@ -242,6 +314,7 @@ pub fn try_acquire_with_client_request_id(
         return Err(ActiveTurnError {
             session_id: session_id.to_string(),
             existing_source: source,
+            cancelled_by_global_stop: true,
         });
     }
     if stop_cleanups()
@@ -253,6 +326,7 @@ pub fn try_acquire_with_client_request_id(
         return Err(ActiveTurnError {
             session_id: session_id.to_string(),
             existing_source: source,
+            cancelled_by_global_stop: false,
         });
     }
     if client_request_id.as_deref().is_some_and(|request_id| {
@@ -949,6 +1023,37 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
         )
         .expect("replacement turn should acquire after global cleanup");
+    }
+
+    #[test]
+    fn global_stop_generation_rejects_requests_that_predate_cleanup() {
+        let _lock = test_lock();
+        let stale_request = begin_foreground_request();
+
+        let gate = begin_global_stop_cleanup();
+        drop(gate);
+
+        let error = try_acquire_foreground_request(
+            stale_request,
+            "test-global-stop-stale-request",
+            ChatSource::Desktop,
+            "turn-stale-request".to_string(),
+            Some("request-stale".to_string()),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect_err("request predating global Stop must be rejected");
+        assert!(error.cancelled_by_global_stop());
+
+        let fresh_request = begin_foreground_request();
+        let _guard = try_acquire_foreground_request(
+            fresh_request,
+            "test-global-stop-fresh-request",
+            ChatSource::Http,
+            "turn-fresh-request".to_string(),
+            Some("request-fresh".to_string()),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("request entering after global Stop should acquire");
     }
 
     #[test]

--- a/crates/ha-core/src/chat_engine/active_turn.rs
+++ b/crates/ha-core/src/chat_engine/active_turn.rs
@@ -228,6 +228,25 @@ pub fn begin_global_stop_cleanup() -> GlobalStopCleanupGuard {
     }
 }
 
+/// Whether session-scoped or process-wide Stop cleanup still owns admission
+/// for this session. ACP does not register an [`ActiveTurnGuard`], so it uses
+/// this read-only gate before accepting a replacement prompt.
+pub fn stop_cleanup_active(session_id: &str) -> bool {
+    let _active = registry_lock();
+    if !global_stop_cleanups()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .is_empty()
+    {
+        return true;
+    }
+    stop_cleanups()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(session_id)
+        .is_some_and(|tokens| !tokens.is_empty())
+}
+
 /// Admission snapshot for a foreground request that may perform async work
 /// before it can register its active turn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ha-core/src/chat_engine/active_turn.rs
+++ b/crates/ha-core/src/chat_engine/active_turn.rs
@@ -422,6 +422,53 @@ pub fn current_for_client_request(client_request_id: &str) -> Option<ActiveTurnS
 }
 
 #[derive(Debug, Clone)]
+pub enum ActiveTurnCancelOutcome {
+    Cancelled(ActiveTurnSnapshot),
+    NotFound,
+    TurnMismatch,
+}
+
+/// Signal one active turn while still holding the registry lock shared with
+/// the pre-turn persistence boundary. This makes Stop linearizable with the
+/// user-message/chat-turn transaction: either persistence commits first and
+/// Stop observes a durable turn, or cancellation wins and persistence is
+/// rejected.
+pub fn cancel_current(session_id: &str, expected_turn_id: Option<&str>) -> ActiveTurnCancelOutcome {
+    let map = registry_lock();
+    let Some(entry) = map.get(session_id) else {
+        return ActiveTurnCancelOutcome::NotFound;
+    };
+    if expected_turn_id.is_some_and(|expected| expected != entry.turn_id) {
+        return ActiveTurnCancelOutcome::TurnMismatch;
+    }
+    entry.cancel.store(true, Ordering::SeqCst);
+    ActiveTurnCancelOutcome::Cancelled(ActiveTurnSnapshot {
+        session_id: session_id.to_string(),
+        turn_id: entry.turn_id.clone(),
+        stream_id: entry.stream_id.clone(),
+        source: entry.source,
+        cancel: Arc::clone(&entry.cancel),
+    })
+}
+
+/// Signal every active turn under the same registry lock used by persistence.
+pub fn cancel_all_current() -> Vec<ActiveTurnSnapshot> {
+    let map = registry_lock();
+    map.iter()
+        .map(|(session_id, entry)| {
+            entry.cancel.store(true, Ordering::SeqCst);
+            ActiveTurnSnapshot {
+                session_id: session_id.clone(),
+                turn_id: entry.turn_id.clone(),
+                stream_id: entry.stream_id.clone(),
+                source: entry.source,
+                cancel: Arc::clone(&entry.cancel),
+            }
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone)]
 pub enum ClientRequestCancelOutcome {
     Active(ActiveTurnSnapshot),
     Latched,
@@ -486,6 +533,17 @@ pub fn cancel_or_latch_client_request(
     ClientRequestCancelOutcome::Latched
 }
 
+/// Observe a pre-registration request cancellation without consuming it.
+/// Project bootstrap uses this after publishing its client-request mapping so
+/// a Stop that arrived even earlier can also latch bootstrap cancellation.
+pub fn has_latched_client_cancel(client_request_id: &str) -> bool {
+    let _map = registry_lock();
+    pending_client_cancels()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .contains_key(client_request_id)
+}
+
 /// Execute a short synchronous operation only while this exact user-facing
 /// turn still accepts queued-message insertion. The registry lock deliberately
 /// spans `operation`: turn finalization takes the same lock to close insertion
@@ -512,6 +570,30 @@ pub fn with_insertion_target<T>(
     }
     if !matches!(entry.source, ChatSource::Desktop | ChatSource::Http) {
         return Err("active turn source does not support insertion");
+    }
+    Ok(operation())
+}
+
+/// Execute the short synchronous transaction that first makes a foreground
+/// prompt durable. Stop signalling takes the same registry lock, so a prompt
+/// cannot slip into history after its cancellation flag was observed false.
+pub fn with_persistence_target<T>(
+    session_id: &str,
+    turn_id: &str,
+    operation: impl FnOnce() -> T,
+) -> Result<T, &'static str> {
+    let map = registry_lock();
+    let Some(entry) = map.get(session_id) else {
+        return Err("no active turn for session");
+    };
+    if entry.turn_id != turn_id {
+        return Err("active turn id does not match");
+    }
+    if entry.cancel.load(Ordering::SeqCst) {
+        return Err("active turn is cancelling");
+    }
+    if !matches!(entry.source, ChatSource::Desktop | ChatSource::Http) {
+        return Err("active turn source does not support prompt persistence");
     }
     Ok(operation())
 }
@@ -1054,6 +1136,46 @@ mod tests {
             Arc::new(AtomicBool::new(false)),
         )
         .expect("request entering after global Stop should acquire");
+    }
+
+    #[test]
+    fn global_stop_generation_rejects_stale_channel_admission() {
+        let _lock = test_lock();
+        let stale_request = begin_foreground_request();
+        drop(begin_global_stop_cleanup());
+
+        let error = try_acquire_foreground_request(
+            stale_request,
+            "test-global-stop-stale-channel",
+            ChatSource::Channel,
+            "turn-stale-channel".to_string(),
+            None,
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect_err("Channel request predating global Stop must be rejected");
+        assert!(error.cancelled_by_global_stop());
+    }
+
+    #[test]
+    fn cancelled_turn_cannot_cross_prompt_persistence_boundary() {
+        let _lock = test_lock();
+        let sid = "test-active-turn-persistence-boundary";
+        let _guard = try_acquire(
+            sid,
+            ChatSource::Desktop,
+            "turn-persistence".to_string(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            cancel_current(sid, Some("turn-persistence")),
+            ActiveTurnCancelOutcome::Cancelled(_)
+        ));
+        assert_eq!(
+            with_persistence_target(sid, "turn-persistence", || "persisted"),
+            Err("active turn is cancelling")
+        );
     }
 
     #[test]

--- a/crates/ha-core/src/chat_engine/active_turn.rs
+++ b/crates/ha-core/src/chat_engine/active_turn.rs
@@ -299,6 +299,27 @@ pub struct ActiveTurnSnapshot {
     pub cancel: Arc<AtomicBool>,
 }
 
+/// Resolve the exact Stop target shared by the desktop and HTTP adapters.
+///
+/// Before `turn_started` reaches the client, a Stop may know the session and
+/// client request id but not the turn id. If the request id already resolves
+/// to an active turn, preserve that turn id even when the caller supplied the
+/// session explicitly; falling back to a session-wide Stop could otherwise
+/// race and cancel a replacement turn.
+pub fn resolve_stop_target(
+    explicit_session_id: Option<&str>,
+    explicit_turn_id: Option<&str>,
+    request_target: Option<&ActiveTurnSnapshot>,
+) -> (Option<String>, Option<String>) {
+    let session_id = explicit_session_id
+        .map(str::to_string)
+        .or_else(|| request_target.map(|active| active.session_id.clone()));
+    let turn_id = explicit_turn_id
+        .map(str::to_string)
+        .or_else(|| request_target.map(|active| active.turn_id.clone()));
+    (session_id, turn_id)
+}
+
 pub fn current(session_id: &str) -> Option<ActiveTurnSnapshot> {
     let map = registry_lock();
     map.get(session_id).map(|entry| ActiveTurnSnapshot {
@@ -695,6 +716,11 @@ mod tests {
         };
         assert_eq!(cancelled.turn_id, "turn-request-target");
         assert!(cancel.load(std::sync::atomic::Ordering::SeqCst));
+
+        let (target_session_id, target_turn_id) =
+            resolve_stop_target(Some(sid), None, Some(&cancelled));
+        assert_eq!(target_session_id.as_deref(), Some(sid));
+        assert_eq!(target_turn_id.as_deref(), Some("turn-request-target"));
     }
 
     #[test]

--- a/crates/ha-core/src/chat_engine/active_turn.rs
+++ b/crates/ha-core/src/chat_engine/active_turn.rs
@@ -33,6 +33,7 @@ impl std::error::Error for ActiveTurnError {}
 struct Entry {
     token: String,
     turn_id: String,
+    client_request_id: Option<String>,
     stream_id: Option<String>,
     source: ChatSource,
     cancel: Arc<AtomicBool>,
@@ -40,9 +41,36 @@ struct Entry {
 }
 
 static ACTIVE_TURNS: OnceLock<Mutex<HashMap<String, Entry>>> = OnceLock::new();
+/// A Stop request keeps this short-lived gate armed while it snapshots and
+/// settles work owned by the old turn. Without the gate, the old cleanup can
+/// race a freshly-acquired turn in the same session and mistake its resources
+/// for leftovers.
+static STOP_CLEANUPS: OnceLock<Mutex<HashMap<String, HashSet<String>>>> = OnceLock::new();
+/// Process-wide emergency Stop gate. This closes the enumeration gap in
+/// `stop_all_sessions`: a turn must not acquire after the active snapshot yet
+/// before runtime work is captured, otherwise global cleanup could cancel its
+/// resources without signalling its foreground token.
+static GLOBAL_STOP_CLEANUPS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+/// Request-scoped stops may arrive before the shell has registered a turn.
+/// When the caller already knows the target session, retain that binding so a
+/// reused/malformed request id cannot cancel a turn in another session.
+static PENDING_CLIENT_CANCELS: OnceLock<Mutex<HashMap<String, Option<String>>>> = OnceLock::new();
+const PENDING_CLIENT_CANCELS_MAX: usize = 4096;
 
 fn registry() -> &'static Mutex<HashMap<String, Entry>> {
     ACTIVE_TURNS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn pending_client_cancels() -> &'static Mutex<HashMap<String, Option<String>>> {
+    PENDING_CLIENT_CANCELS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn stop_cleanups() -> &'static Mutex<HashMap<String, HashSet<String>>> {
+    STOP_CLEANUPS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn global_stop_cleanups() -> &'static Mutex<HashSet<String>> {
+    GLOBAL_STOP_CLEANUPS.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
 /// Poison-tolerant lock on the active-turn registry. A panic while another
@@ -68,9 +96,7 @@ impl ActiveTurnGuard {
         if self.released {
             return;
         }
-        let mut map = registry()
-            .lock()
-            .expect("active chat turn registry poisoned");
+        let mut map = registry_lock();
         if map
             .get(&self.session_id)
             .map(|entry| entry.token.as_str() == self.token)
@@ -88,10 +114,116 @@ impl Drop for ActiveTurnGuard {
     }
 }
 
+#[derive(Debug)]
+pub struct StopCleanupGuard {
+    session_id: String,
+    token: String,
+    released: bool,
+}
+
+impl StopCleanupGuard {
+    pub fn release(&mut self) {
+        if self.released {
+            return;
+        }
+        let mut stopping = stop_cleanups()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(tokens) = stopping.get_mut(&self.session_id) {
+            tokens.remove(&self.token);
+            if tokens.is_empty() {
+                stopping.remove(&self.session_id);
+            }
+        }
+        self.released = true;
+    }
+}
+
+impl Drop for StopCleanupGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+#[derive(Debug)]
+pub struct GlobalStopCleanupGuard {
+    token: String,
+    released: bool,
+}
+
+impl GlobalStopCleanupGuard {
+    pub fn release(&mut self) {
+        if self.released {
+            return;
+        }
+        global_stop_cleanups()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.token);
+        self.released = true;
+    }
+}
+
+impl Drop for GlobalStopCleanupGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+/// Prevent a replacement foreground turn from acquiring this session until
+/// the Stop caller has captured the old turn's exact cleanup targets.
+///
+/// Acquisition and gate installation both serialize through `ACTIVE_TURNS`,
+/// so either a racing turn is visible to Stop and gets cancelled, or it sees
+/// this gate and is rejected. They cannot pass each other unseen.
+pub fn begin_stop_cleanup(session_id: &str) -> StopCleanupGuard {
+    let token = uuid::Uuid::new_v4().to_string();
+    let _active = registry_lock();
+    stop_cleanups()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .entry(session_id.to_string())
+        .or_default()
+        .insert(token.clone());
+    StopCleanupGuard {
+        session_id: session_id.to_string(),
+        token,
+        released: false,
+    }
+}
+
+/// Prevent any replacement foreground turn from entering while a process-wide
+/// emergency Stop enumerates and settles its exact cleanup targets.
+pub fn begin_global_stop_cleanup() -> GlobalStopCleanupGuard {
+    let token = uuid::Uuid::new_v4().to_string();
+    let _active = registry_lock();
+    global_stop_cleanups()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(token.clone());
+    GlobalStopCleanupGuard {
+        token,
+        released: false,
+    }
+}
+
 pub fn try_acquire(
     session_id: &str,
     source: ChatSource,
     turn_id: String,
+    cancel: Arc<AtomicBool>,
+) -> Result<ActiveTurnGuard, ActiveTurnError> {
+    try_acquire_with_client_request_id(session_id, source, turn_id, None, cancel)
+}
+
+/// Acquire a foreground turn and associate it with the client request that
+/// initiated it. The request id lets a draft-session Stop target this exact
+/// turn before `session_created` / `turn_started` has reached the UI.
+pub fn try_acquire_with_client_request_id(
+    session_id: &str,
+    source: ChatSource,
+    turn_id: String,
+    client_request_id: Option<String>,
     cancel: Arc<AtomicBool>,
 ) -> Result<ActiveTurnGuard, ActiveTurnError> {
     let token = uuid::Uuid::new_v4().to_string();
@@ -102,11 +234,49 @@ pub fn try_acquire(
             existing_source: existing.source,
         });
     }
+    if !global_stop_cleanups()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .is_empty()
+    {
+        return Err(ActiveTurnError {
+            session_id: session_id.to_string(),
+            existing_source: source,
+        });
+    }
+    if stop_cleanups()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(session_id)
+        .is_some_and(|tokens| !tokens.is_empty())
+    {
+        return Err(ActiveTurnError {
+            session_id: session_id.to_string(),
+            existing_source: source,
+        });
+    }
+    if client_request_id.as_deref().is_some_and(|request_id| {
+        let mut pending = pending_client_cancels()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let matches_session = pending.get(request_id).is_some_and(|expected_session_id| {
+            expected_session_id
+                .as_deref()
+                .is_none_or(|expected| expected == session_id)
+        });
+        if matches_session {
+            pending.remove(request_id);
+        }
+        matches_session
+    }) {
+        cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
     map.insert(
         session_id.to_string(),
         Entry {
             token: token.clone(),
             turn_id,
+            client_request_id,
             stream_id: None,
             source,
             cancel,
@@ -138,6 +308,87 @@ pub fn current(session_id: &str) -> Option<ActiveTurnSnapshot> {
         source: entry.source,
         cancel: Arc::clone(&entry.cancel),
     })
+}
+
+/// Resolve an active foreground turn by the opaque client request id.
+pub fn current_for_client_request(client_request_id: &str) -> Option<ActiveTurnSnapshot> {
+    let map = registry_lock();
+    map.iter().find_map(|(session_id, entry)| {
+        (entry.client_request_id.as_deref() == Some(client_request_id)).then(|| {
+            ActiveTurnSnapshot {
+                session_id: session_id.clone(),
+                turn_id: entry.turn_id.clone(),
+                stream_id: entry.stream_id.clone(),
+                source: entry.source,
+                cancel: Arc::clone(&entry.cancel),
+            }
+        })
+    })
+}
+
+#[derive(Debug, Clone)]
+pub enum ClientRequestCancelOutcome {
+    Active(ActiveTurnSnapshot),
+    Latched,
+    SessionMismatch,
+}
+
+/// Cancel an already-registered client request, or latch the cancellation if
+/// the Stop request won the transport race and arrived first. Both this path
+/// and acquisition take the active registry before the pending map, so the
+/// lookup/insert and consume/register transitions cannot pass each other.
+pub fn cancel_or_latch_client_request(
+    client_request_id: &str,
+    expected_session_id: Option<&str>,
+) -> ClientRequestCancelOutcome {
+    let map = registry_lock();
+    if let Some((session_id, entry)) = map
+        .iter()
+        .find(|(_, entry)| entry.client_request_id.as_deref() == Some(client_request_id))
+    {
+        if expected_session_id.is_some_and(|expected| expected != session_id) {
+            return ClientRequestCancelOutcome::SessionMismatch;
+        }
+        entry
+            .cancel
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        return ClientRequestCancelOutcome::Active(ActiveTurnSnapshot {
+            session_id: session_id.clone(),
+            turn_id: entry.turn_id.clone(),
+            stream_id: entry.stream_id.clone(),
+            source: entry.source,
+            cancel: Arc::clone(&entry.cancel),
+        });
+    }
+
+    let mut pending = pending_client_cancels()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(existing_session_id) = pending.get(client_request_id) {
+        if existing_session_id.as_deref().is_some()
+            && expected_session_id.is_some()
+            && existing_session_id.as_deref() != expected_session_id
+        {
+            return ClientRequestCancelOutcome::SessionMismatch;
+        }
+        if existing_session_id.is_none() && expected_session_id.is_some() {
+            pending.insert(
+                client_request_id.to_string(),
+                expected_session_id.map(str::to_string),
+            );
+        }
+        return ClientRequestCancelOutcome::Latched;
+    }
+    if pending.len() >= PENDING_CLIENT_CANCELS_MAX {
+        if let Some(evicted) = pending.keys().next().cloned() {
+            pending.remove(&evicted);
+        }
+    }
+    pending.insert(
+        client_request_id.to_string(),
+        expected_session_id.map(str::to_string),
+    );
+    ClientRequestCancelOutcome::Latched
 }
 
 /// Execute a short synchronous operation only while this exact user-facing
@@ -251,6 +502,18 @@ pub fn clear_all() -> usize {
     let mut map = registry_lock();
     let n = map.len();
     map.clear();
+    pending_client_cancels()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
+    stop_cleanups()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
+    global_stop_cleanups()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
     n
 }
 
@@ -407,6 +670,90 @@ mod tests {
     }
 
     #[test]
+    fn request_id_targets_a_draft_turn_before_session_events_arrive() {
+        let _lock = test_lock();
+        let sid = "test-active-turn-request-target";
+        let cancel = Arc::new(AtomicBool::new(false));
+        let _guard = try_acquire_with_client_request_id(
+            sid,
+            ChatSource::Desktop,
+            "turn-request-target".to_string(),
+            Some("request-target".to_string()),
+            Arc::clone(&cancel),
+        )
+        .unwrap();
+
+        assert!(current_for_client_request("unknown-request").is_none());
+        let snapshot = current_for_client_request("request-target").unwrap();
+        assert_eq!(snapshot.session_id, sid);
+        assert_eq!(snapshot.turn_id, "turn-request-target");
+        assert!(Arc::ptr_eq(&snapshot.cancel, &cancel));
+
+        let cancelled = cancel_or_latch_client_request("request-target", Some(sid));
+        let ClientRequestCancelOutcome::Active(cancelled) = cancelled else {
+            panic!("expected an active request cancellation");
+        };
+        assert_eq!(cancelled.turn_id, "turn-request-target");
+        assert!(cancel.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn request_stop_latches_when_it_arrives_before_turn_registration() {
+        let _lock = test_lock();
+        let sid = "test-active-turn-request-latch";
+        let cancel = Arc::new(AtomicBool::new(false));
+
+        assert!(matches!(
+            cancel_or_latch_client_request("request-latch", Some(sid)),
+            ClientRequestCancelOutcome::Latched
+        ));
+        let _guard = try_acquire_with_client_request_id(
+            sid,
+            ChatSource::Http,
+            "turn-request-latch".to_string(),
+            Some("request-latch".to_string()),
+            Arc::clone(&cancel),
+        )
+        .unwrap();
+
+        assert!(cancel.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn request_stop_for_known_session_does_not_cancel_another_session() {
+        let _lock = test_lock();
+        let expected_sid = "test-active-turn-request-expected-session";
+        let other_sid = "test-active-turn-request-other-session";
+
+        assert!(matches!(
+            cancel_or_latch_client_request("request-session-bound", Some(expected_sid)),
+            ClientRequestCancelOutcome::Latched
+        ));
+
+        let other_cancel = Arc::new(AtomicBool::new(false));
+        let _other_guard = try_acquire_with_client_request_id(
+            other_sid,
+            ChatSource::Http,
+            "turn-other-session".to_string(),
+            Some("request-session-bound".to_string()),
+            Arc::clone(&other_cancel),
+        )
+        .unwrap();
+        assert!(!other_cancel.load(std::sync::atomic::Ordering::SeqCst));
+
+        let expected_cancel = Arc::new(AtomicBool::new(false));
+        let _expected_guard = try_acquire_with_client_request_id(
+            expected_sid,
+            ChatSource::Desktop,
+            "turn-expected-session".to_string(),
+            Some("request-session-bound".to_string()),
+            Arc::clone(&expected_cancel),
+        )
+        .unwrap();
+        assert!(expected_cancel.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
     fn is_accepting_and_has_entry_match_current_semantics() {
         let _lock = test_lock();
         let sid = "test-active-turn-is-accepting";
@@ -501,6 +848,57 @@ mod tests {
         assert!(current(sid).is_some());
         assert!(force_release(sid, "turn-force"));
         assert!(current(sid).is_none());
+    }
+
+    #[test]
+    fn stop_cleanup_gate_blocks_only_until_old_snapshot_finishes() {
+        let _lock = test_lock();
+        let sid = "test-active-turn-stop-cleanup-gate";
+        let gate = begin_stop_cleanup(sid);
+
+        assert!(try_acquire(
+            sid,
+            ChatSource::Desktop,
+            "turn-during-stop".to_string(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .is_err());
+
+        drop(gate);
+        let _guard = try_acquire(
+            sid,
+            ChatSource::Desktop,
+            "turn-after-stop".to_string(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("replacement turn should acquire after cleanup snapshot");
+    }
+
+    #[test]
+    fn global_stop_cleanup_gate_blocks_every_session_until_release() {
+        let _lock = test_lock();
+        let gate = begin_global_stop_cleanup();
+        for (session_id, source) in [
+            ("test-global-stop-a", ChatSource::Desktop),
+            ("test-global-stop-b", ChatSource::Http),
+        ] {
+            assert!(try_acquire(
+                session_id,
+                source,
+                format!("turn-{session_id}"),
+                Arc::new(AtomicBool::new(false)),
+            )
+            .is_err());
+        }
+
+        drop(gate);
+        let _guard = try_acquire(
+            "test-global-stop-a",
+            ChatSource::Desktop,
+            "turn-after-global-stop".to_string(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("replacement turn should acquire after global cleanup");
     }
 
     #[test]

--- a/crates/ha-core/src/chat_engine/active_turn.rs
+++ b/crates/ha-core/src/chat_engine/active_turn.rs
@@ -746,6 +746,30 @@ mod tests {
     }
 
     #[test]
+    fn latched_request_stop_does_not_signal_another_turn_in_the_session() {
+        let _lock = test_lock();
+        let sid = "test-active-turn-request-latch-isolation";
+        let active_cancel = Arc::new(AtomicBool::new(false));
+        let _active_guard = try_acquire_with_client_request_id(
+            sid,
+            ChatSource::Http,
+            "turn-a".to_string(),
+            Some("request-a".to_string()),
+            Arc::clone(&active_cancel),
+        )
+        .expect("active request A");
+
+        assert!(matches!(
+            cancel_or_latch_client_request("request-b", Some(sid)),
+            ClientRequestCancelOutcome::Latched
+        ));
+        assert!(
+            !active_cancel.load(std::sync::atomic::Ordering::SeqCst),
+            "request B's latch must not become a session-wide signal for request A"
+        );
+    }
+
+    #[test]
     fn request_stop_for_known_session_does_not_cancel_another_session() {
         let _lock = test_lock();
         let expected_sid = "test-active-turn-request-expected-session";

--- a/crates/ha-core/src/chat_engine/active_turn.rs
+++ b/crates/ha-core/src/chat_engine/active_turn.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use super::stream_seq::{ChatSource, ACTIVE_STREAM_ERROR_CODE};
@@ -46,8 +46,14 @@ struct Entry {
     stream_id: Option<String>,
     source: ChatSource,
     cancel: Arc<AtomicBool>,
+    persistence_state: Arc<AtomicU8>,
     accepting_insertions: bool,
 }
+
+const PERSISTENCE_PENDING: u8 = 0;
+const PERSISTENCE_RUNNING: u8 = 1;
+const PERSISTENCE_DURABLE: u8 = 2;
+const PERSISTENCE_CANCELLED: u8 = 3;
 
 static ACTIVE_TURNS: OnceLock<Mutex<HashMap<String, Entry>>> = OnceLock::new();
 /// A Stop request keeps this short-lived gate armed while it snapshots and
@@ -345,6 +351,11 @@ fn try_acquire_inner(
     }) {
         cancel.store(true, std::sync::atomic::Ordering::SeqCst);
     }
+    let persistence_state = Arc::new(AtomicU8::new(if cancel.load(Ordering::SeqCst) {
+        PERSISTENCE_CANCELLED
+    } else {
+        PERSISTENCE_PENDING
+    }));
     map.insert(
         session_id.to_string(),
         Entry {
@@ -354,6 +365,7 @@ fn try_acquire_inner(
             stream_id: None,
             source,
             cancel,
+            persistence_state,
             accepting_insertions: true,
         },
     );
@@ -442,6 +454,12 @@ pub fn cancel_current(session_id: &str, expected_turn_id: Option<&str>) -> Activ
         return ActiveTurnCancelOutcome::TurnMismatch;
     }
     entry.cancel.store(true, Ordering::SeqCst);
+    let _ = entry.persistence_state.compare_exchange(
+        PERSISTENCE_PENDING,
+        PERSISTENCE_CANCELLED,
+        Ordering::SeqCst,
+        Ordering::SeqCst,
+    );
     ActiveTurnCancelOutcome::Cancelled(ActiveTurnSnapshot {
         session_id: session_id.to_string(),
         turn_id: entry.turn_id.clone(),
@@ -457,6 +475,12 @@ pub fn cancel_all_current() -> Vec<ActiveTurnSnapshot> {
     map.iter()
         .map(|(session_id, entry)| {
             entry.cancel.store(true, Ordering::SeqCst);
+            let _ = entry.persistence_state.compare_exchange(
+                PERSISTENCE_PENDING,
+                PERSISTENCE_CANCELLED,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            );
             ActiveTurnSnapshot {
                 session_id: session_id.clone(),
                 turn_id: entry.turn_id.clone(),
@@ -494,6 +518,12 @@ pub fn cancel_or_latch_client_request(
         entry
             .cancel
             .store(true, std::sync::atomic::Ordering::SeqCst);
+        let _ = entry.persistence_state.compare_exchange(
+            PERSISTENCE_PENDING,
+            PERSISTENCE_CANCELLED,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
         return ClientRequestCancelOutcome::Active(ActiveTurnSnapshot {
             session_id: session_id.clone(),
             turn_id: entry.turn_id.clone(),
@@ -574,28 +604,65 @@ pub fn with_insertion_target<T>(
     Ok(operation())
 }
 
-/// Execute the short synchronous transaction that first makes a foreground
-/// prompt durable. Stop signalling takes the same registry lock, so a prompt
-/// cannot slip into history after its cancellation flag was observed false.
+/// Claim and execute the transaction that first makes a foreground prompt
+/// durable. The atomic state is the ordering point with Stop; the registry
+/// lock is deliberately released before the potentially blocking operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PersistenceTargetOutcome<T> {
+    Committed(T),
+    CommittedAfterCancel(T),
+    CancelledBeforeCommit,
+}
+
 pub fn with_persistence_target<T>(
     session_id: &str,
     turn_id: &str,
-    operation: impl FnOnce() -> T,
-) -> Result<T, &'static str> {
-    let map = registry_lock();
-    let Some(entry) = map.get(session_id) else {
-        return Err("no active turn for session");
+    operation: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<PersistenceTargetOutcome<T>> {
+    let (cancel, persistence_state) = {
+        let map = registry_lock();
+        let Some(entry) = map.get(session_id) else {
+            return Ok(PersistenceTargetOutcome::CancelledBeforeCommit);
+        };
+        if entry.turn_id != turn_id {
+            return Ok(PersistenceTargetOutcome::CancelledBeforeCommit);
+        }
+        (
+            Arc::clone(&entry.cancel),
+            Arc::clone(&entry.persistence_state),
+        )
     };
-    if entry.turn_id != turn_id {
-        return Err("active turn id does not match");
+
+    // This atomic claim is the ordering point with Stop. The registry mutex is
+    // released before SQLite/filesystem work starts, so a stalled persistence
+    // cannot block cancellation or admission for unrelated sessions.
+    if persistence_state
+        .compare_exchange(
+            PERSISTENCE_PENDING,
+            PERSISTENCE_RUNNING,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        )
+        .is_err()
+    {
+        return Ok(PersistenceTargetOutcome::CancelledBeforeCommit);
     }
-    if entry.cancel.load(Ordering::SeqCst) {
-        return Err("active turn is cancelling");
+
+    let result = operation();
+    match result {
+        Ok(value) => {
+            persistence_state.store(PERSISTENCE_DURABLE, Ordering::SeqCst);
+            if cancel.load(Ordering::SeqCst) {
+                Ok(PersistenceTargetOutcome::CommittedAfterCancel(value))
+            } else {
+                Ok(PersistenceTargetOutcome::Committed(value))
+            }
+        }
+        Err(error) => {
+            persistence_state.store(PERSISTENCE_CANCELLED, Ordering::SeqCst);
+            Err(error)
+        }
     }
-    if !matches!(entry.source, ChatSource::Desktop | ChatSource::Http) {
-        return Err("active turn source does not support prompt persistence");
-    }
-    Ok(operation())
 }
 
 /// Close the insertion gate for an exact turn before its durable queue rows
@@ -1173,8 +1240,42 @@ mod tests {
             ActiveTurnCancelOutcome::Cancelled(_)
         ));
         assert_eq!(
-            with_persistence_target(sid, "turn-persistence", || "persisted"),
-            Err("active turn is cancelling")
+            with_persistence_target(sid, "turn-persistence", || Ok("persisted")).unwrap(),
+            PersistenceTargetOutcome::CancelledBeforeCommit
+        );
+    }
+
+    #[test]
+    fn persistence_does_not_hold_registry_mutex_during_slow_io() {
+        let _lock = test_lock();
+        let sid = "test-active-turn-persistence-nonblocking";
+        let _guard = try_acquire(
+            sid,
+            ChatSource::Desktop,
+            "turn-persistence-nonblocking".to_string(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            with_persistence_target(sid, "turn-persistence-nonblocking", || {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                Ok("persisted")
+            })
+            .unwrap()
+        });
+        started_rx.recv().unwrap();
+
+        assert!(matches!(
+            cancel_current(sid, Some("turn-persistence-nonblocking")),
+            ActiveTurnCancelOutcome::Cancelled(_)
+        ));
+        release_tx.send(()).unwrap();
+        assert_eq!(
+            worker.join().unwrap(),
+            PersistenceTargetOutcome::CommittedAfterCancel("persisted")
         );
     }
 

--- a/crates/ha-core/src/chat_engine/engine.rs
+++ b/crates/ha-core/src/chat_engine/engine.rs
@@ -18,6 +18,12 @@ use super::stream_seq;
 use super::types::*;
 
 const CHAT_CANCEL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+/// Once a turn has emitted runtime-visible output we first give the provider /
+/// tool loop a bounded window to propagate cancellation and clean up owned
+/// resources.  The previous unbounded await meant one cancellation-unaware
+/// tool or hook could keep the caller future alive forever, even though the
+/// stop watchdog had already made the turn look terminal to the UI.
+const CHAT_CANCEL_COOPERATIVE_GRACE: std::time::Duration = std::time::Duration::from_secs(6);
 const CHAT_CANCELLED_BY_CALLER: &str = "chat cancelled by caller";
 
 async fn wait_for_chat_cancel(cancel: Arc<std::sync::atomic::AtomicBool>) {
@@ -1312,7 +1318,24 @@ pub(crate) async fn run_chat_engine_classified(
                             None if allow_hard_cancel.load(std::sync::atomic::Ordering::SeqCst) => {
                                 Err(anyhow::anyhow!(CHAT_CANCELLED_BY_CALLER))
                             }
-                            None => chat_future.as_mut().await,
+                            None => match tokio::time::timeout(
+                                CHAT_CANCEL_COOPERATIVE_GRACE,
+                                chat_future.as_mut(),
+                            )
+                            .await
+                            {
+                                Ok(result) => result,
+                                Err(_) => {
+                                    app_warn!(
+                                        "chat",
+                                        "cancel",
+                                        "Force-dropping session {} model/tool loop after {}ms cancellation grace",
+                                        session_id_owned,
+                                        CHAT_CANCEL_COOPERATIVE_GRACE.as_millis()
+                                    );
+                                    Err(anyhow::anyhow!(CHAT_CANCELLED_BY_CALLER))
+                                }
+                            },
                         };
                         drop(chat_future);
 
@@ -1638,6 +1661,18 @@ pub(crate) async fn run_chat_engine_classified(
                     };
                     let committed = match committed {
                         Ok(committed) => committed,
+                        Err(_) if cancel.load(std::sync::atomic::Ordering::SeqCst) => {
+                            // Stop may win after the final in-memory cancel
+                            // check but before the atomic success transaction.
+                            // The DB refuses to overwrite `cancelling`; converge
+                            // the durable journal through the normal UserStop
+                            // finalizer instead of misclassifying that CAS as a
+                            // persistence failure.
+                            last_reason = None;
+                            last_error = Some(CHAT_CANCELLED_BY_CALLER.to_string());
+                            last_was_no_profile = false;
+                            break;
+                        }
                         Err(error) => {
                             let message = format!("final assistant transaction failed: {error}");
                             // Do not terminalize the persistence run here.

--- a/crates/ha-core/src/chat_engine/mod.rs
+++ b/crates/ha-core/src/chat_engine/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod persister;
 pub(crate) mod quote;
 pub mod sink_registry;
 pub(crate) mod spool;
+pub mod stop;
 pub mod stream_broadcast;
 pub mod stream_seq;
 pub mod turn_injection;
@@ -259,7 +260,28 @@ fn snapshot_blocks(
     (blocks, usage)
 }
 
-pub const CHAT_STOP_WATCHDOG_GRACE: Duration = Duration::from_secs(5);
+/// The engine gives an already-visible provider/tool loop six seconds for
+/// cooperative cleanup.  The watchdog intentionally fires later: it is the
+/// last-resort durable convergence path, not a competing normal finalizer.
+pub const CHAT_STOP_WATCHDOG_GRACE: Duration = Duration::from_secs(8);
+
+async fn stopped_turn_is_latest_session_generation(
+    db: &Arc<crate::session::SessionDB>,
+    session_id: &str,
+    turn_id: &str,
+) -> bool {
+    if active_turn::current(session_id).is_some_and(|active| active.turn_id != turn_id) {
+        return false;
+    }
+    let session_id = session_id.to_string();
+    let turn_id = turn_id.to_string();
+    db.clone()
+        .run(move |db| db.get_latest_chat_turn(&session_id))
+        .await
+        .ok()
+        .flatten()
+        .is_some_and(|latest| latest.id == turn_id)
+}
 
 /// Recover a unified persistence run when its owning async engine future is
 /// dropped before it can execute the normal finalizer (HTTP disconnect,
@@ -283,6 +305,7 @@ pub fn spawn_abandoned_stream_recovery(
             &session_id,
             turn_id.as_deref(),
             source,
+            finalize::TerminationReason::RuntimeCancel,
             &persistence_run_id,
         )
         .await;
@@ -303,6 +326,7 @@ async fn converge_abandoned_stream(
     session_id: &str,
     turn_id: Option<&str>,
     source: ChatSource,
+    reason: finalize::TerminationReason,
     run_id: &str,
 ) -> anyhow::Result<()> {
     // Import any frames that were acknowledged through the emergency spool
@@ -373,7 +397,9 @@ async fn converge_abandoned_stream(
         checkpoint_seq,
         provider_kind,
     )?;
-    let reason = finalize::TerminationReason::RuntimeCancel;
+    let terminal_status = reason.to_chat_turn_status();
+    let interrupt_reason = reason.to_chat_turn_interrupt_reason();
+    let is_user_stop = matches!(reason, finalize::TerminationReason::UserStop);
     history.push(serde_json::json!({
         "role": "assistant",
         "content": finalize::copy::model_marker(&reason),
@@ -382,10 +408,9 @@ async fn converge_abandoned_stream(
     let trailing = crate::session::trailing_text_from_journal_events(&events);
     let assistant = crate::session::journal_events_have_assistant_output(&events)
         .then(|| crate::session::NewMessage::assistant(&trailing).with_source(source));
-    let recovery_event = Some(
-        crate::session::NewMessage::event(&finalize::copy::user_notice(&reason))
-            .with_source(source),
-    );
+    let recovery_event = (!is_user_stop).then(|| {
+        crate::session::NewMessage::event(&finalize::copy::user_notice(&reason)).with_source(source)
+    });
     let error = journal_error.or(spool_integrity_error);
     let commit = crate::session::CommitInterruptedTurn {
         run_id: Some(run_id.to_string()),
@@ -396,8 +421,8 @@ async fn converge_abandoned_stream(
         expected_context_revision: context_revision,
         turn_id: turn_id.map(ToOwned::to_owned),
         final_seq: through_seq,
-        status: crate::session::ChatTurnStatus::Interrupted,
-        interrupt_reason: Some("runtime_cancel".to_string()),
+        status: terminal_status,
+        interrupt_reason: Some(interrupt_reason.as_str().to_string()),
         error,
         recovery_event,
     };
@@ -427,8 +452,8 @@ async fn converge_abandoned_stream(
             session_id,
             snapshot.run.stream_id.as_deref(),
             turn_id,
-            Some(crate::session::ChatTurnStatus::Interrupted),
-            Some(crate::session::ChatTurnInterruptReason::RuntimeCancel),
+            Some(terminal_status),
+            Some(interrupt_reason),
             None,
         );
     }
@@ -438,10 +463,11 @@ async fn converge_abandoned_stream(
     app_info!(
         "chat",
         "abandoned_stream_recovery",
-        "atomically recovered runtime-cancelled run {} through seq {} assistant_id={}",
+        "atomically recovered abandoned run {} through seq {} assistant_id={} reason={}",
         run_id,
         committed.committed_seq,
-        committed.assistant_message_id
+        committed.assistant_message_id,
+        interrupt_reason.as_str()
     );
     Ok(())
 }
@@ -455,7 +481,18 @@ pub fn spawn_user_stop_watchdog(
     tokio::spawn(async move {
         tokio::time::sleep(CHAT_STOP_WATCHDOG_GRACE).await;
 
-        let turn = match db.get_chat_turn(&turn_id) {
+        // Re-establish the Stop generation gate before inspecting any
+        // session-scoped legacy state. If a replacement turn won the race it
+        // is now visible below; otherwise no new turn can start while this
+        // watchdog converges the old one.
+        let _stop_cleanup_guard = active_turn::begin_stop_cleanup(&session_id);
+
+        let turn_id_for_load = turn_id.clone();
+        let turn = match db
+            .clone()
+            .run(move |db| db.get_chat_turn(&turn_id_for_load))
+            .await
+        {
             Ok(Some(turn)) if !turn.status.is_terminal() => turn,
             _ => return,
         };
@@ -465,10 +502,15 @@ pub fn spawn_user_stop_watchdog(
                 .and_then(|active| active.stream_id)
         });
 
-        // New streams converge from their durable journal. This branch races
-        // safely with the normal engine finalizer: context revision + turn
-        // status CAS allow exactly one transaction to win.
-        if let Some(durability) = durability::active(&session_id) {
+        // New streams converge from their durable journal. The registry is
+        // keyed by session for the streaming hot path, so a delayed watchdog
+        // must additionally bind the coordinator to its exact turn. A newer
+        // turn may already own the session after the stopped engine released.
+        let active_durability = durability::active(&session_id);
+        let matching_durability = active_durability.as_ref().filter(|coordinator| {
+            coordinator.snapshot().turn_id.as_deref() == Some(turn_id.as_str())
+        });
+        if let Some(durability) = matching_durability.cloned() {
             let convergence = async {
                 let durable_seq = durability.flush(FlushReason::Stop).await?;
                 durability.reconcile_spool_to_sqlite().await?;
@@ -615,6 +657,65 @@ pub fn spawn_user_stop_watchdog(
             return;
         }
 
+        // The old coordinator may already have been force-dropped and
+        // unregistered. Recover its run by turn id rather than touching the
+        // session's current coordinator or latest run.
+        let turn_id_for_run = turn_id.clone();
+        let exact_run = db
+            .clone()
+            .run(move |db| db.stream_run_snapshot_for_turn(&turn_id_for_run))
+            .await;
+        match exact_run {
+            Ok(Some(snapshot)) if snapshot.run.status == "running" => {
+                let run_id = snapshot.run.run_id;
+                if let Err(error) = converge_abandoned_stream(
+                    db.clone(),
+                    &session_id,
+                    Some(&turn_id),
+                    source,
+                    finalize::TerminationReason::UserStop,
+                    &run_id,
+                )
+                .await
+                {
+                    app_warn!(
+                        "chat",
+                        "stop_watchdog",
+                        "Exact stopped run {} for turn {} remains recoverable: {}",
+                        run_id,
+                        turn_id,
+                        error
+                    );
+                }
+                return;
+            }
+            Ok(Some(_)) => return,
+            Err(error) => {
+                app_warn!(
+                    "chat",
+                    "stop_watchdog",
+                    "Failed to resolve persistence run for stopped turn {}: {}",
+                    turn_id,
+                    error
+                );
+                return;
+            }
+            Ok(None) if active_durability.is_some() => {
+                // A different live coordinator proves this is not a legacy
+                // stream. Never fall through to session-wide reconstruction.
+                return;
+            }
+            Ok(None) => {}
+        }
+
+        // Everything below is the one-minor legacy fallback and is keyed only
+        // by session. It is safe solely while the stopped turn is still the
+        // latest generation and no different turn is active. The cleanup gate
+        // above makes this check stable until fallback finalization completes.
+        if !stopped_turn_is_latest_session_generation(&db, &session_id, &turn_id).await {
+            return;
+        }
+
         let flushed = active_persisters::cancel_flush_session(&session_id);
         if flushed > 0 {
             app_info!(
@@ -672,6 +773,38 @@ mod abandoned_stream_tests {
     use crate::session::{CreateStreamRun, JournalBatch, JournalEvent, NewMessage, SessionDB};
 
     #[tokio::test]
+    async fn legacy_stop_watchdog_rejects_a_completed_replacement_turn() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Arc::new(
+            SessionDB::open_ephemeral_for_test(&dir.path().join("legacy-generation.db"))
+                .expect("db"),
+        );
+        let session = db
+            .create_session(crate::agent_loader::DEFAULT_AGENT_ID)
+            .expect("session");
+        let stopped = db
+            .create_chat_turn(&session.id, "desktop", None, None)
+            .expect("stopped turn");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let replacement = db
+            .create_chat_turn(&session.id, "desktop", None, None)
+            .expect("replacement turn");
+        db.finish_chat_turn_once(
+            &replacement.id,
+            crate::session::ChatTurnStatus::Completed,
+            None,
+            None,
+            None,
+        )
+        .expect("finish replacement");
+
+        assert!(
+            !stopped_turn_is_latest_session_generation(&db, &session.id, &stopped.id).await,
+            "a delayed legacy watchdog must not rebuild from a completed newer turn"
+        );
+    }
+
+    #[tokio::test]
     async fn dropped_engine_materializes_only_its_durable_prefix() {
         let dir = tempfile::tempdir().expect("tempdir");
         let db = Arc::new(
@@ -722,6 +855,7 @@ mod abandoned_stream_tests {
             &session.id,
             Some(&turn.id),
             ChatSource::Http,
+            finalize::TerminationReason::RuntimeCancel,
             &run_id,
         )
         .await
@@ -782,6 +916,7 @@ mod abandoned_stream_tests {
             &session.id,
             Some(&turn.id),
             ChatSource::Http,
+            finalize::TerminationReason::RuntimeCancel,
             &run_id,
         )
         .await

--- a/crates/ha-core/src/chat_engine/mod.rs
+++ b/crates/ha-core/src/chat_engine/mod.rs
@@ -264,6 +264,15 @@ fn snapshot_blocks(
 /// cooperative cleanup.  The watchdog intentionally fires later: it is the
 /// last-resort durable convergence path, not a competing normal finalizer.
 pub const CHAT_STOP_WATCHDOG_GRACE: Duration = Duration::from_secs(8);
+const CHAT_STOP_RECOVERY_RETRY_MIN: Duration = Duration::from_millis(250);
+const CHAT_STOP_RECOVERY_RETRY_MAX: Duration = Duration::from_secs(5);
+
+fn stop_recovery_retry_delay(failures: u32) -> Duration {
+    let multiplier = 1u32 << failures.saturating_sub(1).min(4);
+    CHAT_STOP_RECOVERY_RETRY_MIN
+        .saturating_mul(multiplier)
+        .min(CHAT_STOP_RECOVERY_RETRY_MAX)
+}
 
 async fn stopped_turn_is_latest_session_generation(
     db: &Arc<crate::session::SessionDB>,
@@ -431,19 +440,9 @@ async fn converge_abandoned_stream(
         .run(move |db| db.commit_interrupted_turn(&commit))
         .await?;
 
-    let run_id_for_cleanup = run_id.to_string();
-    if spool.integrity_error.is_some() {
-        crate::blocking::run_blocking(move || {
-            crate::chat_engine::spool::quarantine(&run_id_for_cleanup)
-        })
-        .await?;
-    } else {
-        crate::blocking::run_blocking(move || {
-            crate::chat_engine::spool::remove(&run_id_for_cleanup)
-        })
-        .await?;
-    }
-
+    // The DB transaction is the terminal truth. Release the visible stream
+    // before best-effort spool housekeeping so a filesystem cleanup error
+    // cannot leave an already-committed turn looking active forever.
     if let Some(stream_id) = snapshot.run.stream_id.as_deref() {
         let _ = stream_seq::end_if_stream(session_id, stream_id);
     }
@@ -460,6 +459,28 @@ async fn converge_abandoned_stream(
     if let Some(turn_id) = turn_id {
         active_turn::force_release(session_id, turn_id);
     }
+
+    let run_id_for_cleanup = run_id.to_string();
+    let spool_cleanup = if spool.integrity_error.is_some() {
+        crate::blocking::run_blocking(move || {
+            crate::chat_engine::spool::quarantine(&run_id_for_cleanup)
+        })
+        .await
+    } else {
+        crate::blocking::run_blocking(move || {
+            crate::chat_engine::spool::remove(&run_id_for_cleanup)
+        })
+        .await
+    };
+    if let Err(error) = spool_cleanup {
+        app_warn!(
+            "chat",
+            "abandoned_stream_recovery",
+            "Recovered run {} but could not archive/remove its spool; startup cleanup will retry: {}",
+            run_id,
+            error
+        );
+    }
     app_info!(
         "chat",
         "abandoned_stream_recovery",
@@ -470,6 +491,69 @@ async fn converge_abandoned_stream(
         interrupt_reason.as_str()
     );
     Ok(())
+}
+
+/// Resolve the persistence run owned by an exact stopped turn. Transient
+/// spool/SQLite failures are retried while the caller retains the session Stop
+/// gate, so a replacement turn cannot advance the context revision out from
+/// under recoverable partial output. `false` means no exact run exists and the
+/// caller may evaluate the one-minor legacy fallback.
+async fn converge_exact_stopped_run(
+    db: Arc<crate::session::SessionDB>,
+    session_id: &str,
+    turn_id: &str,
+    source: ChatSource,
+    retry_missing: bool,
+) -> bool {
+    let mut failures = 0u32;
+    loop {
+        let turn_id_for_run = turn_id.to_string();
+        let exact_run = db
+            .clone()
+            .run(move |db| db.stream_run_snapshot_for_turn(&turn_id_for_run))
+            .await;
+        let failure = match exact_run {
+            Ok(Some(snapshot)) if snapshot.run.status == "running" => {
+                let run_id = snapshot.run.run_id;
+                match converge_abandoned_stream(
+                    db.clone(),
+                    session_id,
+                    Some(turn_id),
+                    source,
+                    finalize::TerminationReason::UserStop,
+                    &run_id,
+                )
+                .await
+                {
+                    Ok(()) => return true,
+                    Err(error) => (Some(run_id), error),
+                }
+            }
+            Ok(Some(_)) => return true,
+            Ok(None) if !retry_missing => return false,
+            Ok(None) => (
+                None,
+                anyhow::anyhow!("expected stopped persistence run is temporarily unavailable"),
+            ),
+            Err(error) => (None, error),
+        };
+
+        failures = failures.saturating_add(1);
+        if failures == 1 || failures.is_power_of_two() {
+            let run = failure.0.as_deref().unwrap_or("unresolved");
+            app_warn!(
+                "chat",
+                "stop_watchdog",
+                "Retrying exact stopped-run recovery while admission remains closed: session={} turn={} run={} failures={} error={}",
+                session_id,
+                turn_id,
+                run,
+                failures,
+                failure.1
+            );
+        }
+        tokio::time::sleep(stop_recovery_retry_delay(failures)).await;
+    }
 }
 
 pub fn spawn_user_stop_watchdog(
@@ -487,14 +571,32 @@ pub fn spawn_user_stop_watchdog(
         // watchdog converges the old one.
         let _stop_cleanup_guard = active_turn::begin_stop_cleanup(&session_id);
 
-        let turn_id_for_load = turn_id.clone();
-        let turn = match db
-            .clone()
-            .run(move |db| db.get_chat_turn(&turn_id_for_load))
-            .await
-        {
-            Ok(Some(turn)) if !turn.status.is_terminal() => turn,
-            _ => return,
+        let mut turn_load_failures = 0u32;
+        let turn = loop {
+            let turn_id_for_load = turn_id.clone();
+            match db
+                .clone()
+                .run(move |db| db.get_chat_turn(&turn_id_for_load))
+                .await
+            {
+                Ok(Some(turn)) if !turn.status.is_terminal() => break turn,
+                Ok(Some(_)) | Ok(None) => return,
+                Err(error) => {
+                    turn_load_failures = turn_load_failures.saturating_add(1);
+                    if turn_load_failures == 1 || turn_load_failures.is_power_of_two() {
+                        app_warn!(
+                            "chat",
+                            "stop_watchdog",
+                            "Retrying stopped-turn lookup while admission remains closed: session={} turn={} failures={} error={}",
+                            session_id,
+                            turn_id,
+                            turn_load_failures,
+                            error
+                        );
+                    }
+                    tokio::time::sleep(stop_recovery_retry_delay(turn_load_failures)).await;
+                }
+            }
         };
         let stream_id = turn.stream_id.clone().or_else(|| {
             active_turn::current(&session_id)
@@ -618,94 +720,77 @@ pub fn spawn_user_stop_watchdog(
             }
             .await;
 
-            let (status, interrupt, error) = match convergence {
+            match convergence {
                 Ok(()) => {
                     durability.mark_interrupted("interrupted");
-                    (
-                        crate::session::ChatTurnStatus::Interrupted,
+                    let _released_stream = stream_id
+                        .as_deref()
+                        .map(|id| stream_seq::end_if_stream(&session_id, id))
+                        .unwrap_or(false);
+                    stream_broadcast::broadcast_stream_end(
+                        &session_id,
+                        stream_id.as_deref(),
+                        Some(&turn_id),
+                        Some(crate::session::ChatTurnStatus::Interrupted),
                         Some(crate::session::ChatTurnInterruptReason::UserStop),
                         None,
-                    )
+                    );
+                    active_turn::force_release(&session_id, &turn_id);
+                    return;
+                }
+                Err(convergence_error) if durability.is_persistent() => {
+                    app_warn!(
+                        "chat",
+                        "stop_watchdog",
+                        "Live stopped-run convergence failed; retaining admission gate for exact recovery: session={} turn={} run={} error={}",
+                        session_id,
+                        turn_id,
+                        durability.persistence_run_id(),
+                        convergence_error
+                    );
+                    // Unregister the failed live coordinator, but leave its DB
+                    // run in `running` so exact journal recovery can converge
+                    // it without exposing a replacement-turn window.
+                    durability.mark_interrupted("recovering");
+                    let _recovered =
+                        converge_exact_stopped_run(db.clone(), &session_id, &turn_id, source, true)
+                            .await;
+                    return;
                 }
                 Err(convergence_error) => {
                     let message =
                         format!("stop persistence convergence failed: {convergence_error}");
-                    // Keep the DB run recoverable. Terminalizing it without
-                    // materializing the journal would make already displayed
-                    // bytes unreachable on restart.
                     durability.mark_interrupted("failed");
-                    (
-                        crate::session::ChatTurnStatus::Failed,
+                    let _released_stream = stream_id
+                        .as_deref()
+                        .map(|id| stream_seq::end_if_stream(&session_id, id))
+                        .unwrap_or(false);
+                    stream_broadcast::broadcast_stream_end(
+                        &session_id,
+                        stream_id.as_deref(),
+                        Some(&turn_id),
+                        Some(crate::session::ChatTurnStatus::Failed),
                         Some(crate::session::ChatTurnInterruptReason::Unknown),
-                        Some(message),
-                    )
+                        Some(&message),
+                    );
+                    active_turn::force_release(&session_id, &turn_id);
+                    return;
                 }
-            };
-            let _released_stream = stream_id
-                .as_deref()
-                .map(|id| stream_seq::end_if_stream(&session_id, id))
-                .unwrap_or(false);
-            stream_broadcast::broadcast_stream_end(
-                &session_id,
-                stream_id.as_deref(),
-                Some(&turn_id),
-                Some(status),
-                interrupt,
-                error.as_deref(),
-            );
-            active_turn::force_release(&session_id, &turn_id);
+            }
+        }
+
+        // A different live coordinator proves this is not a legacy stream.
+        // Never recover or reconstruct session-wide state across its boundary.
+        if active_durability.is_some() {
             return;
         }
 
         // The old coordinator may already have been force-dropped and
         // unregistered. Recover its run by turn id rather than touching the
-        // session's current coordinator or latest run.
-        let turn_id_for_run = turn_id.clone();
-        let exact_run = db
-            .clone()
-            .run(move |db| db.stream_run_snapshot_for_turn(&turn_id_for_run))
-            .await;
-        match exact_run {
-            Ok(Some(snapshot)) if snapshot.run.status == "running" => {
-                let run_id = snapshot.run.run_id;
-                if let Err(error) = converge_abandoned_stream(
-                    db.clone(),
-                    &session_id,
-                    Some(&turn_id),
-                    source,
-                    finalize::TerminationReason::UserStop,
-                    &run_id,
-                )
-                .await
-                {
-                    app_warn!(
-                        "chat",
-                        "stop_watchdog",
-                        "Exact stopped run {} for turn {} remains recoverable: {}",
-                        run_id,
-                        turn_id,
-                        error
-                    );
-                }
-                return;
-            }
-            Ok(Some(_)) => return,
-            Err(error) => {
-                app_warn!(
-                    "chat",
-                    "stop_watchdog",
-                    "Failed to resolve persistence run for stopped turn {}: {}",
-                    turn_id,
-                    error
-                );
-                return;
-            }
-            Ok(None) if active_durability.is_some() => {
-                // A different live coordinator proves this is not a legacy
-                // stream. Never fall through to session-wide reconstruction.
-                return;
-            }
-            Ok(None) => {}
+        // session's current coordinator or latest run. The Stop gate remains
+        // held across transient failures and retry backoff.
+        if converge_exact_stopped_run(db.clone(), &session_id, &turn_id, source, false).await {
+            return;
         }
 
         // Everything below is the one-minor legacy fallback and is keyed only

--- a/crates/ha-core/src/chat_engine/stop.rs
+++ b/crates/ha-core/src/chat_engine/stop.rs
@@ -38,6 +38,32 @@ pub struct StopAllOutcome {
     pub runtime_cancellation_error: Option<String>,
 }
 
+/// Persistence won its atomic claim, but Stop arrived while the blocking DB
+/// operation was still running. Converge the now-durable turn off the async
+/// worker so the earlier watchdog cannot miss a row that did not exist yet.
+pub async fn finalize_persisted_user_stop(
+    db: Arc<SessionDB>,
+    session_id: String,
+    turn_id: String,
+    user_message: String,
+    source: crate::chat_engine::ChatSource,
+) -> crate::chat_engine::finalize::FinalizeOutcome {
+    crate::blocking::run_blocking(move || {
+        crate::chat_engine::finalize::finalize_turn_context_blocking(
+            &db,
+            &session_id,
+            crate::chat_engine::finalize::TerminationReason::UserStop,
+            crate::chat_engine::finalize::PartialMeta {
+                user_message: Some(user_message),
+                turn_id: Some(turn_id),
+                ..Default::default()
+            },
+            source,
+        )
+    })
+    .await
+}
+
 /// Cleanup owned state for a prompt that was cancelled before a durable chat
 /// turn existed. Construction installs the session cleanup gate immediately;
 /// callers may then publish/release any transport-visible lifecycle before

--- a/crates/ha-core/src/chat_engine/stop.rs
+++ b/crates/ha-core/src/chat_engine/stop.rs
@@ -1,0 +1,477 @@
+//! Shared foreground-session Stop orchestration.
+//!
+//! Transport/UI entry points may differ in how they identify a turn, but once
+//! a session target is known they must converge through this module so Desktop,
+//! HTTP, and IM `/stop` resolve interaction waits and owned runtime work with
+//! the same semantics.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+use std::{collections::HashSet, future::Future};
+
+use crate::runtime_tasks::CancelRuntimeTaskResult;
+use crate::session::{ChatTurnInterruptReason, ChatTurnStatus, SessionDB};
+use crate::tools::ApprovalResolutionSource;
+
+const STOP_DB_MARK_TIMEOUT: Duration = Duration::from_secs(2);
+const STOP_INTERACTION_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+const STOP_RUNTIME_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Default)]
+pub struct StopSessionOutcome {
+    pub stopped: bool,
+    pub turn_mismatch: bool,
+    pub denied_approvals: usize,
+    pub cancelled_questions: usize,
+    pub runtime_cancellations: Vec<CancelRuntimeTaskResult>,
+    pub runtime_cancellation_error: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub struct StopAllOutcome {
+    pub stopped: bool,
+    pub stopped_session_count: usize,
+    pub denied_approvals: usize,
+    pub cancelled_questions: usize,
+    pub runtime_cancellations: Vec<CancelRuntimeTaskResult>,
+    pub runtime_cancellation_error: Option<String>,
+}
+
+async fn timeout_count(operation: &'static str, future: impl Future<Output = usize>) -> usize {
+    // Time the operation itself rather than a detached JoinHandle. Both
+    // interaction cleanup functions drain their exact entries before their
+    // first post-lock await, so dropping this future cannot later consume an
+    // interaction registered by a replacement turn.
+    match tokio::time::timeout(STOP_INTERACTION_CLEANUP_TIMEOUT, future).await {
+        Ok(count) => count,
+        Err(_) => {
+            crate::app_warn!(
+                "chat",
+                "stop",
+                "Timed out after {}ms during {}",
+                STOP_INTERACTION_CLEANUP_TIMEOUT.as_millis(),
+                operation
+            );
+            0
+        }
+    }
+}
+
+async fn timeout_runtime_cleanup(
+    future: impl Future<Output = anyhow::Result<Vec<CancelRuntimeTaskResult>>>,
+) -> anyhow::Result<Vec<CancelRuntimeTaskResult>> {
+    match tokio::time::timeout(STOP_RUNTIME_CLEANUP_TIMEOUT, future).await {
+        Ok(result) => result,
+        Err(_) => Err(anyhow::anyhow!(
+            "runtime cancellation timed out after {}ms",
+            STOP_RUNTIME_CLEANUP_TIMEOUT.as_millis()
+        )),
+    }
+}
+
+/// Stop the foreground work owned by one session.
+///
+/// `already_signalled` covers transport-specific pre-registration handles
+/// outside core (for example an HTTP request handle). Channel preflight handles
+/// are resolved here so GUI, HTTP, and IM `/stop` cannot diverge. An
+/// `expected_turn_id` keeps an exact stale Stop from cancelling a newer turn;
+/// `None` intentionally means "whatever is active in this session" and still
+/// reaps interaction/runtime work when the active-turn entry disappeared.
+pub async fn stop_session(
+    db: Arc<SessionDB>,
+    session_id: &str,
+    expected_turn_id: Option<&str>,
+    already_signalled: bool,
+) -> StopSessionOutcome {
+    // Keep replacement turns out until the runtime snapshot below has captured
+    // only work belonging to the stopped generation.
+    let mut stop_cleanup_guard = Some(super::active_turn::begin_stop_cleanup(session_id));
+    let mut outcome = StopSessionOutcome {
+        stopped: already_signalled,
+        ..Default::default()
+    };
+    let mut matched_active = false;
+    let mut durable_turn_id = None;
+
+    if let Some(active) = super::active_turn::current(session_id) {
+        let matches_turn = expected_turn_id
+            .map(|turn_id| turn_id == active.turn_id)
+            .unwrap_or(true);
+        if matches_turn {
+            matched_active = true;
+            outcome.stopped = true;
+            active.cancel.store(true, Ordering::SeqCst);
+
+            // Channel has its own stream lifecycle bus and deliberately does
+            // not create a GUI chat_turn row. Desktop/HTTP use the normal
+            // chat:* status + durable watchdog path. Broadcast and arm the
+            // watchdog before any DB/cleanup await so Stop feedback and guard
+            // release cannot be delayed by a saturated blocking pool.
+            if active.source.broadcasts_to_user_ui() {
+                super::stream_broadcast::broadcast_turn_status(
+                    session_id,
+                    &active.turn_id,
+                    ChatTurnStatus::Cancelling,
+                    Some(ChatTurnInterruptReason::UserStop),
+                );
+                super::spawn_user_stop_watchdog(
+                    db.clone(),
+                    session_id.to_string(),
+                    active.turn_id.clone(),
+                    active.source,
+                );
+                durable_turn_id = Some(active.turn_id);
+            }
+        } else {
+            outcome.turn_mismatch = true;
+        }
+    }
+
+    // A session-only Stop is authoritative even if the active entry vanished
+    // between UI observation and this call. An exact stale turn must not tear
+    // down Channel preflight, waits, or runtime that may belong to a newer turn.
+    let settle_session = expected_turn_id.is_none() || matched_active;
+    if !settle_session {
+        stop_cleanup_guard.take();
+    }
+    if settle_session {
+        let channel_signalled = crate::globals::get_channel_cancels()
+            .map(|registry| registry.cancel(session_id))
+            .unwrap_or(false);
+        outcome.stopped |= channel_signalled;
+    }
+
+    // Durable marking, interaction resolution and runtime reaping are
+    // independent. Run them concurrently and bound each wait: the synchronous
+    // cancel flags above are authoritative, while these convergence steps must
+    // never make the Stop request itself unbounded.
+    let mark_turn = async {
+        let Some(turn_id) = durable_turn_id else {
+            return;
+        };
+        let turn_id_for_mark = turn_id.clone();
+        match tokio::time::timeout(
+            STOP_DB_MARK_TIMEOUT,
+            db.clone().run(move |db| {
+                db.mark_chat_turn_cancelling(&turn_id_for_mark, ChatTurnInterruptReason::UserStop)
+            }),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => crate::app_warn!(
+                "chat",
+                "stop_session",
+                "Failed to mark stopped turn {} for session {} as cancelling: {}",
+                turn_id,
+                session_id,
+                error
+            ),
+            Err(_) => crate::app_warn!(
+                "chat",
+                "stop_session",
+                "Timed out after {}ms marking stopped turn {} for session {} as cancelling",
+                STOP_DB_MARK_TIMEOUT.as_millis(),
+                turn_id,
+                session_id
+            ),
+        }
+    };
+    let approval_session_id = session_id.to_string();
+    let deny_approvals = async move {
+        if !settle_session {
+            return 0;
+        }
+        timeout_count("denying approvals for stopped session", async move {
+            crate::tools::deny_pending_for_session(
+                &approval_session_id,
+                ApprovalResolutionSource::UserStop,
+            )
+            .await
+        })
+        .await
+    };
+    let question_session_id = session_id.to_string();
+    let cancel_questions = async move {
+        if !settle_session {
+            return 0;
+        }
+        timeout_count("cancelling questions for stopped session", async move {
+            crate::ask_user::cancel_pending_ask_user_questions_for_session(
+                &question_session_id,
+                "user_stop",
+            )
+            .await
+        })
+        .await
+    };
+    let runtime_session_id = session_id.to_string();
+    let cancel_runtime = async move {
+        if !settle_session {
+            return Ok(Vec::new());
+        }
+        timeout_runtime_cleanup(async move {
+            let snapshot =
+                crate::runtime_tasks::snapshot_runtime_tasks_for_session(Some(&runtime_session_id))
+                    .await?;
+            crate::runtime_tasks::cancel_runtime_task_snapshot(snapshot).await
+        })
+        .await
+    };
+    let ((), denied_approvals, cancelled_questions, runtime_result) =
+        tokio::join!(mark_turn, deny_approvals, cancel_questions, cancel_runtime);
+    outcome.denied_approvals = denied_approvals;
+    outcome.cancelled_questions = cancelled_questions;
+    match runtime_result {
+        Ok(results) => outcome.runtime_cancellations = results,
+        Err(error) => {
+            crate::app_warn!(
+                "chat",
+                "stop_session",
+                "Runtime cancellation failed after stopping session {}: {}",
+                session_id,
+                error
+            );
+            outcome.runtime_cancellation_error = Some(error.to_string());
+        }
+    }
+
+    if settle_session {
+        outcome.stopped = outcome.stopped
+            || outcome.denied_approvals > 0
+            || outcome.cancelled_questions > 0
+            || outcome
+                .runtime_cancellations
+                .iter()
+                .any(|result| result.accepted);
+    }
+
+    drop(stop_cleanup_guard);
+
+    crate::app_info!(
+        "chat",
+        "stop_session",
+        "Session stop settled: session={} expected_turn={:?} stopped={} turn_mismatch={} approvals_denied={} questions_cancelled={} runtime_cancellations={}",
+        session_id,
+        expected_turn_id,
+        outcome.stopped,
+        outcome.turn_mismatch,
+        outcome.denied_approvals,
+        outcome.cancelled_questions,
+        outcome.runtime_cancellations.len()
+    );
+
+    outcome
+}
+
+/// Emergency Stop for every foreground surface.
+///
+/// Shells must synchronously flip any transport-local handles first and pass
+/// their session ids in `pre_signalled_sessions`. Core then applies the exact
+/// same active-turn, Channel, durable-state, interaction and runtime cleanup
+/// semantics for Desktop and HTTP. Every fallible convergence step is bounded;
+/// the cancel flags and watchdogs are installed before the first await.
+pub async fn stop_all_sessions(
+    db: Arc<SessionDB>,
+    pre_signalled_sessions: impl IntoIterator<Item = String>,
+    already_signalled: bool,
+) -> StopAllOutcome {
+    let global_stop_cleanup_guard = super::active_turn::begin_global_stop_cleanup();
+    let mut stopped_sessions: HashSet<String> = pre_signalled_sessions.into_iter().collect();
+    let mut durable_turn_ids = Vec::new();
+
+    for active in super::active_turn::all_current() {
+        active.cancel.store(true, Ordering::SeqCst);
+        stopped_sessions.insert(active.session_id.clone());
+        if active.source.broadcasts_to_user_ui() {
+            super::stream_broadcast::broadcast_turn_status(
+                &active.session_id,
+                &active.turn_id,
+                ChatTurnStatus::Cancelling,
+                Some(ChatTurnInterruptReason::UserStop),
+            );
+            super::spawn_user_stop_watchdog(
+                db.clone(),
+                active.session_id,
+                active.turn_id.clone(),
+                active.source,
+            );
+            durable_turn_ids.push(active.turn_id);
+        }
+    }
+    if let Some(registry) = crate::globals::get_channel_cancels() {
+        stopped_sessions.extend(registry.cancel_all());
+    }
+    let mark_turns = async {
+        if durable_turn_ids.is_empty() {
+            return;
+        }
+        let turn_ids_for_mark = durable_turn_ids.clone();
+        match tokio::time::timeout(
+            STOP_DB_MARK_TIMEOUT,
+            db.run(move |db| {
+                for turn_id in &turn_ids_for_mark {
+                    if let Err(error) =
+                        db.mark_chat_turn_cancelling(turn_id, ChatTurnInterruptReason::UserStop)
+                    {
+                        crate::app_warn!(
+                            "chat",
+                            "stop_all_sessions",
+                            "Failed to mark stopped turn {} as cancelling: {}",
+                            turn_id,
+                            error
+                        );
+                    }
+                }
+            }),
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(_) => crate::app_warn!(
+                "chat",
+                "stop_all_sessions",
+                "Timed out after {}ms marking stopped turns as cancelling",
+                STOP_DB_MARK_TIMEOUT.as_millis()
+            ),
+        }
+    };
+    let deny_approvals = timeout_count(
+        "denying all pending approvals",
+        crate::tools::deny_all_pending(ApprovalResolutionSource::UserStop),
+    );
+    let cancel_questions = timeout_count(
+        "cancelling all pending questions",
+        crate::ask_user::cancel_all_pending_ask_user_questions("user_stop"),
+    );
+    let cancel_runtime = timeout_runtime_cleanup(async {
+        let snapshot = crate::runtime_tasks::snapshot_runtime_tasks_for_session(None).await?;
+        crate::runtime_tasks::cancel_runtime_task_snapshot(snapshot).await
+    });
+
+    let ((), denied_approvals, cancelled_questions, runtime_result) =
+        tokio::join!(mark_turns, deny_approvals, cancel_questions, cancel_runtime);
+    let mut outcome = StopAllOutcome {
+        stopped: already_signalled || !stopped_sessions.is_empty(),
+        stopped_session_count: stopped_sessions.len(),
+        denied_approvals,
+        cancelled_questions,
+        ..Default::default()
+    };
+    match runtime_result {
+        Ok(results) => outcome.runtime_cancellations = results,
+        Err(error) => {
+            crate::app_warn!(
+                "chat",
+                "stop_all_sessions",
+                "Global runtime cancellation failed after stop signals: {}",
+                error
+            );
+            outcome.runtime_cancellation_error = Some(error.to_string());
+        }
+    }
+    outcome.stopped = outcome.stopped
+        || outcome.denied_approvals > 0
+        || outcome.cancelled_questions > 0
+        || outcome
+            .runtime_cancellations
+            .iter()
+            .any(|result| result.accepted);
+    drop(global_stop_cleanup_guard);
+    crate::app_info!(
+        "chat",
+        "stop_all_sessions",
+        "Global stop settled: stopped={} sessions={} approvals_denied={} questions_cancelled={} runtime_cancellations={}",
+        outcome.stopped,
+        outcome.stopped_session_count,
+        outcome.denied_approvals,
+        outcome.cancelled_questions,
+        outcome.runtime_cancellations.len()
+    );
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+
+    fn fixture() -> (tempfile::TempDir, Arc<SessionDB>, String, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Arc::new(
+            SessionDB::open_ephemeral_for_test(&dir.path().join("stop.db")).expect("session db"),
+        );
+        let session = db.create_session("ha-main").expect("session");
+        let turn = db
+            .create_chat_turn(&session.id, "desktop", None, None)
+            .expect("turn");
+        (dir, db, session.id, turn.id)
+    }
+
+    #[tokio::test]
+    async fn shared_stop_marks_and_signals_the_exact_turn() {
+        let (_dir, db, session_id, turn_id) = fixture();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let _guard = crate::chat_engine::active_turn::try_acquire(
+            &session_id,
+            crate::chat_engine::ChatSource::Desktop,
+            turn_id.clone(),
+            cancel.clone(),
+        )
+        .expect("active turn");
+
+        let outcome = stop_session(db.clone(), &session_id, Some(&turn_id), false).await;
+
+        assert!(outcome.stopped);
+        assert!(!outcome.turn_mismatch);
+        assert!(cancel.load(Ordering::SeqCst));
+        assert_eq!(
+            db.get_chat_turn(&turn_id).unwrap().unwrap().status,
+            ChatTurnStatus::Cancelling
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_stale_stop_does_not_cancel_a_newer_turn() {
+        let (_dir, db, session_id, turn_id) = fixture();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let _guard = crate::chat_engine::active_turn::try_acquire(
+            &session_id,
+            crate::chat_engine::ChatSource::Desktop,
+            turn_id,
+            cancel.clone(),
+        )
+        .expect("active turn");
+
+        let outcome = stop_session(db, &session_id, Some("older-turn"), false).await;
+
+        assert!(!outcome.stopped);
+        assert!(outcome.turn_mismatch);
+        assert!(!cancel.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn shared_stop_cancels_channel_turn_without_a_gui_turn_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Arc::new(
+            SessionDB::open_ephemeral_for_test(&dir.path().join("channel-stop.db"))
+                .expect("session db"),
+        );
+        let session = db.create_session("ha-main").expect("session");
+        let cancel = Arc::new(AtomicBool::new(false));
+        let _guard = crate::chat_engine::active_turn::try_acquire(
+            &session.id,
+            crate::chat_engine::ChatSource::Channel,
+            "channel-synthetic-turn".to_string(),
+            cancel.clone(),
+        )
+        .expect("active turn");
+
+        let outcome = stop_session(db, &session.id, None, true).await;
+
+        assert!(outcome.stopped);
+        assert!(!outcome.turn_mismatch);
+        assert!(cancel.load(Ordering::SeqCst));
+    }
+}

--- a/crates/ha-core/src/chat_engine/stop.rs
+++ b/crates/ha-core/src/chat_engine/stop.rs
@@ -38,6 +38,105 @@ pub struct StopAllOutcome {
     pub runtime_cancellation_error: Option<String>,
 }
 
+/// Cleanup owned state for a prompt that was cancelled before a durable chat
+/// turn existed. Construction installs the session cleanup gate immediately;
+/// callers may then publish/release any transport-visible lifecycle before
+/// spawning the potentially blocking Git/SQLite work.
+pub struct PreTurnCancelCleanup {
+    db: Arc<SessionDB>,
+    session_id: String,
+    bootstrap_request_id: Option<String>,
+    delete_empty_session: bool,
+    cleanup_gate: super::active_turn::StopCleanupGuard,
+}
+
+impl PreTurnCancelCleanup {
+    pub fn begin(
+        db: Arc<SessionDB>,
+        session_id: String,
+        bootstrap_request_id: Option<String>,
+        delete_empty_session: bool,
+    ) -> Option<Self> {
+        if bootstrap_request_id.is_none() && !delete_empty_session {
+            return None;
+        }
+        let cleanup_gate = super::active_turn::begin_stop_cleanup(&session_id);
+        Some(Self {
+            db,
+            session_id,
+            bootstrap_request_id,
+            delete_empty_session,
+            cleanup_gate,
+        })
+    }
+
+    pub fn spawn(self) {
+        tokio::spawn(self.run());
+    }
+
+    async fn run(self) {
+        let Self {
+            db,
+            session_id,
+            bootstrap_request_id,
+            delete_empty_session,
+            cleanup_gate,
+        } = self;
+        let had_bootstrap = bootstrap_request_id.is_some();
+        let bootstrap_rollback_succeeded = if let Some(request_id) = bootstrap_request_id {
+            match db
+                .clone()
+                .run(move |db| db.rollback_project_bootstrap_after_chat_cancel(&request_id))
+                .await
+            {
+                Ok(()) => true,
+                Err(error) => {
+                    // Preserve the Session + managed-worktree row when
+                    // Git-aware cleanup fails; startup recovery can retry it
+                    // without orphaning the physical worktree.
+                    crate::app_warn!(
+                        "project",
+                        "bootstrap_cancel_rollback",
+                        "Failed to roll back project bootstrap for stopped chat {}: {}",
+                        session_id,
+                        error
+                    );
+                    false
+                }
+            }
+        } else {
+            true
+        };
+        let mut session_deleted = false;
+        if delete_empty_session && bootstrap_rollback_succeeded {
+            let sid_for_delete = session_id.clone();
+            match db.run(move |db| db.delete_session(&sid_for_delete)).await {
+                Ok(()) => session_deleted = true,
+                Err(error) => {
+                    crate::app_warn!(
+                        "chat",
+                        "pre_turn_cancel_cleanup",
+                        "Failed to delete empty stopped session {}: {}",
+                        session_id,
+                        error
+                    );
+                }
+            }
+        }
+        crate::app_info!(
+            "chat",
+            "pre_turn_cancel_cleanup",
+            "Pre-turn Stop cleanup settled: session={} bootstrap={} bootstrap_rollback_succeeded={} delete_requested={} session_deleted={}",
+            session_id,
+            had_bootstrap,
+            bootstrap_rollback_succeeded,
+            delete_empty_session,
+            session_deleted
+        );
+        drop(cleanup_gate);
+    }
+}
+
 async fn timeout_count(operation: &'static str, future: impl Future<Output = usize>) -> usize {
     // Time the operation itself rather than a detached JoinHandle. Both
     // interaction cleanup functions drain their exact entries before their
@@ -473,5 +572,45 @@ mod tests {
         assert!(outcome.stopped);
         assert!(!outcome.turn_mismatch);
         assert!(cancel.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn pre_turn_cancel_cleanup_deletes_lazy_session_and_releases_gate() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Arc::new(
+            SessionDB::open_ephemeral_for_test(&dir.path().join("pre-turn-cleanup.db"))
+                .expect("session db"),
+        );
+        crate::channel::ChannelDB::new(db.clone())
+            .migrate()
+            .expect("channel schema");
+        let session = db.create_session("ha-main").expect("session");
+        let cleanup = PreTurnCancelCleanup::begin(db.clone(), session.id.clone(), None, true)
+            .expect("new lazy sessions require cleanup");
+
+        assert!(crate::chat_engine::active_turn::try_acquire(
+            &session.id,
+            crate::chat_engine::ChatSource::Desktop,
+            "blocked-during-cleanup".to_string(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .is_err());
+
+        cleanup.run().await;
+
+        let sid = session.id.clone();
+        assert!(db
+            .clone()
+            .run(move |db| db.get_session(&sid))
+            .await
+            .expect("read session")
+            .is_none());
+        let _guard = crate::chat_engine::active_turn::try_acquire(
+            &session.id,
+            crate::chat_engine::ChatSource::Desktop,
+            "after-cleanup".to_string(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("cleanup gate must be released");
     }
 }

--- a/crates/ha-core/src/chat_engine/stop.rs
+++ b/crates/ha-core/src/chat_engine/stop.rs
@@ -5,7 +5,6 @@
 //! HTTP, and IM `/stop` resolve interaction waits and owned runtime work with
 //! the same semantics.
 
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{collections::HashSet, future::Future};
@@ -240,14 +239,10 @@ pub async fn stop_session(
     let mut matched_active = false;
     let mut durable_turn_id = None;
 
-    if let Some(active) = super::active_turn::current(session_id) {
-        let matches_turn = expected_turn_id
-            .map(|turn_id| turn_id == active.turn_id)
-            .unwrap_or(true);
-        if matches_turn {
+    match super::active_turn::cancel_current(session_id, expected_turn_id) {
+        super::active_turn::ActiveTurnCancelOutcome::Cancelled(active) => {
             matched_active = true;
             outcome.stopped = true;
-            active.cancel.store(true, Ordering::SeqCst);
 
             // Channel has its own stream lifecycle bus and deliberately does
             // not create a GUI chat_turn row. Desktop/HTTP use the normal
@@ -269,9 +264,11 @@ pub async fn stop_session(
                 );
                 durable_turn_id = Some(active.turn_id);
             }
-        } else {
+        }
+        super::active_turn::ActiveTurnCancelOutcome::TurnMismatch => {
             outcome.turn_mismatch = true;
         }
+        super::active_turn::ActiveTurnCancelOutcome::NotFound => {}
     }
 
     // A session-only Stop is authoritative even if the active entry vanished
@@ -427,8 +424,7 @@ pub async fn stop_all_sessions(
     let mut stopped_sessions: HashSet<String> = pre_signalled_sessions.into_iter().collect();
     let mut durable_turn_ids = Vec::new();
 
-    for active in super::active_turn::all_current() {
-        active.cancel.store(true, Ordering::SeqCst);
+    for active in super::active_turn::cancel_all_current() {
         stopped_sessions.insert(active.session_id.clone());
         if active.source.broadcasts_to_user_ui() {
             super::stream_broadcast::broadcast_turn_status(
@@ -541,7 +537,7 @@ pub async fn stop_all_sessions(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     fn fixture() -> (tempfile::TempDir, Arc<SessionDB>, String, String) {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/crates/ha-core/src/chat_engine/stop.rs
+++ b/crates/ha-core/src/chat_engine/stop.rs
@@ -15,6 +15,7 @@ use crate::session::{ChatTurnInterruptReason, ChatTurnStatus, SessionDB};
 use crate::tools::ApprovalResolutionSource;
 
 const STOP_DB_MARK_TIMEOUT: Duration = Duration::from_secs(2);
+const PRE_TURN_QUEUE_RELEASE_TIMEOUT: Duration = Duration::from_secs(2);
 const STOP_INTERACTION_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
 const STOP_RUNTIME_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -47,6 +48,7 @@ pub struct PreTurnCancelCleanup {
     session_id: String,
     bootstrap_request_id: Option<String>,
     delete_empty_session: bool,
+    queued_dispatch: Option<(String, String)>,
     cleanup_gate: super::active_turn::StopCleanupGuard,
 }
 
@@ -56,8 +58,9 @@ impl PreTurnCancelCleanup {
         session_id: String,
         bootstrap_request_id: Option<String>,
         delete_empty_session: bool,
+        queued_dispatch: Option<(String, String)>,
     ) -> Option<Self> {
-        if bootstrap_request_id.is_none() && !delete_empty_session {
+        if bootstrap_request_id.is_none() && !delete_empty_session && queued_dispatch.is_none() {
             return None;
         }
         let cleanup_gate = super::active_turn::begin_stop_cleanup(&session_id);
@@ -66,6 +69,7 @@ impl PreTurnCancelCleanup {
             session_id,
             bootstrap_request_id,
             delete_empty_session,
+            queued_dispatch,
             cleanup_gate,
         })
     }
@@ -80,8 +84,49 @@ impl PreTurnCancelCleanup {
             session_id,
             bootstrap_request_id,
             delete_empty_session,
+            queued_dispatch,
             cleanup_gate,
         } = self;
+        let queued_release_requested = queued_dispatch.is_some();
+        let queued_release_succeeded = if let Some((request_id, turn_id)) = queued_dispatch {
+            let sid_for_release = session_id.clone();
+            match tokio::time::timeout(
+                PRE_TURN_QUEUE_RELEASE_TIMEOUT,
+                db.clone().run(move |db| {
+                    db.release_queued_turn_message_dispatch(&sid_for_release, &request_id, &turn_id)
+                }),
+            )
+            .await
+            {
+                Ok(Ok(_)) => true,
+                Ok(Err(error)) => {
+                    crate::app_warn!(
+                        "chat",
+                        "pre_turn_cancel_cleanup",
+                        "Failed to release queued dispatch for stopped chat {}: {}",
+                        session_id,
+                        error
+                    );
+                    false
+                }
+                Err(_) => {
+                    // The exact session/request/turn CAS may still finish on
+                    // the detached blocking worker. Releasing this cleanup
+                    // gate is safe because it cannot mutate a replacement
+                    // turn's queue claim.
+                    crate::app_warn!(
+                        "chat",
+                        "pre_turn_cancel_cleanup",
+                        "Timed out after {}ms releasing queued dispatch for stopped chat {}",
+                        PRE_TURN_QUEUE_RELEASE_TIMEOUT.as_millis(),
+                        session_id
+                    );
+                    false
+                }
+            }
+        } else {
+            true
+        };
         let had_bootstrap = bootstrap_request_id.is_some();
         let bootstrap_rollback_succeeded = if let Some(request_id) = bootstrap_request_id {
             match db
@@ -126,8 +171,10 @@ impl PreTurnCancelCleanup {
         crate::app_info!(
             "chat",
             "pre_turn_cancel_cleanup",
-            "Pre-turn Stop cleanup settled: session={} bootstrap={} bootstrap_rollback_succeeded={} delete_requested={} session_deleted={}",
+            "Pre-turn Stop cleanup settled: session={} queued_release_requested={} queued_release_succeeded={} bootstrap={} bootstrap_rollback_succeeded={} delete_requested={} session_deleted={}",
             session_id,
+            queued_release_requested,
+            queued_release_succeeded,
             had_bootstrap,
             bootstrap_rollback_succeeded,
             delete_empty_session,
@@ -585,7 +632,7 @@ mod tests {
             .migrate()
             .expect("channel schema");
         let session = db.create_session("ha-main").expect("session");
-        let cleanup = PreTurnCancelCleanup::begin(db.clone(), session.id.clone(), None, true)
+        let cleanup = PreTurnCancelCleanup::begin(db.clone(), session.id.clone(), None, true, None)
             .expect("new lazy sessions require cleanup");
 
         assert!(crate::chat_engine::active_turn::try_acquire(
@@ -609,6 +656,59 @@ mod tests {
             &session.id,
             crate::chat_engine::ChatSource::Desktop,
             "after-cleanup".to_string(),
+            Arc::new(AtomicBool::new(false)),
+        )
+        .expect("cleanup gate must be released");
+    }
+
+    #[tokio::test]
+    async fn pre_turn_cancel_cleanup_releases_exact_queued_dispatch() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = Arc::new(
+            SessionDB::open_ephemeral_for_test(&dir.path().join("pre-turn-queue-cleanup.db"))
+                .expect("session db"),
+        );
+        let session = db.create_session("ha-main").expect("session");
+        db.enqueue_turn_user_message(crate::session::NewQueuedTurnMessage {
+            request_id: "queued-request".to_string(),
+            session_id: session.id.clone(),
+            message: "queued message".to_string(),
+            display_text: None,
+            attachments: Vec::new(),
+            is_plan_trigger: false,
+            goal_trigger: false,
+            plan_comment: None,
+            plan_mode: None,
+            workflow_mode: None,
+        })
+        .expect("enqueue");
+        db.claim_queued_turn_message_for_dispatch(&session.id, "queued-request", "stopped-turn")
+            .expect("claim queue row")
+            .expect("queued row");
+
+        let cleanup = PreTurnCancelCleanup::begin(
+            db.clone(),
+            session.id.clone(),
+            None,
+            false,
+            Some(("queued-request".to_string(), "stopped-turn".to_string())),
+        )
+        .expect("queued dispatch requires cleanup");
+        cleanup.run().await;
+
+        let queue = db
+            .list_queued_turn_user_messages(&session.id)
+            .expect("list queue");
+        assert_eq!(queue.len(), 1);
+        assert_eq!(
+            queue[0].status,
+            crate::session::QueuedTurnMessageStatus::Queued
+        );
+        assert_eq!(queue[0].turn_id, None);
+        let _guard = crate::chat_engine::active_turn::try_acquire(
+            &session.id,
+            crate::chat_engine::ChatSource::Desktop,
+            "after-queue-cleanup".to_string(),
             Arc::new(AtomicBool::new(false)),
         )
         .expect("cleanup gate must be released");

--- a/crates/ha-core/src/project_bootstrap.rs
+++ b/crates/ha-core/src/project_bootstrap.rs
@@ -2,10 +2,11 @@
 //! The desktop and HTTP shells both call this module so validation, durable
 //! progress, Git semantics, and session binding stay identical.
 
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use anyhow::{anyhow, bail, Result};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -15,11 +16,44 @@ use serde_json::json;
 use crate::session::SessionDB;
 use crate::worktree::{CreateManagedWorktreeInput, ManagedWorktree, ManagedWorktreePurpose};
 
-type ActiveBootstrapMap = std::collections::HashMap<String, Arc<AtomicBool>>;
-static ACTIVE_BOOTSTRAPS: OnceLock<Mutex<ActiveBootstrapMap>> = OnceLock::new();
+const PENDING_BOOTSTRAP_CANCELS_MAX: usize = 4096;
 
-fn active_bootstraps() -> &'static Mutex<ActiveBootstrapMap> {
-    ACTIVE_BOOTSTRAPS.get_or_init(|| Mutex::new(ActiveBootstrapMap::new()))
+#[derive(Debug)]
+struct ClientBootstrapBinding {
+    token: String,
+    bootstrap_request_id: String,
+}
+
+#[derive(Default)]
+struct BootstrapCancellationRegistry {
+    active: HashMap<String, Arc<AtomicBool>>,
+    pending: HashSet<String>,
+    client_bindings: HashMap<String, ClientBootstrapBinding>,
+}
+
+static BOOTSTRAP_CANCELLATIONS: OnceLock<Mutex<BootstrapCancellationRegistry>> = OnceLock::new();
+
+fn bootstrap_cancellations() -> &'static Mutex<BootstrapCancellationRegistry> {
+    BOOTSTRAP_CANCELLATIONS.get_or_init(|| Mutex::new(BootstrapCancellationRegistry::default()))
+}
+
+fn bootstrap_cancellations_lock() -> MutexGuard<'static, BootstrapCancellationRegistry> {
+    bootstrap_cancellations()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn arm_bootstrap_cancel(registry: &mut BootstrapCancellationRegistry, request_id: &str) {
+    if let Some(flag) = registry.active.get(request_id) {
+        flag.store(true, Ordering::SeqCst);
+        return;
+    }
+    if registry.pending.len() >= PENDING_BOOTSTRAP_CANCELS_MAX {
+        if let Some(evicted) = registry.pending.iter().next().cloned() {
+            registry.pending.remove(&evicted);
+        }
+    }
+    registry.pending.insert(request_id.to_string());
 }
 
 struct ActiveBootstrapGuard {
@@ -29,34 +63,103 @@ struct ActiveBootstrapGuard {
 
 impl Drop for ActiveBootstrapGuard {
     fn drop(&mut self) {
-        if let Ok(mut active) = active_bootstraps().lock() {
-            if active
-                .get(&self.id)
-                .is_some_and(|current| Arc::ptr_eq(current, &self.flag))
-            {
-                active.remove(&self.id);
-            }
+        let mut registry = bootstrap_cancellations_lock();
+        if registry
+            .active
+            .get(&self.id)
+            .is_some_and(|current| Arc::ptr_eq(current, &self.flag))
+        {
+            registry.active.remove(&self.id);
         }
     }
 }
 
 pub fn cancel_project_bootstrap(request_id: &str) -> bool {
-    let Ok(active) = active_bootstraps().lock() else {
+    if request_id.is_empty() {
+        return false;
+    }
+    arm_bootstrap_cancel(&mut bootstrap_cancellations_lock(), request_id);
+    true
+}
+
+/// Bind a transport-level chat request to the independently generated project
+/// bootstrap request. The mapping is installed before bootstrap awaits begin,
+/// allowing the normal Stop endpoint to cancel Git preparation without the UI
+/// having to issue a second control request.
+pub struct ProjectBootstrapClientRequestGuard {
+    client_request_id: String,
+    token: String,
+}
+
+impl Drop for ProjectBootstrapClientRequestGuard {
+    fn drop(&mut self) {
+        let mut registry = bootstrap_cancellations_lock();
+        if registry
+            .client_bindings
+            .get(&self.client_request_id)
+            .is_some_and(|binding| binding.token == self.token)
+        {
+            registry.client_bindings.remove(&self.client_request_id);
+        }
+    }
+}
+
+pub fn register_project_bootstrap_client_request(
+    client_request_id: &str,
+    bootstrap_request_id: &str,
+) -> ProjectBootstrapClientRequestGuard {
+    let token = uuid::Uuid::new_v4().to_string();
+    bootstrap_cancellations_lock().client_bindings.insert(
+        client_request_id.to_string(),
+        ClientBootstrapBinding {
+            token: token.clone(),
+            bootstrap_request_id: bootstrap_request_id.to_string(),
+        },
+    );
+    // A request-scoped Stop can win before this handler executes at all. The
+    // active-turn latch is authoritative in that ordering; mirror it into the
+    // bootstrap-id latch immediately after publishing the relationship.
+    if crate::chat_engine::active_turn::has_latched_client_cancel(client_request_id) {
+        cancel_project_bootstrap(bootstrap_request_id);
+    }
+    ProjectBootstrapClientRequestGuard {
+        client_request_id: client_request_id.to_string(),
+        token,
+    }
+}
+
+pub fn cancel_project_bootstrap_for_client_request(client_request_id: &str) -> bool {
+    let mut registry = bootstrap_cancellations_lock();
+    let Some(bootstrap_request_id) = registry
+        .client_bindings
+        .get(client_request_id)
+        .map(|binding| binding.bootstrap_request_id.clone())
+    else {
         return false;
     };
-    let Some(flag) = active.get(request_id) else {
-        return false;
-    };
-    flag.store(true, Ordering::SeqCst);
+    arm_bootstrap_cancel(&mut registry, &bootstrap_request_id);
     true
 }
 
 pub(crate) fn is_project_bootstrap_cancelled(request_id: &str) -> bool {
-    active_bootstraps()
-        .lock()
-        .ok()
-        .and_then(|active| active.get(request_id).cloned())
+    bootstrap_cancellations_lock()
+        .active
+        .get(request_id)
+        .cloned()
         .is_some_and(|flag| flag.load(Ordering::SeqCst))
+}
+
+fn register_active_bootstrap(request_id: &str) -> (Arc<AtomicBool>, ActiveBootstrapGuard) {
+    let mut registry = bootstrap_cancellations_lock();
+    let cancel = Arc::new(AtomicBool::new(registry.pending.remove(request_id)));
+    registry
+        .active
+        .insert(request_id.to_string(), cancel.clone());
+    let guard = ActiveBootstrapGuard {
+        id: request_id.to_string(),
+        flag: cancel.clone(),
+    };
+    (cancel, guard)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -335,17 +438,26 @@ impl SessionDB {
 
         self.insert_project_bootstrap_run_async(&input, &base_ref)
             .await?;
-        let cancel = Arc::new(AtomicBool::new(false));
-        {
-            let mut active = active_bootstraps()
-                .lock()
-                .map_err(|_| anyhow!("bootstrap cancellation registry is unavailable"))?;
-            active.insert(input.request.request_id.clone(), cancel.clone());
+        let (cancel, _active_guard) = register_active_bootstrap(&input.request.request_id);
+        if cancel.load(Ordering::SeqCst) {
+            self.update_project_bootstrap_stage_async(
+                &input.request.request_id,
+                "cancelled",
+                "cancelled",
+                None,
+                Some(("cancelled", "Local branch preparation was cancelled")),
+            )
+            .await?;
+            emit_progress(
+                &input.request.request_id,
+                "cancelled",
+                "cancelled",
+                Some(&input.session_id),
+                None,
+                Some(("cancelled", "Local branch preparation was cancelled")),
+            );
+            bail!("local branch preparation was cancelled");
         }
-        let _active_guard = ActiveBootstrapGuard {
-            id: input.request.request_id.clone(),
-            flag: cancel.clone(),
-        };
         self.report_project_bootstrap_stage_async(
             &input.request.request_id,
             "resolving_git",
@@ -580,17 +692,26 @@ impl SessionDB {
 
         self.insert_project_bootstrap_run_async(&input, &base_ref)
             .await?;
-        let cancel = Arc::new(AtomicBool::new(false));
-        {
-            let mut active = active_bootstraps()
-                .lock()
-                .map_err(|_| anyhow!("bootstrap cancellation registry is unavailable"))?;
-            active.insert(input.request.request_id.clone(), cancel.clone());
+        let (cancel, _active_guard) = register_active_bootstrap(&input.request.request_id);
+        if cancel.load(Ordering::SeqCst) {
+            self.update_project_bootstrap_stage_async(
+                &input.request.request_id,
+                "cancelled",
+                "cancelled",
+                None,
+                Some(("cancelled", "Worktree preparation was cancelled")),
+            )
+            .await?;
+            emit_progress(
+                &input.request.request_id,
+                "cancelled",
+                "cancelled",
+                Some(&input.session_id),
+                None,
+                Some(("cancelled", "Worktree preparation was cancelled")),
+            );
+            bail!("worktree preparation was cancelled");
         }
-        let _active_guard = ActiveBootstrapGuard {
-            id: input.request.request_id.clone(),
-            flag: cancel.clone(),
-        };
         self.report_project_bootstrap_stage_async(
             &input.request.request_id,
             "resolving_git",
@@ -1083,6 +1204,44 @@ fn emit_completed(request_id: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn client_request_stop_latches_until_bootstrap_registers() {
+        let client_request_id = format!("bootstrap-client-{}", uuid::Uuid::new_v4());
+        let bootstrap_request_id = format!("bootstrap-run-{}", uuid::Uuid::new_v4());
+        let binding =
+            register_project_bootstrap_client_request(&client_request_id, &bootstrap_request_id);
+
+        assert!(cancel_project_bootstrap_for_client_request(
+            &client_request_id
+        ));
+        let (cancel, active) = register_active_bootstrap(&bootstrap_request_id);
+        assert!(cancel.load(Ordering::SeqCst));
+        drop(active);
+        drop(binding);
+        assert!(!cancel_project_bootstrap_for_client_request(
+            &client_request_id
+        ));
+    }
+
+    #[test]
+    fn stop_before_client_binding_is_mirrored_into_bootstrap_latch() {
+        let client_request_id = format!("bootstrap-early-client-{}", uuid::Uuid::new_v4());
+        let bootstrap_request_id = format!("bootstrap-early-run-{}", uuid::Uuid::new_v4());
+        assert!(matches!(
+            crate::chat_engine::active_turn::cancel_or_latch_client_request(
+                &client_request_id,
+                None,
+            ),
+            crate::chat_engine::active_turn::ClientRequestCancelOutcome::Latched
+        ));
+
+        let _binding =
+            register_project_bootstrap_client_request(&client_request_id, &bootstrap_request_id);
+        let (bootstrap_cancel, active_bootstrap) = register_active_bootstrap(&bootstrap_request_id);
+        assert!(bootstrap_cancel.load(Ordering::SeqCst));
+        drop(active_bootstrap);
+    }
 
     fn git(cwd: &Path, args: &[&str]) {
         git_output(cwd, args).unwrap_or_else(|error| panic!("git {args:?}: {error:#}"));

--- a/crates/ha-core/src/project_bootstrap.rs
+++ b/crates/ha-core/src/project_bootstrap.rs
@@ -245,6 +245,59 @@ fn prepare_local_branch_on_disk(
 }
 
 impl SessionDB {
+    async fn insert_project_bootstrap_run_async(
+        self: &Arc<Self>,
+        input: &PrepareProjectWorktreeInput,
+        base_ref: &str,
+    ) -> Result<()> {
+        let db = self.clone();
+        let input = input.clone();
+        let base_ref = base_ref.to_string();
+        db.run(move |db| db.insert_project_bootstrap_run(&input, &base_ref))
+            .await
+    }
+
+    async fn update_project_bootstrap_stage_async(
+        self: &Arc<Self>,
+        id: &str,
+        status: &str,
+        stage: &str,
+        worktree_id: Option<&str>,
+        error: Option<(&str, &str)>,
+    ) -> Result<()> {
+        let db = self.clone();
+        let id = id.to_string();
+        let status = status.to_string();
+        let stage = stage.to_string();
+        let worktree_id = worktree_id.map(str::to_string);
+        let error = error.map(|(code, message)| (code.to_string(), message.to_string()));
+        db.run(move |db| {
+            db.update_project_bootstrap_stage(
+                &id,
+                &status,
+                &stage,
+                worktree_id.as_deref(),
+                error
+                    .as_ref()
+                    .map(|(code, message)| (code.as_str(), message.as_str())),
+            )
+        })
+        .await
+    }
+
+    async fn report_project_bootstrap_stage_async(
+        self: &Arc<Self>,
+        id: &str,
+        stage: &str,
+        session_id: Option<&str>,
+        worktree_id: Option<&str>,
+    ) -> Result<()> {
+        self.update_project_bootstrap_stage_async(id, "preparing", stage, worktree_id, None)
+            .await?;
+        emit_progress(id, "preparing", stage, session_id, worktree_id, None);
+        Ok(())
+    }
+
     async fn prepare_project_local_branch(
         self: &Arc<Self>,
         input: PrepareProjectWorktreeInput,
@@ -280,7 +333,8 @@ impl SessionDB {
             bail!("bootstrap session is not bound to the requested project");
         }
 
-        self.insert_project_bootstrap_run(&input, &base_ref)?;
+        self.insert_project_bootstrap_run_async(&input, &base_ref)
+            .await?;
         let cancel = Arc::new(AtomicBool::new(false));
         {
             let mut active = active_bootstraps()
@@ -292,12 +346,13 @@ impl SessionDB {
             id: input.request.request_id.clone(),
             flag: cancel.clone(),
         };
-        self.report_project_bootstrap_stage(
+        self.report_project_bootstrap_stage_async(
             &input.request.request_id,
             "resolving_git",
             Some(&input.session_id),
             None,
-        )?;
+        )
+        .await?;
 
         let source = input.source_working_dir.clone();
         let include_local_changes = input.request.include_local_changes;
@@ -311,13 +366,14 @@ impl SessionDB {
 
         match switch_result {
             Ok(()) if !cancel.load(Ordering::SeqCst) => {
-                self.update_project_bootstrap_stage(
+                self.update_project_bootstrap_stage_async(
                     &input.request.request_id,
                     "ready",
                     "ready",
                     None,
                     None,
-                )?;
+                )
+                .await?;
                 emit_progress(
                     &input.request.request_id,
                     "ready",
@@ -329,13 +385,14 @@ impl SessionDB {
                 Ok(())
             }
             Ok(()) => {
-                self.update_project_bootstrap_stage(
+                self.update_project_bootstrap_stage_async(
                     &input.request.request_id,
                     "cancelled",
                     "cancelled",
                     None,
                     Some(("cancelled", "Local branch preparation was cancelled")),
-                )?;
+                )
+                .await?;
                 emit_progress(
                     &input.request.request_id,
                     "cancelled",
@@ -348,13 +405,14 @@ impl SessionDB {
             }
             Err(error) => {
                 let message = format!("{error:#}");
-                self.update_project_bootstrap_stage(
+                self.update_project_bootstrap_stage_async(
                     &input.request.request_id,
                     "failed",
                     "failed",
                     None,
                     Some(("local_branch_prepare_failed", message.as_str())),
-                )?;
+                )
+                .await?;
                 emit_progress(
                     &input.request.request_id,
                     "failed",
@@ -520,7 +578,8 @@ impl SessionDB {
             bail!("bootstrap session is not bound to the requested project");
         }
 
-        self.insert_project_bootstrap_run(&input, &base_ref)?;
+        self.insert_project_bootstrap_run_async(&input, &base_ref)
+            .await?;
         let cancel = Arc::new(AtomicBool::new(false));
         {
             let mut active = active_bootstraps()
@@ -532,12 +591,13 @@ impl SessionDB {
             id: input.request.request_id.clone(),
             flag: cancel.clone(),
         };
-        self.report_project_bootstrap_stage(
+        self.report_project_bootstrap_stage_async(
             &input.request.request_id,
             "resolving_git",
             Some(&input.session_id),
             None,
-        )?;
+        )
+        .await?;
 
         let source = input.source_working_dir.clone();
         let base_ref_for_validation = base_ref.clone();
@@ -560,13 +620,14 @@ impl SessionDB {
         .await;
         if let Err(error) = validation {
             let message = format!("{error:#}");
-            self.update_project_bootstrap_stage(
+            self.update_project_bootstrap_stage_async(
                 &input.request.request_id,
                 "failed",
                 "failed",
                 None,
                 Some(("git_validation_failed", message.as_str())),
-            )?;
+            )
+            .await?;
             emit_progress(
                 &input.request.request_id,
                 "failed",
@@ -578,13 +639,14 @@ impl SessionDB {
             return Err(error);
         }
         if cancel.load(Ordering::SeqCst) {
-            self.update_project_bootstrap_stage(
+            self.update_project_bootstrap_stage_async(
                 &input.request.request_id,
                 "cancelled",
                 "cancelled",
                 None,
                 Some(("cancelled", "Worktree preparation was cancelled")),
-            )?;
+            )
+            .await?;
             emit_progress(
                 &input.request.request_id,
                 "cancelled",
@@ -596,13 +658,14 @@ impl SessionDB {
             bail!("worktree preparation was cancelled");
         }
         if input.request.include_local_changes {
-            self.update_project_bootstrap_stage(
+            self.update_project_bootstrap_stage_async(
                 &input.request.request_id,
                 "preparing",
                 "snapshotting",
                 None,
                 None,
-            )?;
+            )
+            .await?;
             emit_progress(
                 &input.request.request_id,
                 "preparing",
@@ -613,13 +676,14 @@ impl SessionDB {
             );
         }
         if cancel.load(Ordering::SeqCst) {
-            self.update_project_bootstrap_stage(
+            self.update_project_bootstrap_stage_async(
                 &input.request.request_id,
                 "cancelled",
                 "cancelled",
                 None,
                 Some(("cancelled", "Worktree preparation was cancelled")),
-            )?;
+            )
+            .await?;
             emit_progress(
                 &input.request.request_id,
                 "cancelled",
@@ -659,13 +723,14 @@ impl SessionDB {
 
         match result {
             Ok(worktree) => {
-                self.update_project_bootstrap_stage(
+                self.update_project_bootstrap_stage_async(
                     &input.request.request_id,
                     "ready",
                     "ready",
                     Some(&worktree.id),
                     None,
-                )?;
+                )
+                .await?;
                 emit_progress(
                     &input.request.request_id,
                     "ready",
@@ -689,20 +754,28 @@ impl SessionDB {
                     if let Some(worktree_id) = run.and_then(|run| run.worktree_id) {
                         let db = self.clone();
                         let cleanup_id = worktree_id.clone();
-                        db.run(move |db| {
-                            if db.get_managed_worktree(&cleanup_id)?.is_some() {
-                                db.discard_managed_worktree(&cleanup_id)
-                            } else {
-                                crate::worktree::cleanup_orphan_builtin_worktree(&cleanup_id)
-                                    .map(|_| ())
-                            }
-                        })
-                        .await
-                        .err()
-                        .map(|cleanup_error| {
-                            let _ = self.mark_managed_worktree_bootstrap_failed(&worktree_id);
-                            format!("; cleanup failed: {cleanup_error:#}")
-                        })
+                        let cleanup_result = db
+                            .run(move |db| {
+                                if db.get_managed_worktree(&cleanup_id)?.is_some() {
+                                    db.discard_managed_worktree(&cleanup_id)
+                                } else {
+                                    crate::worktree::cleanup_orphan_builtin_worktree(&cleanup_id)
+                                        .map(|_| ())
+                                }
+                            })
+                            .await;
+                        if let Err(cleanup_error) = cleanup_result {
+                            let db = self.clone();
+                            let failed_worktree_id = worktree_id.clone();
+                            let _ = db
+                                .run(move |db| {
+                                    db.mark_managed_worktree_bootstrap_failed(&failed_worktree_id)
+                                })
+                                .await;
+                            Some(format!("; cleanup failed: {cleanup_error:#}"))
+                        } else {
+                            None
+                        }
                     } else {
                         None
                     }
@@ -715,13 +788,14 @@ impl SessionDB {
                 } else {
                     "worktree_prepare_failed"
                 };
-                self.update_project_bootstrap_stage(
+                self.update_project_bootstrap_stage_async(
                     &input.request.request_id,
                     status,
                     status,
                     None,
                     Some((error_code, message.as_str())),
-                )?;
+                )
+                .await?;
                 emit_progress(
                     &input.request.request_id,
                     status,

--- a/crates/ha-core/src/project_bootstrap.rs
+++ b/crates/ha-core/src/project_bootstrap.rs
@@ -924,13 +924,17 @@ impl SessionDB {
             if let Some(worktree_id) = run.worktree_id.as_deref() {
                 let _ = self.mark_managed_worktree_bootstrap_failed(worktree_id);
             }
-            let _ = self.update_project_bootstrap_stage(
+            if let Err(update_error) = self.update_project_bootstrap_stage(
                 id,
                 "failed",
                 "failed",
                 run.worktree_id.as_deref(),
                 Some(("worktree_cleanup_failed", message.as_str())),
-            );
+            ) {
+                return Err(anyhow!(
+                    "{message}; failed to persist bootstrap failure: {update_error:#}"
+                ));
+            }
             emit_progress(
                 id,
                 "failed",
@@ -1136,6 +1140,68 @@ mod tests {
         assert_eq!(run.stage, "cancelled");
         assert_eq!(run.error_code.as_deref(), Some("cancelled"));
         assert!(run.completed_at.is_some());
+    }
+
+    #[test]
+    fn cleanup_failure_is_not_emitted_when_terminal_write_fails() {
+        let (_dir, db) = test_db();
+        let bus = crate::globals::EVENT_BUS
+            .get_or_init(|| {
+                let bus: Arc<dyn crate::event_bus::EventBus> =
+                    Arc::new(crate::event_bus::BroadcastEventBus::new(256));
+                bus
+            })
+            .clone();
+        let mut events = bus.subscribe();
+
+        insert_run(&db, "request-terminal-write-fails", "ready");
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE project_bootstrap_runs SET worktree_id = 'invalid-id' WHERE id = ?1",
+                params!["request-terminal-write-fails"],
+            )
+            .unwrap();
+            conn.execute_batch(
+                "CREATE TRIGGER reject_bootstrap_failed_update
+                 BEFORE UPDATE OF status ON project_bootstrap_runs
+                 WHEN NEW.id = 'request-terminal-write-fails' AND NEW.status = 'failed'
+                 BEGIN
+                   SELECT RAISE(ABORT, 'forced bootstrap status write failure');
+                 END;",
+            )
+            .unwrap();
+        }
+
+        let error = db
+            .rollback_project_bootstrap_after_chat_cancel("request-terminal-write-fails")
+            .expect_err("cleanup and terminal write must fail");
+        assert!(
+            format!("{error:#}").contains("failed to persist bootstrap failure"),
+            "unexpected error: {error:#}"
+        );
+        assert_eq!(
+            db.get_project_bootstrap_run("request-terminal-write-fails")
+                .unwrap()
+                .unwrap()
+                .status,
+            "ready"
+        );
+
+        while let Ok(event) = events.try_recv() {
+            assert!(
+                event.name != "project:bootstrap_progress"
+                    || event
+                        .payload
+                        .get("requestId")
+                        .and_then(|value| value.as_str())
+                        != Some("request-terminal-write-fails")
+                    || event.payload.get("status").and_then(|value| value.as_str())
+                        != Some("failed"),
+                "failed progress must not be emitted before its durable write: {:?}",
+                event.payload
+            );
+        }
     }
 
     #[test]

--- a/crates/ha-core/src/project_bootstrap.rs
+++ b/crates/ha-core/src/project_bootstrap.rs
@@ -818,6 +818,80 @@ impl SessionDB {
         Ok(changed > 0)
     }
 
+    /// Roll back a prepared project launch when the first chat is explicitly
+    /// stopped during `UserPromptSubmit`, before any user message exists.
+    ///
+    /// Worktree preparation has already completed by this point, so deleting
+    /// the Session first would cascade away the registry row without asking Git
+    /// to remove the physical worktree. Keep cleanup Git-aware, then terminalize
+    /// the durable bootstrap run before the shell deletes the empty Session.
+    pub fn rollback_project_bootstrap_after_chat_cancel(&self, id: &str) -> Result<()> {
+        let run = self
+            .get_project_bootstrap_run(id)?
+            .ok_or_else(|| anyhow!("project bootstrap run not found: {id}"))?;
+        if !matches!(run.status.as_str(), "ready" | "chatting") {
+            bail!(
+                "project bootstrap {id} cannot be cancelled from status {}",
+                run.status
+            );
+        }
+
+        let cleanup_result = if let Some(worktree_id) = run.worktree_id.as_deref() {
+            if self.get_managed_worktree(worktree_id)?.is_some() {
+                self.discard_managed_worktree(worktree_id)
+            } else {
+                crate::worktree::cleanup_orphan_builtin_worktree(worktree_id).map(|_| ())
+            }
+        } else {
+            Ok(())
+        };
+        if let Err(cleanup_error) = cleanup_result {
+            let message = format!("Failed to clean up stopped chat worktree: {cleanup_error:#}");
+            if let Some(worktree_id) = run.worktree_id.as_deref() {
+                let _ = self.mark_managed_worktree_bootstrap_failed(worktree_id);
+            }
+            let _ = self.update_project_bootstrap_stage(
+                id,
+                "failed",
+                "failed",
+                run.worktree_id.as_deref(),
+                Some(("worktree_cleanup_failed", message.as_str())),
+            );
+            emit_progress(
+                id,
+                "failed",
+                "failed",
+                run.session_id.as_deref(),
+                run.worktree_id.as_deref(),
+                Some(("worktree_cleanup_failed", message.as_str())),
+            );
+            return Err(anyhow!(message));
+        }
+
+        self.update_project_bootstrap_stage(
+            id,
+            "cancelled",
+            "cancelled",
+            run.worktree_id.as_deref(),
+            Some((
+                "cancelled",
+                "Chat was stopped before prompt submission completed",
+            )),
+        )?;
+        emit_progress(
+            id,
+            "cancelled",
+            "cancelled",
+            run.session_id.as_deref(),
+            run.worktree_id.as_deref(),
+            Some((
+                "cancelled",
+                "Chat was stopped before prompt submission completed",
+            )),
+        );
+        Ok(())
+    }
+
     pub(crate) fn report_project_bootstrap_stage(
         &self,
         id: &str,
@@ -966,6 +1040,106 @@ mod tests {
         assert!(!db.mark_project_bootstrap_completed("request-1").unwrap());
         let run = db.get_project_bootstrap_run("request-1").unwrap().unwrap();
         assert_eq!(run.status, "completed");
+        assert!(run.completed_at.is_some());
+    }
+
+    #[test]
+    fn chat_cancel_rolls_claimed_bootstrap_to_cancelled() {
+        let (_dir, db) = test_db();
+        insert_run(&db, "request-cancelled", "ready");
+        assert!(db
+            .claim_project_bootstrap_chatting("request-cancelled")
+            .unwrap());
+
+        db.rollback_project_bootstrap_after_chat_cancel("request-cancelled")
+            .expect("rollback claimed bootstrap");
+
+        let run = db
+            .get_project_bootstrap_run("request-cancelled")
+            .unwrap()
+            .unwrap();
+        assert_eq!(run.status, "cancelled");
+        assert_eq!(run.stage, "cancelled");
+        assert_eq!(run.error_code.as_deref(), Some("cancelled"));
+        assert!(run.completed_at.is_some());
+    }
+
+    #[test]
+    fn chat_cancel_discards_prepared_worktree_before_session_cleanup() {
+        let (dir, db) = test_db();
+        let repo = dir.path().join("repo");
+        std::fs::create_dir(&repo).expect("create repo directory");
+        git(&repo, &["init", "-b", "main"]);
+        std::fs::write(repo.join("file.txt"), "main\n").expect("write repository file");
+        git(&repo, &["add", "."]);
+        git(
+            &repo,
+            &[
+                "-c",
+                "user.name=Hope Test",
+                "-c",
+                "user.email=hope@example.invalid",
+                "commit",
+                "-m",
+                "main",
+            ],
+        );
+
+        let worktree_path = dir.path().join("prepared-worktree");
+        let worktree_path_arg = worktree_path.to_string_lossy().into_owned();
+        git(
+            &repo,
+            &["worktree", "add", "--detach", &worktree_path_arg, "HEAD"],
+        );
+        let session = db.create_session("default").expect("create session");
+        insert_run(&db, "request-with-worktree", "ready");
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO managed_worktrees (
+                    id, session_id, purpose, state, repo_root,
+                    source_working_dir, path, created_at, updated_at, path_source
+                 ) VALUES (
+                    'worktree-cancelled', ?1, 'manual', 'active', ?2,
+                    ?2, ?3, '2026-08-01T00:00:00Z', '2026-08-01T00:00:00Z', 'builtin'
+                 )",
+                params![session.id, repo.to_string_lossy(), worktree_path_arg],
+            )
+            .expect("register managed worktree");
+            conn.execute(
+                "UPDATE project_bootstrap_runs
+                 SET session_id = ?2, worktree_id = 'worktree-cancelled'
+                 WHERE id = ?1",
+                params!["request-with-worktree", session.id],
+            )
+            .expect("bind bootstrap run");
+        }
+        assert!(db
+            .claim_project_bootstrap_chatting("request-with-worktree")
+            .unwrap());
+        assert!(worktree_path.exists());
+
+        db.rollback_project_bootstrap_after_chat_cancel("request-with-worktree")
+            .expect("rollback bootstrap with prepared worktree");
+
+        assert!(!worktree_path.exists());
+        assert!(db
+            .get_managed_worktree("worktree-cancelled")
+            .unwrap()
+            .is_none());
+        assert!(!git_output(&repo, &["worktree", "list", "--porcelain"])
+            .unwrap()
+            .contains(&worktree_path_arg));
+        {
+            let conn = db.conn.lock().unwrap();
+            conn.execute("DELETE FROM sessions WHERE id = ?1", params![session.id])
+                .expect("delete empty session after worktree cleanup");
+        }
+        let run = db
+            .get_project_bootstrap_run("request-with-worktree")
+            .unwrap()
+            .unwrap();
+        assert_eq!(run.status, "cancelled");
         assert!(run.completed_at.is_some());
     }
 

--- a/crates/ha-core/src/runtime_tasks.rs
+++ b/crates/ha-core/src/runtime_tasks.rs
@@ -141,11 +141,47 @@ pub async fn snapshot_runtime_tasks_for_session(
 pub async fn cancel_runtime_task_snapshot(
     snapshot: RuntimeTaskSnapshot,
 ) -> anyhow::Result<Vec<CancelRuntimeTaskResult>> {
+    Ok(
+        cancel_runtime_task_snapshot_with(snapshot, |kind, id| async move {
+            cancel_runtime_task(kind, &id).await
+        })
+        .await,
+    )
+}
+
+async fn cancel_runtime_task_snapshot_with<F, Fut>(
+    snapshot: RuntimeTaskSnapshot,
+    mut cancel_task: F,
+) -> Vec<CancelRuntimeTaskResult>
+where
+    F: FnMut(RuntimeTaskKind, String) -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<CancelRuntimeTaskResult>>,
+{
     let mut results = Vec::with_capacity(snapshot.tasks.len());
     for (kind, id) in snapshot.tasks {
-        results.push(cancel_runtime_task(kind, &id).await?);
+        match cancel_task(kind, id.clone()).await {
+            Ok(result) => results.push(result),
+            Err(error) => {
+                let message = crate::logging::redact_sensitive(&error.to_string());
+                crate::app_warn!(
+                    "chat",
+                    "runtime_task_cancel",
+                    "Runtime task cancellation failed; continuing snapshot: kind={} id={} error={}",
+                    kind.as_str(),
+                    id,
+                    message
+                );
+                results.push(CancelRuntimeTaskResult::new(
+                    kind,
+                    &id,
+                    false,
+                    "error",
+                    format!("Runtime task cancellation failed: {message}"),
+                ));
+            }
+        }
     }
-    Ok(results)
+    results
 }
 
 fn cancel_async_job(id: &str) -> anyhow::Result<CancelRuntimeTaskResult> {
@@ -299,5 +335,47 @@ fn cancel_cron(id: &str) -> anyhow::Result<CancelRuntimeTaskResult> {
             "not_found",
             "Cron job not found",
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[tokio::test]
+    async fn snapshot_cancellation_continues_after_individual_failure() {
+        let snapshot = RuntimeTaskSnapshot {
+            tasks: vec![
+                (RuntimeTaskKind::AsyncJob, "fails".to_string()),
+                (RuntimeTaskKind::Process, "continues".to_string()),
+            ],
+        };
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let calls_for_cancel = calls.clone();
+
+        let results = cancel_runtime_task_snapshot_with(snapshot, move |kind, id| {
+            calls_for_cancel.lock().unwrap().push(id.clone());
+            async move {
+                if id == "fails" {
+                    anyhow::bail!("transient cancellation failure");
+                }
+                Ok(CancelRuntimeTaskResult::new(
+                    kind,
+                    &id,
+                    true,
+                    "killed",
+                    "cancelled",
+                ))
+            }
+        })
+        .await;
+
+        assert_eq!(&*calls.lock().unwrap(), &["fails", "continues"]);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].status, "error");
+        assert!(!results[0].accepted);
+        assert_eq!(results[1].status, "killed");
+        assert!(results[1].accepted);
     }
 }

--- a/crates/ha-core/src/runtime_tasks.rs
+++ b/crates/ha-core/src/runtime_tasks.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 const RUNTIME_SNAPSHOT_SOURCE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+const DEFERRED_SNAPSHOT_CANCEL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Runtime work units that can be cancelled best-effort.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -110,10 +111,10 @@ pub async fn cancel_runtime_tasks_for_session(
     cancel_runtime_task_snapshot(snapshot).await
 }
 
-/// Capture runtime work associated with a session without performing any
-/// cancellation side effects. A caller may safely time this future out: an
-/// already-running blocking DB read can finish in the background, but it
-/// cannot affect a later turn.
+/// Capture runtime work associated with a session without performing immediate
+/// cancellation side effects. A source that misses its bound is transferred to
+/// a gated continuation, which cancels its exact late identities before
+/// replacement foreground work can register.
 pub async fn snapshot_runtime_tasks_for_session(
     session_id: Option<&str>,
 ) -> anyhow::Result<RuntimeTaskSnapshot> {
@@ -154,7 +155,7 @@ pub async fn snapshot_runtime_tasks_for_session(
         }
     });
 
-    let process_session_id = owned_session_id;
+    let process_session_id = owned_session_id.clone();
     let processes = async move {
         let registry = crate::process_registry::get_registry().lock().await;
         anyhow::Ok(
@@ -170,9 +171,17 @@ pub async fn snapshot_runtime_tasks_for_session(
     // wedged SQLite read or process-registry lock must not prevent the other
     // exact identities from being captured and cancelled.
     let (async_jobs, subagents, processes) = tokio::join!(
-        timeout_snapshot_source("async_jobs", async_jobs),
-        timeout_snapshot_source("subagents", subagents),
-        timeout_snapshot_source("processes", processes),
+        timeout_snapshot_source(
+            "async_jobs",
+            owned_session_id.clone(),
+            tokio::spawn(async_jobs)
+        ),
+        timeout_snapshot_source(
+            "subagents",
+            owned_session_id.clone(),
+            tokio::spawn(subagents)
+        ),
+        timeout_snapshot_source("processes", owned_session_id, tokio::spawn(processes)),
     );
     let mut tasks = Vec::new();
     for discovered in [async_jobs, subagents, processes] {
@@ -182,29 +191,106 @@ pub async fn snapshot_runtime_tasks_for_session(
     Ok(RuntimeTaskSnapshot { tasks })
 }
 
-async fn timeout_snapshot_source<F>(
+enum DeferredSnapshotGate {
+    Session(crate::chat_engine::active_turn::StopCleanupGuard),
+    Global(crate::chat_engine::active_turn::GlobalStopCleanupGuard),
+}
+
+impl DeferredSnapshotGate {
+    fn begin(session_id: Option<&str>) -> Self {
+        match session_id {
+            Some(session_id) => Self::Session(crate::chat_engine::active_turn::begin_stop_cleanup(
+                session_id,
+            )),
+            None => Self::Global(crate::chat_engine::active_turn::begin_global_stop_cleanup()),
+        }
+    }
+}
+
+impl Drop for DeferredSnapshotGate {
+    fn drop(&mut self) {
+        match self {
+            Self::Session(guard) => guard.release(),
+            Self::Global(guard) => guard.release(),
+        }
+    }
+}
+
+async fn timeout_snapshot_source(
     source: &'static str,
-    future: F,
-) -> Vec<(RuntimeTaskKind, String)>
-where
-    F: std::future::Future<Output = anyhow::Result<Vec<(RuntimeTaskKind, String)>>>,
-{
-    match tokio::time::timeout(RUNTIME_SNAPSHOT_SOURCE_TIMEOUT, future).await {
+    session_id: Option<String>,
+    handle: tokio::task::JoinHandle<anyhow::Result<Vec<(RuntimeTaskKind, String)>>>,
+) -> Vec<(RuntimeTaskKind, String)> {
+    timeout_snapshot_source_with(source, session_id, handle, RUNTIME_SNAPSHOT_SOURCE_TIMEOUT).await
+}
+
+async fn timeout_snapshot_source_with(
+    source: &'static str,
+    session_id: Option<String>,
+    mut handle: tokio::task::JoinHandle<anyhow::Result<Vec<(RuntimeTaskKind, String)>>>,
+    timeout: std::time::Duration,
+) -> Vec<(RuntimeTaskKind, String)> {
+    match tokio::time::timeout(timeout, &mut handle).await {
+        Ok(joined) => snapshot_source_join_result(source, joined),
+        Err(_) => {
+            // Transfer an additional generation gate to the continuation
+            // before returning. The blocked read may finish later, but a
+            // replacement foreground turn cannot register resources that the
+            // eventual snapshot might mistake for the stopped generation.
+            let gate = DeferredSnapshotGate::begin(session_id.as_deref());
+            crate::app_warn!(
+                "chat",
+                "runtime_task_snapshot",
+                "Runtime task source snapshot timed out; continuing it behind the Stop gate: source={} timeout_ms={}",
+                source,
+                timeout.as_millis()
+            );
+            tokio::spawn(async move {
+                let discovered = snapshot_source_join_result(source, handle.await);
+                if !discovered.is_empty() {
+                    let snapshot = RuntimeTaskSnapshot { tasks: discovered };
+                    if tokio::time::timeout(
+                        DEFERRED_SNAPSHOT_CANCEL_TIMEOUT,
+                        cancel_runtime_task_snapshot(snapshot),
+                    )
+                    .await
+                    .is_err()
+                    {
+                        crate::app_warn!(
+                            "chat",
+                            "runtime_task_cancel",
+                            "Deferred runtime cancellation timed out after {}ms: source={}",
+                            DEFERRED_SNAPSHOT_CANCEL_TIMEOUT.as_millis(),
+                            source
+                        );
+                    }
+                }
+                drop(gate);
+            });
+            Vec::new()
+        }
+    }
+}
+
+fn snapshot_source_join_result(
+    source: &'static str,
+    joined: Result<anyhow::Result<Vec<(RuntimeTaskKind, String)>>, tokio::task::JoinError>,
+) -> Vec<(RuntimeTaskKind, String)> {
+    match joined {
         Ok(Ok(discovered)) => discovered,
         Ok(Err(error)) => {
             let mut tasks = Vec::new();
             extend_snapshot_source(&mut tasks, source, Err(error));
             tasks
         }
-        Err(_) => {
-            crate::app_warn!(
-                "chat",
-                "runtime_task_snapshot",
-                "Runtime task source snapshot timed out; continuing other sources: source={} timeout_ms={}",
+        Err(error) => {
+            let mut tasks = Vec::new();
+            extend_snapshot_source(
+                &mut tasks,
                 source,
-                RUNTIME_SNAPSHOT_SOURCE_TIMEOUT.as_millis()
+                Err(anyhow::anyhow!("snapshot task failed: {error}")),
             );
-            Vec::new()
+            tasks
         }
     }
 }
@@ -546,5 +632,57 @@ mod tests {
         let results = cancellation.await.unwrap();
         assert_eq!(results.len(), 2);
         assert!(results.iter().all(|result| result.accepted));
+    }
+
+    #[tokio::test]
+    async fn timed_out_snapshot_source_continues_behind_gate() {
+        let session_id = format!("deferred-snapshot-{}", uuid::Uuid::new_v4());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let completed = Arc::new(tokio::sync::Notify::new());
+        let release_for_source = release.clone();
+        let completed_for_source = completed.clone();
+        let handle = tokio::spawn(async move {
+            release_for_source.notified().await;
+            completed_for_source.notify_one();
+            anyhow::Ok(Vec::new())
+        });
+
+        let immediate = timeout_snapshot_source_with(
+            "test_source",
+            Some(session_id.clone()),
+            handle,
+            std::time::Duration::from_millis(10),
+        )
+        .await;
+        assert!(immediate.is_empty());
+        assert!(crate::chat_engine::active_turn::try_acquire(
+            &session_id,
+            crate::chat_engine::ChatSource::Desktop,
+            "turn-before-late-snapshot".to_string(),
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        )
+        .is_err());
+
+        release.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(1), completed.notified())
+            .await
+            .expect("timed-out source should remain attached to its continuation");
+
+        let replacement = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Ok(guard) = crate::chat_engine::active_turn::try_acquire(
+                    &session_id,
+                    crate::chat_engine::ChatSource::Desktop,
+                    "turn-after-late-snapshot".to_string(),
+                    Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                ) {
+                    break guard;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("replacement should acquire after the late snapshot settles");
+        drop(replacement);
     }
 }

--- a/crates/ha-core/src/runtime_tasks.rs
+++ b/crates/ha-core/src/runtime_tasks.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+const RUNTIME_SNAPSHOT_SOURCE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Runtime work units that can be cancelled best-effort.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -116,27 +118,29 @@ pub async fn snapshot_runtime_tasks_for_session(
     session_id: Option<&str>,
 ) -> anyhow::Result<RuntimeTaskSnapshot> {
     let owned_session_id = session_id.map(str::to_string);
-    let session_for_blocking = owned_session_id.clone();
-    let mut tasks = crate::blocking::run_blocking(move || {
-        let mut tasks = Vec::new();
-
+    let async_job_session_id = owned_session_id.clone();
+    let async_jobs = crate::blocking::run_blocking(move || {
         if let Some(db) = crate::async_jobs::get_async_jobs_db() {
-            let discovered = db.list_running().map(|jobs| {
+            db.list_running().map(|jobs| {
                 jobs.into_iter()
                     .filter(|job| {
-                        session_for_blocking
+                        async_job_session_id
                             .as_deref()
                             .map(|sid| job.session_id.as_deref() == Some(sid))
                             .unwrap_or(true)
                     })
                     .map(|job| (RuntimeTaskKind::AsyncJob, job.job_id))
                     .collect()
-            });
-            extend_snapshot_source(&mut tasks, "async_jobs", discovered);
+            })
+        } else {
+            Ok(Vec::new())
         }
+    });
 
+    let subagent_session_id = owned_session_id.clone();
+    let subagents = crate::blocking::run_blocking(move || {
         if let Some(db) = crate::get_session_db() {
-            let discovered = match session_for_blocking.as_deref() {
+            match subagent_session_id.as_deref() {
                 Some(sid) => db.list_nonterminal_subagent_runs(sid),
                 None => db.list_all_nonterminal_subagent_runs(),
             }
@@ -144,23 +148,65 @@ pub async fn snapshot_runtime_tasks_for_session(
                 runs.into_iter()
                     .map(|run| (RuntimeTaskKind::Subagent, run.run_id))
                     .collect()
-            });
-            extend_snapshot_source(&mut tasks, "subagents", discovered);
+            })
+        } else {
+            Ok(Vec::new())
         }
+    });
 
-        tasks
-    })
-    .await;
-
-    let process_ids = {
+    let process_session_id = owned_session_id;
+    let processes = async move {
         let registry = crate::process_registry::get_registry().lock().await;
-        registry.list_running_ids_for_parent_session(owned_session_id.as_deref())
+        anyhow::Ok(
+            registry
+                .list_running_ids_for_parent_session(process_session_id.as_deref())
+                .into_iter()
+                .map(|id| (RuntimeTaskKind::Process, id))
+                .collect(),
+        )
     };
-    for process_id in process_ids {
-        tasks.push((RuntimeTaskKind::Process, process_id));
+
+    // Each source gets its own bound and all sources are polled together. A
+    // wedged SQLite read or process-registry lock must not prevent the other
+    // exact identities from being captured and cancelled.
+    let (async_jobs, subagents, processes) = tokio::join!(
+        timeout_snapshot_source("async_jobs", async_jobs),
+        timeout_snapshot_source("subagents", subagents),
+        timeout_snapshot_source("processes", processes),
+    );
+    let mut tasks = Vec::new();
+    for discovered in [async_jobs, subagents, processes] {
+        tasks.extend(discovered);
     }
 
     Ok(RuntimeTaskSnapshot { tasks })
+}
+
+async fn timeout_snapshot_source<F>(
+    source: &'static str,
+    future: F,
+) -> Vec<(RuntimeTaskKind, String)>
+where
+    F: std::future::Future<Output = anyhow::Result<Vec<(RuntimeTaskKind, String)>>>,
+{
+    match tokio::time::timeout(RUNTIME_SNAPSHOT_SOURCE_TIMEOUT, future).await {
+        Ok(Ok(discovered)) => discovered,
+        Ok(Err(error)) => {
+            let mut tasks = Vec::new();
+            extend_snapshot_source(&mut tasks, source, Err(error));
+            tasks
+        }
+        Err(_) => {
+            crate::app_warn!(
+                "chat",
+                "runtime_task_snapshot",
+                "Runtime task source snapshot timed out; continuing other sources: source={} timeout_ms={}",
+                source,
+                RUNTIME_SNAPSHOT_SOURCE_TIMEOUT.as_millis()
+            );
+            Vec::new()
+        }
+    }
 }
 
 /// Cancel only the identities in a previously captured snapshot.
@@ -177,17 +223,31 @@ pub async fn cancel_runtime_task_snapshot(
 
 async fn cancel_runtime_task_snapshot_with<F, Fut>(
     snapshot: RuntimeTaskSnapshot,
-    mut cancel_task: F,
+    cancel_task: F,
 ) -> Vec<CancelRuntimeTaskResult>
 where
-    F: FnMut(RuntimeTaskKind, String) -> Fut,
-    Fut: std::future::Future<Output = anyhow::Result<CancelRuntimeTaskResult>>,
+    F: Fn(RuntimeTaskKind, String) -> Fut + Send + Sync + 'static,
+    Fut: std::future::Future<Output = anyhow::Result<CancelRuntimeTaskResult>> + Send + 'static,
 {
-    let mut results = Vec::with_capacity(snapshot.tasks.len());
+    let cancel_task = std::sync::Arc::new(cancel_task);
+    let mut cancellations = Vec::with_capacity(snapshot.tasks.len());
     for (kind, id) in snapshot.tasks {
-        match cancel_task(kind, id.clone()).await {
-            Ok(result) => results.push(result),
-            Err(error) => {
+        let task_id = id.clone();
+        let cancel_task = cancel_task.clone();
+        let handle = tokio::spawn(async move { cancel_task(kind, task_id).await });
+        cancellations.push(async move { (kind, id, handle.await) });
+    }
+
+    // All exact cancellation tasks have been spawned before the first await.
+    // If the caller's overall Stop timeout expires, dropping these JoinHandles
+    // detaches (rather than aborts) the tasks, so a slow first cancellation
+    // cannot prevent later snapshot members from being attempted.
+    futures_util::future::join_all(cancellations)
+        .await
+        .into_iter()
+        .map(|(kind, id, joined)| match joined {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => {
                 let message = crate::logging::redact_sensitive(&error.to_string());
                 crate::app_warn!(
                     "chat",
@@ -197,17 +257,34 @@ where
                     id,
                     message
                 );
-                results.push(CancelRuntimeTaskResult::new(
+                CancelRuntimeTaskResult::new(
                     kind,
                     &id,
                     false,
                     "error",
                     format!("Runtime task cancellation failed: {message}"),
-                ));
+                )
             }
-        }
-    }
-    results
+            Err(error) => {
+                let message = crate::logging::redact_sensitive(&error.to_string());
+                crate::app_warn!(
+                    "chat",
+                    "runtime_task_cancel",
+                    "Runtime task cancellation task failed: kind={} id={} error={}",
+                    kind.as_str(),
+                    id,
+                    message
+                );
+                CancelRuntimeTaskResult::new(
+                    kind,
+                    &id,
+                    false,
+                    "error",
+                    format!("Runtime task cancellation task failed: {message}"),
+                )
+            }
+        })
+        .collect()
 }
 
 fn cancel_async_job(id: &str) -> anyhow::Result<CancelRuntimeTaskResult> {
@@ -417,11 +494,57 @@ mod tests {
         })
         .await;
 
-        assert_eq!(&*calls.lock().unwrap(), &["fails", "continues"]);
+        let mut calls = calls.lock().unwrap().clone();
+        calls.sort();
+        assert_eq!(calls, ["continues", "fails"]);
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].status, "error");
         assert!(!results[0].accepted);
         assert_eq!(results[1].status, "killed");
         assert!(results[1].accepted);
+    }
+
+    #[tokio::test]
+    async fn slow_cancellation_does_not_block_later_snapshot_members() {
+        let snapshot = RuntimeTaskSnapshot {
+            tasks: vec![
+                (RuntimeTaskKind::AsyncJob, "slow".to_string()),
+                (RuntimeTaskKind::Process, "later".to_string()),
+            ],
+        };
+        let slow_release = Arc::new(tokio::sync::Notify::new());
+        let later_started = Arc::new(tokio::sync::Notify::new());
+        let release_for_cancel = slow_release.clone();
+        let started_for_cancel = later_started.clone();
+
+        let cancellation = tokio::spawn(cancel_runtime_task_snapshot_with(
+            snapshot,
+            move |kind, id| {
+                let slow_release = release_for_cancel.clone();
+                let later_started = started_for_cancel.clone();
+                async move {
+                    if id == "slow" {
+                        slow_release.notified().await;
+                    } else {
+                        later_started.notify_one();
+                    }
+                    Ok(CancelRuntimeTaskResult::new(
+                        kind,
+                        &id,
+                        true,
+                        "cancelled",
+                        "cancelled",
+                    ))
+                }
+            },
+        ));
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), later_started.notified())
+            .await
+            .expect("later snapshot member should start while the first is blocked");
+        slow_release.notify_one();
+        let results = cancellation.await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|result| result.accepted));
     }
 }

--- a/crates/ha-core/src/runtime_tasks.rs
+++ b/crates/ha-core/src/runtime_tasks.rs
@@ -39,6 +39,26 @@ pub struct RuntimeTaskSnapshot {
     tasks: Vec<(RuntimeTaskKind, String)>,
 }
 
+fn extend_snapshot_source(
+    tasks: &mut Vec<(RuntimeTaskKind, String)>,
+    source: &'static str,
+    discovered: anyhow::Result<Vec<(RuntimeTaskKind, String)>>,
+) {
+    match discovered {
+        Ok(discovered) => tasks.extend(discovered),
+        Err(error) => {
+            let message = crate::logging::redact_sensitive(&error.to_string());
+            crate::app_warn!(
+                "chat",
+                "runtime_task_snapshot",
+                "Runtime task source snapshot failed; continuing other sources: source={} error={}",
+                source,
+                message
+            );
+        }
+    }
+}
+
 impl CancelRuntimeTaskResult {
     fn new(
         kind: RuntimeTaskKind,
@@ -101,30 +121,36 @@ pub async fn snapshot_runtime_tasks_for_session(
         let mut tasks = Vec::new();
 
         if let Some(db) = crate::async_jobs::get_async_jobs_db() {
-            for job in db.list_running()? {
-                let matches_session = session_for_blocking
-                    .as_deref()
-                    .map(|sid| job.session_id.as_deref() == Some(sid))
-                    .unwrap_or(true);
-                if matches_session {
-                    tasks.push((RuntimeTaskKind::AsyncJob, job.job_id));
-                }
-            }
+            let discovered = db.list_running().map(|jobs| {
+                jobs.into_iter()
+                    .filter(|job| {
+                        session_for_blocking
+                            .as_deref()
+                            .map(|sid| job.session_id.as_deref() == Some(sid))
+                            .unwrap_or(true)
+                    })
+                    .map(|job| (RuntimeTaskKind::AsyncJob, job.job_id))
+                    .collect()
+            });
+            extend_snapshot_source(&mut tasks, "async_jobs", discovered);
         }
 
         if let Some(db) = crate::get_session_db() {
-            let runs = match session_for_blocking.as_deref() {
-                Some(sid) => db.list_active_subagent_runs(sid)?,
-                None => db.list_all_active_subagent_runs()?,
-            };
-            for run in runs {
-                tasks.push((RuntimeTaskKind::Subagent, run.run_id));
+            let discovered = match session_for_blocking.as_deref() {
+                Some(sid) => db.list_active_subagent_runs(sid),
+                None => db.list_all_active_subagent_runs(),
             }
+            .map(|runs| {
+                runs.into_iter()
+                    .map(|run| (RuntimeTaskKind::Subagent, run.run_id))
+                    .collect()
+            });
+            extend_snapshot_source(&mut tasks, "subagents", discovered);
         }
 
-        anyhow::Ok(tasks)
+        tasks
     })
-    .await?;
+    .await;
 
     let process_ids = {
         let registry = crate::process_registry::get_registry().lock().await;
@@ -342,6 +368,26 @@ fn cancel_cron(id: &str) -> anyhow::Result<CancelRuntimeTaskResult> {
 mod tests {
     use super::*;
     use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn snapshot_collection_continues_after_source_failure() {
+        let mut tasks = Vec::new();
+        extend_snapshot_source(
+            &mut tasks,
+            "async_jobs",
+            Err(anyhow::anyhow!("transient database read failure")),
+        );
+        extend_snapshot_source(
+            &mut tasks,
+            "subagents",
+            Ok(vec![(RuntimeTaskKind::Subagent, "continues".to_string())]),
+        );
+
+        assert_eq!(
+            tasks,
+            vec![(RuntimeTaskKind::Subagent, "continues".to_string())]
+        );
+    }
 
     #[tokio::test]
     async fn snapshot_cancellation_continues_after_individual_failure() {

--- a/crates/ha-core/src/runtime_tasks.rs
+++ b/crates/ha-core/src/runtime_tasks.rs
@@ -31,6 +31,14 @@ pub struct CancelRuntimeTaskResult {
     pub message: String,
 }
 
+/// Exact runtime identities captured while a stopped session is still gated.
+/// Cancellation may finish later, but it must never re-enumerate the session
+/// and accidentally pick up work from a replacement turn.
+#[derive(Debug, Clone, Default)]
+pub struct RuntimeTaskSnapshot {
+    tasks: Vec<(RuntimeTaskKind, String)>,
+}
+
 impl CancelRuntimeTaskResult {
     fn new(
         kind: RuntimeTaskKind,
@@ -54,10 +62,19 @@ pub async fn cancel_runtime_task(
     id: &str,
 ) -> anyhow::Result<CancelRuntimeTaskResult> {
     match kind {
-        RuntimeTaskKind::AsyncJob => cancel_async_job(id),
-        RuntimeTaskKind::Subagent => cancel_subagent(id),
+        RuntimeTaskKind::AsyncJob => {
+            let id = id.to_string();
+            crate::blocking::run_blocking(move || cancel_async_job(&id)).await
+        }
+        RuntimeTaskKind::Subagent => {
+            let id = id.to_string();
+            crate::blocking::run_blocking(move || cancel_subagent(&id)).await
+        }
         RuntimeTaskKind::Process => cancel_process(id).await,
-        RuntimeTaskKind::Cron => cancel_cron(id),
+        RuntimeTaskKind::Cron => {
+            let id = id.to_string();
+            crate::blocking::run_blocking(move || cancel_cron(&id)).await
+        }
     }
 }
 
@@ -67,37 +84,67 @@ pub async fn cancel_runtime_task(
 pub async fn cancel_runtime_tasks_for_session(
     session_id: Option<&str>,
 ) -> anyhow::Result<Vec<CancelRuntimeTaskResult>> {
-    let mut results = Vec::new();
+    let snapshot = snapshot_runtime_tasks_for_session(session_id).await?;
+    cancel_runtime_task_snapshot(snapshot).await
+}
 
-    if let Some(db) = crate::async_jobs::get_async_jobs_db() {
-        for job in db.list_running()? {
-            let matches_session = session_id
-                .map(|sid| job.session_id.as_deref() == Some(sid))
-                .unwrap_or(true);
-            if matches_session {
-                results.push(cancel_async_job(&job.job_id)?);
+/// Capture runtime work associated with a session without performing any
+/// cancellation side effects. A caller may safely time this future out: an
+/// already-running blocking DB read can finish in the background, but it
+/// cannot affect a later turn.
+pub async fn snapshot_runtime_tasks_for_session(
+    session_id: Option<&str>,
+) -> anyhow::Result<RuntimeTaskSnapshot> {
+    let owned_session_id = session_id.map(str::to_string);
+    let session_for_blocking = owned_session_id.clone();
+    let mut tasks = crate::blocking::run_blocking(move || {
+        let mut tasks = Vec::new();
+
+        if let Some(db) = crate::async_jobs::get_async_jobs_db() {
+            for job in db.list_running()? {
+                let matches_session = session_for_blocking
+                    .as_deref()
+                    .map(|sid| job.session_id.as_deref() == Some(sid))
+                    .unwrap_or(true);
+                if matches_session {
+                    tasks.push((RuntimeTaskKind::AsyncJob, job.job_id));
+                }
             }
         }
-    }
 
-    if let Some(db) = crate::get_session_db() {
-        let runs = match session_id {
-            Some(sid) => db.list_active_subagent_runs(sid)?,
-            None => db.list_all_active_subagent_runs()?,
-        };
-        for run in runs {
-            results.push(cancel_subagent(&run.run_id)?);
+        if let Some(db) = crate::get_session_db() {
+            let runs = match session_for_blocking.as_deref() {
+                Some(sid) => db.list_active_subagent_runs(sid)?,
+                None => db.list_all_active_subagent_runs()?,
+            };
+            for run in runs {
+                tasks.push((RuntimeTaskKind::Subagent, run.run_id));
+            }
         }
-    }
+
+        anyhow::Ok(tasks)
+    })
+    .await?;
 
     let process_ids = {
         let registry = crate::process_registry::get_registry().lock().await;
-        registry.list_running_ids_for_parent_session(session_id)
+        registry.list_running_ids_for_parent_session(owned_session_id.as_deref())
     };
     for process_id in process_ids {
-        results.push(cancel_process(&process_id).await?);
+        tasks.push((RuntimeTaskKind::Process, process_id));
     }
 
+    Ok(RuntimeTaskSnapshot { tasks })
+}
+
+/// Cancel only the identities in a previously captured snapshot.
+pub async fn cancel_runtime_task_snapshot(
+    snapshot: RuntimeTaskSnapshot,
+) -> anyhow::Result<Vec<CancelRuntimeTaskResult>> {
+    let mut results = Vec::with_capacity(snapshot.tasks.len());
+    for (kind, id) in snapshot.tasks {
+        results.push(cancel_runtime_task(kind, &id).await?);
+    }
     Ok(results)
 }
 
@@ -168,25 +215,23 @@ fn cancel_subagent(id: &str) -> anyhow::Result<CancelRuntimeTaskResult> {
         ));
     }
 
-    let signalled = crate::get_subagent_cancels()
-        .map(|registry| registry.cancel(id))
-        .unwrap_or(false);
-    if !signalled {
-        let _ = db.update_subagent_status(
-            id,
-            crate::subagent::SubagentStatus::Killed,
-            None,
-            Some("Killed by runtime cancel"),
-            None,
-            None,
-        );
-    }
+    // This is the only cancellation entry that atomically claims parked runs,
+    // reuses the running token, and synchronizes the background projection.
+    let accepted = crate::subagent::request_cancel_run(id);
     Ok(CancelRuntimeTaskResult::new(
         RuntimeTaskKind::Subagent,
         id,
-        true,
-        "killed",
-        "Sub-agent cancellation requested",
+        accepted,
+        if accepted {
+            "killed"
+        } else {
+            run.status.as_str()
+        },
+        if accepted {
+            "Sub-agent cancellation requested"
+        } else {
+            "Sub-agent is no longer active"
+        },
     ))
 }
 
@@ -194,8 +239,11 @@ async fn cancel_process(id: &str) -> anyhow::Result<CancelRuntimeTaskResult> {
     use crate::process_registry::{get_registry, ProcessStatus};
 
     crate::process_notification::mark_observed(id);
-    let mut registry = get_registry().lock().await;
-    let Some(session) = registry.get_session(id).cloned() else {
+    let session = {
+        let registry = get_registry().lock().await;
+        registry.get_session(id).cloned()
+    };
+    let Some(session) = session else {
         return Ok(CancelRuntimeTaskResult::new(
             RuntimeTaskKind::Process,
             id,
@@ -214,8 +262,9 @@ async fn cancel_process(id: &str) -> anyhow::Result<CancelRuntimeTaskResult> {
         ));
     }
     if let Some(pid) = session.pid {
-        crate::platform::terminate_process_tree(pid);
+        crate::blocking::run_blocking(move || crate::platform::terminate_process_tree(pid)).await;
     }
+    let mut registry = get_registry().lock().await;
     registry.mark_exited(id, None, Some("SIGKILL".to_string()), ProcessStatus::Failed);
     Ok(CancelRuntimeTaskResult::new(
         RuntimeTaskKind::Process,

--- a/crates/ha-core/src/runtime_tasks.rs
+++ b/crates/ha-core/src/runtime_tasks.rs
@@ -137,8 +137,8 @@ pub async fn snapshot_runtime_tasks_for_session(
 
         if let Some(db) = crate::get_session_db() {
             let discovered = match session_for_blocking.as_deref() {
-                Some(sid) => db.list_active_subagent_runs(sid),
-                None => db.list_all_active_subagent_runs(),
+                Some(sid) => db.list_nonterminal_subagent_runs(sid),
+                None => db.list_all_nonterminal_subagent_runs(),
             }
             .map(|runs| {
                 runs.into_iter()

--- a/crates/ha-core/src/session/stream_persistence.rs
+++ b/crates/ha-core/src/session/stream_persistence.rs
@@ -675,7 +675,7 @@ impl SessionDB {
                  SET status = 'completed', interrupt_reason = NULL, error = NULL,
                      assistant_message_id = ?1, ended_at = ?2, updated_at = ?2
                  WHERE id = ?3 AND session_id = ?4
-                   AND status NOT IN ('completed','interrupted','failed')",
+                   AND status = 'running'",
                 params![assistant_id, now, turn_id, input.session_id],
             )?;
             if changed_turn != 1 {
@@ -1043,6 +1043,38 @@ impl SessionDB {
                         started_at, ended_at, error
                  FROM chat_stream_runs WHERE run_id = ?1",
                 params![run_id],
+                row_to_run,
+            )
+            .optional()?;
+        let Some(run) = run else {
+            return Ok(None);
+        };
+        let attempts = load_attempts(&conn, &run.run_id)?;
+        let journal = load_journal(&conn, &run.run_id)?;
+        let mut snapshot = StreamRunSnapshot {
+            run,
+            attempts,
+            journal,
+            through_seq: 0,
+        };
+        snapshot.through_seq = select_recoverable_attempt_prefix(&snapshot).1;
+        Ok(Some(snapshot))
+    }
+
+    /// Load the persistence run owned by one exact foreground turn. Stop
+    /// watchdogs must never fall back to the session's latest run because a
+    /// replacement turn may already be active by the time recovery fires.
+    pub fn stream_run_snapshot_for_turn(&self, turn_id: &str) -> Result<Option<StreamRunSnapshot>> {
+        let conn = self.read_conn()?;
+        let run = conn
+            .query_row(
+                "SELECT run_id, session_id, source, stream_id, turn_id, status,
+                        accepted_seq, durable_seq, checkpoint_seq, committed_seq, provider_shape,
+                        started_at, ended_at, error
+                 FROM chat_stream_runs
+                 WHERE turn_id = ?1
+                 ORDER BY started_at DESC LIMIT 1",
+                params![turn_id],
                 row_to_run,
             )
             .optional()?;
@@ -2000,6 +2032,7 @@ pub fn journal_events_have_assistant_output(events: &[JournalEvent]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::ChatTurnInterruptReason;
 
     struct RunFixture {
         _dir: tempfile::TempDir,
@@ -2195,6 +2228,79 @@ mod tests {
             .expect("turn exists");
         assert_eq!(turn.status, ChatTurnStatus::Completed);
         assert_eq!(turn.assistant_message_id, Some(first.assistant_message_id));
+    }
+
+    #[test]
+    fn cancelling_turn_rejects_late_success_commit_atomically() {
+        let fixture = fixture("cancel-wins-final-commit");
+        fixture
+            .db
+            .mark_chat_turn_cancelling(&fixture.turn_id, ChatTurnInterruptReason::UserStop)
+            .expect("mark cancelling");
+
+        fixture
+            .db
+            .commit_assistant_turn(&success_commit(&fixture, None))
+            .expect_err("late success must not overwrite a cancelling turn");
+
+        assert_eq!(
+            scalar_i64(
+                &fixture.db,
+                "SELECT COUNT(*) FROM messages WHERE session_id = ?1",
+                &fixture.session_id,
+            ),
+            1,
+            "the whole success transaction must roll back"
+        );
+        let turn = fixture
+            .db
+            .get_chat_turn(&fixture.turn_id)
+            .expect("load turn")
+            .expect("turn exists");
+        assert_eq!(turn.status, ChatTurnStatus::Cancelling);
+        assert_eq!(
+            turn.interrupt_reason,
+            Some(ChatTurnInterruptReason::UserStop)
+        );
+        assert_eq!(
+            scalar_i64(
+                &fixture.db,
+                "SELECT COUNT(*) FROM model_usage_events WHERE session_id = ?1",
+                &fixture.session_id,
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn turn_scoped_snapshot_never_selects_a_newer_session_run() {
+        let fixture = fixture("turn-scoped-run");
+        let newer_turn = fixture
+            .db
+            .create_chat_turn(&fixture.session_id, "desktop", Some("stream-new"), None)
+            .expect("newer turn");
+        let newer_run_id = uuid::Uuid::new_v4().to_string();
+        fixture
+            .db
+            .create_stream_run(&CreateStreamRun {
+                run_id: newer_run_id.clone(),
+                session_id: fixture.session_id.clone(),
+                source: "desktop".to_string(),
+                stream_id: Some("stream-new".to_string()),
+                turn_id: Some(newer_turn.id),
+                provider_shape: None,
+            })
+            .expect("newer run");
+
+        let exact_run = fixture
+            .db
+            .stream_run_snapshot_for_turn(&fixture.turn_id)
+            .expect("turn run")
+            .expect("turn run exists")
+            .run
+            .run_id;
+        assert_eq!(exact_run, fixture.run_id);
+        assert_ne!(exact_run, newer_run_id);
     }
 
     #[test]

--- a/crates/ha-core/src/session/subagent_db.rs
+++ b/crates/ha-core/src/session/subagent_db.rs
@@ -1040,6 +1040,32 @@ impl SessionDB {
         Ok(runs)
     }
 
+    /// List every non-terminal sub-agent run owned by a parent session.
+    /// Unlike the active-run query, this includes parked `queued` runs so a
+    /// parent Stop can cancel them before the scheduler promotes them.
+    pub fn list_nonterminal_subagent_runs(
+        &self,
+        parent_session_id: &str,
+    ) -> Result<Vec<crate::subagent::SubagentRun>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+        let sql = format!(
+            "SELECT {SUBAGENT_RUN_COLUMNS}
+               FROM subagent_runs
+              WHERE parent_session_id = ?1 AND status IN ('queued', 'spawning', 'running')
+              ORDER BY started_at DESC"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(params![parent_session_id], Self::row_to_subagent_run)?;
+        let mut runs = Vec::new();
+        for row in rows {
+            runs.push(row?);
+        }
+        Ok(runs)
+    }
+
     /// R8 follow-up: the active (`spawning`/`running`) sub-agent run whose CHILD
     /// session is `child_session_id`. An inner-tool approval event carries the
     /// child session that requested it; this maps that back to the run whose
@@ -1078,6 +1104,28 @@ impl SessionDB {
             "SELECT {SUBAGENT_RUN_COLUMNS}
                FROM subagent_runs
               WHERE status IN ('spawning', 'running')
+              ORDER BY started_at DESC"
+        );
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map([], Self::row_to_subagent_run)?;
+        let mut runs = Vec::new();
+        for row in rows {
+            runs.push(row?);
+        }
+        Ok(runs)
+    }
+
+    /// List all queued or active sub-agent runs across sessions. This is the
+    /// process-wide Stop counterpart of [`Self::list_nonterminal_subagent_runs`].
+    pub fn list_all_nonterminal_subagent_runs(&self) -> Result<Vec<crate::subagent::SubagentRun>> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| anyhow::anyhow!("Lock error: {}", e))?;
+        let sql = format!(
+            "SELECT {SUBAGENT_RUN_COLUMNS}
+               FROM subagent_runs
+              WHERE status IN ('queued', 'spawning', 'running')
               ORDER BY started_at DESC"
         );
         let mut stmt = conn.prepare(&sql)?;
@@ -1356,6 +1404,33 @@ mod tests {
             .find_active_run_by_child_session("child-nope")
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn nonterminal_stop_snapshot_includes_queued_runs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = SessionDB::open_ephemeral_for_test(&tmp.path().join("s.db")).unwrap();
+        db.insert_subagent_run(&run("run-q", "child-q", SubagentStatus::Queued))
+            .unwrap();
+        db.insert_subagent_run(&run("run-s", "child-s", SubagentStatus::Spawning))
+            .unwrap();
+        db.insert_subagent_run(&run("run-r", "child-r", SubagentStatus::Running))
+            .unwrap();
+        db.insert_subagent_run(&run("run-done", "child-done", SubagentStatus::Completed))
+            .unwrap();
+
+        let run_ids = db
+            .list_nonterminal_subagent_runs("parent")
+            .unwrap()
+            .into_iter()
+            .map(|run| run.run_id)
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(run_ids.len(), 3);
+        assert!(run_ids.contains("run-q"));
+        assert!(run_ids.contains("run-s"));
+        assert!(run_ids.contains("run-r"));
+        assert!(!run_ids.contains("run-done"));
+        assert_eq!(db.list_all_nonterminal_subagent_runs().unwrap().len(), 3);
     }
 
     #[test]

--- a/crates/ha-core/src/tools/approval.rs
+++ b/crates/ha-core/src/tools/approval.rs
@@ -657,15 +657,22 @@ pub async fn deny_pending_for_session(session_id: &str, source: ApprovalResoluti
         return 0;
     }
     let count = drained.len();
+    let mut cleanup_request_ids = Vec::with_capacity(count);
     for (request_id, entry) in drained {
         let _ = entry.sender.send(ApprovalResponse::Deny);
-        // EventBus delivery is best-effort and the IM listener can lag. Clear
-        // its text-reply state directly so Stop cannot leave a stale prompt
-        // that captures a later ordinary chat message.
-        crate::channel::worker::approval::drop_pending_by_request_id(&request_id).await;
         emit_approval_resolved(&request_id, Some(session_id), "deny", source);
+        cleanup_request_ids.push(request_id);
     }
     emit_pending_interactions_changed(Some(session_id));
+
+    // Publish every terminal event before the first blocking IM cleanup. Stop
+    // bounds this whole routine with a timeout; if cleanup stalls, cancelling
+    // here is safe because the approval is already denied and every surface
+    // has already been told to dismiss it. The exact request-id cleanup below
+    // remains a best-effort guard against stale IM text replies.
+    for request_id in cleanup_request_ids {
+        crate::channel::worker::approval::drop_pending_by_request_id(&request_id).await;
+    }
     count
 }
 
@@ -681,12 +688,19 @@ pub async fn deny_all_pending(source: ApprovalResolutionSource) -> usize {
         return 0;
     }
     let count = drained.len();
+    let mut cleanup_request_ids = Vec::with_capacity(count);
     for (request_id, entry) in drained {
         let session_id = entry.request.session_id;
         let _ = entry.sender.send(ApprovalResponse::Deny);
-        crate::channel::worker::approval::drop_pending_by_request_id(&request_id).await;
         emit_approval_resolved(&request_id, session_id.as_deref(), "deny", source);
         emit_pending_interactions_changed(session_id.as_deref());
+        cleanup_request_ids.push(request_id);
+    }
+    // Keep global Stop cancellation-safe for the same reason as the
+    // per-session path above: terminal events are non-negotiable; IM's
+    // secondary text-reply cleanup is bounded best effort.
+    for request_id in cleanup_request_ids {
+        crate::channel::worker::approval::drop_pending_by_request_id(&request_id).await;
     }
     count
 }
@@ -1381,6 +1395,92 @@ mod tests {
             .await
             .iter()
             .all(|candidate| candidate.request_id != request_id));
+    }
+
+    /// Stop bounds approval cleanup with a short timeout. Even if the IM
+    /// text-reply registry is contended for that whole window, the authoritative
+    /// denial and cross-surface dismissal event must happen first.
+    #[tokio::test]
+    async fn user_stop_resolves_approval_before_im_cleanup_can_block() {
+        let bus = crate::globals::EVENT_BUS
+            .get_or_init(|| {
+                let bus: std::sync::Arc<dyn crate::event_bus::EventBus> =
+                    std::sync::Arc::new(crate::event_bus::BroadcastEventBus::new(256));
+                bus
+            })
+            .clone();
+        let mut events = bus.subscribe();
+
+        let request_id = format!("approval-stop-order-{}", create_session_id());
+        let session_id = format!("session-stop-order-{}", create_session_id());
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        get_pending_approvals().lock().await.insert(
+            request_id.clone(),
+            PendingApprovalEntry {
+                sender,
+                request: ApprovalRequest {
+                    request_id: request_id.clone(),
+                    command: "blocked cleanup test".into(),
+                    cwd: "/tmp".into(),
+                    session_id: Some(session_id.clone()),
+                    reason: None,
+                    incognito: false,
+                    created_at_ms: 1_000,
+                    server_now_ms: 1_000,
+                    timeout_at_ms: None,
+                    timeout_secs: 0,
+                    timeout_action: crate::config::ApprovalTimeoutAction::Deny,
+                },
+            },
+        );
+
+        let (lock_acquired_tx, lock_acquired_rx) = tokio::sync::oneshot::channel();
+        let (release_lock_tx, release_lock_rx) = tokio::sync::oneshot::channel();
+        let lock_task = tokio::spawn(
+            crate::channel::worker::approval::hold_text_pending_lock_for_test(
+                lock_acquired_tx,
+                release_lock_rx,
+            ),
+        );
+        lock_acquired_rx.await.expect("IM cleanup lock acquired");
+
+        let stopped_session_id = session_id.clone();
+        let mut deny_task = tokio::spawn(async move {
+            deny_pending_for_session(&stopped_session_id, ApprovalResolutionSource::UserStop).await
+        });
+
+        assert_eq!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), receiver)
+                .await
+                .expect("approval denied before IM cleanup")
+                .expect("approval sender still active"),
+            ApprovalResponse::Deny
+        );
+        let resolved = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let event = events.recv().await.expect("event bus remains open");
+                if event.name == EVENT_APPROVAL_RESOLVED
+                    && event.payload.get("requestId").and_then(|v| v.as_str())
+                        == Some(request_id.as_str())
+                {
+                    break event;
+                }
+            }
+        })
+        .await
+        .expect("approval resolved event emitted before IM cleanup");
+        assert_eq!(resolved.payload["source"], "user_stop");
+        assert_eq!(resolved.payload["decision"], "deny");
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut deny_task)
+                .await
+                .is_err(),
+            "cleanup should still be waiting on the deliberately held IM lock"
+        );
+
+        release_lock_tx.send(()).expect("release IM cleanup lock");
+        assert_eq!(deny_task.await.expect("deny task completed"), 1);
+        lock_task.await.expect("lock task completed");
     }
 
     /// Sidebar countdown: the per-session aggregate counts every pending

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -1757,16 +1757,12 @@ pub async fn stop_chat(
                 | ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::Latched
         )
     );
-    let target_session_id = body.session_id.clone().or_else(|| {
-        request_target
-            .as_ref()
-            .map(|active| active.session_id.clone())
-    });
-    let target_turn_id = if body.session_id.is_some() {
-        body.turn_id.clone()
-    } else {
-        request_target.as_ref().map(|active| active.turn_id.clone())
-    };
+    let (target_session_id, target_turn_id) =
+        ha_core::chat_engine::active_turn::resolve_stop_target(
+            body.session_id.as_deref(),
+            body.turn_id.as_deref(),
+            request_target.as_ref(),
+        );
     let global_stop = body.session_id.is_none() && body.client_request_id.is_none();
     let registered_cancels: std::collections::HashMap<_, _> = ctx
         .chat_cancels

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -1719,6 +1719,22 @@ pub async fn stop_chat(
             "runtimeCancellationError": Value::Null,
         })));
     }
+    if matches!(
+        request_cancel.as_ref(),
+        Some(ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::Latched)
+    ) {
+        // The opaque request is not registered yet. Its Stop is now
+        // authoritatively represented by the in-memory request latch; a session id supplied
+        // by the caller is only an ownership constraint, not permission to
+        // cancel a different active turn in that session.
+        return Ok(Json(json!({
+            "stopped": true,
+            "scope": "request",
+            "reason": Value::Null,
+            "runtimeCancellations": [],
+            "runtimeCancellationError": Value::Null,
+        })));
+    }
     let request_target = request_cancel.as_ref().and_then(|outcome| match outcome {
         ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::Active(active) => {
             Some(active.clone())
@@ -1727,10 +1743,7 @@ pub async fn stop_chat(
     });
     let mut already_signalled = matches!(
         request_cancel,
-        Some(
-            ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::Active(_)
-                | ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::Latched
-        )
+        Some(ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::Active(_))
     );
     let (target_session_id, target_turn_id) =
         ha_core::chat_engine::active_turn::resolve_stop_target(

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -927,6 +927,16 @@ async fn chat_inner(
         ) {
             Ok(guard) => guard,
             Err(error) => {
+                // Session creation and bootstrap claiming precede active-turn
+                // admission. Hold a session cleanup gate before awaiting any
+                // queue release so a global Stop rejection cannot leak this
+                // unpublished lazy Session or its managed worktree.
+                let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+                    db.clone(),
+                    sid.clone(),
+                    bootstrap_request_id.clone(),
+                    new_session_created,
+                );
                 if let Some(request_id) = queued_request_id.as_ref() {
                     let sid_for_release = sid.clone();
                     let request_id_for_release = request_id.clone();
@@ -940,6 +950,9 @@ async fn chat_inner(
                             )
                         })
                         .await;
+                }
+                if let Some(cleanup) = cleanup {
+                    cleanup.spawn();
                 }
                 return Err(AppError::conflict_with_code(
                     ha_core::chat_engine::stream_seq::ACTIVE_STREAM_ERROR_CODE,
@@ -981,9 +994,12 @@ async fn chat_inner(
         }
         // There is no chat_turn row yet, so terminate the transport-visible
         // lifecycle and release the exact guard before Git-aware cleanup.
-        let needs_background_cleanup = bootstrap_request_id.is_some() || new_session_created;
-        let cleanup_gate = needs_background_cleanup
-            .then(|| ha_core::chat_engine::active_turn::begin_stop_cleanup(&sid));
+        let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+            db.clone(),
+            sid.clone(),
+            bootstrap_request_id.clone(),
+            new_session_created,
+        );
         ha_core::chat_engine::stream_broadcast::broadcast_stream_end(
             &sid,
             None,
@@ -994,49 +1010,8 @@ async fn chat_inner(
         );
         ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
 
-        if needs_background_cleanup {
-            let cleanup_db = db.clone();
-            let cleanup_sid = sid.clone();
-            let cleanup_request_id = bootstrap_request_id.clone();
-            tokio::spawn(async move {
-                let bootstrap_rollback_succeeded = if let Some(request_id) = cleanup_request_id {
-                    match cleanup_db
-                        .clone()
-                        .run(move |db| db.rollback_project_bootstrap_after_chat_cancel(&request_id))
-                        .await
-                    {
-                        Ok(()) => true,
-                        Err(error) => {
-                            ha_core::app_warn!(
-                                "project",
-                                "bootstrap_cancel_rollback",
-                                "Failed to roll back project bootstrap for stopped chat {}: {}",
-                                cleanup_sid,
-                                error
-                            );
-                            false
-                        }
-                    }
-                } else {
-                    true
-                };
-                if new_session_created && bootstrap_rollback_succeeded {
-                    let sid_for_delete = cleanup_sid.clone();
-                    if let Err(error) = cleanup_db
-                        .run(move |db| db.delete_session(&sid_for_delete))
-                        .await
-                    {
-                        ha_core::app_warn!(
-                            "chat",
-                            "preflight_cancel_cleanup",
-                            "Failed to delete empty stopped session {}: {}",
-                            cleanup_sid,
-                            error
-                        );
-                    }
-                }
-                drop(cleanup_gate);
-            });
+        if let Some(cleanup) = cleanup {
+            cleanup.spawn();
         }
         return Err(AppError::conflict_with_code(
             ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE,

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -945,21 +945,10 @@ async fn chat_inner(
                 sid.clone(),
                 bootstrap_request_id.clone(),
                 new_session_created,
+                queued_request_id
+                    .as_ref()
+                    .map(|request_id| (request_id.clone(), turn_id.clone())),
             );
-            if let Some(request_id) = queued_request_id.as_ref() {
-                let sid_for_release = sid.clone();
-                let request_id_for_release = request_id.clone();
-                let turn_for_release = turn_id.clone();
-                let _ = db
-                    .run(move |db| {
-                        db.release_queued_turn_message_dispatch(
-                            &sid_for_release,
-                            &request_id_for_release,
-                            &turn_for_release,
-                        )
-                    })
-                    .await;
-            }
             if let Some(cleanup) = cleanup {
                 cleanup.spawn();
             }
@@ -984,27 +973,18 @@ async fn chat_inner(
     )
     .await;
     let Some(preflight) = preflight else {
-        if let Some(request_id) = queued_request_id.as_ref() {
-            let sid_for_release = sid.clone();
-            let request_id_for_release = request_id.clone();
-            let turn_for_release = turn_id.clone();
-            let _ = db
-                .run(move |db| {
-                    db.release_queued_turn_message_dispatch(
-                        &sid_for_release,
-                        &request_id_for_release,
-                        &turn_for_release,
-                    )
-                })
-                .await;
-        }
         // There is no chat_turn row yet, so terminate the transport-visible
-        // lifecycle and release the exact guard before Git-aware cleanup.
+        // lifecycle and release the exact guard before Git/SQLite cleanup. The
+        // cleanup gate keeps a replacement turn out until the exact queued-row
+        // CAS settles or reaches its bounded timeout.
         let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
             db.clone(),
             sid.clone(),
             bootstrap_request_id.clone(),
             new_session_created,
+            queued_request_id
+                .as_ref()
+                .map(|request_id| (request_id.clone(), turn_id.clone())),
         );
         ha_core::chat_engine::stream_broadcast::broadcast_stream_end(
             &sid,

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -45,6 +45,10 @@ pub struct ChatRequest {
     pub ui_surface: Option<ha_core::pet::ChatUiSurface>,
     #[serde(default)]
     pub session_id: Option<String>,
+    /// Opaque UI request identity used to target Stop before a lazily-created
+    /// session id has reached the frontend.
+    #[serde(default)]
+    pub client_request_id: Option<String>,
     #[serde(default)]
     pub incognito: Option<bool>,
     #[serde(default)]
@@ -237,13 +241,15 @@ impl ChatCancelRegistrationGuard {
         if !self.armed {
             return;
         }
-        if let Ok(mut cancels) = self.registry.write() {
-            let should_remove = cancels
-                .get(&self.session_id)
-                .is_some_and(|current| Arc::ptr_eq(current, &self.cancel));
-            if should_remove {
-                cancels.remove(&self.session_id);
-            }
+        let mut cancels = self
+            .registry
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let should_remove = cancels
+            .get(&self.session_id)
+            .is_some_and(|current| Arc::ptr_eq(current, &self.cancel));
+        if should_remove {
+            cancels.remove(&self.session_id);
         }
         self.armed = false;
     }
@@ -459,12 +465,15 @@ fn validate_http_uploaded_attachment_path(session_id: &str, path: &str) -> Resul
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct StopChatRequest {
-    /// When omitted, cancels every running chat (mirrors the Tauri command's
-    /// "stop the current chat" semantics — frontend calls `stop_chat` with
-    /// no args).
+    /// When omitted, cancels every running chat. First-party callers normally
+    /// provide a session id; the global form is a legacy/emergency fallback.
     pub session_id: Option<String>,
     #[serde(default)]
     pub turn_id: Option<String>,
+    /// Opaque first-party request id used while a lazy session has not yet
+    /// been announced to the client.
+    #[serde(default)]
+    pub client_request_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -908,34 +917,36 @@ async fn chat_inner(
             .map_err(|e| AppError::bad_request(e.to_string()))?;
     }
     let cancel = Arc::new(AtomicBool::new(false));
-    let _active_turn_guard = match ha_core::chat_engine::active_turn::try_acquire(
-        &sid,
-        ha_core::chat_engine::stream_seq::ChatSource::Http,
-        turn_id.clone(),
-        cancel.clone(),
-    ) {
-        Ok(guard) => guard,
-        Err(error) => {
-            if let Some(request_id) = queued_request_id.as_ref() {
-                let sid_for_release = sid.clone();
-                let request_id_for_release = request_id.clone();
-                let turn_for_release = turn_id.clone();
-                let _ = db
-                    .run(move |db| {
-                        db.release_queued_turn_message_dispatch(
-                            &sid_for_release,
-                            &request_id_for_release,
-                            &turn_for_release,
-                        )
-                    })
-                    .await;
+    let _active_turn_guard =
+        match ha_core::chat_engine::active_turn::try_acquire_with_client_request_id(
+            &sid,
+            ha_core::chat_engine::stream_seq::ChatSource::Http,
+            turn_id.clone(),
+            body.client_request_id.clone(),
+            cancel.clone(),
+        ) {
+            Ok(guard) => guard,
+            Err(error) => {
+                if let Some(request_id) = queued_request_id.as_ref() {
+                    let sid_for_release = sid.clone();
+                    let request_id_for_release = request_id.clone();
+                    let turn_for_release = turn_id.clone();
+                    let _ = db
+                        .run(move |db| {
+                            db.release_queued_turn_message_dispatch(
+                                &sid_for_release,
+                                &request_id_for_release,
+                                &turn_for_release,
+                            )
+                        })
+                        .await;
+                }
+                return Err(AppError::conflict_with_code(
+                    ha_core::chat_engine::stream_seq::ACTIVE_STREAM_ERROR_CODE,
+                    error.to_string(),
+                ));
             }
-            return Err(AppError::conflict_with_code(
-                ha_core::chat_engine::stream_seq::ACTIVE_STREAM_ERROR_CODE,
-                error.to_string(),
-            ));
-        }
-    };
+        };
 
     // Prefer display_text for DB/title, fall back to the LLM-bound message.
     let raw_prompt = ha_core::non_empty_trim_or(body.display_text.as_deref(), &body.message);
@@ -943,16 +954,96 @@ async fn chat_inner(
     // Preflight chokepoint: every user-message entry point routes through this
     // before persisting. Pass-through in Phase 0.1; PR 1.2 runs the
     // `UserPromptSubmit` hook here (may block / rewrite the prompt).
-    let effective_prompt = match ha_core::agent::preflight::user_prompt_preflight(
+    let preflight = ha_core::agent::preflight::user_prompt_preflight_cancellable(
         ha_core::agent::preflight::PreflightArgs {
             session_id: &sid,
             agent_id: Some(agent_id.as_str()),
             raw_prompt,
             turn_id: &turn_id,
         },
+        cancel.as_ref(),
     )
-    .await
-    {
+    .await;
+    let Some(preflight) = preflight else {
+        if let Some(request_id) = queued_request_id.as_ref() {
+            let sid_for_release = sid.clone();
+            let request_id_for_release = request_id.clone();
+            let turn_for_release = turn_id.clone();
+            let _ = db
+                .run(move |db| {
+                    db.release_queued_turn_message_dispatch(
+                        &sid_for_release,
+                        &request_id_for_release,
+                        &turn_for_release,
+                    )
+                })
+                .await;
+        }
+        // There is no chat_turn row yet, so terminate the transport-visible
+        // lifecycle and release the exact guard before Git-aware cleanup.
+        let needs_background_cleanup = bootstrap_request_id.is_some() || new_session_created;
+        let cleanup_gate = needs_background_cleanup
+            .then(|| ha_core::chat_engine::active_turn::begin_stop_cleanup(&sid));
+        ha_core::chat_engine::stream_broadcast::broadcast_stream_end(
+            &sid,
+            None,
+            Some(&turn_id),
+            Some(session::ChatTurnStatus::Interrupted),
+            Some(session::ChatTurnInterruptReason::UserStop),
+            None,
+        );
+        ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
+
+        if needs_background_cleanup {
+            let cleanup_db = db.clone();
+            let cleanup_sid = sid.clone();
+            let cleanup_request_id = bootstrap_request_id.clone();
+            tokio::spawn(async move {
+                let bootstrap_rollback_succeeded = if let Some(request_id) = cleanup_request_id {
+                    match cleanup_db
+                        .clone()
+                        .run(move |db| db.rollback_project_bootstrap_after_chat_cancel(&request_id))
+                        .await
+                    {
+                        Ok(()) => true,
+                        Err(error) => {
+                            ha_core::app_warn!(
+                                "project",
+                                "bootstrap_cancel_rollback",
+                                "Failed to roll back project bootstrap for stopped chat {}: {}",
+                                cleanup_sid,
+                                error
+                            );
+                            false
+                        }
+                    }
+                } else {
+                    true
+                };
+                if new_session_created && bootstrap_rollback_succeeded {
+                    let sid_for_delete = cleanup_sid.clone();
+                    if let Err(error) = cleanup_db
+                        .run(move |db| db.delete_session(&sid_for_delete))
+                        .await
+                    {
+                        ha_core::app_warn!(
+                            "chat",
+                            "preflight_cancel_cleanup",
+                            "Failed to delete empty stopped session {}: {}",
+                            cleanup_sid,
+                            error
+                        );
+                    }
+                }
+                drop(cleanup_gate);
+            });
+        }
+        return Err(AppError::conflict_with_code(
+            ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE,
+            "chat stopped before prompt submission completed",
+        ));
+    };
+    let effective_prompt = match preflight {
         ha_core::agent::preflight::PreflightOutcome::Proceed { effective_prompt } => {
             effective_prompt
         }
@@ -1327,7 +1418,7 @@ async fn chat_inner(
         let mut cancels = ctx
             .chat_cancels
             .write()
-            .map_err(|_| AppError::internal("chat cancel registry lock poisoned"))?;
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         cancels.insert(sid.clone(), cancel.clone());
     }
     let mut cancel_registration_guard =
@@ -1621,8 +1712,7 @@ pub async fn cancel_queued_turn_user_message(
 /// `POST /api/chat/stop` — stop ongoing chat(s).
 ///
 /// When the request body provides `sessionId`, only that session's cancel
-/// flag is flipped. Otherwise every running chat is cancelled (this matches
-/// the desktop Tauri command which has no per-session targeting). Accepts
+/// flag is flipped. Otherwise every running chat is cancelled. Accepts
 /// either `{}` or omitted body — `axum::Json` with a `Default` body handles
 /// `{}`; for a completely empty body the Tauri caller wouldn't reach this
 /// route anyway.
@@ -1630,133 +1720,121 @@ pub async fn stop_chat(
     State(ctx): State<Arc<AppContext>>,
     Json(body): Json<StopChatRequest>,
 ) -> Result<Json<Value>, AppError> {
-    // The whole flip-and-mark pass runs on the blocking pool: it holds the
-    // in-memory cancel-registry lock while issuing synchronous SQLite writes
-    // (`mark_chat_turn_cancelling`), which must not pin a runtime worker.
-    let (stopped, stopped_count, active_session_ids, watchdog_turns) = {
-        let ctx = ctx.clone();
-        let session_id = body.session_id.clone();
-        let turn_id = body.turn_id.clone();
-        ha_core::blocking::run_blocking(move || -> Result<_, AppError> {
-            let mut stopped = false;
-            let mut stopped_count = 0usize;
-            let mut active_session_ids = Vec::new();
-            let mut watchdog_turns = Vec::new();
-            let cancels = ctx
-                .chat_cancels
-                .read()
-                .map_err(|_| AppError::internal("chat cancel registry lock poisoned"))?;
-            if let Some(sid) = session_id.as_deref() {
-                if let Some(active) = ha_core::chat_engine::active_turn::current(sid) {
-                    let matches_turn = turn_id
-                        .as_deref()
-                        .map(|id| id == active.turn_id)
-                        .unwrap_or(true);
-                    if matches_turn {
-                        active.cancel.store(true, Ordering::SeqCst);
-                        let _ = ctx.session_db.mark_chat_turn_cancelling(
-                            &active.turn_id,
-                            session::ChatTurnInterruptReason::UserStop,
-                        );
-                        ha_core::chat_engine::stream_broadcast::broadcast_turn_status(
-                            sid,
-                            &active.turn_id,
-                            session::ChatTurnStatus::Cancelling,
-                            Some(session::ChatTurnInterruptReason::UserStop),
-                        );
-                        watchdog_turns.push((
-                            sid.to_string(),
-                            active.turn_id.clone(),
-                            active.source,
-                        ));
-                        stopped = true;
-                        stopped_count = 1;
-                    }
-                } else if turn_id.is_none() {
-                    if let Some(cancel) = cancels.get(sid) {
-                        cancel.store(true, Ordering::SeqCst);
-                        stopped = true;
-                        stopped_count = 1;
-                    }
-                }
-            } else {
-                for (sid, cancel) in cancels.iter() {
-                    cancel.store(true, Ordering::SeqCst);
-                    if let Some(active) = ha_core::chat_engine::active_turn::current(sid) {
-                        let _ = ctx.session_db.mark_chat_turn_cancelling(
-                            &active.turn_id,
-                            session::ChatTurnInterruptReason::UserStop,
-                        );
-                        ha_core::chat_engine::stream_broadcast::broadcast_turn_status(
-                            sid,
-                            &active.turn_id,
-                            session::ChatTurnStatus::Cancelling,
-                            Some(session::ChatTurnInterruptReason::UserStop),
-                        );
-                        watchdog_turns.push((sid.clone(), active.turn_id.clone(), active.source));
-                    }
-                    active_session_ids.push(sid.clone());
-                    stopped_count += 1;
-                }
-                stopped = stopped_count > 0;
-            }
-            Ok((stopped, stopped_count, active_session_ids, watchdog_turns))
+    let request_scoped_stop =
+        body.client_request_id.is_some() && (body.session_id.is_none() || body.turn_id.is_none());
+    let request_cancel = if request_scoped_stop {
+        body.client_request_id.as_deref().map(|request_id| {
+            ha_core::chat_engine::active_turn::cancel_or_latch_client_request(
+                request_id,
+                body.session_id.as_deref(),
+            )
         })
-        .await?
-    };
-
-    // Approval waits are separate oneshots and do not wake merely because the
-    // chat cancel flag changed. Resolve them before any fallible runtime-task
-    // cancellation so Stop cannot return early with an authorizable prompt.
-    if let Some(sid) = body.session_id.as_deref() {
-        if stopped || body.turn_id.is_none() {
-            tools::deny_pending_for_session(sid, tools::ApprovalResolutionSource::UserStop).await;
-            ha_core::ask_user::cancel_pending_ask_user_questions_for_session(sid, "user_stop")
-                .await;
-        }
     } else {
-        tools::deny_all_pending(tools::ApprovalResolutionSource::UserStop).await;
-        ha_core::ask_user::cancel_all_pending_ask_user_questions("user_stop").await;
-    }
-
-    let runtime_cancellations = if let Some(sid) = body.session_id.as_deref() {
-        if stopped {
-            ha_core::runtime_tasks::cancel_runtime_tasks_for_session(Some(sid)).await?
-        } else {
-            Vec::new()
-        }
-    } else if active_session_ids.is_empty() {
-        ha_core::runtime_tasks::cancel_runtime_tasks_for_session(None).await?
-    } else {
-        let mut out = Vec::new();
-        for sid in active_session_ids {
-            out.extend(ha_core::runtime_tasks::cancel_runtime_tasks_for_session(Some(&sid)).await?);
-        }
-        out
+        None
     };
-
-    for (sid, turn_id, source) in watchdog_turns {
-        ha_core::chat_engine::spawn_user_stop_watchdog(
-            ctx.session_db.clone(),
-            sid,
-            turn_id,
-            source,
-        );
-    }
-
-    if body.session_id.is_some() {
+    if matches!(
+        request_cancel.as_ref(),
+        Some(ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::SessionMismatch)
+    ) {
         return Ok(Json(json!({
-            "stopped": stopped,
-            "scope": "session",
-            "reason": if stopped { Value::Null } else { json!("no matching active chat for session") },
-            "runtimeCancellations": runtime_cancellations,
+            "stopped": false,
+            "scope": if body.session_id.is_some() { "session" } else { "request" },
+            "reason": "client request is not owned by the target session",
+            "runtimeCancellations": [],
+            "runtimeCancellationError": Value::Null,
         })));
     }
+    let request_target = request_cancel.as_ref().and_then(|outcome| match outcome {
+        ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::Active(active) => {
+            Some(active.clone())
+        }
+        _ => None,
+    });
+    let mut already_signalled = matches!(
+        request_cancel,
+        Some(
+            ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::Active(_)
+                | ha_core::chat_engine::active_turn::ClientRequestCancelOutcome::Latched
+        )
+    );
+    let target_session_id = body.session_id.clone().or_else(|| {
+        request_target
+            .as_ref()
+            .map(|active| active.session_id.clone())
+    });
+    let target_turn_id = if body.session_id.is_some() {
+        body.turn_id.clone()
+    } else {
+        request_target.as_ref().map(|active| active.turn_id.clone())
+    };
+    let global_stop = body.session_id.is_none() && body.client_request_id.is_none();
+    let registered_cancels: std::collections::HashMap<_, _> = ctx
+        .chat_cancels
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .iter()
+        .map(|(sid, cancel)| (sid.clone(), cancel.clone()))
+        .collect();
+
+    if let Some(sid) = target_session_id.as_deref() {
+        // A session-only Stop is authoritative during the HTTP shell's
+        // pre-active-turn window. An exact turn Stop must not flip this
+        // session-keyed handle because it may already belong to a newer turn.
+        if target_turn_id.is_none() {
+            if let Some(cancel) = registered_cancels.get(sid) {
+                cancel.store(true, Ordering::SeqCst);
+                already_signalled = true;
+            }
+        }
+
+        let outcome = ha_core::chat_engine::stop::stop_session(
+            ctx.session_db.clone(),
+            sid,
+            target_turn_id.as_deref(),
+            already_signalled,
+        )
+        .await;
+        return Ok(Json(json!({
+            "stopped": outcome.stopped,
+            "scope": if body.session_id.is_some() { "session" } else { "request" },
+            "reason": if outcome.stopped { Value::Null } else { json!("no matching active chat for target") },
+            "runtimeCancellations": outcome.runtime_cancellations,
+            "runtimeCancellationError": outcome.runtime_cancellation_error,
+        })));
+    }
+
+    if !global_stop {
+        return Ok(Json(json!({
+            "stopped": already_signalled,
+            "scope": "request",
+            "reason": if already_signalled { Value::Null } else { json!("no matching active chat for target") },
+            "runtimeCancellations": [],
+            "runtimeCancellationError": Value::Null,
+        })));
+    }
+
+    // Signal transport-local handles before the shared service's first await.
+    // Core owns active turns, Channel inbounds, durable state, interaction
+    // waits, runtime work and watchdog convergence for every shell.
+    let pre_signalled_sessions = registered_cancels
+        .iter()
+        .map(|(sid, cancel)| {
+            cancel.store(true, Ordering::SeqCst);
+            sid.clone()
+        })
+        .collect::<Vec<_>>();
+    let outcome = ha_core::chat_engine::stop::stop_all_sessions(
+        ctx.session_db.clone(),
+        pre_signalled_sessions,
+        false,
+    )
+    .await;
     Ok(Json(json!({
-        "stopped": stopped,
+        "stopped": outcome.stopped,
         "scope": "all",
-        "count": stopped_count,
-        "runtimeCancellations": runtime_cancellations,
+        "count": outcome.stopped_session_count,
+        "runtimeCancellations": outcome.runtime_cancellations,
+        "runtimeCancellationError": outcome.runtime_cancellation_error,
     })))
 }
 

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -551,6 +551,10 @@ async fn chat_inner(
     ctx: Arc<AppContext>,
     mut body: ChatRequest,
 ) -> Result<Json<ChatResponse>, AppError> {
+    // Snapshot before the first await. A global Stop that begins while this
+    // request is still resolving/bootstrapping must remain authoritative even
+    // after its bounded cleanup gate has been released.
+    let foreground_admission = ha_core::chat_engine::active_turn::begin_foreground_request();
     let db = ctx.session_db.clone();
     let eval_context_pending = body.eval_context.take();
     if eval_context_pending.is_some() && !ha_core::eval_context::model_eval_mode_enabled() {
@@ -917,49 +921,51 @@ async fn chat_inner(
             .map_err(|e| AppError::bad_request(e.to_string()))?;
     }
     let cancel = Arc::new(AtomicBool::new(false));
-    let _active_turn_guard =
-        match ha_core::chat_engine::active_turn::try_acquire_with_client_request_id(
-            &sid,
-            ha_core::chat_engine::stream_seq::ChatSource::Http,
-            turn_id.clone(),
-            body.client_request_id.clone(),
-            cancel.clone(),
-        ) {
-            Ok(guard) => guard,
-            Err(error) => {
-                // Session creation and bootstrap claiming precede active-turn
-                // admission. Hold a session cleanup gate before awaiting any
-                // queue release so a global Stop rejection cannot leak this
-                // unpublished lazy Session or its managed worktree.
-                let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
-                    db.clone(),
-                    sid.clone(),
-                    bootstrap_request_id.clone(),
-                    new_session_created,
-                );
-                if let Some(request_id) = queued_request_id.as_ref() {
-                    let sid_for_release = sid.clone();
-                    let request_id_for_release = request_id.clone();
-                    let turn_for_release = turn_id.clone();
-                    let _ = db
-                        .run(move |db| {
-                            db.release_queued_turn_message_dispatch(
-                                &sid_for_release,
-                                &request_id_for_release,
-                                &turn_for_release,
-                            )
-                        })
-                        .await;
-                }
-                if let Some(cleanup) = cleanup {
-                    cleanup.spawn();
-                }
-                return Err(AppError::conflict_with_code(
-                    ha_core::chat_engine::stream_seq::ACTIVE_STREAM_ERROR_CODE,
-                    error.to_string(),
-                ));
+    let _active_turn_guard = match ha_core::chat_engine::active_turn::try_acquire_foreground_request(
+        foreground_admission,
+        &sid,
+        ha_core::chat_engine::stream_seq::ChatSource::Http,
+        turn_id.clone(),
+        body.client_request_id.clone(),
+        cancel.clone(),
+    ) {
+        Ok(guard) => guard,
+        Err(error) => {
+            let error_code = if error.cancelled_by_global_stop() {
+                ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE
+            } else {
+                ha_core::chat_engine::stream_seq::ACTIVE_STREAM_ERROR_CODE
+            };
+            // Session creation and bootstrap claiming precede active-turn
+            // admission. Hold a session cleanup gate before awaiting any
+            // queue release so a global Stop rejection cannot leak this
+            // unpublished lazy Session or its managed worktree.
+            let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+                db.clone(),
+                sid.clone(),
+                bootstrap_request_id.clone(),
+                new_session_created,
+            );
+            if let Some(request_id) = queued_request_id.as_ref() {
+                let sid_for_release = sid.clone();
+                let request_id_for_release = request_id.clone();
+                let turn_for_release = turn_id.clone();
+                let _ = db
+                    .run(move |db| {
+                        db.release_queued_turn_message_dispatch(
+                            &sid_for_release,
+                            &request_id_for_release,
+                            &turn_for_release,
+                        )
+                    })
+                    .await;
             }
-        };
+            if let Some(cleanup) = cleanup {
+                cleanup.spawn();
+            }
+            return Err(AppError::conflict_with_code(error_code, error.to_string()));
+        }
+    };
 
     // Prefer display_text for DB/title, fall back to the LLM-bound message.
     let raw_prompt = ha_core::non_empty_trim_or(body.display_text.as_deref(), &body.message);

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -596,6 +596,18 @@ async fn chat_inner(
         .project_bootstrap
         .as_ref()
         .map(|bootstrap| bootstrap.request_id.clone());
+    let project_bootstrap_request_guard = match (
+        body.client_request_id.as_deref(),
+        bootstrap_request_id.as_deref(),
+    ) {
+        (Some(client_request_id), Some(bootstrap_request_id)) => Some(
+            ha_core::project_bootstrap::register_project_bootstrap_client_request(
+                client_request_id,
+                bootstrap_request_id,
+            ),
+        ),
+        _ => None,
+    };
     let auto_create_session = existing_session_id.is_none();
     if body.edit_message_id.is_some() && auto_create_session {
         return Err(AppError::bad_request(
@@ -853,6 +865,10 @@ async fn chat_inner(
             }
         }
     }
+    // Bootstrap is no longer running beyond this point. Remove the temporary
+    // client mapping so a later Stop for the model turn does not create a
+    // stale bootstrap-id cancellation latch.
+    drop(project_bootstrap_request_guard);
     let runtime_defaults = {
         let sid = sid.clone();
         db.run(move |db| ha_core::session::ensure_session_runtime_defaults(db, &sid))
@@ -1199,52 +1215,58 @@ async fn chat_inner(
         let queue_id_for_consume = queued_request_id.clone();
         let edit_message_id = body.edit_message_id;
         let ui_surface_for_turn = body.ui_surface;
-        db.run(move |db| -> anyhow::Result<_> {
-            if let Some(message_id) = edit_message_id {
-                let replacement_id = db.replace_last_user_message_for_edit(
-                    &sid,
-                    message_id,
-                    &user_msg,
-                    &turn_id,
-                    ha_core::chat_engine::ChatSource::Http.as_str(),
-                    ui_surface_for_turn,
-                )?;
-                let turn = db
-                    .get_chat_turn(&turn_id)?
-                    .ok_or_else(|| anyhow::anyhow!("replacement chat turn was not created"))?;
-                return Ok((Some(replacement_id), turn));
-            }
-            let user_message_id = if queue_id_for_consume.is_some() {
-                Some(db.append_message(&sid, &user_msg)?)
-            } else {
-                db.append_message(&sid, &user_msg).ok()
-            };
-            let turn = db.create_chat_turn_with_id_surface(
+        db.run(move |db| {
+            ha_core::chat_engine::active_turn::with_persistence_target(
+                &sid,
                 &turn_id,
-                &sid,
-                ha_core::chat_engine::ChatSource::Http.as_str(),
-                None,
-                user_message_id,
-                ui_surface_for_turn,
-            )?;
-            if let Some(request_id) = queue_id_for_consume.as_deref() {
-                db.consume_dispatched_turn_message(&sid, request_id, &turn_id)?;
-            }
+                || -> anyhow::Result<_> {
+                    if let Some(message_id) = edit_message_id {
+                        let replacement_id = db.replace_last_user_message_for_edit(
+                            &sid,
+                            message_id,
+                            &user_msg,
+                            &turn_id,
+                            ha_core::chat_engine::ChatSource::Http.as_str(),
+                            ui_surface_for_turn,
+                        )?;
+                        let turn = db.get_chat_turn(&turn_id)?.ok_or_else(|| {
+                            anyhow::anyhow!("replacement chat turn was not created")
+                        })?;
+                        return Ok((Some(replacement_id), turn));
+                    }
+                    let user_message_id = if queue_id_for_consume.is_some() {
+                        Some(db.append_message(&sid, &user_msg)?)
+                    } else {
+                        db.append_message(&sid, &user_msg).ok()
+                    };
+                    let turn = db.create_chat_turn_with_id_surface(
+                        &turn_id,
+                        &sid,
+                        ha_core::chat_engine::ChatSource::Http.as_str(),
+                        None,
+                        user_message_id,
+                        ui_surface_for_turn,
+                    )?;
+                    if let Some(request_id) = queue_id_for_consume.as_deref() {
+                        db.consume_dispatched_turn_message(&sid, request_id, &turn_id)?;
+                    }
 
-            // Auto-generate fallback title from first user message (prefer display text so titles read naturally).
-            let _ = session::ensure_first_message_title(
-                db,
-                &sid,
-                &effective_prompt,
-                title_attachments_meta.as_deref(),
-            );
-            Ok((user_message_id, turn))
+                    // Auto-generate fallback title from first user message (prefer display text so titles read naturally).
+                    let _ = session::ensure_first_message_title(
+                        db,
+                        &sid,
+                        &effective_prompt,
+                        title_attachments_meta.as_deref(),
+                    );
+                    Ok((user_message_id, turn))
+                },
+            )
         })
         .await
     };
     let (_user_message_id, _turn) = match user_message_result {
-        Ok(value) => value,
-        Err(error) => {
+        Ok(Ok(value)) => value,
+        Ok(Err(error)) => {
             if let Some(request_id) = queued_request_id.as_ref() {
                 let sid_for_reconcile = sid.clone();
                 let request_for_reconcile = request_id.clone();
@@ -1260,6 +1282,42 @@ async fn chat_inner(
                     .await;
             }
             return Err(error.into());
+        }
+        Err(reason) => {
+            ha_core::hooks::set_user_prompt_context(&sid, None);
+            let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+                db.clone(),
+                sid.clone(),
+                bootstrap_request_id.clone(),
+                new_session_created,
+                queued_request_id
+                    .as_ref()
+                    .map(|request_id| (request_id.clone(), turn_id.clone())),
+            );
+            ha_core::chat_engine::stream_broadcast::broadcast_stream_end(
+                &sid,
+                None,
+                Some(&turn_id),
+                Some(session::ChatTurnStatus::Interrupted),
+                Some(session::ChatTurnInterruptReason::UserStop),
+                None,
+            );
+            ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
+            if let Some(cleanup) = cleanup {
+                cleanup.spawn();
+            }
+            ha_core::app_info!(
+                "chat",
+                "persistence_cancelled",
+                "Stopped HTTP prompt at persistence boundary: session={} turn={} reason={}",
+                sid,
+                turn_id,
+                reason
+            );
+            return Err(AppError::conflict_with_code(
+                ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE,
+                "chat stopped before prompt persistence completed",
+            ));
         }
     };
     let mut turn_drop_finalizer =
@@ -1683,6 +1741,10 @@ pub async fn stop_chat(
 ) -> Result<Json<Value>, AppError> {
     let request_scoped_stop =
         body.client_request_id.is_some() && (body.session_id.is_none() || body.turn_id.is_none());
+    let _bootstrap_signalled = body
+        .client_request_id
+        .as_deref()
+        .is_some_and(ha_core::project_bootstrap::cancel_project_bootstrap_for_client_request);
     let request_cancel = if request_scoped_stop {
         body.client_request_id.as_deref().map(|request_id| {
             ha_core::chat_engine::active_turn::cancel_or_latch_client_request(

--- a/crates/ha-server/src/routes/chat.rs
+++ b/crates/ha-server/src/routes/chat.rs
@@ -1265,8 +1265,67 @@ async fn chat_inner(
         .await
     };
     let (_user_message_id, _turn) = match user_message_result {
-        Ok(Ok(value)) => value,
-        Ok(Err(error)) => {
+        Ok(ha_core::chat_engine::active_turn::PersistenceTargetOutcome::Committed(value)) => value,
+        Ok(ha_core::chat_engine::active_turn::PersistenceTargetOutcome::CommittedAfterCancel(
+            _value,
+        )) => {
+            ha_core::hooks::set_user_prompt_context(&sid, None);
+            if new_session_created {
+                let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+                    db.clone(),
+                    sid.clone(),
+                    bootstrap_request_id.clone(),
+                    true,
+                    None,
+                );
+                ha_core::chat_engine::stream_broadcast::broadcast_stream_end(
+                    &sid,
+                    None,
+                    Some(&turn_id),
+                    Some(session::ChatTurnStatus::Interrupted),
+                    Some(session::ChatTurnInterruptReason::UserStop),
+                    None,
+                );
+                ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
+                if let Some(cleanup) = cleanup {
+                    cleanup.spawn();
+                }
+            } else {
+                let outcome = ha_core::chat_engine::stop::finalize_persisted_user_stop(
+                    db.clone(),
+                    sid.clone(),
+                    turn_id.clone(),
+                    effective_prompt.clone(),
+                    ha_core::chat_engine::ChatSource::Http,
+                )
+                .await;
+                ha_core::chat_engine::stream_broadcast::broadcast_stream_end(
+                    &sid,
+                    None,
+                    Some(&turn_id),
+                    outcome
+                        .turn_status
+                        .or(Some(session::ChatTurnStatus::Interrupted)),
+                    outcome
+                        .interrupt_reason
+                        .or(Some(session::ChatTurnInterruptReason::UserStop)),
+                    None,
+                );
+                ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
+            }
+            ha_core::app_info!(
+                "chat",
+                "persistence_cancelled",
+                "Stopped HTTP prompt after persistence claim: session={} turn={}",
+                sid,
+                turn_id
+            );
+            return Err(AppError::conflict_with_code(
+                ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE,
+                "chat stopped while prompt persistence completed",
+            ));
+        }
+        Err(error) => {
             if let Some(request_id) = queued_request_id.as_ref() {
                 let sid_for_reconcile = sid.clone();
                 let request_for_reconcile = request_id.clone();
@@ -1283,7 +1342,7 @@ async fn chat_inner(
             }
             return Err(error.into());
         }
-        Err(reason) => {
+        Ok(ha_core::chat_engine::active_turn::PersistenceTargetOutcome::CancelledBeforeCommit) => {
             ha_core::hooks::set_user_prompt_context(&sid, None);
             let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
                 db.clone(),
@@ -1309,10 +1368,9 @@ async fn chat_inner(
             ha_core::app_info!(
                 "chat",
                 "persistence_cancelled",
-                "Stopped HTTP prompt at persistence boundary: session={} turn={} reason={}",
+                "Stopped HTTP prompt before persistence claim: session={} turn={}",
                 sid,
-                turn_id,
-                reason
+                turn_id
             );
             return Err(AppError::conflict_with_code(
                 ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE,

--- a/docs/architecture/api-reference.md
+++ b/docs/architecture/api-reference.md
@@ -820,6 +820,18 @@ Loop owner API 管理 session-scoped recurring triggers。`create_loop_schedule`
 | `update_task_status` | `PATCH /api/tasks/{id}/status` | ✅ TaskProgressPanel 用户控件 |
 | `delete_task` | `DELETE /api/tasks/{id}` | ✅ TaskProgressPanel 用户控件 |
 
+`chat` 的可选 `clientRequestId` 是前端生成的不透明请求 id，只用于主动停止定位：在懒创建会话的
+`session_created` 尚未到达前，`stop_chat` / `POST /api/chat/stop` 可传
+`{ clientRequestId }` 精确取消该请求，不会误停其他会话。已知会话时依旧传
+`{ sessionId, turnId?, clientRequestId? }`：`turnId` 尚未发布时由 `clientRequestId`
+封住 active-turn 注册前的竞态，已有 `turnId` 后以精确 turn 为准；session 与 request
+绑定不一致时不得跨会话取消。`sessionId` 与 `clientRequestId` 都缺失才表示全局停止。
+
+三种入口在定位 session 后共用 core Stop 编排：先同步发出 cancel/`cancelling`/watchdog，再以
+有界等待并行收敛 DB、审批、`ask_user` 与 session-owned runtime；响应超时不取消已经启动的
+后台清理。全局停止同样走 core `stop_all_sessions`，HTTP / Tauri 只先翻转 transport-local
+cancel handle。精确 `turnId` 不匹配时 fail closed，不得误停同 session 的新回合。
+
 #### Chat `attachments` wire format
 
 `chat` / `POST /api/chat` 与 `queue_turn_user_message` / `POST /api/chat/turn-message` 共用同一份 `attachments` 数组；Tauri IPC 和 HTTP 都按 snake_case 原样序列化。每项的基础字段为 `{ name, mime_type, source?, upload_id?, data?, file_path? }`。GUI 新客户端点击发送后统一经通用 `chat_attachment` 分块 lease，再只传 `upload_id`；`upload_id` 与 `data` / `file_path` 互斥。图片不再由 GUI 转 Base64。旧字段保留给 ACP、IM、历史客户端与历史消息，旧 stage/Base64 固定 20 MiB；HTTP 旧 `file_path` 必须 canonicalize 后位于对应 session 或 `_temp` 附件目录。单文件动态上限取当前后端 `filesystem.maxChatAttachmentMb`（默认 20 MiB），单消息最多 64 个，前后端双重校验；claim 采用全量 prepare + rollback，部分失败不会消费其他 lease。

--- a/docs/architecture/chat-engine.md
+++ b/docs/architecture/chat-engine.md
@@ -1,6 +1,6 @@
 # Chat Engine 对话引擎架构
 
-> 返回 [文档索引](../README.md) | 更新时间：2026-07-19
+> 返回 [文档索引](../README.md) | 更新时间：2026-08-01
 
 ## 目录
 
@@ -385,6 +385,55 @@ Plan task、stream seq 与消息持久化：
 interruptReason / error / finalSeq / durableSeq / assistantMessageId /
 persistenceStatus`，前端据此清理 loading 并恢复停止后的展示状态。completed 只允许与
 committed 同时出现。
+
+主动 Stop 的退出预算分三层：cancel flag 立即阻止新 provider round / 新 tool dispatch，
+在途 tool 最多用 5 秒撤销审批、结束子进程并回收刚 detach 的 job；已经产生可见 runtime
+事件的 Agent loop 最多再等 6 秒协作收尾，超时就 drop future 并进入统一中断提交；8 秒
+watchdog 只作最后的 journal 收敛兜底，不能与正常 finalizer 同时抢终态。并发安全工具中
+尚在 semaphore 后排队的调用必须在获得槽后重新检查 cancel，停止后不得再启动副作用。
+Stop 编排自身也有独立预算：先同步翻转所有已知 cancel flag、广播 `cancelling` 并启动
+watchdog，再并行执行 DB 标记（2 秒）、审批/问答撤销（2 秒）与 runtime 清理（5 秒）。
+编排开始时须建立 session 的短暂 Stop gate（全局 Stop 使用 process-wide gate），阻止替代 turn
+在旧资源快照完成前 acquire；runtime
+先快照精确 job/subagent/process id，再逐项取消，超时后不得重新按 session 枚举。审批/问答直接
+timeout 原 future（禁止 detach 会话级 sweep），因此迟到清理不会消费续聊新建的交互。
+watchdog 读取 session-keyed live durability 时必须再校验 `turn_id`；不匹配时只按旧 turn 查找并
+恢复其 persistence run，绝不能把新 turn 的 journal 提交到旧 turn。进入仅按 session 定位的
+legacy fallback 前须重新建立 Stop gate，并确认没有不同 active turn、旧 turn 仍是 DB 最新一代；
+即使续聊已经快速完成、live coordinator 已注销，也不得从最新消息反向重建旧 turn。
+`UserPromptSubmit` 预检同样必须与该 turn 的 cancel flag 竞争；若停止在用户消息落库前发生，
+必须先广播终态并释放精确 active-turn guard；空会话/worktree 的 Git-aware 回滚随后在后台按
+durable bootstrap row 收敛，不能让 Git/SQLite 清理阻塞续聊。前端将未发出内容恢复为草稿。
+GUI 的 plan mention 展开、文件系统配置读取与附件 staging 同样属于 request 生命周期；本地 Stop
+必须立即 abort 等待。底层上传若不可物理取消，迟到返回的 upload lease 必须自动 discard，
+不得形成孤儿附件，也不得把用户停止显示为上传失败。
+项目首轮已经完成 bootstrap 时，回滚必须先把 bootstrap 置为终态并经 Git-aware 路径
+discard 托管 worktree，再删空会话；禁止先靠 session FK cascade 丢掉 worktree 注册行。
+懒创建会话在 `session_created` 前用不透明 `clientRequestId` 定位 active turn，此时点击
+停止不得退化成“停止所有会话”；已知 session 但 `turn_started` 尚未到达的窗口也必须用
+同一 request id latch，不能让 Stop 跑在 active-turn 注册前而静默丢失。
+Desktop、HTTP 与 IM `/stop` 在解析出 session 后必须统一进入
+`chat_engine::stop::stop_session`：设置精确 active-turn cancel、写 `cancelling`、拒绝待审批、
+撤销 live `ask_user` 并取消 session-owned runtime；共享服务也负责翻转该 session 的全部
+Channel preflight registrations，所以 GUI / HTTP 停止 attached session 时不会漏掉 IM 的
+active-turn 注册前窗口。同 session 的并发入站必须逐个注册、一次 Stop 全部翻转；交互入口
+与 stream transport 可以不同，停止的业务语义不得分叉。
+无 target 的全局紧急停止统一进入 `chat_engine::stop::stop_all_sessions`，Desktop / HTTP shell
+只负责先翻转各自 transport-local handle；全局路径不得复制一套 DB、审批或 runtime 清理逻辑。
+ACP 的 `session/cancel` 也调用同一 session-stop 服务；由于 ACP prompt 同步占用业务主循环，stdio
+reader 必须独立读取并先翻转每轮独立 token，不能等 prompt 返回后才处理 cancel。ACP 的 hook、provider
+构造、重试和 Agent loop 均须观察该 token，停止胜出后同样以 `Interrupted/user_stop` 保留 journal 前缀。
+终态 CAS 上 `cancelling` 优先于迟到的 success commit：成功事务只能从 `running` 转为
+`completed`，不得清掉已写入的 `user_stop` 并把会话翻回成功。
+
+前端的 loading / optimistic placeholder 归属于具体 chat request。旧请求即使在 watchdog
+放行后才返回，其 `finally` 也不得清掉同 session 新 turn 的状态；迟到的
+`chat:turn_status` / `chat:stream_end` 必须按 `turnId` 拒绝覆盖新 turn。用户主动停止后，
+durable queued message 保留为可编辑待发送项，但不得在中断回合收尾时自动启动下一轮。
+重连握手期间若已经观察到更新的 live `turn_started`，较早返回的 active snapshot 不得再
+覆盖 live turn id 或覆盖该新请求的 optimistic cache。
+watchdog 精确释放旧 `turnId` 后允许用户继续对话；旧请求迟到的 `finally`、status、stream end
+及 success commit 都必须按 request/turn ownership 拒绝覆盖新回合。
 
 启动恢复会把 DB 中残留的 `running` / `cancelling` turn 走统一 finalize（见下节）
 拿到正确的 `Shutdown` / `Crash` reason 落 chat_turn 终态，同时清理内存

--- a/docs/architecture/im-channel.md
+++ b/docs/architecture/im-channel.md
@@ -405,7 +405,7 @@ flowchart TD
     ENGINE --> S8 --> S9 --> S10
 ```
 
-> **入站单飞（I8 / MISC-2 修复）**：dispatcher 用 `MAX_CONCURRENT_INBOUND` semaphore 限**全局**并发，但不串行化**同一会话**——两条快速到达的消息会并发 spawn 两个 `handle_inbound_message`，后到者在引擎深处输给 `stream_seq::begin` 竞争（此时 pipeline 已 spawn），以「active stream」错误回复收场。步骤 5c 接上 GUI/HTTP 同款 `active_turn::try_acquire` 单飞守卫：在持久化用户消息**之后**、引擎启动**之前**加闸，故每条入站照常入库 + 过 `UserPromptSubmit` preflight，仅「引擎回合」被单飞。守卫跨 IM/GUI/HTTP 在同一（1:1 attach）会话上互斥。用**合成 turn_id** 仅作单飞锁、引擎仍 `turn_id: None`（Channel 走 `channel:*` 总线，给它 seq-tracked turn_id 会改变 stream 接受 / 广播语义）；cancel `Arc` 一处创建供 `try_acquire` / `engine_params` / channel 取消注册表共用，使跨端取消能真正中止该引擎回合。被拒的消息已入库、搭下一回合上下文（无自动出队）。
+> **入站单飞与停止（I8 / MISC-2 修复）**：dispatcher 用 `MAX_CONCURRENT_INBOUND` semaphore 限**全局**并发，但不串行化**同一会话**——两条快速到达的消息会并发 spawn 两个 `handle_inbound_message`。每条非 Reply-only 入站在 typing、延迟附件下载和 `UserPromptSubmit` preflight **之前**向 Channel cancel registry 注册独立 token；网络准备也与该 token 竞争。同 session 多条在飞入站不能相互覆盖，一次 Stop 会同时翻转全部 token。通过 preflight 并持久化 user message 后，步骤 5c 再接 GUI/HTTP 同款 `active_turn::try_acquire` 单飞守卫，故仅一个「引擎回合」可运行；被单飞拒绝的消息已入库、搭下一回合上下文（无自动出队）。守卫跨 IM/GUI/HTTP 在同一（1:1 attach）会话上互斥。用**合成 turn_id** 仅作单飞锁、引擎仍 `turn_id: None`（Channel 走 `channel:*` 总线，给它 seq-tracked turn_id 会改变 stream 接受 / 广播语义）；同一 cancel `Arc` 贯穿 typing / 附件下载、preflight、`try_acquire`、可选语音转写、`engine_params`、preview 收尾和 final/error delivery。stream pipeline 只在可取消准备完成后创建，Stop 会 abort 卡住的 preview / 渠道投递并释放单飞 guard，已渲染的半截 preview 保留作为中止视觉信号。
 
 ### 出站流程
 
@@ -870,6 +870,7 @@ mirror 与入站共享同一份 chunk 管道(`send_text_chunks` → `markdown_to
 | `/projects` | 列所有未归档项目 | inline buttons,callback `slash:project <id>` |
 | `/project <name>` | 模糊匹配后切项目 | 发 `AssignProject` —— UPDATE `sessions.project_id`,**不创建新 session**;GUI 模式发 `EnterProject` 创建新 session 进入 |
 | `/handover <ch:acc:chat[:thread]>` | GUI 把当前 session 推到 IM chat | 不下发菜单;实际入口 GUI Handover dialog,slash 给 power user / 脚本 |
+| `/stop` | 停止当前 session 的前台回合 | 与 GUI / HTTP Stop 共用 `chat_engine::stop::stop_session`：取消 Channel slash/preflight/active turn、拒绝待审批、撤销 `ask_user`、取消 session-owned runtime；`/stop` 是控制面输入，不得被自由输入型 `ask_user` 当作答案；仅回执与流事件走 Channel 自己的 transport |
 | `/kb [on\|off]` | 知识空间访问 per-chat 确认(WS8)。无参 / `status` 报生效态;群聊 `on`/`off` 写 `kbAccessChats`;DM 仅报状态(账号级 opt-in 在桌面 Settings) | 群聊确认入口;**账号级 `kbAccessOptIn` 仍为 owner GUI-only**,`/kb` 只翻 per-chat 确认位,且需账号已 opt-in 才生效 |
 
 `/status` 末尾追加 **Attached IM Channel** 段,显示该 session 的 IM attach 行(1:1,0 或 1 行) —— channel / chat 标识 + `attached_at`。
@@ -967,6 +968,7 @@ pub fn spawn_dispatcher(
 - **入站事件枚举**：分发器收 `InboundEvent`（`Message` / `Reaction` / `MessageEdited` / `MessageRecalled` / `Membership` / `ReadReceipt` 多变体），仅 `Message` 触发完整 chat round，其余变体当前仅 log
 - **并发处理 + 全局上限**：每条 `Message` 在独立 `tokio::spawn` 中处理，不阻塞其他消息；`Semaphore::new(MAX_CONCURRENT_INBOUND=20)` 的 owned permit 限全局在飞消息并发上限。整个 dispatcher 跑在专用线程自建的 tokio runtime 上
 - **斜杠命令拦截**：在调用 LLM 和写入 user turn 之前，`dispatch_slash_for_channel()` 检测以 `/` 开头的消息并转发给 `slash_commands::handlers::dispatch()`。`Reply` 类命令（`/help`、`/clear`、`/model`、`/status` 等）把原始 slash 与结果落为 `messages.role="event"`（command event 带 `displayAs="user"` 供 GUI 渲染成用户气泡），直接回复并跳过 LLM；`PassThrough` 类命令（技能调用、`/search`）将转换后的指令作为 `engine_message` 交给 LLM，并按真实对话 user turn 落库（详见 [斜杠命令系统](slash-commands.md)）
+- **Stop 只分入口、不分语义**：IM `/stop`、GUI 与 HTTP 都进入同一个 session-stop 编排，由共享服务统一翻转 Channel slash/preflight token 与 active-turn cancel，并清理审批、结构化问答及 runtime；不得只停 Channel preview，也不得在入口另写清理分支。Channel cancel registration 必须早于通用 slash dispatch，使 `/compact` 等尚未进入 Chat Engine 的长命令也可停止；`/stop` 自身不注册 token，且在审批/`ask_user` 文本回复解析前被识别为控制面消息，避免被吞作答案。Channel 只保留「如何定位当前 attach session、如何发送回执和流事件」的 transport 差异
 - **共享 ChatEngine**：调用 `chat_engine::run_chat_engine()` — 与 UI 聊天使用完全相同的 Agent 执行引擎，拥有相同的能力：流式输出、会话历史恢复、工具事件持久化、Failover 降级、Context compaction、Token 跟踪、异步记忆提取
 - **EventSink 抽象**：UI 聊天在桌面通过 `ChannelSink`（Tauri Channel）推流，在 HTTP 模式通过 `chat:stream_delta` EventBus 推到 `/ws/events`；IM 聊天通过 `ChannelStreamSink`（EventBus）推流到前端 + 累积 text_delta 发送 `channel:stream_delta` 事件
 - **每个渠道可绑定独立 Agent**：`ChannelAccountConfig.agent_id` 字段支持每个渠道账户绑定不同 Agent，未设置时回退到全局默认

--- a/docs/architecture/slash-commands.md
+++ b/docs/architecture/slash-commands.md
@@ -115,7 +115,7 @@ sequenceDiagram
 | `/new` | 无 | 创建新会话 | `NewSession` |
 | `/clear` | 无 | 删除当前会话所有消息 | `SessionCleared` |
 | `/compact` | 无 | 压缩当前会话上下文（触发渐进式压缩） | `Compact` |
-| `/stop` | 无 | 停止当前流式回复 | `StopStream` |
+| `/stop` | 无 | 停止当前会话主动回合；IM 与 GUI / HTTP 共用同一 session-stop 编排，仅交互入口不同；在 IM 中优先于审批/结构化问答回复解析 | `StopStream` |
 | `/rename` | `<title>` 必需 | 重命名当前会话标题 | `DisplayOnly` |
 | `/plan` | `[enter\|exit\|show\|approve]` | 进入/管理计划模式（详见下方） | 多种 |
 | `/project` | `[name]` 可选 | 无参：弹出项目选择器（桌面端 markdown 列表 + sidebar 项目树）；有参：模糊匹配项目名进入并在该项目下新建会话。**IM 渠道**：`AssignProject`（不创建新 session，UPDATE 当前 chat 的 `sessions.project_id`） | `ShowProjectPicker` / `EnterProject` / `AssignProject` |

--- a/docs/architecture/tool-system.md
+++ b/docs/architecture/tool-system.md
@@ -485,7 +485,7 @@ flowchart TD
     F --> G["下一轮 API 调用（或退出 loop）"]
 ```
 
-每个工具执行都通过 `tokio::select!` 与 cancel flag 竞争，支持用户随时取消。只有 `BackgroundPolicy::GenericJob` 工具进入 `execute_tool_with_context` 后会经过下文的“异步决策”三道闸；显式后台或自动后台化时**会立即把 synthetic `{job_id, status: "started"}` 当作合法 tool_result 写回**，对话不阻塞继续推进，真实结果走异步注入回流。`SelfManaged` 工具则直接执行其派发 action 并立即返回 native durable handle。
+每个工具执行都通过 `tokio::select!` 与 cancel flag 竞争，cancel 分支必须排在 dispatch 前；进入 executor 前还要再检查一次，使并发批次里等 semaphore 的调用在用户停止后不会补启动。只有 `BackgroundPolicy::GenericJob` 工具进入 `execute_tool_with_context` 后会经过下文的“异步决策”三道闸；显式后台或自动后台化时**会立即把 synthetic `{job_id, status: "started"}` 当作合法 tool_result 写回**，对话不阻塞继续推进，真实结果走异步注入回流。`SelfManaged` 工具则直接执行其派发 action 并立即返回 native durable handle。
 
 ---
 

--- a/docs/architecture/transport-modes.md
+++ b/docs/architecture/transport-modes.md
@@ -14,6 +14,12 @@
 
 三种模式共享 `ha-core` 业务逻辑和 `EventBus` 抽象。Tauri 与 HTTP 只是把同一批核心能力分别桥接成 IPC 或 REST/WS；ACP 是另一条协议入口，不参与前端 Transport 选择。
 
+### ACP Stop 与 stdin 并发
+
+ACP 的 `session/prompt` 业务处理保持单线程串行，但 NDJSON stdin 必须由独立 reader 持续读取；否则主线程同步等待 provider / tool 时无法看见同一流上的 `session/cancel`。reader 在把 prompt 排入主循环前为该轮安装独立 cancel token，收到 cancel 后立即翻转 token，并异步调用共享 `chat_engine::stop::stop_session` 清理该 session 的审批、`ask_user` 与 runtime。`UserPromptSubmit`、SessionStart hook、provider 构造、重试退避和 Agent chat 都与 token 竞争；Agent chat 最多保留 6 秒协作退出窗口。
+
+每轮 token 不复用：旧 provider/tool future 即使在停止响应后迟到，也不能因下一轮把同一 flag 重置而恢复。自然完成 / provider failure 与 Stop 在 cancel-state 锁内确定唯一线性化终点；Stop 胜出时 journal 的可恢复前缀写为 `Interrupted/user_stop` 并追加下一轮可理解的系统 marker，随后 prompt response 返回 `stopReason=cancelled`。已完成终态之后才到达的 cancel 是 no-op，不得污染下一轮。
+
 ### Server 模式的工具审批
 
 HTTP 入口的 `ChatEngineParams.auto_approve_tools` 在桌面 Web GUI 客户端下默认 `false`（跟桌面 GUI 一致），审批通过 EventBus `approval_required` 事件等浏览器侧 UI 响应。但 headless 客户端（curl / pipeline / Docker entrypoint）通常不会订阅这个事件，工具调用会卡到 5 分钟超时再被 deny —— 表现就是「模型一个 shell 命令都跑不了」。
@@ -137,7 +143,7 @@ HTTP 模式没有 per-call browser Channel，主流式路径就是 EventBus：
 - `chat:stream_delta` payload 的 `seq` 是 session/stream 内递增游标。
 - 前端 `lastSeqRef` 由 `useChatStream` 与 `useChatStreamReattach` 共享，哪个路径先处理事件就推进 cursor。
 - 切换会话时，前端会读 `get_session_stream_state`，用后端 cursor 给 `lastSeqRef` 播种，避免把 DB 快照里已有的 delta 再播一遍。
-- `chat:stream_end` 用于清理 loading 状态、记录 ended stream id，并在当前会话上重拉最新消息兜底。
+- `chat:stream_end` 用于清理 loading 状态、记录 ended stream id，并在当前会话上重拉最新消息兜底。ended 集合与 rAF delta buffer 都按 `sessionId + streamId` 隔离；旧 turn 的迟到 end/delta 只能封存旧 stream，不能清空或写入新 turn 的占位消息。
 
 ## `/ws/events` EventBus 桥
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1030,8 +1030,67 @@ pub async fn chat(
         .await
     };
     let _user_message_id = match user_message_result {
-        Ok(Ok(message_id)) => message_id,
-        Ok(Err(error)) => {
+        Ok(ha_core::chat_engine::active_turn::PersistenceTargetOutcome::Committed(message_id)) => {
+            message_id
+        }
+        Ok(ha_core::chat_engine::active_turn::PersistenceTargetOutcome::CommittedAfterCancel(
+            _message_id,
+        )) => {
+            ha_core::hooks::set_user_prompt_context(&sid, None);
+            if new_session_created.is_some() {
+                let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+                    db.clone(),
+                    sid.clone(),
+                    bootstrap_request_id.clone(),
+                    true,
+                    None,
+                );
+                broadcast_turn_end(
+                    &sid,
+                    &turn_id,
+                    session::ChatTurnStatus::Interrupted,
+                    Some(session::ChatTurnInterruptReason::UserStop),
+                    None,
+                );
+                ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
+                if let Some(cleanup) = cleanup {
+                    cleanup.spawn();
+                }
+            } else {
+                let outcome = ha_core::chat_engine::stop::finalize_persisted_user_stop(
+                    db.clone(),
+                    sid.clone(),
+                    turn_id.clone(),
+                    effective_prompt.clone(),
+                    ha_core::chat_engine::ChatSource::Desktop,
+                )
+                .await;
+                broadcast_turn_end(
+                    &sid,
+                    &turn_id,
+                    outcome
+                        .turn_status
+                        .unwrap_or(session::ChatTurnStatus::Interrupted),
+                    outcome
+                        .interrupt_reason
+                        .or(Some(session::ChatTurnInterruptReason::UserStop)),
+                    None,
+                );
+                ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
+            }
+            app_info!(
+                "chat",
+                "persistence_cancelled",
+                "Stopped desktop prompt after persistence claim: session={} turn={}",
+                sid,
+                turn_id
+            );
+            return Err(CmdError::msg(format!(
+                "{}: chat stopped while prompt persistence completed",
+                ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE
+            )));
+        }
+        Err(error) => {
             if let Some(request_id) = queued_request_id.as_ref() {
                 let sid_for_reconcile = sid.clone();
                 let request_for_reconcile = request_id.clone();
@@ -1048,7 +1107,7 @@ pub async fn chat(
             }
             return Err(error.into());
         }
-        Err(reason) => {
+        Ok(ha_core::chat_engine::active_turn::PersistenceTargetOutcome::CancelledBeforeCommit) => {
             ha_core::hooks::set_user_prompt_context(&sid, None);
             let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
                 db.clone(),
@@ -1073,10 +1132,9 @@ pub async fn chat(
             app_info!(
                 "chat",
                 "persistence_cancelled",
-                "Stopped desktop prompt at persistence boundary: session={} turn={} reason={}",
+                "Stopped desktop prompt before persistence claim: session={} turn={}",
                 sid,
-                turn_id,
-                reason
+                turn_id
             );
             return Err(CmdError::msg(format!(
                 "{}: chat stopped before prompt persistence completed",

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -703,6 +703,16 @@ pub async fn chat(
         ) {
             Ok(guard) => guard,
             Err(error) => {
+                // The lazy Session/bootstrap already exists by this point.
+                // Install its cleanup gate before the first await so a global
+                // Stop admission failure cannot leak unpublished state or let
+                // a replacement turn race the rollback.
+                let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+                    db.clone(),
+                    sid.clone(),
+                    bootstrap_request_id.clone(),
+                    new_session_created.is_some(),
+                );
                 if let Some(request_id) = queued_request_id.as_ref() {
                     let sid_for_release = sid.clone();
                     let request_id_for_release = request_id.clone();
@@ -716,6 +726,9 @@ pub async fn chat(
                             )
                         })
                         .await;
+                }
+                if let Some(cleanup) = cleanup {
+                    cleanup.spawn();
                 }
                 return Err(error.into());
             }
@@ -762,10 +775,12 @@ pub async fn chat(
         // This turn has no chat_turn row yet, so the ordinary Stop watchdog
         // cannot release it. Publish the terminal state and release the exact
         // active-turn entry before any Git/SQLite cleanup that may block.
-        let needs_background_cleanup =
-            bootstrap_request_id.is_some() || new_session_created.is_some();
-        let cleanup_gate = needs_background_cleanup
-            .then(|| ha_core::chat_engine::active_turn::begin_stop_cleanup(&sid));
+        let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+            db.clone(),
+            sid.clone(),
+            bootstrap_request_id.clone(),
+            new_session_created.is_some(),
+        );
         broadcast_turn_end(
             &sid,
             &turn_id,
@@ -775,53 +790,8 @@ pub async fn chat(
         );
         ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
 
-        if needs_background_cleanup {
-            let cleanup_db = db.clone();
-            let cleanup_sid = sid.clone();
-            let cleanup_request_id = bootstrap_request_id.clone();
-            let delete_empty_session = new_session_created.is_some();
-            tokio::spawn(async move {
-                let bootstrap_rollback_succeeded = if let Some(request_id) = cleanup_request_id {
-                    match cleanup_db
-                        .clone()
-                        .run(move |db| db.rollback_project_bootstrap_after_chat_cancel(&request_id))
-                        .await
-                    {
-                        Ok(()) => true,
-                        Err(error) => {
-                            // Preserve the Session + managed-worktree row
-                            // when Git-aware cleanup fails; startup recovery
-                            // can retry it without orphaning the worktree.
-                            app_warn!(
-                                "project",
-                                "bootstrap_cancel_rollback",
-                                "Failed to roll back project bootstrap for stopped chat {}: {}",
-                                cleanup_sid,
-                                error
-                            );
-                            false
-                        }
-                    }
-                } else {
-                    true
-                };
-                if delete_empty_session && bootstrap_rollback_succeeded {
-                    let sid_for_delete = cleanup_sid.clone();
-                    if let Err(error) = cleanup_db
-                        .run(move |db| db.delete_session(&sid_for_delete))
-                        .await
-                    {
-                        app_warn!(
-                            "chat",
-                            "preflight_cancel_cleanup",
-                            "Failed to delete empty stopped session {}: {}",
-                            cleanup_sid,
-                            error
-                        );
-                    }
-                }
-                drop(cleanup_gate);
-            });
+        if let Some(cleanup) = cleanup {
+            cleanup.spawn();
         }
         return Err(CmdError::msg(format!(
             "{}: chat stopped before prompt submission completed",

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -395,6 +395,18 @@ pub async fn chat(
     let bootstrap_request_id = project_bootstrap
         .as_ref()
         .map(|bootstrap| bootstrap.request_id.clone());
+    let project_bootstrap_request_guard = match (
+        client_request_id.as_deref(),
+        bootstrap_request_id.as_deref(),
+    ) {
+        (Some(client_request_id), Some(bootstrap_request_id)) => Some(
+            ha_core::project_bootstrap::register_project_bootstrap_client_request(
+                client_request_id,
+                bootstrap_request_id,
+            ),
+        ),
+        _ => None,
+    };
     let auto_create_session = session_id.as_deref().is_none_or(|id| id.is_empty());
     if edit_message_id.is_some() && auto_create_session {
         return Err(CmdError::msg("editMessageId requires an existing session"));
@@ -648,6 +660,10 @@ pub async fn chat(
             );
         }
     }
+    // Bootstrap is no longer running beyond this point. Remove the temporary
+    // client mapping so a later Stop for the model turn does not create a
+    // stale bootstrap-id cancellation latch.
+    drop(project_bootstrap_request_guard);
 
     if let Some(request_id) = bootstrap_request_id.as_deref() {
         let claimed = {
@@ -702,7 +718,7 @@ pub async fn chat(
         &sid,
         crate::chat_engine::stream_seq::ChatSource::Desktop,
         turn_id.clone(),
-        client_request_id,
+        client_request_id.clone(),
         cancel.clone(),
     ) {
         Ok(guard) => guard,
@@ -975,41 +991,47 @@ pub async fn chat(
         let queue_id_for_consume = queued_request_id.clone();
         let edit_message_id = edit_message_id;
         let ui_surface_for_turn = ui_surface;
-        db.run(move |db| -> anyhow::Result<Option<i64>> {
-            if let Some(message_id) = edit_message_id {
-                let replacement_id = db.replace_last_user_message_for_edit(
-                    &sid,
-                    message_id,
-                    &user_msg,
-                    &turn_id,
-                    ha_core::chat_engine::ChatSource::Desktop.as_str(),
-                    ui_surface_for_turn,
-                )?;
-                return Ok(Some(replacement_id));
-            }
-            let user_message_id = if queue_id_for_consume.is_some() {
-                Some(db.append_message(&sid, &user_msg)?)
-            } else {
-                db.append_message(&sid, &user_msg).ok()
-            };
-            db.create_chat_turn_with_id_surface(
-                &turn_id,
+        db.run(move |db| {
+            ha_core::chat_engine::active_turn::with_persistence_target(
                 &sid,
-                ha_core::chat_engine::ChatSource::Desktop.as_str(),
-                None,
-                user_message_id,
-                ui_surface_for_turn,
-            )?;
-            if let Some(request_id) = queue_id_for_consume.as_deref() {
-                db.consume_dispatched_turn_message(&sid, request_id, &turn_id)?;
-            }
-            Ok(user_message_id)
+                &turn_id,
+                || -> anyhow::Result<Option<i64>> {
+                    if let Some(message_id) = edit_message_id {
+                        let replacement_id = db.replace_last_user_message_for_edit(
+                            &sid,
+                            message_id,
+                            &user_msg,
+                            &turn_id,
+                            ha_core::chat_engine::ChatSource::Desktop.as_str(),
+                            ui_surface_for_turn,
+                        )?;
+                        return Ok(Some(replacement_id));
+                    }
+                    let user_message_id = if queue_id_for_consume.is_some() {
+                        Some(db.append_message(&sid, &user_msg)?)
+                    } else {
+                        db.append_message(&sid, &user_msg).ok()
+                    };
+                    db.create_chat_turn_with_id_surface(
+                        &turn_id,
+                        &sid,
+                        ha_core::chat_engine::ChatSource::Desktop.as_str(),
+                        None,
+                        user_message_id,
+                        ui_surface_for_turn,
+                    )?;
+                    if let Some(request_id) = queue_id_for_consume.as_deref() {
+                        db.consume_dispatched_turn_message(&sid, request_id, &turn_id)?;
+                    }
+                    Ok(user_message_id)
+                },
+            )
         })
         .await
     };
     let _user_message_id = match user_message_result {
-        Ok(message_id) => message_id,
-        Err(error) => {
+        Ok(Ok(message_id)) => message_id,
+        Ok(Err(error)) => {
             if let Some(request_id) = queued_request_id.as_ref() {
                 let sid_for_reconcile = sid.clone();
                 let request_for_reconcile = request_id.clone();
@@ -1025,6 +1047,41 @@ pub async fn chat(
                     .await;
             }
             return Err(error.into());
+        }
+        Err(reason) => {
+            ha_core::hooks::set_user_prompt_context(&sid, None);
+            let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+                db.clone(),
+                sid.clone(),
+                bootstrap_request_id.clone(),
+                new_session_created.is_some(),
+                queued_request_id
+                    .as_ref()
+                    .map(|request_id| (request_id.clone(), turn_id.clone())),
+            );
+            broadcast_turn_end(
+                &sid,
+                &turn_id,
+                session::ChatTurnStatus::Interrupted,
+                Some(session::ChatTurnInterruptReason::UserStop),
+                None,
+            );
+            ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
+            if let Some(cleanup) = cleanup {
+                cleanup.spawn();
+            }
+            app_info!(
+                "chat",
+                "persistence_cancelled",
+                "Stopped desktop prompt at persistence boundary: session={} turn={} reason={}",
+                sid,
+                turn_id,
+                reason
+            );
+            return Err(CmdError::msg(format!(
+                "{}: chat stopped before prompt persistence completed",
+                ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE
+            )));
         }
     };
 
@@ -1428,6 +1485,9 @@ pub async fn stop_chat(
     // that pre-registration window, use the request id even for an existing
     // session; otherwise Stop can race ahead of active-turn acquisition and be
     // silently forgotten.
+    let bootstrap_signalled = client_request_id
+        .as_deref()
+        .is_some_and(ha_core::project_bootstrap::cancel_project_bootstrap_for_client_request);
     let request_cancel =
         if client_request_id.is_some() && (session_id.is_none() || turn_id.is_none()) {
             client_request_id.as_deref().map(|request_id| {
@@ -1462,9 +1522,10 @@ pub async fn stop_chat(
         app_info!(
             "chat",
             "stop_chat",
-            "Latched pre-registration Stop for client request {:?} session {:?}",
+            "Latched pre-registration Stop for client request {:?} session {:?} bootstrap_signalled={}",
             client_request_id,
-            session_id
+            session_id,
+            bootstrap_signalled
         );
         return Ok(());
     }

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -48,30 +48,43 @@ fn broadcast_turn_end(
     );
 }
 
-fn commit_local_reply(
-    db: &SessionDB,
+async fn commit_local_reply(
+    db: Arc<SessionDB>,
     session_id: &str,
     turn_id: &str,
     content: &str,
-) -> Result<(), CmdError> {
-    let (context_json, context_revision) = db
-        .load_context_with_revision(session_id)
-        .map_err(CmdError::from)?;
-    let commit = session::CommitAssistantTurn {
-        run_id: None,
-        attempt_no: 0,
-        session_id: session_id.to_string(),
-        assistant: session::NewMessage::assistant(content)
-            .with_source(ha_core::chat_engine::ChatSource::Desktop),
-        trailing_placeholder_id: None,
-        context_json: context_json.unwrap_or_else(|| "[]".to_string()),
-        expected_context_revision: context_revision,
-        turn_id: Some(turn_id.to_string()),
-        usage: None,
-        final_seq: 0,
-    };
-    db.commit_assistant_turn(&commit).map_err(CmdError::from)?;
-    Ok(())
+    cancel: &AtomicBool,
+) -> Result<bool, CmdError> {
+    if cancel.load(Ordering::Acquire) {
+        return Ok(false);
+    }
+    let session_id = session_id.to_string();
+    let turn_id = turn_id.to_string();
+    let content = content.to_string();
+    let result = db
+        .run(move |db| {
+            let (context_json, context_revision) = db.load_context_with_revision(&session_id)?;
+            let commit = session::CommitAssistantTurn {
+                run_id: None,
+                attempt_no: 0,
+                session_id,
+                assistant: session::NewMessage::assistant(&content)
+                    .with_source(ha_core::chat_engine::ChatSource::Desktop),
+                trailing_placeholder_id: None,
+                context_json: context_json.unwrap_or_else(|| "[]".to_string()),
+                expected_context_revision: context_revision,
+                turn_id: Some(turn_id),
+                usage: None,
+                final_seq: 0,
+            };
+            db.commit_assistant_turn(&commit)
+        })
+        .await;
+    match result {
+        Ok(_) => Ok(true),
+        Err(_) if cancel.load(Ordering::Acquire) => Ok(false),
+        Err(error) => Err(error.into()),
+    }
 }
 
 /// Save an attachment file to disk. Uses a temp directory when session_id is empty.
@@ -282,6 +295,7 @@ pub async fn chat(
     mut message: String,
     mut attachments: Vec<Attachment>,
     session_id: Option<String>,
+    client_request_id: Option<String>,
     incognito: Option<bool>,
     model_override: Option<String>,
     session_defaults: Option<ha_core::session::SessionDefaultsInput>,
@@ -679,31 +693,33 @@ pub async fn chat(
     if let Some(mode) = workflow_mode_pending {
         db.update_session_workflow_mode(&sid, mode)?;
     }
-    let _active_turn_guard = match crate::chat_engine::active_turn::try_acquire(
-        &sid,
-        crate::chat_engine::stream_seq::ChatSource::Desktop,
-        turn_id.clone(),
-        cancel.clone(),
-    ) {
-        Ok(guard) => guard,
-        Err(error) => {
-            if let Some(request_id) = queued_request_id.as_ref() {
-                let sid_for_release = sid.clone();
-                let request_id_for_release = request_id.clone();
-                let turn_for_release = turn_id.clone();
-                let _ = db
-                    .run(move |db| {
-                        db.release_queued_turn_message_dispatch(
-                            &sid_for_release,
-                            &request_id_for_release,
-                            &turn_for_release,
-                        )
-                    })
-                    .await;
+    let _active_turn_guard =
+        match crate::chat_engine::active_turn::try_acquire_with_client_request_id(
+            &sid,
+            crate::chat_engine::stream_seq::ChatSource::Desktop,
+            turn_id.clone(),
+            client_request_id,
+            cancel.clone(),
+        ) {
+            Ok(guard) => guard,
+            Err(error) => {
+                if let Some(request_id) = queued_request_id.as_ref() {
+                    let sid_for_release = sid.clone();
+                    let request_id_for_release = request_id.clone();
+                    let turn_for_release = turn_id.clone();
+                    let _ = db
+                        .run(move |db| {
+                            db.release_queued_turn_message_dispatch(
+                                &sid_for_release,
+                                &request_id_for_release,
+                                &turn_for_release,
+                            )
+                        })
+                        .await;
+                }
+                return Err(error.into());
             }
-            return Err(error.into());
-        }
-    };
+        };
 
     // Mark this session as active — cancels any running subagent injection and blocks new ones
     let _chat_session_guard = crate::subagent::ChatSessionGuard::new(&sid);
@@ -718,16 +734,101 @@ pub async fn chat(
     // persisted", but the attachment IO had already touched disk. The preflight
     // only consumes `raw_prompt` / `session_id` / `agent_id`, so it doesn't need
     // any attachment metadata — moving it up is purely a side-effect deferral.
-    let effective_prompt = match ha_core::agent::preflight::user_prompt_preflight(
+    let preflight = ha_core::agent::preflight::user_prompt_preflight_cancellable(
         ha_core::agent::preflight::PreflightArgs {
             session_id: &sid,
             agent_id: Some(current_agent_id.as_str()),
             raw_prompt,
             turn_id: &turn_id,
         },
+        cancel.as_ref(),
     )
-    .await
-    {
+    .await;
+    let Some(preflight) = preflight else {
+        if let Some(request_id) = queued_request_id.as_ref() {
+            let sid_for_release = sid.clone();
+            let request_id_for_release = request_id.clone();
+            let turn_for_release = turn_id.clone();
+            let _ = db
+                .run(move |db| {
+                    db.release_queued_turn_message_dispatch(
+                        &sid_for_release,
+                        &request_id_for_release,
+                        &turn_for_release,
+                    )
+                })
+                .await;
+        }
+        // This turn has no chat_turn row yet, so the ordinary Stop watchdog
+        // cannot release it. Publish the terminal state and release the exact
+        // active-turn entry before any Git/SQLite cleanup that may block.
+        let needs_background_cleanup =
+            bootstrap_request_id.is_some() || new_session_created.is_some();
+        let cleanup_gate = needs_background_cleanup
+            .then(|| ha_core::chat_engine::active_turn::begin_stop_cleanup(&sid));
+        broadcast_turn_end(
+            &sid,
+            &turn_id,
+            session::ChatTurnStatus::Interrupted,
+            Some(session::ChatTurnInterruptReason::UserStop),
+            None,
+        );
+        ha_core::chat_engine::active_turn::force_release(&sid, &turn_id);
+
+        if needs_background_cleanup {
+            let cleanup_db = db.clone();
+            let cleanup_sid = sid.clone();
+            let cleanup_request_id = bootstrap_request_id.clone();
+            let delete_empty_session = new_session_created.is_some();
+            tokio::spawn(async move {
+                let bootstrap_rollback_succeeded = if let Some(request_id) = cleanup_request_id {
+                    match cleanup_db
+                        .clone()
+                        .run(move |db| db.rollback_project_bootstrap_after_chat_cancel(&request_id))
+                        .await
+                    {
+                        Ok(()) => true,
+                        Err(error) => {
+                            // Preserve the Session + managed-worktree row
+                            // when Git-aware cleanup fails; startup recovery
+                            // can retry it without orphaning the worktree.
+                            app_warn!(
+                                "project",
+                                "bootstrap_cancel_rollback",
+                                "Failed to roll back project bootstrap for stopped chat {}: {}",
+                                cleanup_sid,
+                                error
+                            );
+                            false
+                        }
+                    }
+                } else {
+                    true
+                };
+                if delete_empty_session && bootstrap_rollback_succeeded {
+                    let sid_for_delete = cleanup_sid.clone();
+                    if let Err(error) = cleanup_db
+                        .run(move |db| db.delete_session(&sid_for_delete))
+                        .await
+                    {
+                        app_warn!(
+                            "chat",
+                            "preflight_cancel_cleanup",
+                            "Failed to delete empty stopped session {}: {}",
+                            cleanup_sid,
+                            error
+                        );
+                    }
+                }
+                drop(cleanup_gate);
+            });
+        }
+        return Err(CmdError::msg(format!(
+            "{}: chat stopped before prompt submission completed",
+            ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE
+        )));
+    };
+    let effective_prompt = match preflight {
         ha_core::agent::preflight::PreflightOutcome::Proceed { effective_prompt } => {
             effective_prompt
         }
@@ -1072,71 +1173,101 @@ pub async fn chat(
     // ── Plan Sub-Agent: optionally dispatch Planning to an isolated sub-agent ──
     // When plan_subagent=true, keeps the main agent's context clean for execution.
     // When plan_subagent=false (default), planning runs inline in the main agent.
-    if early_plan_state == crate::plan::PlanModeState::Planning {
+    if early_plan_state == crate::plan::PlanModeState::Planning && !cancel.load(Ordering::Acquire) {
         let use_subagent = cfg.plan_subagent;
 
         if use_subagent {
             // Check if a plan sub-agent is already active for this session
-            if let Some(run_id) = crate::plan::get_active_plan_run_id(&sid).await {
-                // User sent a message while planning → route as steer to the sub-agent
-                crate::subagent::SUBAGENT_MAILBOX.push(&run_id, message.clone());
-                let reply = "💬 Message forwarded to planning agent.";
-                commit_local_reply(&db, &sid, &turn_id, reply)?;
-                let _ = on_event.send(
-                    serde_json::json!({
-                        "type": "text",
-                        "text": "💬 Message forwarded to planning agent."
-                    })
-                    .to_string(),
-                );
-                broadcast_turn_end(
-                    &sid,
-                    &turn_id,
-                    session::ChatTurnStatus::Completed,
-                    None,
-                    None,
-                );
-                return Ok(reply.to_string());
+            let active_plan_run_id = crate::plan::get_active_plan_run_id(&sid).await;
+            if !cancel.load(Ordering::Acquire) {
+                if let Some(run_id) = active_plan_run_id {
+                    // User sent a message while planning → route as steer to the sub-agent
+                    crate::subagent::SUBAGENT_MAILBOX.push(&run_id, message.clone());
+                    let reply = "💬 Message forwarded to planning agent.";
+                    if commit_local_reply(db.clone(), &sid, &turn_id, reply, cancel.as_ref())
+                        .await?
+                    {
+                        let _ = on_event.send(
+                            serde_json::json!({
+                                "type": "text",
+                                "text": "💬 Message forwarded to planning agent."
+                            })
+                            .to_string(),
+                        );
+                        broadcast_turn_end(
+                            &sid,
+                            &turn_id,
+                            session::ChatTurnStatus::Completed,
+                            None,
+                            None,
+                        );
+                        return Ok(reply.to_string());
+                    }
+                }
             }
 
             // First message in Planning state → spawn plan sub-agent
-            let recent_summary = build_recent_context_summary(&db, &sid).await;
-            let cancel_registry = crate::get_subagent_cancels()
-                .cloned()
-                .ok_or_else(|| CmdError::msg("Sub-agent cancel registry not initialized"))?;
-            match crate::plan::spawn_plan_subagent(
-                &sid,
-                &current_agent_id,
-                &message,
-                &recent_summary,
-                db.clone(),
-                cancel_registry,
-            )
-            .await
-            {
-                Ok(run_id) => {
-                    app_info!("plan", "chat", "Plan sub-agent spawned: run_id={}", run_id);
-                    let reply = "🗂️ Plan creation started...";
-                    commit_local_reply(&db, &sid, &turn_id, reply)?;
-                    let _ = on_event.send(
-                        serde_json::json!({
-                            "type": "text",
-                            "text": "🗂️ Plan creation started..."
-                        })
-                        .to_string(),
-                    );
-                    broadcast_turn_end(
+            if !cancel.load(Ordering::Acquire) {
+                let recent_summary = build_recent_context_summary(&db, &sid).await;
+                if !cancel.load(Ordering::Acquire) {
+                    let cancel_registry =
+                        crate::get_subagent_cancels().cloned().ok_or_else(|| {
+                            CmdError::msg("Sub-agent cancel registry not initialized")
+                        })?;
+                    match crate::plan::spawn_plan_subagent(
                         &sid,
-                        &turn_id,
-                        session::ChatTurnStatus::Completed,
-                        None,
-                        None,
-                    );
-                    return Ok(format!("Plan sub-agent spawned: {}", run_id));
-                }
-                Err(e) => {
-                    app_error!("plan", "chat", "Failed to spawn plan sub-agent: {}", e);
-                    // Fall through to inline planning as fallback
+                        &current_agent_id,
+                        &message,
+                        &recent_summary,
+                        db.clone(),
+                        cancel_registry.clone(),
+                    )
+                    .await
+                    {
+                        Ok(run_id) if cancel.load(Ordering::Acquire) => {
+                            cancel_registry.cancel(&run_id);
+                            app_info!(
+                                "plan",
+                                "chat",
+                                "Cancelled plan sub-agent spawned during stop: run_id={}",
+                                run_id
+                            );
+                        }
+                        Ok(run_id) => {
+                            app_info!("plan", "chat", "Plan sub-agent spawned: run_id={}", run_id);
+                            let reply = "🗂️ Plan creation started...";
+                            if commit_local_reply(
+                                db.clone(),
+                                &sid,
+                                &turn_id,
+                                reply,
+                                cancel.as_ref(),
+                            )
+                            .await?
+                            {
+                                let _ = on_event.send(
+                                    serde_json::json!({
+                                        "type": "text",
+                                        "text": "🗂️ Plan creation started..."
+                                    })
+                                    .to_string(),
+                                );
+                                broadcast_turn_end(
+                                    &sid,
+                                    &turn_id,
+                                    session::ChatTurnStatus::Completed,
+                                    None,
+                                    None,
+                                );
+                                return Ok(format!("Plan sub-agent spawned: {}", run_id));
+                            }
+                            cancel_registry.cancel(&run_id);
+                        }
+                        Err(e) => {
+                            app_error!("plan", "chat", "Failed to spawn plan sub-agent: {}", e);
+                            // Fall through to inline planning as fallback
+                        }
+                    }
                 }
             }
         }
@@ -1329,136 +1460,114 @@ pub async fn control_model_recovery(
 pub async fn stop_chat(
     session_id: Option<String>,
     turn_id: Option<String>,
+    client_request_id: Option<String>,
     state: State<'_, AppState>,
 ) -> Result<(), CmdError> {
-    let mut stopped = false;
-    let mut watchdog_turns = Vec::new();
-    if let Some(sid) = session_id.as_deref() {
-        if let Some(active) = crate::chat_engine::active_turn::current(sid) {
-            let matches_turn = turn_id
-                .as_deref()
-                .map(|id| id == active.turn_id)
-                .unwrap_or(true);
-            if matches_turn {
-                active.cancel.store(true, Ordering::SeqCst);
-                let _ = {
-                    let turn_id = active.turn_id.clone();
-                    state
-                        .session_db
-                        .run(move |db| {
-                            db.mark_chat_turn_cancelling(
-                                &turn_id,
-                                session::ChatTurnInterruptReason::UserStop,
-                            )
-                        })
-                        .await
-                };
-                ha_core::chat_engine::stream_broadcast::broadcast_turn_status(
-                    sid,
-                    &active.turn_id,
-                    session::ChatTurnStatus::Cancelling,
-                    Some(session::ChatTurnInterruptReason::UserStop),
-                );
-                watchdog_turns.push((sid.to_string(), active.turn_id.clone(), active.source));
-                stopped = true;
-            } else {
-                app_info!(
-                    "chat",
-                    "stop_chat",
-                    "Ignoring stale stop for session {} turn {:?}; active turn is {}",
-                    sid,
-                    turn_id,
-                    active.turn_id
-                );
-            }
-        }
-    } else {
-        // Legacy fallback for callers that cannot target a session. Keep the
-        // old global flag, but all new UI paths pass a session id.
-        state.chat_cancel.store(true, Ordering::SeqCst);
-        let mut cancelling_turn_ids = Vec::new();
-        for active in crate::chat_engine::active_turn::all_current() {
-            active.cancel.store(true, Ordering::SeqCst);
-            ha_core::chat_engine::stream_broadcast::broadcast_turn_status(
-                &active.session_id,
-                &active.turn_id,
-                session::ChatTurnStatus::Cancelling,
-                Some(session::ChatTurnInterruptReason::UserStop),
-            );
-            cancelling_turn_ids.push(active.turn_id.clone());
-            watchdog_turns.push((
-                active.session_id.clone(),
-                active.turn_id.clone(),
-                active.source,
-            ));
-        }
-        // One blocking-pool hop for all the DB marks (a stalled DB otherwise
-        // multiplies into one queued task per turn).
-        if !cancelling_turn_ids.is_empty() {
-            let _ = state
-                .session_db
-                .run(move |db| {
-                    for turn_id in &cancelling_turn_ids {
-                        let _ = db.mark_chat_turn_cancelling(
-                            turn_id,
-                            session::ChatTurnInterruptReason::UserStop,
-                        );
-                    }
-                })
-                .await;
-        }
-        stopped = true;
+    // `turn_id` is not known until the backend announces turn_started. During
+    // that pre-registration window, use the request id even for an existing
+    // session; otherwise Stop can race ahead of active-turn acquisition and be
+    // silently forgotten.
+    let request_cancel =
+        if client_request_id.is_some() && (session_id.is_none() || turn_id.is_none()) {
+            client_request_id.as_deref().map(|request_id| {
+                crate::chat_engine::active_turn::cancel_or_latch_client_request(
+                    request_id,
+                    session_id.as_deref(),
+                )
+            })
+        } else {
+            None
+        };
+    if matches!(
+        request_cancel.as_ref(),
+        Some(crate::chat_engine::active_turn::ClientRequestCancelOutcome::SessionMismatch)
+    ) {
+        app_warn!(
+            "chat",
+            "stop_chat",
+            "Ignoring Stop because client request {:?} is not owned by session {:?}",
+            client_request_id,
+            session_id
+        );
+        return Ok(());
     }
-    // A foreground approval wait does not observe the chat cancel flag itself.
-    // Resolve it explicitly so Stop cannot leave a modal orphaned or allow the
-    // user to authorize a tool after the turn has been marked cancelled.
-    if let Some(sid) = session_id.as_deref() {
-        if stopped || turn_id.is_none() {
-            ha_core::tools::deny_pending_for_session(
-                sid,
-                ha_core::tools::ApprovalResolutionSource::UserStop,
-            )
-            .await;
-            ha_core::ask_user::cancel_pending_ask_user_questions_for_session(sid, "user_stop")
-                .await;
+    let request_target = request_cancel.as_ref().and_then(|outcome| match outcome {
+        crate::chat_engine::active_turn::ClientRequestCancelOutcome::Active(active) => {
+            Some(active.clone())
         }
+        _ => None,
+    });
+    let target_session_id = session_id.clone().or_else(|| {
+        request_target
+            .as_ref()
+            .map(|active| active.session_id.clone())
+    });
+    let target_turn_id = if session_id.is_some() {
+        turn_id.clone()
     } else {
-        ha_core::tools::deny_all_pending(ha_core::tools::ApprovalResolutionSource::UserStop).await;
-        ha_core::ask_user::cancel_all_pending_ask_user_questions("user_stop").await;
-    }
-    let runtime_scope = stopped.then_some(session_id.as_deref()).flatten();
-    let runtime_cancellations = if stopped || session_id.is_none() {
-        ha_core::runtime_tasks::cancel_runtime_tasks_for_session(runtime_scope).await
-    } else {
-        Ok(Vec::new())
+        request_target.as_ref().map(|active| active.turn_id.clone())
     };
-    match runtime_cancellations {
-        Ok(results) => {
+    let global_stop = session_id.is_none() && client_request_id.is_none();
+    if let Some(sid) = target_session_id.as_deref() {
+        let already_signalled = matches!(
+            request_cancel,
+            Some(
+                crate::chat_engine::active_turn::ClientRequestCancelOutcome::Active(_)
+                    | crate::chat_engine::active_turn::ClientRequestCancelOutcome::Latched
+            )
+        );
+        let outcome = crate::chat_engine::stop::stop_session(
+            state.session_db.clone(),
+            sid,
+            target_turn_id.as_deref(),
+            already_signalled,
+        )
+        .await;
+        if outcome.turn_mismatch {
             app_info!(
                 "chat",
                 "stop_chat",
-                "Stop chat requested; stopped={} runtime cancellations attempted: {}",
-                stopped,
-                results.len()
+                "Ignoring stale stop for session {} turn {:?}",
+                sid,
+                target_turn_id
             );
         }
-        Err(e) => {
-            app_warn!(
-                "chat",
-                "stop_chat",
-                "Stop chat runtime cancellation failed: {}",
-                e
-            );
-        }
-    }
-    for (sid, turn_id, source) in watchdog_turns {
-        crate::chat_engine::spawn_user_stop_watchdog(
-            state.session_db.clone(),
-            sid,
-            turn_id,
-            source,
+        app_info!(
+            "chat",
+            "stop_chat",
+            "Stop chat requested; stopped={} approvals_denied={} questions_cancelled={} runtime cancellations attempted: {}",
+            outcome.stopped,
+            outcome.denied_approvals,
+            outcome.cancelled_questions,
+            outcome.runtime_cancellations.len()
         );
+        return Ok(());
     }
+    if !global_stop {
+        // A request-scoped Stop that arrived before lazy session creation is
+        // latched in active_turn and will be consumed by registration.
+        return Ok(());
+    }
+    // Legacy/emergency callers without a target still flip the shell-level
+    // flag synchronously. Core owns every other Stop semantic so this path
+    // cannot drift from HTTP or IM `/stop` again.
+    state.chat_cancel.store(true, Ordering::SeqCst);
+    let outcome = ha_core::chat_engine::stop::stop_all_sessions(
+        state.session_db.clone(),
+        std::iter::empty(),
+        true,
+    )
+    .await;
+    app_info!(
+        "chat",
+        "stop_chat",
+        "Global Stop requested; stopped={} sessions={} approvals_denied={} questions_cancelled={} runtime cancellations attempted: {}",
+        outcome.stopped,
+        outcome.stopped_session_count,
+        outcome.denied_approvals,
+        outcome.cancelled_questions,
+        outcome.runtime_cancellations.len()
+    );
     Ok(())
 }
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -717,21 +717,10 @@ pub async fn chat(
                 sid.clone(),
                 bootstrap_request_id.clone(),
                 new_session_created.is_some(),
+                queued_request_id
+                    .as_ref()
+                    .map(|request_id| (request_id.clone(), turn_id.clone())),
             );
-            if let Some(request_id) = queued_request_id.as_ref() {
-                let sid_for_release = sid.clone();
-                let request_id_for_release = request_id.clone();
-                let turn_for_release = turn_id.clone();
-                let _ = db
-                    .run(move |db| {
-                        db.release_queued_turn_message_dispatch(
-                            &sid_for_release,
-                            &request_id_for_release,
-                            &turn_for_release,
-                        )
-                    })
-                    .await;
-            }
             if let Some(cleanup) = cleanup {
                 cleanup.spawn();
             }
@@ -769,28 +758,19 @@ pub async fn chat(
     )
     .await;
     let Some(preflight) = preflight else {
-        if let Some(request_id) = queued_request_id.as_ref() {
-            let sid_for_release = sid.clone();
-            let request_id_for_release = request_id.clone();
-            let turn_for_release = turn_id.clone();
-            let _ = db
-                .run(move |db| {
-                    db.release_queued_turn_message_dispatch(
-                        &sid_for_release,
-                        &request_id_for_release,
-                        &turn_for_release,
-                    )
-                })
-                .await;
-        }
         // This turn has no chat_turn row yet, so the ordinary Stop watchdog
         // cannot release it. Publish the terminal state and release the exact
-        // active-turn entry before any Git/SQLite cleanup that may block.
+        // active-turn entry before any Git/SQLite cleanup that may block. The
+        // cleanup gate keeps a replacement turn out until the exact queued-row
+        // CAS settles or reaches its bounded timeout.
         let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
             db.clone(),
             sid.clone(),
             bootstrap_request_id.clone(),
             new_session_created.is_some(),
+            queued_request_id
+                .as_ref()
+                .map(|request_id| (request_id.clone(), turn_id.clone())),
         );
         broadcast_turn_end(
             &sid,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1497,16 +1497,11 @@ pub async fn stop_chat(
         }
         _ => None,
     });
-    let target_session_id = session_id.clone().or_else(|| {
-        request_target
-            .as_ref()
-            .map(|active| active.session_id.clone())
-    });
-    let target_turn_id = if session_id.is_some() {
-        turn_id.clone()
-    } else {
-        request_target.as_ref().map(|active| active.turn_id.clone())
-    };
+    let (target_session_id, target_turn_id) = crate::chat_engine::active_turn::resolve_stop_target(
+        session_id.as_deref(),
+        turn_id.as_deref(),
+        request_target.as_ref(),
+    );
     let global_stop = session_id.is_none() && client_request_id.is_none();
     if let Some(sid) = target_session_id.as_deref() {
         let already_signalled = matches!(

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -369,6 +369,10 @@ pub async fn chat(
     on_event: tauri::ipc::Channel<String>,
     state: State<'_, AppState>,
 ) -> Result<String, CmdError> {
+    // Snapshot before the first await. A global Stop that begins while this
+    // request is still resolving/bootstrapping must remain authoritative even
+    // after its bounded cleanup gate has been released.
+    let foreground_admission = ha_core::chat_engine::active_turn::begin_foreground_request();
     // Capture optional per-session modes — applied below once we have a session id.
     let permission_mode_pending = permission_mode;
     let sandbox_mode_pending = sandbox_mode;
@@ -693,46 +697,53 @@ pub async fn chat(
     if let Some(mode) = workflow_mode_pending {
         db.update_session_workflow_mode(&sid, mode)?;
     }
-    let _active_turn_guard =
-        match crate::chat_engine::active_turn::try_acquire_with_client_request_id(
-            &sid,
-            crate::chat_engine::stream_seq::ChatSource::Desktop,
-            turn_id.clone(),
-            client_request_id,
-            cancel.clone(),
-        ) {
-            Ok(guard) => guard,
-            Err(error) => {
-                // The lazy Session/bootstrap already exists by this point.
-                // Install its cleanup gate before the first await so a global
-                // Stop admission failure cannot leak unpublished state or let
-                // a replacement turn race the rollback.
-                let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
-                    db.clone(),
-                    sid.clone(),
-                    bootstrap_request_id.clone(),
-                    new_session_created.is_some(),
-                );
-                if let Some(request_id) = queued_request_id.as_ref() {
-                    let sid_for_release = sid.clone();
-                    let request_id_for_release = request_id.clone();
-                    let turn_for_release = turn_id.clone();
-                    let _ = db
-                        .run(move |db| {
-                            db.release_queued_turn_message_dispatch(
-                                &sid_for_release,
-                                &request_id_for_release,
-                                &turn_for_release,
-                            )
-                        })
-                        .await;
-                }
-                if let Some(cleanup) = cleanup {
-                    cleanup.spawn();
-                }
-                return Err(error.into());
+    let _active_turn_guard = match crate::chat_engine::active_turn::try_acquire_foreground_request(
+        foreground_admission,
+        &sid,
+        crate::chat_engine::stream_seq::ChatSource::Desktop,
+        turn_id.clone(),
+        client_request_id,
+        cancel.clone(),
+    ) {
+        Ok(guard) => guard,
+        Err(error) => {
+            let cancelled_by_global_stop = error.cancelled_by_global_stop();
+            // The lazy Session/bootstrap already exists by this point.
+            // Install its cleanup gate before the first await so a global
+            // Stop admission failure cannot leak unpublished state or let
+            // a replacement turn race the rollback.
+            let cleanup = ha_core::chat_engine::stop::PreTurnCancelCleanup::begin(
+                db.clone(),
+                sid.clone(),
+                bootstrap_request_id.clone(),
+                new_session_created.is_some(),
+            );
+            if let Some(request_id) = queued_request_id.as_ref() {
+                let sid_for_release = sid.clone();
+                let request_id_for_release = request_id.clone();
+                let turn_for_release = turn_id.clone();
+                let _ = db
+                    .run(move |db| {
+                        db.release_queued_turn_message_dispatch(
+                            &sid_for_release,
+                            &request_id_for_release,
+                            &turn_for_release,
+                        )
+                    })
+                    .await;
             }
-        };
+            if let Some(cleanup) = cleanup {
+                cleanup.spawn();
+            }
+            if cancelled_by_global_stop {
+                return Err(CmdError::msg(format!(
+                    "{}: request cancelled by global Stop before turn registration",
+                    ha_core::agent::preflight::CHAT_CANCELLED_DURING_PREFLIGHT_CODE
+                )));
+            }
+            return Err(error.into());
+        }
+    };
 
     // Mark this session as active — cancels any running subagent injection and blocks new ones
     let _chat_session_guard = crate::subagent::ChatSessionGuard::new(&sid);

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -1461,6 +1461,22 @@ pub async fn stop_chat(
         );
         return Ok(());
     }
+    if matches!(
+        request_cancel.as_ref(),
+        Some(crate::chat_engine::active_turn::ClientRequestCancelOutcome::Latched)
+    ) {
+        // The request-scoped latch is the complete Stop result until this
+        // opaque request registers. Do not reinterpret its optional session
+        // ownership constraint as a session-wide Stop and cancel another turn.
+        app_info!(
+            "chat",
+            "stop_chat",
+            "Latched pre-registration Stop for client request {:?} session {:?}",
+            client_request_id,
+            session_id
+        );
+        return Ok(());
+    }
     let request_target = request_cancel.as_ref().and_then(|outcome| match outcome {
         crate::chat_engine::active_turn::ClientRequestCancelOutcome::Active(active) => {
             Some(active.clone())
@@ -1476,10 +1492,7 @@ pub async fn stop_chat(
     if let Some(sid) = target_session_id.as_deref() {
         let already_signalled = matches!(
             request_cancel,
-            Some(
-                crate::chat_engine::active_turn::ClientRequestCancelOutcome::Active(_)
-                    | crate::chat_engine::active_turn::ClientRequestCancelOutcome::Latched
-            )
+            Some(crate::chat_engine::active_turn::ClientRequestCancelOutcome::Active(_))
         );
         let outcome = crate::chat_engine::stop::stop_session(
             state.session_db.clone(),

--- a/src/QuickChatWindow.tsx
+++ b/src/QuickChatWindow.tsx
@@ -29,15 +29,10 @@ const QUICK_CHAT_MESSAGES_HEIGHT = 500
 export default function QuickChatWindow() {
   const session = useQuickChatSession(true)
   const quickStreamSeqRef = useRef<Map<string, number>>(new Map())
-  const quickEndedStreamIdsRef = useRef<Map<string, string>>(new Map())
+  const quickEndedStreamIdsRef = useRef<Map<string, Set<string>>>(new Map())
   const [composerFocusSignal, setComposerFocusSignal] = useState<number | undefined>(undefined)
   const [messageTailVisible, setMessageTailVisible] = useState(true)
-  useEmbeddedChatReadReceipt(
-    true,
-    messageTailVisible,
-    session.currentSessionId,
-    session.messages,
-  )
+  useEmbeddedChatReadReceipt(true, messageTailVisible, session.currentSessionId, session.messages)
 
   // Effective incognito = persisted session.incognito (continued chat) or
   // draft toggle (new chat). Mirrors `ChatScreen` semantics so the toggle
@@ -351,25 +346,25 @@ function AgentSelector({
         className="ha-menu-from-top min-w-[200px] max-h-[240px] overflow-y-auto p-1.5"
         onEscapeKeyDown={() => setMenuOpen(false)}
       >
-          {agents.map((agent) => (
-            <button
-              key={agent.id}
-              onClick={() => {
-                onSelect(agent.id)
-                setMenuOpen(false)
-              }}
-              className={cn(
-                "w-full text-left px-3 py-1.5 text-sm hover:bg-muted transition-colors flex items-center gap-2",
-                agent.id === currentAgent?.id && "bg-muted/50",
-              )}
-            >
-              <AgentAvatarIcon agent={agent} />
-              <span className="truncate">{agent.name}</span>
-              {agent.id === currentAgent?.id && (
-                <span className="ml-auto text-xs text-primary">●</span>
-              )}
-            </button>
-          ))}
+        {agents.map((agent) => (
+          <button
+            key={agent.id}
+            onClick={() => {
+              onSelect(agent.id)
+              setMenuOpen(false)
+            }}
+            className={cn(
+              "w-full text-left px-3 py-1.5 text-sm hover:bg-muted transition-colors flex items-center gap-2",
+              agent.id === currentAgent?.id && "bg-muted/50",
+            )}
+          >
+            <AgentAvatarIcon agent={agent} />
+            <span className="truncate">{agent.name}</span>
+            {agent.id === currentAgent?.id && (
+              <span className="ml-auto text-xs text-primary">●</span>
+            )}
+          </button>
+        ))}
       </FloatingMenu>
     </div>
   )

--- a/src/components/chat/ChatScreen.tsx
+++ b/src/components/chat/ChatScreen.tsx
@@ -836,7 +836,7 @@ export default function ChatScreen({
   // (useChatStreamReattach). Cursors are keyed by session + stream id so a
   // delayed frame from a finished stream cannot mutate the next DB snapshot.
   const streamSeqRef = useRef<Map<string, number>>(new Map())
-  const endedStreamIdsRef = useRef<Map<string, string>>(new Map())
+  const endedStreamIdsRef = useRef<Map<string, Set<string>>>(new Map())
   const manualModelOverrideRef = useRef<ActiveModel | null>(null)
 
   // ── Projects ────────────────────────────────────────────────
@@ -3288,11 +3288,14 @@ export default function ChatScreen({
     setWorkspaceFocusRequest((current) => (current?.nonce === nonce ? null : current))
   }, [])
 
-  const openPullRequestPanel = useCallback((expectedUrl?: string | null) => {
-    setPullRequestExpectedUrl(expectedUrl ?? null)
-    setShowPullRequestPanel(true)
-    showRightPanelByUser("pull-request")
-  }, [showRightPanelByUser])
+  const openPullRequestPanel = useCallback(
+    (expectedUrl?: string | null) => {
+      setPullRequestExpectedUrl(expectedUrl ?? null)
+      setShowPullRequestPanel(true)
+      showRightPanelByUser("pull-request")
+    },
+    [showRightPanelByUser],
+  )
 
   const openBrowserPanel = useCallback(() => {
     browserPanelDismissedRef.current = false
@@ -4076,708 +4079,712 @@ export default function ChatScreen({
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <div className="flex min-h-0 flex-1 overflow-hidden">
-          <div
-            className="relative flex-1 flex flex-col min-w-0"
-            style={{ minWidth: chatMainMinWidth }}
-          >
-            {activeTeamId && !showTeamPanel && (
-              <div className="px-3 py-1 border-b border-border">
-                <TeamMiniIndicator teamId={activeTeamId} onClick={() => setShowTeamPanel(true)} />
-              </div>
-            )}
-
-            {searchBarOpen && session.currentSessionId && (
-              <SessionSearchBar
-                sessionId={session.currentSessionId}
-                onJumpTo={session.jumpToMessage}
-                onClose={() => setSearchBarOpen(false)}
-                focusSignal={searchFocusSignal}
-              />
-            )}
-
-            <CrashRecoveryBanner />
-
-            {forkSourceSession && (
-              <div className="border-b border-border/60 px-4 py-2">
-                <button
-                  type="button"
-                  onClick={() => void rawHandleSwitchSession(forkSourceSession.id)}
-                  className="mx-auto flex max-w-[880px] items-center gap-2 rounded-lg px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
-                >
-                  <GitFork className="h-3.5 w-3.5 shrink-0" />
-                  <span className="shrink-0">
-                    {t("chat.fork.continuedFrom", {
-                      defaultValue: "接续自",
-                    })}
-                  </span>
-                  <span className="min-w-0 truncate font-medium text-foreground/80">
-                    {forkSourceSession.title}
-                  </span>
-                </button>
-              </div>
-            )}
-
-            <FileActionsContext.Provider value={fileActionsValue}>
-              <MessageList
-                messages={session.messages}
-                historyLoading={session.historyLoading}
-                loading={session.loading}
-                executionState={
-                  session.currentSessionId
-                    ? (stream.executionStateBySession.get(session.currentSessionId) ?? null)
-                    : null
-                }
-                agents={session.agents}
-                hasMore={session.hasMore}
-                loadingMore={session.loadingMore}
-                onLoadMore={session.handleLoadMore}
-                hasMoreAfter={session.hasMoreAfter}
-                loadingMoreAfter={session.loadingMoreAfter}
-                onLoadMoreAfter={session.handleLoadMoreAfter}
-                onResetToLatest={session.resetToLatest}
-                sessionId={session.currentSessionId}
-                incognito={incognitoEnabled}
-                heroComposer={heroComposerActive}
-                projectName={currentProject?.name ?? null}
-                onProjectSuggestion={currentProject ? handleProjectWelcomeSuggestion : undefined}
-                pendingScrollIntent={session.pendingScrollIntent}
-                onScrollTargetHandled={session.clearPendingScrollIntent}
-                pendingQuestionGroup={planMode.pendingQuestionGroup}
-                onQuestionSubmitted={() => {
-                  planMode.setPendingQuestionGroup(null)
-                  void planMode.refreshPendingQuestion()
-                }}
-                planCardData={planMode.planCardInfo ? { title: planMode.planCardInfo.title } : null}
-                planState={planMode.planState}
-                onOpenPlanPanel={planMode.openPlanPanel}
-                onApprovePlan={handlePlanApprove}
-                onExitPlan={planMode.exitPlanMode}
-                planSubagentRunning={planMode.planSubagentRunning}
-                onSwitchModel={handleMessageSwitchModel}
-                onViewSystemPrompt={loadSystemPrompt}
-                compacting={compacting}
-                onCompactContext={runCompactContextForCurrentSession}
-                onOpenDashboardTab={onOpenDashboardTab}
-                onViewChildSession={(sid) => {
-                  setSubagentPreviewSessionId(sid)
-                }}
-                onOpenSubagentRun={handleOpenSubagentRun}
-                subagentRunsSnapshot={subagentRuns}
-                bottomInset={isCronSession || isSubagentSession}
-                onOpenDiff={diffPanel.openDiff}
-                onResume={(message) => {
-                  void stream.handleSend(message)
-                }}
-                onForkFromMessage={handleForkFromMessage}
-                onEditAndResend={
-                  !isCronSession && !isSubagentSession && stream.pendingSends.length === 0
-                    ? handleEditAndResend
-                    : undefined
-                }
-                onOpenMemorySettings={onOpenSettings ? () => onOpenSettings("memory") : undefined}
-                onOpenKnowledge={onOpenKnowledge}
-                onAddQuickPrompt={incognitoEnabled ? undefined : handleAddQuickPrompt}
-                onAddMessageQuote={handleMessageQuote}
-                displayMode={displayMode}
-                autoCollapseCompletedTurns={autoCollapseCompletedTurns}
-                onAtBottomChange={setMessageTailVisible}
-              />
-
-              {/* Memory extraction toast — absolute-positioned above ChatInput
-               * so it doesn't shrink the MessageList scroll container when it
-               * appears/disappears. */}
-              {!isCronSession && !isSubagentSession && (
-                <div
-                  className={cn(
-                    "relative",
-                    emptySessionInputHero &&
-                      "absolute inset-x-0 top-[48%] z-20 flex -translate-y-1/2 justify-center px-5 sm:px-8",
-                  )}
-                >
-                  {(activeMemoryToast || memoryToast) && (
-                    <div
-                      className={cn(
-                        "absolute bottom-full mb-2 flex flex-col gap-2 animate-in fade-in slide-in-from-bottom-2 duration-300 z-10",
-                        emptySessionInputHero
-                          ? "inset-x-5 mx-auto max-w-[880px] sm:inset-x-8"
-                          : "inset-x-3 mx-auto max-w-[880px]",
-                      )}
-                    >
-                      {activeMemoryToast && (
-                        <div className="flex items-center gap-2 rounded-lg border border-primary/15 bg-primary/8 px-3 py-1.5 text-xs text-foreground shadow-sm">
-                          <Brain className="h-3.5 w-3.5 shrink-0 text-primary" />
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-1.5">
-                              <span className="font-medium">
-                                {t("memory.activeRecallToastTitle", "已引用记忆")}
-                              </span>
-                              {activeMemoryToast.selected && (
-                                <span className="truncate text-[10px] text-muted-foreground">
-                                  {memorySourceLabel(activeMemoryToast.selected, t)}
-                                </span>
-                              )}
-                            </div>
-                            <div className="truncate text-muted-foreground">
-                              {activeMemoryToast.summary}
-                            </div>
-                          </div>
-                          <button
-                            onClick={() => setActiveMemoryToast(null)}
-                            className="ml-auto text-muted-foreground/60 hover:text-muted-foreground"
-                            aria-label={t("common.close", "关闭")}
-                          >
-                            ×
-                          </button>
-                        </div>
-                      )}
-                      {memoryToast && (
-                        <div className="flex items-center gap-2 rounded-lg bg-secondary/50 px-3 py-1.5 text-xs text-muted-foreground">
-                          <Brain className="h-3.5 w-3.5 shrink-0" />
-                          <span>
-                            {t("settings.memoryExtractedToast", { count: memoryToast.count })}
-                          </span>
-                          <button
-                            onClick={() => setMemoryToast(null)}
-                            className="ml-auto text-muted-foreground/60 hover:text-muted-foreground"
-                            aria-label={t("common.close", "关闭")}
-                          >
-                            ×
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  )}
-
-                  <div
-                    className={cn(
-                      "mx-auto w-full max-w-[880px]",
-                      emptySessionInputHero && "flex flex-col",
-                    )}
-                  >
-                    {heroComposerActive && (
-                      <div className="mb-5 sm:mb-6">
-                        <ChatWelcomeHero
-                          incognito={incognitoEnabled}
-                          projectName={currentProject?.name ?? null}
-                          onProjectSuggestion={
-                            currentProject ? handleProjectWelcomeSuggestion : undefined
-                          }
-                        />
-                      </div>
-                    )}
-                    <ChatInput
-                      topAccessory={
-                        !session.currentSessionId && !incognitoEnabled ? (
-                          <ProjectSessionDraftBar
-                            project={currentProject}
-                            projects={projects}
-                            draft={draftProjectRuntime}
-                            disabled={session.loading}
-                            progressStage={projectBootstrapProgress?.stage ?? null}
-                            progressError={projectBootstrapProgress?.error ?? null}
-                            onDraftChange={handleProjectRuntimeDraftChange}
-                            onSelectProject={(projectId, defaultAgentId) => {
-                              void handleNewChatInProject(projectId, defaultAgentId)
-                            }}
-                            onRemoveProject={() => {
-                              void handleStartNewChat(currentAgentId)
-                            }}
-                            onRetry={() => {
-                              setProjectBootstrapProgress(null)
-                              window.setTimeout(() => {
-                                void stream.handleSend()
-                              }, 0)
-                            }}
-                            onUseLocal={() => {
-                              handleProjectRuntimeDraftChange({
-                                ...draftProjectRuntime,
-                                launchMode: "local",
-                              })
-                            }}
-                          />
-                        ) : undefined
-                      }
-                      input={stream.input}
-                      onInputChange={stream.setInput}
-                      inputHistory={inputHistory}
-                      quickPrompts={quickPrompts}
-                      onSend={() =>
-                        stream.handleSend(
-                          undefined,
-                          shouldSendDraftWorkflowMode(
-                            session.currentSessionId,
-                            incognitoEnabled,
-                            draftWorkflowMode,
-                          )
-                            ? { workflowMode: draftWorkflowMode }
-                            : undefined,
-                        )
-                      }
-                      sendDisabled={
-                        session.historyLoading ||
-                        (draftProjectRuntime.launchMode === "worktree" &&
-                          (!draftProjectBootstrap || session.loading))
-                      }
-                      loading={session.loading}
-                      availableModels={availableModels}
-                      activeModel={activeModel}
-                      unavailableModelPreference={unavailableModelPreference}
-                      reasoningEffort={reasoningEffort}
-                      onModelChange={handleManualModelChange}
-                      onEffortChange={handleSessionEffortChange}
-                      onEffortReset={handleSessionEffortReset}
-                      attachedFiles={stream.attachedFiles}
-                      maxAttachmentBytes={stream.maxChatAttachmentBytes}
-                      onAttachFiles={(files) =>
-                        stream.setAttachedFiles((prev) => [...prev, ...files])
-                      }
-                      onRemoveFile={(index) =>
-                        stream.setAttachedFiles((prev) => prev.filter((_, i) => i !== index))
-                      }
-                      onUpdateFile={(index, file) =>
-                        stream.setAttachedFiles((prev) =>
-                          prev.map((existing, i) =>
-                            i === index
-                              ? { ...existing, file, status: "ready", error: undefined }
-                              : existing,
-                          ),
-                        )
-                      }
-                      pendingQuotes={stream.pendingQuotes}
-                      onRemoveQuote={(index) => {
-                        stream.setPendingQuotes((prev) => prev.filter((_, i) => i !== index))
-                        setRevealFile(null) // dropping a quote clears its reveal highlight
-                      }}
-                      onJumpToQuote={handleQuoteJump}
-                      pendingMessageQuotes={stream.pendingMessageQuotes}
-                      onRemoveMessageQuote={(index) =>
-                        stream.setPendingMessageQuotes((prev) => prev.filter((_, i) => i !== index))
-                      }
-                      focusSignal={composerFocusSignal}
-                      pendingMessage={stream.pendingMessage}
-                      pendingSends={stream.pendingSends}
-                      onCancelPending={() => {
-                        stream.setInput(stream.pendingMessage || "")
-                        stream.setPendingMessage(null)
-                      }}
-                      onDiscardPending={() => {
-                        stream.setPendingMessage(null)
-                      }}
-                      onEditPending={stream.editPendingSend}
-                      onDiscardPendingItem={stream.discardPendingSend}
-                      onSendPending={stream.sendPendingSend}
-                      onForceInsertPending={stream.forceInsertPendingSend}
-                      onCancelForceInsertPending={stream.cancelForceInsertPendingSend}
-                      onStop={stream.handleStop}
-                      currentSessionId={session.currentSessionId}
-                      currentAgentId={session.currentAgentId}
-                      onEnsureSession={ensureWorkflowSession}
-                      onCommandAction={handleCommandAction}
-                      permissionMode={stream.permissionMode}
-                      onPermissionModeChange={stream.setPermissionModeByUser}
-                      sandboxMode={stream.sandboxMode}
-                      onSandboxModeChange={stream.setSandboxModeByUser}
-                      sessionTemperature={sessionTemperature}
-                      onSessionTemperatureChange={handleSessionTemperatureChange}
-                      incognitoEnabled={incognitoEnabled}
-                      projectId={effectiveProjectId}
-                      draftKbAttachments={draftKbAttachments}
-                      onDraftKbAttachChange={setDraftKbAttachments}
-                      enableNoteMention
-                      enableSkillMention
-                      enableAgentMention
-                      agents={session.agents}
-                      workingDir={
-                        session.currentSessionId
-                          ? effectiveWorkingDir
-                          : (draftWorkingDir ?? projectWorkingDir)
-                      }
-                      workingDirInherited={
-                        session.currentSessionId
-                          ? workingDirSource === "project"
-                          : draftWorkingDir
-                            ? false
-                            : !!projectWorkingDir
-                      }
-                      workingDirSaving={workingDirSaving}
-                      onWorkingDirChange={effectiveProjectId ? undefined : handleWorkingDirChange}
-                      planState={planMode.planState}
-                      onEnterPlanMode={planMode.enterPlanMode}
-                      onExitPlanMode={planMode.exitPlanMode}
-                      onTogglePlanPanel={() => planMode.setShowPanel((p) => !p)}
-                      draftWorkflowMode={draftWorkflowMode}
-                      onDraftWorkflowModeChange={setDraftWorkflowMode}
-                      goalSnapshot={chatGoal.snapshot}
-                      autonomyActivity={chatGoal.activity}
-                      goalLoading={chatGoal.loading}
-                      onGoalModeSubmit={handleGoalModeSubmit}
-                      onLoopModeSubmit={handleLoopModeSubmit}
-                      onGoalUpdate={handleGoalUpdate}
-                      onPauseGoal={() => runGoalControlAction("pause_goal")}
-                      onResumeGoal={() => runGoalControlAction("resume_goal")}
-                      onClearGoal={() => runGoalControlAction("clear_goal")}
-                      onEvaluateGoal={() => runGoalControlAction("evaluate_goal")}
-                      taskProgressSnapshot={taskProgressSnapshot}
-                      onOpenWorkspace={openWorkspacePanel}
-                      workflowProgressRun={workflowInputProgress.run}
-                      workflowProgressCount={workflowInputProgress.count}
-                      workspacePanelVisible={workspacePanelVisibleInRightPanel}
-                      executionState={
-                        session.currentSessionId
-                          ? (stream.executionStateBySession.get(session.currentSessionId) ?? null)
-                          : null
-                      }
-                      hero={emptySessionInputHero}
-                      contextUsage={contextUsage}
-                    />
-                  </div>
+            <div
+              className="relative flex-1 flex flex-col min-w-0"
+              style={{ minWidth: chatMainMinWidth }}
+            >
+              {activeTeamId && !showTeamPanel && (
+                <div className="px-3 py-1 border-b border-border">
+                  <TeamMiniIndicator teamId={activeTeamId} onClick={() => setShowTeamPanel(true)} />
                 </div>
               )}
-            </FileActionsContext.Provider>
-          </div>
 
-          {/* Diff panel (right side, selected from the title-bar panel switcher) */}
-          {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "diff" && (
-            <RightPanelShell
-              width={rightPanelWidth}
-              onWidthChange={setRightPanelWidth}
-              resizeLabel={t("diffPanel.resizePanel", "Resize diff panel")}
-              maxWidth={860}
-              reservedMainWidth={rightPanelReservedMainWidth}
-              collapsed={rightPanelCollapsed}
-              overlay={rightPanelOverlay}
-              animateOnMount={animateRightPanelOnMount}
-              contentKey="diff"
-            >
-              <DiffPanel
-                changes={diffPanel.activeChanges}
-                activeIndex={diffPanel.activeIndex}
-                openNonce={diffPanel.openNonce}
-                onActiveIndexChange={diffPanel.setActiveIndex}
-                onClose={diffPanel.closeDiff}
-                onPreviewFile={filePreview.openPreview}
-                gitContext={diffPanel.gitContext}
-                onGitSnapshotChange={diffPanel.replaceGitDiff}
-                embedded
-              />
-            </RightPanelShell>
-          )}
+              {searchBarOpen && session.currentSessionId && (
+                <SessionSearchBar
+                  sessionId={session.currentSessionId}
+                  onJumpTo={session.jumpToMessage}
+                  onClose={() => setSearchBarOpen(false)}
+                  focusSignal={searchFocusSignal}
+                />
+              )}
 
-          {shouldRenderRightPanelContent &&
-            renderedExclusiveRightPanel === "pull-request" &&
-            session.currentSessionId && (
+              <CrashRecoveryBanner />
+
+              {forkSourceSession && (
+                <div className="border-b border-border/60 px-4 py-2">
+                  <button
+                    type="button"
+                    onClick={() => void rawHandleSwitchSession(forkSourceSession.id)}
+                    className="mx-auto flex max-w-[880px] items-center gap-2 rounded-lg px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground"
+                  >
+                    <GitFork className="h-3.5 w-3.5 shrink-0" />
+                    <span className="shrink-0">
+                      {t("chat.fork.continuedFrom", {
+                        defaultValue: "接续自",
+                      })}
+                    </span>
+                    <span className="min-w-0 truncate font-medium text-foreground/80">
+                      {forkSourceSession.title}
+                    </span>
+                  </button>
+                </div>
+              )}
+
+              <FileActionsContext.Provider value={fileActionsValue}>
+                <MessageList
+                  messages={session.messages}
+                  historyLoading={session.historyLoading}
+                  loading={session.loading}
+                  executionState={
+                    session.currentSessionId
+                      ? (stream.executionStateBySession.get(session.currentSessionId) ?? null)
+                      : null
+                  }
+                  agents={session.agents}
+                  hasMore={session.hasMore}
+                  loadingMore={session.loadingMore}
+                  onLoadMore={session.handleLoadMore}
+                  hasMoreAfter={session.hasMoreAfter}
+                  loadingMoreAfter={session.loadingMoreAfter}
+                  onLoadMoreAfter={session.handleLoadMoreAfter}
+                  onResetToLatest={session.resetToLatest}
+                  sessionId={session.currentSessionId}
+                  incognito={incognitoEnabled}
+                  heroComposer={heroComposerActive}
+                  projectName={currentProject?.name ?? null}
+                  onProjectSuggestion={currentProject ? handleProjectWelcomeSuggestion : undefined}
+                  pendingScrollIntent={session.pendingScrollIntent}
+                  onScrollTargetHandled={session.clearPendingScrollIntent}
+                  pendingQuestionGroup={planMode.pendingQuestionGroup}
+                  onQuestionSubmitted={() => {
+                    planMode.setPendingQuestionGroup(null)
+                    void planMode.refreshPendingQuestion()
+                  }}
+                  planCardData={
+                    planMode.planCardInfo ? { title: planMode.planCardInfo.title } : null
+                  }
+                  planState={planMode.planState}
+                  onOpenPlanPanel={planMode.openPlanPanel}
+                  onApprovePlan={handlePlanApprove}
+                  onExitPlan={planMode.exitPlanMode}
+                  planSubagentRunning={planMode.planSubagentRunning}
+                  onSwitchModel={handleMessageSwitchModel}
+                  onViewSystemPrompt={loadSystemPrompt}
+                  compacting={compacting}
+                  onCompactContext={runCompactContextForCurrentSession}
+                  onOpenDashboardTab={onOpenDashboardTab}
+                  onViewChildSession={(sid) => {
+                    setSubagentPreviewSessionId(sid)
+                  }}
+                  onOpenSubagentRun={handleOpenSubagentRun}
+                  subagentRunsSnapshot={subagentRuns}
+                  bottomInset={isCronSession || isSubagentSession}
+                  onOpenDiff={diffPanel.openDiff}
+                  onResume={(message) => {
+                    void stream.handleSend(message)
+                  }}
+                  onForkFromMessage={handleForkFromMessage}
+                  onEditAndResend={
+                    !isCronSession && !isSubagentSession && stream.pendingSends.length === 0
+                      ? handleEditAndResend
+                      : undefined
+                  }
+                  onOpenMemorySettings={onOpenSettings ? () => onOpenSettings("memory") : undefined}
+                  onOpenKnowledge={onOpenKnowledge}
+                  onAddQuickPrompt={incognitoEnabled ? undefined : handleAddQuickPrompt}
+                  onAddMessageQuote={handleMessageQuote}
+                  displayMode={displayMode}
+                  autoCollapseCompletedTurns={autoCollapseCompletedTurns}
+                  onAtBottomChange={setMessageTailVisible}
+                />
+
+                {/* Memory extraction toast — absolute-positioned above ChatInput
+                 * so it doesn't shrink the MessageList scroll container when it
+                 * appears/disappears. */}
+                {!isCronSession && !isSubagentSession && (
+                  <div
+                    className={cn(
+                      "relative",
+                      emptySessionInputHero &&
+                        "absolute inset-x-0 top-[48%] z-20 flex -translate-y-1/2 justify-center px-5 sm:px-8",
+                    )}
+                  >
+                    {(activeMemoryToast || memoryToast) && (
+                      <div
+                        className={cn(
+                          "absolute bottom-full mb-2 flex flex-col gap-2 animate-in fade-in slide-in-from-bottom-2 duration-300 z-10",
+                          emptySessionInputHero
+                            ? "inset-x-5 mx-auto max-w-[880px] sm:inset-x-8"
+                            : "inset-x-3 mx-auto max-w-[880px]",
+                        )}
+                      >
+                        {activeMemoryToast && (
+                          <div className="flex items-center gap-2 rounded-lg border border-primary/15 bg-primary/8 px-3 py-1.5 text-xs text-foreground shadow-sm">
+                            <Brain className="h-3.5 w-3.5 shrink-0 text-primary" />
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-1.5">
+                                <span className="font-medium">
+                                  {t("memory.activeRecallToastTitle", "已引用记忆")}
+                                </span>
+                                {activeMemoryToast.selected && (
+                                  <span className="truncate text-[10px] text-muted-foreground">
+                                    {memorySourceLabel(activeMemoryToast.selected, t)}
+                                  </span>
+                                )}
+                              </div>
+                              <div className="truncate text-muted-foreground">
+                                {activeMemoryToast.summary}
+                              </div>
+                            </div>
+                            <button
+                              onClick={() => setActiveMemoryToast(null)}
+                              className="ml-auto text-muted-foreground/60 hover:text-muted-foreground"
+                              aria-label={t("common.close", "关闭")}
+                            >
+                              ×
+                            </button>
+                          </div>
+                        )}
+                        {memoryToast && (
+                          <div className="flex items-center gap-2 rounded-lg bg-secondary/50 px-3 py-1.5 text-xs text-muted-foreground">
+                            <Brain className="h-3.5 w-3.5 shrink-0" />
+                            <span>
+                              {t("settings.memoryExtractedToast", { count: memoryToast.count })}
+                            </span>
+                            <button
+                              onClick={() => setMemoryToast(null)}
+                              className="ml-auto text-muted-foreground/60 hover:text-muted-foreground"
+                              aria-label={t("common.close", "关闭")}
+                            >
+                              ×
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    )}
+
+                    <div
+                      className={cn(
+                        "mx-auto w-full max-w-[880px]",
+                        emptySessionInputHero && "flex flex-col",
+                      )}
+                    >
+                      {heroComposerActive && (
+                        <div className="mb-5 sm:mb-6">
+                          <ChatWelcomeHero
+                            incognito={incognitoEnabled}
+                            projectName={currentProject?.name ?? null}
+                            onProjectSuggestion={
+                              currentProject ? handleProjectWelcomeSuggestion : undefined
+                            }
+                          />
+                        </div>
+                      )}
+                      <ChatInput
+                        topAccessory={
+                          !session.currentSessionId && !incognitoEnabled ? (
+                            <ProjectSessionDraftBar
+                              project={currentProject}
+                              projects={projects}
+                              draft={draftProjectRuntime}
+                              disabled={session.loading}
+                              progressStage={projectBootstrapProgress?.stage ?? null}
+                              progressError={projectBootstrapProgress?.error ?? null}
+                              onDraftChange={handleProjectRuntimeDraftChange}
+                              onSelectProject={(projectId, defaultAgentId) => {
+                                void handleNewChatInProject(projectId, defaultAgentId)
+                              }}
+                              onRemoveProject={() => {
+                                void handleStartNewChat(currentAgentId)
+                              }}
+                              onRetry={() => {
+                                setProjectBootstrapProgress(null)
+                                window.setTimeout(() => {
+                                  void stream.handleSend()
+                                }, 0)
+                              }}
+                              onUseLocal={() => {
+                                handleProjectRuntimeDraftChange({
+                                  ...draftProjectRuntime,
+                                  launchMode: "local",
+                                })
+                              }}
+                            />
+                          ) : undefined
+                        }
+                        input={stream.input}
+                        onInputChange={stream.setInput}
+                        inputHistory={inputHistory}
+                        quickPrompts={quickPrompts}
+                        onSend={() =>
+                          stream.handleSend(
+                            undefined,
+                            shouldSendDraftWorkflowMode(
+                              session.currentSessionId,
+                              incognitoEnabled,
+                              draftWorkflowMode,
+                            )
+                              ? { workflowMode: draftWorkflowMode }
+                              : undefined,
+                          )
+                        }
+                        sendDisabled={
+                          session.historyLoading ||
+                          (draftProjectRuntime.launchMode === "worktree" &&
+                            (!draftProjectBootstrap || session.loading))
+                        }
+                        loading={session.loading}
+                        availableModels={availableModels}
+                        activeModel={activeModel}
+                        unavailableModelPreference={unavailableModelPreference}
+                        reasoningEffort={reasoningEffort}
+                        onModelChange={handleManualModelChange}
+                        onEffortChange={handleSessionEffortChange}
+                        onEffortReset={handleSessionEffortReset}
+                        attachedFiles={stream.attachedFiles}
+                        maxAttachmentBytes={stream.maxChatAttachmentBytes}
+                        onAttachFiles={(files) =>
+                          stream.setAttachedFiles((prev) => [...prev, ...files])
+                        }
+                        onRemoveFile={(index) =>
+                          stream.setAttachedFiles((prev) => prev.filter((_, i) => i !== index))
+                        }
+                        onUpdateFile={(index, file) =>
+                          stream.setAttachedFiles((prev) =>
+                            prev.map((existing, i) =>
+                              i === index
+                                ? { ...existing, file, status: "ready", error: undefined }
+                                : existing,
+                            ),
+                          )
+                        }
+                        pendingQuotes={stream.pendingQuotes}
+                        onRemoveQuote={(index) => {
+                          stream.setPendingQuotes((prev) => prev.filter((_, i) => i !== index))
+                          setRevealFile(null) // dropping a quote clears its reveal highlight
+                        }}
+                        onJumpToQuote={handleQuoteJump}
+                        pendingMessageQuotes={stream.pendingMessageQuotes}
+                        onRemoveMessageQuote={(index) =>
+                          stream.setPendingMessageQuotes((prev) =>
+                            prev.filter((_, i) => i !== index),
+                          )
+                        }
+                        focusSignal={composerFocusSignal}
+                        pendingMessage={stream.pendingMessage}
+                        pendingSends={stream.pendingSends}
+                        onCancelPending={() => {
+                          stream.setInput(stream.pendingMessage || "")
+                          stream.setPendingMessage(null)
+                        }}
+                        onDiscardPending={() => {
+                          stream.setPendingMessage(null)
+                        }}
+                        onEditPending={stream.editPendingSend}
+                        onDiscardPendingItem={stream.discardPendingSend}
+                        onSendPending={stream.sendPendingSend}
+                        onForceInsertPending={stream.forceInsertPendingSend}
+                        onCancelForceInsertPending={stream.cancelForceInsertPendingSend}
+                        onStop={stream.handleStop}
+                        currentSessionId={session.currentSessionId}
+                        currentAgentId={session.currentAgentId}
+                        onEnsureSession={ensureWorkflowSession}
+                        onCommandAction={handleCommandAction}
+                        permissionMode={stream.permissionMode}
+                        onPermissionModeChange={stream.setPermissionModeByUser}
+                        sandboxMode={stream.sandboxMode}
+                        onSandboxModeChange={stream.setSandboxModeByUser}
+                        sessionTemperature={sessionTemperature}
+                        onSessionTemperatureChange={handleSessionTemperatureChange}
+                        incognitoEnabled={incognitoEnabled}
+                        projectId={effectiveProjectId}
+                        draftKbAttachments={draftKbAttachments}
+                        onDraftKbAttachChange={setDraftKbAttachments}
+                        enableNoteMention
+                        enableSkillMention
+                        enableAgentMention
+                        agents={session.agents}
+                        workingDir={
+                          session.currentSessionId
+                            ? effectiveWorkingDir
+                            : (draftWorkingDir ?? projectWorkingDir)
+                        }
+                        workingDirInherited={
+                          session.currentSessionId
+                            ? workingDirSource === "project"
+                            : draftWorkingDir
+                              ? false
+                              : !!projectWorkingDir
+                        }
+                        workingDirSaving={workingDirSaving}
+                        onWorkingDirChange={effectiveProjectId ? undefined : handleWorkingDirChange}
+                        planState={planMode.planState}
+                        onEnterPlanMode={planMode.enterPlanMode}
+                        onExitPlanMode={planMode.exitPlanMode}
+                        onTogglePlanPanel={() => planMode.setShowPanel((p) => !p)}
+                        draftWorkflowMode={draftWorkflowMode}
+                        onDraftWorkflowModeChange={setDraftWorkflowMode}
+                        goalSnapshot={chatGoal.snapshot}
+                        autonomyActivity={chatGoal.activity}
+                        goalLoading={chatGoal.loading}
+                        onGoalModeSubmit={handleGoalModeSubmit}
+                        onLoopModeSubmit={handleLoopModeSubmit}
+                        onGoalUpdate={handleGoalUpdate}
+                        onPauseGoal={() => runGoalControlAction("pause_goal")}
+                        onResumeGoal={() => runGoalControlAction("resume_goal")}
+                        onClearGoal={() => runGoalControlAction("clear_goal")}
+                        onEvaluateGoal={() => runGoalControlAction("evaluate_goal")}
+                        taskProgressSnapshot={taskProgressSnapshot}
+                        onOpenWorkspace={openWorkspacePanel}
+                        workflowProgressRun={workflowInputProgress.run}
+                        workflowProgressCount={workflowInputProgress.count}
+                        workspacePanelVisible={workspacePanelVisibleInRightPanel}
+                        executionState={
+                          session.currentSessionId
+                            ? (stream.executionStateBySession.get(session.currentSessionId) ?? null)
+                            : null
+                        }
+                        hero={emptySessionInputHero}
+                        contextUsage={contextUsage}
+                      />
+                    </div>
+                  </div>
+                )}
+              </FileActionsContext.Provider>
+            </div>
+
+            {/* Diff panel (right side, selected from the title-bar panel switcher) */}
+            {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "diff" && (
               <RightPanelShell
                 width={rightPanelWidth}
                 onWidthChange={setRightPanelWidth}
-                resizeLabel={t("workspace.git.resizePullRequestPanel", "调整拉取请求面板宽度")}
-                maxWidth={960}
+                resizeLabel={t("diffPanel.resizePanel", "Resize diff panel")}
+                maxWidth={860}
                 reservedMainWidth={rightPanelReservedMainWidth}
                 collapsed={rightPanelCollapsed}
                 overlay={rightPanelOverlay}
                 animateOnMount={animateRightPanelOnMount}
-                contentKey={`pull-request:${session.currentSessionId}`}
+                contentKey="diff"
               >
-                <PullRequestPanel
-                  sessionId={session.currentSessionId}
-                  expectedUrl={pullRequestExpectedUrl}
-                  onFillInput={stream.setInput}
-                  onClose={() => {
-                    setShowPullRequestPanel(false)
-                    setPullRequestExpectedUrl(null)
-                  }}
+                <DiffPanel
+                  changes={diffPanel.activeChanges}
+                  activeIndex={diffPanel.activeIndex}
+                  openNonce={diffPanel.openNonce}
+                  onActiveIndexChange={diffPanel.setActiveIndex}
+                  onClose={diffPanel.closeDiff}
+                  onPreviewFile={filePreview.openPreview}
+                  gitContext={diffPanel.gitContext}
+                  onGitSnapshotChange={diffPanel.replaceGitDiff}
+                  embedded
                 />
               </RightPanelShell>
             )}
 
-          {/* Plan workspace (right side, integrated under the shared title bar) */}
-          {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "plan" && (
-            <RightPanelShell
-              width={rightPanelWidth}
-              onWidthChange={setRightPanelWidth}
-              resizeLabel={t("planMode.resizePanel", "Resize plan panel")}
-              maxWidth={860}
-              reservedMainWidth={rightPanelReservedMainWidth}
-              collapsed={rightPanelCollapsed}
-              overlay={rightPanelOverlay}
-              animateOnMount={animateRightPanelOnMount}
-              contentKey="plan"
-            >
-              <PlanPanel
-                planState={planMode.planState}
-                planContent={planMode.planContent}
-                sessionId={session.currentSessionId}
-                onApprove={handlePlanApprove}
-                onExit={planMode.exitPlanMode}
-                onClose={() => planMode.setShowPanel(false)}
-                onContinue={handlePlanContinue}
-                isExecutionActive={session.loading && planMode.planState === "executing"}
-                onRequestChanges={handleRequestChanges}
-                embedded
-              />
-            </RightPanelShell>
-          )}
+            {shouldRenderRightPanelContent &&
+              renderedExclusiveRightPanel === "pull-request" &&
+              session.currentSessionId && (
+                <RightPanelShell
+                  width={rightPanelWidth}
+                  onWidthChange={setRightPanelWidth}
+                  resizeLabel={t("workspace.git.resizePullRequestPanel", "调整拉取请求面板宽度")}
+                  maxWidth={960}
+                  reservedMainWidth={rightPanelReservedMainWidth}
+                  collapsed={rightPanelCollapsed}
+                  overlay={rightPanelOverlay}
+                  animateOnMount={animateRightPanelOnMount}
+                  contentKey={`pull-request:${session.currentSessionId}`}
+                >
+                  <PullRequestPanel
+                    sessionId={session.currentSessionId}
+                    expectedUrl={pullRequestExpectedUrl}
+                    onFillInput={stream.setInput}
+                    onClose={() => {
+                      setShowPullRequestPanel(false)
+                      setPullRequestExpectedUrl(null)
+                    }}
+                  />
+                </RightPanelShell>
+              )}
 
-          {/* Project file browser (right side, scoped to the working dir) */}
-          {/* File browser panel — permanently mounted (like CanvasPanel) and
+            {/* Plan workspace (right side, integrated under the shared title bar) */}
+            {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "plan" && (
+              <RightPanelShell
+                width={rightPanelWidth}
+                onWidthChange={setRightPanelWidth}
+                resizeLabel={t("planMode.resizePanel", "Resize plan panel")}
+                maxWidth={860}
+                reservedMainWidth={rightPanelReservedMainWidth}
+                collapsed={rightPanelCollapsed}
+                overlay={rightPanelOverlay}
+                animateOnMount={animateRightPanelOnMount}
+                contentKey="plan"
+              >
+                <PlanPanel
+                  planState={planMode.planState}
+                  planContent={planMode.planContent}
+                  sessionId={session.currentSessionId}
+                  onApprove={handlePlanApprove}
+                  onExit={planMode.exitPlanMode}
+                  onClose={() => planMode.setShowPanel(false)}
+                  onContinue={handlePlanContinue}
+                  isExecutionActive={session.loading && planMode.planState === "executing"}
+                  onRequestChanges={handleRequestChanges}
+                  embedded
+                />
+              </RightPanelShell>
+            )}
+
+            {/* Project file browser (right side, scoped to the working dir) */}
+            {/* File browser panel — permanently mounted (like CanvasPanel) and
               toggled via `visible`, so a popped-out window survives panel
               switches / collapses. */}
-          <FileBrowserPanel
-            scope={!session.currentSessionId && currentProject ? "project" : "session"}
-            scopeId={
-              !session.currentSessionId && currentProject
-                ? currentProject.id
-                : session.currentSessionId
-            }
-            rootPath={effectiveWorkingDir}
-            sessionId={session.currentSessionId}
-            visible={shouldRenderRightPanelContent && renderedExclusiveRightPanel === "files"}
-            collapsed={rightPanelCollapsed}
-            overlay={rightPanelOverlay}
-            animateOnMount={animateRightPanelOnMount}
-            panelWidth={rightPanelWidth}
-            onPanelWidthChange={setRightPanelWidth}
-            reservedMainWidth={rightPanelReservedMainWidth}
-            onQuote={handleFileQuote}
-            revealFile={revealFile}
-            onClose={() => setShowFilesPanel(false)}
-          />
-
-          {/* Canvas Preview Panel */}
-          <CanvasPanel
-            panelWidth={rightPanelWidth}
-            onPanelWidthChange={setRightPanelWidth}
-            currentSessionId={currentSessionId}
-            onOpenChange={setCanvasPanelOpen}
-            collapsed={rightPanelCollapsed}
-            overlay={rightPanelOverlay}
-            animateOnMount={animateRightPanelOnMount}
-            reservedMainWidth={rightPanelReservedMainWidth}
-            visible={shouldRenderRightPanelContent && renderedExclusiveRightPanel === "canvas"}
-          />
-
-          {/* Browser live-mirror panel — open on first `browser:frame` push,
-              close-only by user, then switchable from the title bar. */}
-          {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "browser" && (
-            <BrowserPanel
-              sessionId={session.currentSessionId}
-              panelWidth={rightPanelWidth}
-              onPanelWidthChange={setRightPanelWidth}
-              collapsed={rightPanelCollapsed}
-              overlay={rightPanelOverlay}
-              animateOnMount={animateRightPanelOnMount}
-              reservedMainWidth={rightPanelReservedMainWidth}
-              onClose={() => {
-                browserPanelDismissedRef.current = true
-                setShowBrowserPanel(false)
-              }}
-              onFloat={() => floatPanel("browser")}
-            />
-          )}
-
-          {/* Mac Control live-mirror panel — opens on tool-produced managed
-              screenshot frames; panel polling frames only refresh an already
-              open panel and must not re-open after a session switch. */}
-          {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "mac-control" && (
-            <MacControlPanel
-              sessionId={session.currentSessionId}
-              panelWidth={rightPanelWidth}
-              onPanelWidthChange={setRightPanelWidth}
-              collapsed={rightPanelCollapsed}
-              overlay={rightPanelOverlay}
-              animateOnMount={animateRightPanelOnMount}
-              reservedMainWidth={rightPanelReservedMainWidth}
-              onClose={() => {
-                macControlPanelDismissedRef.current = true
-                setShowMacControlPanel(false)
-              }}
-              onFloat={() => floatPanel("mac-control")}
-            />
-          )}
-
-          {/* In-app floating control-panel windows (portal to body). */}
-          <FloatingPanelLayer
-            floatingPanels={floatingPanelList}
-            zIndexOf={floatingPanelZIndex}
-            onDock={(panel: FloatablePanel) => {
-              dockFloatingPanel(panel)
-              showRightPanelByUser(panel)
-            }}
-            onClose={(panel: FloatablePanel) => {
-              closeFloatingPanel(panel)
-              if (panel === "browser") {
-                browserPanelDismissedRef.current = true
-                setShowBrowserPanel(false)
-              } else {
-                macControlPanelDismissedRef.current = true
-                setShowMacControlPanel(false)
+            <FileBrowserPanel
+              scope={!session.currentSessionId && currentProject ? "project" : "session"}
+              scopeId={
+                !session.currentSessionId && currentProject
+                  ? currentProject.id
+                  : session.currentSessionId
               }
-            }}
-            onFocus={focusFloatingPanel}
-            sessionId={session.currentSessionId}
-          />
+              rootPath={effectiveWorkingDir}
+              sessionId={session.currentSessionId}
+              visible={shouldRenderRightPanelContent && renderedExclusiveRightPanel === "files"}
+              collapsed={rightPanelCollapsed}
+              overlay={rightPanelOverlay}
+              animateOnMount={animateRightPanelOnMount}
+              panelWidth={rightPanelWidth}
+              onPanelWidthChange={setRightPanelWidth}
+              reservedMainWidth={rightPanelReservedMainWidth}
+              onQuote={handleFileQuote}
+              revealFile={revealFile}
+              onClose={() => setShowFilesPanel(false)}
+            />
 
-          {/* Team Panel */}
-          {shouldRenderRightPanelContent &&
-            renderedExclusiveRightPanel === "team" &&
-            activeTeamId && (
-              <TeamPanel
-                teamId={activeTeamId}
+            {/* Canvas Preview Panel */}
+            <CanvasPanel
+              panelWidth={rightPanelWidth}
+              onPanelWidthChange={setRightPanelWidth}
+              currentSessionId={currentSessionId}
+              onOpenChange={setCanvasPanelOpen}
+              collapsed={rightPanelCollapsed}
+              overlay={rightPanelOverlay}
+              animateOnMount={animateRightPanelOnMount}
+              reservedMainWidth={rightPanelReservedMainWidth}
+              visible={shouldRenderRightPanelContent && renderedExclusiveRightPanel === "canvas"}
+            />
+
+            {/* Browser live-mirror panel — open on first `browser:frame` push,
+              close-only by user, then switchable from the title bar. */}
+            {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "browser" && (
+              <BrowserPanel
+                sessionId={session.currentSessionId}
                 panelWidth={rightPanelWidth}
                 onPanelWidthChange={setRightPanelWidth}
                 collapsed={rightPanelCollapsed}
                 overlay={rightPanelOverlay}
                 animateOnMount={animateRightPanelOnMount}
                 reservedMainWidth={rightPanelReservedMainWidth}
-                onClose={() => setShowTeamPanel(false)}
-                onViewSession={setSubagentPreviewSessionId}
+                onClose={() => {
+                  browserPanelDismissedRef.current = true
+                  setShowBrowserPanel(false)
+                }}
+                onFloat={() => floatPanel("browser")}
               />
             )}
 
-          {/* Workspace 面板 — 聚合任务进度 / 碰到的文件 / 引用来源 */}
-          {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "workspace" && (
-            <RightPanelShell
-              width={rightPanelWidth}
-              onWidthChange={setRightPanelWidth}
-              resizeLabel={t("workspace.resizePanel", "Resize workspace panel")}
-              maxWidth={860}
-              reservedMainWidth={rightPanelReservedMainWidth}
-              collapsed={rightPanelCollapsed}
-              overlay={rightPanelOverlay}
-              animateOnMount={animateRightPanelOnMount}
-              contentKey="workspace"
-            >
-              <WorkspacePanel
-                taskSnapshot={taskProgressSnapshot}
-                taskExecutionState={workspaceTaskExecutionState}
-                messages={session.messages}
-                contextUsageOverride={contextUsage}
-                onOpenDiff={diffPanel.openDiff}
-                onOpenGitDiff={diffPanel.openGitDiff}
-                onFillInput={stream.setInput}
-                onOpenPullRequest={openPullRequestPanel}
-                onPreviewFile={filePreview.openPreview}
+            {/* Mac Control live-mirror panel — opens on tool-produced managed
+              screenshot frames; panel polling frames only refresh an already
+              open panel and must not re-open after a session switch. */}
+            {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "mac-control" && (
+              <MacControlPanel
                 sessionId={session.currentSessionId}
-                sessionMeta={currentSessionMeta}
-                project={currentProject}
-                effectiveWorkingDir={workspaceEffectiveWorkingDir}
-                workingDirSource={workspaceWorkingDirSource}
-                permissionMode={stream.permissionMode}
-                planState={planMode.planState}
-                activeModel={activeModel}
-                agentName={session.agentName}
-                reasoningEffort={reasoningEffort}
-                availableModels={availableModels}
-                currentAgentId={session.currentAgentId}
-                compacting={compacting}
-                onCompactContext={runCompactContextForCurrentSession}
-                onCommandAction={handleCommandAction}
-                onViewSystemPrompt={loadSystemPrompt}
-                systemPromptLoading={systemPromptLoading}
-                incognito={incognitoEnabled}
-                turnActive={
-                  workspaceTaskExecutionState === "running" ||
-                  workspaceTaskExecutionState === "cancelling"
-                }
-                workflowRunsState={workflowTitleBarRuns}
-                backgroundJobs={backgroundJobs.jobs}
-                backgroundJobExpansionOverrides={backgroundJobExpansionOverrides}
-                onBackgroundJobExpandedChange={handleBackgroundJobExpandedChange}
-                onOpenBackgroundJobs={openBackgroundJobsPanel}
-                onOpenBrowserPanel={openBrowserPanel}
-                onViewSubagentSession={(sid) => openSubagentPanel({ childSessionId: sid })}
-                subagentRunsState={subagentRuns}
-                focusRequest={workspaceFocusRequest}
-                onFocusRequestHandled={handleWorkspaceFocusRequestHandled}
-                onEnsureSession={ensureWorkflowSession}
-                draftWorkflowMode={draftWorkflowMode}
-                onDraftWorkflowModeChange={setDraftWorkflowMode}
+                panelWidth={rightPanelWidth}
+                onPanelWidthChange={setRightPanelWidth}
+                collapsed={rightPanelCollapsed}
+                overlay={rightPanelOverlay}
+                animateOnMount={animateRightPanelOnMount}
+                reservedMainWidth={rightPanelReservedMainWidth}
                 onClose={() => {
-                  workspacePanelDismissedRef.current = true
-                  setWorkspaceFocusRequest(null)
-                  setShowWorkspacePanel(false)
+                  macControlPanelDismissedRef.current = true
+                  setShowMacControlPanel(false)
                 }}
+                onFloat={() => floatPanel("mac-control")}
               />
-            </RightPanelShell>
-          )}
+            )}
 
-          {/* Background-jobs panel (R4) — session jobs (cancellable) + a
+            {/* In-app floating control-panel windows (portal to body). */}
+            <FloatingPanelLayer
+              floatingPanels={floatingPanelList}
+              zIndexOf={floatingPanelZIndex}
+              onDock={(panel: FloatablePanel) => {
+                dockFloatingPanel(panel)
+                showRightPanelByUser(panel)
+              }}
+              onClose={(panel: FloatablePanel) => {
+                closeFloatingPanel(panel)
+                if (panel === "browser") {
+                  browserPanelDismissedRef.current = true
+                  setShowBrowserPanel(false)
+                } else {
+                  macControlPanelDismissedRef.current = true
+                  setShowMacControlPanel(false)
+                }
+              }}
+              onFocus={focusFloatingPanel}
+              sessionId={session.currentSessionId}
+            />
+
+            {/* Team Panel */}
+            {shouldRenderRightPanelContent &&
+              renderedExclusiveRightPanel === "team" &&
+              activeTeamId && (
+                <TeamPanel
+                  teamId={activeTeamId}
+                  panelWidth={rightPanelWidth}
+                  onPanelWidthChange={setRightPanelWidth}
+                  collapsed={rightPanelCollapsed}
+                  overlay={rightPanelOverlay}
+                  animateOnMount={animateRightPanelOnMount}
+                  reservedMainWidth={rightPanelReservedMainWidth}
+                  onClose={() => setShowTeamPanel(false)}
+                  onViewSession={setSubagentPreviewSessionId}
+                />
+              )}
+
+            {/* Workspace 面板 — 聚合任务进度 / 碰到的文件 / 引用来源 */}
+            {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "workspace" && (
+              <RightPanelShell
+                width={rightPanelWidth}
+                onWidthChange={setRightPanelWidth}
+                resizeLabel={t("workspace.resizePanel", "Resize workspace panel")}
+                maxWidth={860}
+                reservedMainWidth={rightPanelReservedMainWidth}
+                collapsed={rightPanelCollapsed}
+                overlay={rightPanelOverlay}
+                animateOnMount={animateRightPanelOnMount}
+                contentKey="workspace"
+              >
+                <WorkspacePanel
+                  taskSnapshot={taskProgressSnapshot}
+                  taskExecutionState={workspaceTaskExecutionState}
+                  messages={session.messages}
+                  contextUsageOverride={contextUsage}
+                  onOpenDiff={diffPanel.openDiff}
+                  onOpenGitDiff={diffPanel.openGitDiff}
+                  onFillInput={stream.setInput}
+                  onOpenPullRequest={openPullRequestPanel}
+                  onPreviewFile={filePreview.openPreview}
+                  sessionId={session.currentSessionId}
+                  sessionMeta={currentSessionMeta}
+                  project={currentProject}
+                  effectiveWorkingDir={workspaceEffectiveWorkingDir}
+                  workingDirSource={workspaceWorkingDirSource}
+                  permissionMode={stream.permissionMode}
+                  planState={planMode.planState}
+                  activeModel={activeModel}
+                  agentName={session.agentName}
+                  reasoningEffort={reasoningEffort}
+                  availableModels={availableModels}
+                  currentAgentId={session.currentAgentId}
+                  compacting={compacting}
+                  onCompactContext={runCompactContextForCurrentSession}
+                  onCommandAction={handleCommandAction}
+                  onViewSystemPrompt={loadSystemPrompt}
+                  systemPromptLoading={systemPromptLoading}
+                  incognito={incognitoEnabled}
+                  turnActive={
+                    workspaceTaskExecutionState === "running" ||
+                    workspaceTaskExecutionState === "cancelling"
+                  }
+                  workflowRunsState={workflowTitleBarRuns}
+                  backgroundJobs={backgroundJobs.jobs}
+                  backgroundJobExpansionOverrides={backgroundJobExpansionOverrides}
+                  onBackgroundJobExpandedChange={handleBackgroundJobExpandedChange}
+                  onOpenBackgroundJobs={openBackgroundJobsPanel}
+                  onOpenBrowserPanel={openBrowserPanel}
+                  onViewSubagentSession={(sid) => openSubagentPanel({ childSessionId: sid })}
+                  subagentRunsState={subagentRuns}
+                  focusRequest={workspaceFocusRequest}
+                  onFocusRequestHandled={handleWorkspaceFocusRequestHandled}
+                  onEnsureSession={ensureWorkflowSession}
+                  draftWorkflowMode={draftWorkflowMode}
+                  onDraftWorkflowModeChange={setDraftWorkflowMode}
+                  onClose={() => {
+                    workspacePanelDismissedRef.current = true
+                    setWorkspaceFocusRequest(null)
+                    setShowWorkspacePanel(false)
+                  }}
+                />
+              </RightPanelShell>
+            )}
+
+            {/* Background-jobs panel (R4) — session jobs (cancellable) + a
               read-only mirror of global local-model jobs. */}
-          {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "background-jobs" && (
-            <RightPanelShell
-              width={rightPanelWidth}
-              onWidthChange={setRightPanelWidth}
-              resizeLabel={t("backgroundJobs.resizePanel", "Resize background jobs panel")}
-              maxWidth={860}
-              reservedMainWidth={rightPanelReservedMainWidth}
-              collapsed={rightPanelCollapsed}
-              overlay={rightPanelOverlay}
-              animateOnMount={animateRightPanelOnMount}
-              contentKey="background-jobs"
-            >
-              <BackgroundJobsPanel
-                jobs={backgroundJobs.jobs}
-                jobExpansionOverrides={backgroundJobExpansionOverrides}
-                onJobExpandedChange={handleBackgroundJobExpandedChange}
-                onClose={closeBackgroundJobsPanel}
-                onViewSubagentSession={(sid) => openSubagentPanel({ childSessionId: sid })}
-              />
-            </RightPanelShell>
-          )}
+            {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "background-jobs" && (
+              <RightPanelShell
+                width={rightPanelWidth}
+                onWidthChange={setRightPanelWidth}
+                resizeLabel={t("backgroundJobs.resizePanel", "Resize background jobs panel")}
+                maxWidth={860}
+                reservedMainWidth={rightPanelReservedMainWidth}
+                collapsed={rightPanelCollapsed}
+                overlay={rightPanelOverlay}
+                animateOnMount={animateRightPanelOnMount}
+                contentKey="background-jobs"
+              >
+                <BackgroundJobsPanel
+                  jobs={backgroundJobs.jobs}
+                  jobExpansionOverrides={backgroundJobExpansionOverrides}
+                  onJobExpandedChange={handleBackgroundJobExpandedChange}
+                  onClose={closeBackgroundJobsPanel}
+                  onViewSubagentSession={(sid) => openSubagentPanel({ childSessionId: sid })}
+                />
+              </RightPanelShell>
+            )}
 
-          {/* Sub-agent panel — this session's sub-agent runs + the selected
+            {/* Sub-agent panel — this session's sub-agent runs + the selected
               run's live child-session transcript. Opened from inline chips. */}
-          {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "subagent" && (
-            <RightPanelShell
-              width={rightPanelWidth}
-              onWidthChange={setRightPanelWidth}
-              resizeLabel={t("subagentPanel.resizePanel", "Resize sub-agents panel")}
-              maxWidth={960}
-              reservedMainWidth={rightPanelReservedMainWidth}
-              collapsed={rightPanelCollapsed}
-              overlay={rightPanelOverlay}
-              animateOnMount={animateRightPanelOnMount}
-              contentKey={`subagent:${session.currentSessionId ?? ""}`}
-            >
-              <SubagentPanel
-                sessionId={session.currentSessionId}
-                runsState={subagentRuns}
-                agents={session.agents}
-                selectRequest={subagentPanelSelectRequest}
-                onClose={closeSubagentPanel}
-              />
-            </RightPanelShell>
-          )}
+            {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "subagent" && (
+              <RightPanelShell
+                width={rightPanelWidth}
+                onWidthChange={setRightPanelWidth}
+                resizeLabel={t("subagentPanel.resizePanel", "Resize sub-agents panel")}
+                maxWidth={960}
+                reservedMainWidth={rightPanelReservedMainWidth}
+                collapsed={rightPanelCollapsed}
+                overlay={rightPanelOverlay}
+                animateOnMount={animateRightPanelOnMount}
+                contentKey={`subagent:${session.currentSessionId ?? ""}`}
+              >
+                <SubagentPanel
+                  sessionId={session.currentSessionId}
+                  runsState={subagentRuns}
+                  agents={session.agents}
+                  selectRequest={subagentPanelSelectRequest}
+                  onClose={closeSubagentPanel}
+                />
+              </RightPanelShell>
+            )}
 
-          {/* File preview panel — single-file viewer opened from Markdown
+            {/* File preview panel — single-file viewer opened from Markdown
               links / attachments / the workspace panel (file-operations
               unification). Reuses the file-browser FilePreviewPane. */}
-          {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "preview" && (
-            <RightPanelShell
-              width={rightPanelWidth}
-              onWidthChange={setRightPanelWidth}
-              resizeLabel={t("filePreview.resizePanel", "Resize preview panel")}
-              maxWidth={860}
-              maximized={filePreviewMaximized}
-              fullscreenTransitionRef={filePreviewFullscreenRef}
-              reservedMainWidth={rightPanelReservedMainWidth}
-              collapsed={rightPanelCollapsed}
-              overlay={rightPanelOverlay}
-              animateOnMount={animateRightPanelOnMount}
-              contentKey="preview"
-            >
-              <FilePreviewPanel
-                target={filePreview.target}
-                sessionId={session.currentSessionId}
-                onReplaceDraft={replaceDraftAttachment}
+            {shouldRenderRightPanelContent && renderedExclusiveRightPanel === "preview" && (
+              <RightPanelShell
+                width={rightPanelWidth}
+                onWidthChange={setRightPanelWidth}
+                resizeLabel={t("filePreview.resizePanel", "Resize preview panel")}
+                maxWidth={860}
                 maximized={filePreviewMaximized}
-                onToggleMaximize={toggleFilePreviewFullscreen}
-                onClose={() => {
-                  resetFilePreviewFullscreen()
-                  filePreview.closePreview()
-                }}
-              />
-            </RightPanelShell>
-          )}
+                fullscreenTransitionRef={filePreviewFullscreenRef}
+                reservedMainWidth={rightPanelReservedMainWidth}
+                collapsed={rightPanelCollapsed}
+                overlay={rightPanelOverlay}
+                animateOnMount={animateRightPanelOnMount}
+                contentKey="preview"
+              >
+                <FilePreviewPanel
+                  target={filePreview.target}
+                  sessionId={session.currentSessionId}
+                  onReplaceDraft={replaceDraftAttachment}
+                  maximized={filePreviewMaximized}
+                  onToggleMaximize={toggleFilePreviewFullscreen}
+                  onClose={() => {
+                    resetFilePreviewFullscreen()
+                    filePreview.closePreview()
+                  }}
+                />
+              </RightPanelShell>
+            )}
           </div>
           <TerminalPanel
             open={terminalOpen}

--- a/src/components/chat/QuickChatDialog.tsx
+++ b/src/components/chat/QuickChatDialog.tsx
@@ -41,16 +41,11 @@ export default function QuickChatDialog({
   // Quick chat is transient — no reattach logic is wired, but the seq cursor
   // still has to be supplied to `useChatStream` and local-only is fine here.
   const quickStreamSeqRef = useRef<Map<string, number>>(new Map())
-  const quickEndedStreamIdsRef = useRef<Map<string, string>>(new Map())
+  const quickEndedStreamIdsRef = useRef<Map<string, Set<string>>>(new Map())
   const [quickPrompts, setQuickPrompts] = useState<QuickPromptItem[]>([])
   const [composerFocusSignal, setComposerFocusSignal] = useState<number | undefined>(undefined)
   const [messageTailVisible, setMessageTailVisible] = useState(true)
-  useEmbeddedChatReadReceipt(
-    open,
-    messageTailVisible,
-    session.currentSessionId,
-    session.messages,
-  )
+  useEmbeddedChatReadReceipt(open, messageTailVisible, session.currentSessionId, session.messages)
 
   // Effective incognito = persisted session.incognito (continued chat) or
   // draft toggle (new chat). Same shape as `ChatScreen` so `useChatStream`
@@ -410,25 +405,25 @@ function AgentSelector({
         className="ha-menu-from-top min-w-[200px] max-h-[240px] overflow-y-auto p-1.5"
         onEscapeKeyDown={() => setMenuOpen(false)}
       >
-          {agents.map((agent) => (
-            <button
-              key={agent.id}
-              onClick={() => {
-                onSelect(agent.id)
-                setMenuOpen(false)
-              }}
-              className={cn(
-                "w-full text-left px-3 py-1.5 text-sm hover:bg-muted transition-colors flex items-center gap-2",
-                agent.id === currentAgent?.id && "bg-muted/50",
-              )}
-            >
-              <AgentAvatarIcon agent={agent} size="sm" />
-              <span className="truncate">{agent.name}</span>
-              {agent.id === currentAgent?.id && (
-                <span className="ml-auto text-xs text-primary">●</span>
-              )}
-            </button>
-          ))}
+        {agents.map((agent) => (
+          <button
+            key={agent.id}
+            onClick={() => {
+              onSelect(agent.id)
+              setMenuOpen(false)
+            }}
+            className={cn(
+              "w-full text-left px-3 py-1.5 text-sm hover:bg-muted transition-colors flex items-center gap-2",
+              agent.id === currentAgent?.id && "bg-muted/50",
+            )}
+          >
+            <AgentAvatarIcon agent={agent} size="sm" />
+            <span className="truncate">{agent.name}</span>
+            {agent.id === currentAgent?.id && (
+              <span className="ml-auto text-xs text-primary">●</span>
+            )}
+          </button>
+        ))}
       </FloatingMenu>
     </div>
   )

--- a/src/components/chat/hooks/chatPreparation.test.ts
+++ b/src/components/chat/hooks/chatPreparation.test.ts
@@ -2,11 +2,34 @@ import { describe, expect, it, vi } from "vitest"
 import type { ChatAttachment, Transport } from "@/lib/transport"
 import {
   beginChatBackendHandoff,
+  deferActiveTurnRelease,
   discardChatAttachmentUploads,
   loadingStateAfterPreparationRelease,
   shouldRollbackNonPersistedStoppedSend,
   validateChatAttachmentCount,
 } from "./chatPreparation"
+
+describe("deferActiveTurnRelease", () => {
+  it("keeps the turn visible through the current terminal event dispatch", async () => {
+    const turns = new Map([["session", "stopped-turn"]])
+
+    deferActiveTurnRelease(turns, "session", "stopped-turn")
+    expect(turns.get("session")).toBe("stopped-turn")
+
+    await Promise.resolve()
+    expect(turns.has("session")).toBe(false)
+  })
+
+  it("does not delete a replacement turn", async () => {
+    const turns = new Map([["session", "stopped-turn"]])
+
+    deferActiveTurnRelease(turns, "session", "stopped-turn")
+    turns.set("session", "replacement-turn")
+    await Promise.resolve()
+
+    expect(turns.get("session")).toBe("replacement-turn")
+  })
+})
 
 describe("shouldRollbackNonPersistedStoppedSend", () => {
   it("rolls back a remote preflight Stop without a local Stop marker", () => {
@@ -29,7 +52,9 @@ describe("discardChatAttachmentUploads", () => {
       { name: "upload", mime_type: "text/plain", upload_id: "lease-1" },
     ]
 
-    await expect(discardChatAttachmentUploads(attachments, transport, false)).resolves.toBeUndefined()
+    await expect(
+      discardChatAttachmentUploads(attachments, transport, false),
+    ).resolves.toBeUndefined()
     expect(discardChatAttachmentUpload).toHaveBeenCalledWith("lease-1")
   })
 

--- a/src/components/chat/hooks/chatPreparation.test.ts
+++ b/src/components/chat/hooks/chatPreparation.test.ts
@@ -4,8 +4,22 @@ import {
   beginChatBackendHandoff,
   discardChatAttachmentUploads,
   loadingStateAfterPreparationRelease,
+  shouldRollbackNonPersistedStoppedSend,
   validateChatAttachmentCount,
 } from "./chatPreparation"
+
+describe("shouldRollbackNonPersistedStoppedSend", () => {
+  it("rolls back a remote preflight Stop without a local Stop marker", () => {
+    expect(shouldRollbackNonPersistedStoppedSend(false, true, false, false)).toBe(true)
+  })
+
+  it("requires a local Stop marker for ambiguous preparation and active-stream errors", () => {
+    expect(shouldRollbackNonPersistedStoppedSend(false, false, true, false)).toBe(false)
+    expect(shouldRollbackNonPersistedStoppedSend(false, false, false, true)).toBe(false)
+    expect(shouldRollbackNonPersistedStoppedSend(true, false, true, false)).toBe(true)
+    expect(shouldRollbackNonPersistedStoppedSend(true, false, false, true)).toBe(true)
+  })
+})
 
 describe("discardChatAttachmentUploads", () => {
   it("does not wait for stalled cleanup after the send was stopped", async () => {

--- a/src/components/chat/hooks/chatPreparation.test.ts
+++ b/src/components/chat/hooks/chatPreparation.test.ts
@@ -2,9 +2,48 @@ import { describe, expect, it, vi } from "vitest"
 import type { ChatAttachment, Transport } from "@/lib/transport"
 import {
   beginChatBackendHandoff,
+  discardChatAttachmentUploads,
   loadingStateAfterPreparationRelease,
   validateChatAttachmentCount,
 } from "./chatPreparation"
+
+describe("discardChatAttachmentUploads", () => {
+  it("does not wait for stalled cleanup after the send was stopped", async () => {
+    const discardChatAttachmentUpload = vi.fn(() => new Promise<void>(() => {}))
+    const transport = { discardChatAttachmentUpload } as unknown as Transport
+    const attachments: ChatAttachment[] = [
+      { name: "upload", mime_type: "text/plain", upload_id: "lease-1" },
+    ]
+
+    await expect(discardChatAttachmentUploads(attachments, transport, false)).resolves.toBeUndefined()
+    expect(discardChatAttachmentUpload).toHaveBeenCalledWith("lease-1")
+  })
+
+  it("waits for cleanup on ordinary failures", async () => {
+    let resolveCleanup: (() => void) | undefined
+    const discardChatAttachmentUpload = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveCleanup = resolve
+        }),
+    )
+    const transport = { discardChatAttachmentUpload } as unknown as Transport
+    const attachments: ChatAttachment[] = [
+      { name: "upload", mime_type: "text/plain", upload_id: "lease-1" },
+    ]
+    let settled = false
+
+    const cleanup = discardChatAttachmentUploads(attachments, transport, true).then(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    resolveCleanup?.()
+    await cleanup
+    expect(settled).toBe(true)
+  })
+})
 
 describe("validateChatAttachmentCount", () => {
   it("releases Stop immediately while excess-upload cleanup is still pending", async () => {

--- a/src/components/chat/hooks/chatPreparation.test.ts
+++ b/src/components/chat/hooks/chatPreparation.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest"
+import type { ChatAttachment, Transport } from "@/lib/transport"
+import { validateChatAttachmentCount } from "./chatPreparation"
+
+describe("validateChatAttachmentCount", () => {
+  it("releases Stop immediately while excess-upload cleanup is still pending", async () => {
+    const discardChatAttachmentUpload = vi.fn(() => new Promise<void>(() => {}))
+    const transport = { discardChatAttachmentUpload } as unknown as Transport
+    const attachments: ChatAttachment[] = Array.from({ length: 65 }, (_, index) => ({
+      name: `upload-${index}`,
+      mime_type: "text/plain",
+      upload_id: `lease-${index}`,
+    }))
+    const controller = new AbortController()
+
+    const validation = validateChatAttachmentCount(
+      attachments,
+      transport,
+      "too many attachments",
+      controller.signal,
+    )
+    expect(discardChatAttachmentUpload).toHaveBeenCalledTimes(65)
+
+    controller.abort()
+    await expect(validation).rejects.toMatchObject({ name: "ChatPreparationCancelledError" })
+  })
+})

--- a/src/components/chat/hooks/chatPreparation.test.ts
+++ b/src/components/chat/hooks/chatPreparation.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
 import type { ChatAttachment, Transport } from "@/lib/transport"
-import { loadingStateAfterPreparationRelease, validateChatAttachmentCount } from "./chatPreparation"
+import {
+  beginChatBackendHandoff,
+  loadingStateAfterPreparationRelease,
+  validateChatAttachmentCount,
+} from "./chatPreparation"
 
 describe("validateChatAttachmentCount", () => {
   it("releases Stop immediately while excess-upload cleanup is still pending", async () => {
@@ -39,5 +43,24 @@ describe("loadingStateAfterPreparationRelease", () => {
       loadingStateAfterPreparationRelease("session-a", "session-a", new Set(["session-a"])),
     ).toBe(true)
     expect(loadingStateAfterPreparationRelease("__pending__", null, new Set())).toBe(false)
+  })
+})
+
+describe("beginChatBackendHandoff", () => {
+  it("does not publish a request when local Stop won the handoff", () => {
+    const backendStarted = new Set<string>()
+
+    expect(() =>
+      beginChatBackendHandoff("request-a", new Set(["request-a"]), backendStarted),
+    ).toThrowError("Chat preparation cancelled by user")
+    expect(backendStarted.has("request-a")).toBe(false)
+  })
+
+  it("marks backend ownership synchronously when Stop has not arrived", () => {
+    const backendStarted = new Set<string>()
+
+    beginChatBackendHandoff("request-a", new Set(), backendStarted)
+
+    expect(backendStarted.has("request-a")).toBe(true)
   })
 })

--- a/src/components/chat/hooks/chatPreparation.test.ts
+++ b/src/components/chat/hooks/chatPreparation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 import type { ChatAttachment, Transport } from "@/lib/transport"
-import { validateChatAttachmentCount } from "./chatPreparation"
+import { loadingStateAfterPreparationRelease, validateChatAttachmentCount } from "./chatPreparation"
 
 describe("validateChatAttachmentCount", () => {
   it("releases Stop immediately while excess-upload cleanup is still pending", async () => {
@@ -23,5 +23,21 @@ describe("validateChatAttachmentCount", () => {
 
     controller.abort()
     await expect(validation).rejects.toMatchObject({ name: "ChatPreparationCancelledError" })
+  })
+})
+
+describe("loadingStateAfterPreparationRelease", () => {
+  it("does not clear a different session's active loading state", () => {
+    expect(
+      loadingStateAfterPreparationRelease("session-a", "session-b", new Set(["session-b"])),
+    ).toBeUndefined()
+  })
+
+  it("reconciles the displayed session against active turns", () => {
+    expect(loadingStateAfterPreparationRelease("session-a", "session-a", new Set())).toBe(false)
+    expect(
+      loadingStateAfterPreparationRelease("session-a", "session-a", new Set(["session-a"])),
+    ).toBe(true)
+    expect(loadingStateAfterPreparationRelease("__pending__", null, new Set())).toBe(false)
   })
 })

--- a/src/components/chat/hooks/chatPreparation.ts
+++ b/src/components/chat/hooks/chatPreparation.ts
@@ -65,6 +65,26 @@ export function awaitUnlessAborted<T>(
   })
 }
 
+/**
+ * Start best-effort cleanup for staged attachment leases. A stopped send must
+ * release its composer state immediately even if the cleanup transport is
+ * stalled; ordinary failures still wait so their leases are settled before
+ * the error lifecycle completes.
+ */
+export async function discardChatAttachmentUploads(
+  attachments: ChatAttachment[],
+  transport: Transport,
+  waitForCompletion: boolean,
+): Promise<void> {
+  const cleanup = Promise.allSettled(
+    attachments
+      .map((attachment) => attachment.upload_id)
+      .filter((id): id is string => !!id)
+      .map((id) => transport.discardChatAttachmentUpload(id)),
+  )
+  if (waitForCompletion) await cleanup
+}
+
 export async function validateChatAttachmentCount(
   attachments: ChatAttachment[],
   transport: Transport,

--- a/src/components/chat/hooks/chatPreparation.ts
+++ b/src/components/chat/hooks/chatPreparation.ts
@@ -1,0 +1,67 @@
+import type { ChatAttachment, Transport } from "@/lib/transport"
+
+export class ChatPreparationCancelledError extends Error {
+  constructor() {
+    super("Chat preparation cancelled by user")
+    this.name = "ChatPreparationCancelledError"
+  }
+}
+
+export function isChatPreparationCancelled(error: unknown): boolean {
+  return error instanceof ChatPreparationCancelledError
+}
+
+export function awaitUnlessAborted<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+  onLateResolve?: (value: T) => void | Promise<void>,
+): Promise<T> {
+  if (!signal) return promise
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+    const onAbort = () => {
+      if (settled) return
+      settled = true
+      signal.removeEventListener("abort", onAbort)
+      reject(new ChatPreparationCancelledError())
+    }
+    promise.then(
+      (value) => {
+        if (settled) {
+          if (signal.aborted && onLateResolve) {
+            void Promise.resolve(onLateResolve(value)).catch(() => {})
+          }
+          return
+        }
+        settled = true
+        signal.removeEventListener("abort", onAbort)
+        resolve(value)
+      },
+      (error) => {
+        if (settled) return
+        settled = true
+        signal.removeEventListener("abort", onAbort)
+        reject(error)
+      },
+    )
+    if (signal.aborted) onAbort()
+    else signal.addEventListener("abort", onAbort, { once: true })
+  })
+}
+
+export async function validateChatAttachmentCount(
+  attachments: ChatAttachment[],
+  transport: Transport,
+  tooManyMessage: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (attachments.length <= 64) return
+  const cleanup = Promise.allSettled(
+    attachments
+      .map((attachment) => attachment.upload_id)
+      .filter((id): id is string => !!id)
+      .map((id) => transport.discardChatAttachmentUpload(id)),
+  )
+  await awaitUnlessAborted(cleanup, signal)
+  throw new Error(tooManyMessage)
+}

--- a/src/components/chat/hooks/chatPreparation.ts
+++ b/src/components/chat/hooks/chatPreparation.ts
@@ -85,6 +85,24 @@ export async function discardChatAttachmentUploads(
   if (waitForCompletion) await cleanup
 }
 
+/**
+ * A preflight Stop is authoritative regardless of which client initiated it:
+ * the backend guarantees that no user message was persisted. Preparation and
+ * active-stream errors are ambiguous, so only the local request's Stop marker
+ * may turn those into a draft rollback.
+ */
+export function shouldRollbackNonPersistedStoppedSend(
+  requestWasUserStopped: boolean,
+  preflightStopError: boolean,
+  preparationCancelled: boolean,
+  activeStreamError: boolean,
+): boolean {
+  return (
+    preflightStopError ||
+    (requestWasUserStopped && (preparationCancelled || activeStreamError))
+  )
+}
+
 export async function validateChatAttachmentCount(
   attachments: ChatAttachment[],
   transport: Transport,

--- a/src/components/chat/hooks/chatPreparation.ts
+++ b/src/components/chat/hooks/chatPreparation.ts
@@ -11,6 +11,22 @@ export function isChatPreparationCancelled(error: unknown): boolean {
   return error instanceof ChatPreparationCancelledError
 }
 
+/**
+ * Linearize local Stop against publishing the backend request. JavaScript
+ * executes the membership check and marker write in one synchronous turn, so
+ * Stop either wins here or observes backend ownership and calls `stop_chat`.
+ */
+export function beginChatBackendHandoff(
+  requestId: string,
+  stoppedRequestIds: ReadonlySet<string>,
+  backendStartedRequestIds: Set<string>,
+): void {
+  if (stoppedRequestIds.has(requestId)) {
+    throw new ChatPreparationCancelledError()
+  }
+  backendStartedRequestIds.add(requestId)
+}
+
 export function awaitUnlessAborted<T>(
   promise: Promise<T>,
   signal?: AbortSignal,

--- a/src/components/chat/hooks/chatPreparation.ts
+++ b/src/components/chat/hooks/chatPreparation.ts
@@ -65,3 +65,18 @@ export async function validateChatAttachmentCount(
   await awaitUnlessAborted(cleanup, signal)
   throw new Error(tooManyMessage)
 }
+
+/**
+ * Resolve the visible loading state when one session's local preparation ends.
+ * `undefined` means the completed request belongs to a background session and
+ * must not mutate the currently displayed session's loading indicator.
+ */
+export function loadingStateAfterPreparationRelease(
+  requestSessionKey: string,
+  currentSessionId: string | null,
+  loadingSessionIds: ReadonlySet<string>,
+): boolean | undefined {
+  const currentSessionKey = currentSessionId ?? "__pending__"
+  if (requestSessionKey !== currentSessionKey) return undefined
+  return currentSessionId ? loadingSessionIds.has(currentSessionId) : false
+}

--- a/src/components/chat/hooks/chatPreparation.ts
+++ b/src/components/chat/hooks/chatPreparation.ts
@@ -98,8 +98,7 @@ export function shouldRollbackNonPersistedStoppedSend(
   activeStreamError: boolean,
 ): boolean {
   return (
-    preflightStopError ||
-    (requestWasUserStopped && (preparationCancelled || activeStreamError))
+    preflightStopError || (requestWasUserStopped && (preparationCancelled || activeStreamError))
   )
 }
 
@@ -133,4 +132,23 @@ export function loadingStateAfterPreparationRelease(
   const currentSessionKey = currentSessionId ?? "__pending__"
   if (requestSessionKey !== currentSessionKey) return undefined
   return currentSessionId ? loadingSessionIds.has(currentSessionId) : false
+}
+
+/**
+ * Keep the exact turn identity visible to every listener handling the current
+ * terminal event. Some consumers use a later listener to clear loading; an
+ * immediate delete in an earlier listener would make that same event look
+ * stale. The exact-id check prevents the deferred cleanup from deleting a
+ * replacement turn that starts in the meantime.
+ */
+export function deferActiveTurnRelease(
+  activeTurns: Map<string, string>,
+  sessionId: string,
+  turnId: string,
+): void {
+  queueMicrotask(() => {
+    if (activeTurns.get(sessionId) === turnId) {
+      activeTurns.delete(sessionId)
+    }
+  })
 }

--- a/src/components/chat/hooks/pendingQueue.test.ts
+++ b/src/components/chat/hooks/pendingQueue.test.ts
@@ -4,6 +4,7 @@ import {
   hasSendableChatPayload,
   nextDispatchablePending,
   shouldApplyPendingQueueSnapshot,
+  shouldReplayNextPending,
 } from "./pendingQueue"
 
 describe("durable pending queue projection", () => {
@@ -25,5 +26,27 @@ describe("durable pending queue projection", () => {
   test("allows a durable attachment-only row to reach the backend", () => {
     expect(hasSendableChatPayload("", false, false, "queued-request")).toBe(true)
     expect(hasSendableChatPayload("", false, false)).toBe(false)
+  })
+
+  test("does not replay after a user Stop from another surface", () => {
+    expect(
+      shouldReplayNextPending(false, {
+        status: "interrupted",
+        interruptReason: "user_stop",
+      }),
+    ).toBe(false)
+    expect(
+      shouldReplayNextPending(false, {
+        status: "cancelling",
+        interruptReason: "user_stop",
+      }),
+    ).toBe(false)
+    expect(shouldReplayNextPending(true, { status: "completed" })).toBe(false)
+    expect(
+      shouldReplayNextPending(false, {
+        status: "interrupted",
+        interruptReason: "runtime_cancel",
+      }),
+    ).toBe(true)
   })
 })

--- a/src/components/chat/hooks/pendingQueue.ts
+++ b/src/components/chat/hooks/pendingQueue.ts
@@ -1,4 +1,4 @@
-import type { PendingSendStatus } from "@/types/chat"
+import type { ChatTurnInterruptReason, ChatTurnStatus, PendingSendStatus } from "@/types/chat"
 
 export interface PendingQueueItemLike {
   id: string
@@ -17,6 +17,16 @@ export function nextDispatchablePending<T extends PendingQueueItemLike>(
   items: readonly T[],
 ): T | undefined {
   return items.find((item) => item.status === "queued" || item.status === "fallback_after_reply")
+}
+
+export function shouldReplayNextPending(
+  wasLocallyStopped: boolean,
+  turnState?: {
+    status: ChatTurnStatus
+    interruptReason?: ChatTurnInterruptReason | null
+  },
+): boolean {
+  return !wasLocallyStopped && turnState?.interruptReason !== "user_stop"
 }
 
 export function hasSendableChatPayload(

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -72,6 +72,7 @@ import {
   awaitUnlessAborted,
   ChatPreparationCancelledError,
   isChatPreparationCancelled,
+  loadingStateAfterPreparationRelease,
   validateChatAttachmentCount,
 } from "./chatPreparation"
 
@@ -1530,7 +1531,12 @@ export function useChatStream({
     }
     const releasePreparationLoading = () => {
       if (chatRequestOwnerBySessionRef.current.get(chatRequestOwnerKey) === chatRequestOwnerId) {
-        setLoading(false)
+        const nextLoading = loadingStateAfterPreparationRelease(
+          chatRequestOwnerKey,
+          currentSessionIdRef.current,
+          loadingSessionsRef.current,
+        )
+        if (nextLoading !== undefined) setLoading(nextLoading)
       }
     }
     bindChatRequestOwner(chatRequestOwnerKey)

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -44,9 +44,13 @@ import {
   discardAllPendingStreamDeltas,
   discardPendingStreamDeltas,
   handleStreamEvent,
+  isStreamEnded,
+  markStreamActive,
+  markStreamEnded,
   streamCursorKey,
   streamIdFromEvent,
   streamIdFromPayload,
+  type EndedStreamIds,
 } from "./useStreamEventHandler"
 import { useApprovals } from "./useApprovals"
 import { generateClientId } from "@/components/chat/chatScrollKeys"
@@ -67,7 +71,57 @@ import {
 
 const ACTIVE_STREAM_ERROR_CODE = "active_stream"
 const QUEUED_MESSAGE_UNAVAILABLE_ERROR_CODE = "queued_message_unavailable"
+const CHAT_CANCELLED_DURING_PREFLIGHT_CODE = "chat_cancelled_during_preflight"
 const CHAT_NOTIFICATION_PREVIEW_MAX_CHARS = 220
+
+class ChatPreparationCancelledError extends Error {
+  constructor() {
+    super("Chat preparation cancelled by user")
+    this.name = "ChatPreparationCancelledError"
+  }
+}
+
+function isChatPreparationCancelled(error: unknown): boolean {
+  return error instanceof ChatPreparationCancelledError
+}
+
+function awaitUnlessAborted<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+  onLateResolve?: (value: T) => void | Promise<void>,
+): Promise<T> {
+  if (!signal) return promise
+  return new Promise<T>((resolve, reject) => {
+    let settled = false
+    const onAbort = () => {
+      if (settled) return
+      settled = true
+      signal.removeEventListener("abort", onAbort)
+      reject(new ChatPreparationCancelledError())
+    }
+    promise.then(
+      (value) => {
+        if (settled) {
+          if (signal.aborted && onLateResolve) {
+            void Promise.resolve(onLateResolve(value)).catch(() => {})
+          }
+          return
+        }
+        settled = true
+        signal.removeEventListener("abort", onAbort)
+        resolve(value)
+      },
+      (error) => {
+        if (settled) return
+        settled = true
+        signal.removeEventListener("abort", onAbort)
+        reject(error)
+      },
+    )
+    if (signal.aborted) onAbort()
+    else signal.addEventListener("abort", onAbort, { once: true })
+  })
+}
 
 function errorText(error: unknown): string {
   if (error instanceof Error) return error.message
@@ -89,6 +143,10 @@ function isQueuedMessageUnavailableError(error: unknown): boolean {
     text.includes(QUEUED_MESSAGE_UNAVAILABLE_ERROR_CODE) ||
     text.includes("Queued message is no longer available")
   )
+}
+
+function isPreflightStopError(error: unknown): boolean {
+  return errorText(error).includes(CHAT_CANCELLED_DURING_PREFLIGHT_CODE)
 }
 
 function normalizeNotificationText(text: string): string {
@@ -295,7 +353,7 @@ export interface UseChatStreamOptions {
   lastSeqRef: React.MutableRefObject<Map<string, number>>
   /** Latest stream id that has ended for each session. Used to drop delayed
    *  primary frames that arrive after DB reconciliation. */
-  endedStreamIdsRef: React.MutableRefObject<Map<string, string>>
+  endedStreamIdsRef: React.MutableRefObject<EndedStreamIds>
   /** Current plan mode state, passed to backend chat() for reliable sync */
   planMode?: string
   /** Session-level temperature override (0.0–2.0). Overrides agent and global settings. */
@@ -411,7 +469,8 @@ export interface UseChatStreamReturn {
     sessionId: string,
     status?: ChatTurnStatus | null,
     interruptReason?: ChatTurnInterruptReason | null,
-  ) => void
+    turnId?: string | null,
+  ) => boolean
   executionStateBySession: Map<string, ChatTurnStatus>
 }
 
@@ -755,6 +814,17 @@ export function useChatStream({
     Map<string, ChatTurnStatus>
   >(() => new Map())
   const activeTurnBySessionRef = useRef<Map<string, string>>(new Map())
+  // A stop watchdog may durably finish and release a turn before the original
+  // transport promise unwinds.  Track which request currently owns each
+  // session's optimistic/loading lifecycle so a late `finally` from the old
+  // request cannot remove the new turn's placeholder or clear its loading bit.
+  const chatRequestOwnerBySessionRef = useRef<Map<string, string>>(new Map())
+  const userStoppedRequestIdsRef = useRef<Set<string>>(new Set())
+  // A request id is only useful to the backend after startChat has begun. A
+  // Stop during local attachment preparation should stay local; sending it to
+  // the backend would create a never-consumed pre-registration cancel latch.
+  const backendStartedRequestIdsRef = useRef<Set<string>>(new Set())
+  const preparationAbortByRequestRef = useRef<Map<string, AbortController>>(new Map())
   const lastTurnStatusBySessionRef = useRef<
     Map<string, { status: ChatTurnStatus; interruptReason?: ChatTurnInterruptReason | null }>
   >(new Map())
@@ -853,6 +923,24 @@ export function useChatStream({
       } | null
       const sid = payload?.sessionId
       if (!sid) return
+      const streamId = streamIdFromPayload(raw)
+      const currentTurnId = activeTurnBySessionRef.current.get(sid)
+      if (payload.turnId && !currentTurnId && chatRequestOwnerBySessionRef.current.has(sid)) {
+        // A new request already owns the session but has not received its
+        // turn_started yet. The backend guarantees started-before-terminal
+        // for that request, so this terminal event can only belong to the old
+        // turn and must not occupy the new request's empty turn-id slot.
+        markStreamEnded(endedStreamIdsRef.current, sid, streamId)
+        if (streamId) discardPendingStreamDeltas(sid, deltaBuffersRef, streamId)
+        return
+      }
+      if (payload?.turnId && currentTurnId && currentTurnId !== payload.turnId) {
+        // A delayed terminal event from the watchdog/transport belongs to an
+        // older turn.  Never let it overwrite a newer turn's running state.
+        markStreamEnded(endedStreamIdsRef.current, sid, streamId)
+        if (streamId) discardPendingStreamDeltas(sid, deltaBuffersRef, streamId)
+        return
+      }
       if (payload?.turnId) activeTurnBySessionRef.current.delete(sid)
       if (payload?.status) {
         lastTurnStatusBySessionRef.current.set(sid, {
@@ -861,9 +949,8 @@ export function useChatStream({
         })
         setExecutionStateBySession((prev) => new Map(prev).set(sid, payload.status!))
       }
-      const streamId = streamIdFromPayload(raw)
-      if (streamId) endedStreamIdsRef.current.set(sid, streamId)
-      discardPendingStreamDeltas(sid, deltaBuffersRef)
+      markStreamEnded(endedStreamIdsRef.current, sid, streamId)
+      discardPendingStreamDeltas(sid, deltaBuffersRef, streamId ?? null)
     })
     return () => {
       unlisten()
@@ -881,6 +968,11 @@ export function useChatStream({
       } | null
       const sid = payload?.sessionId
       if (!sid || !payload?.status) return
+      const currentTurnId = activeTurnBySessionRef.current.get(sid)
+      if (payload.turnId && !currentTurnId && chatRequestOwnerBySessionRef.current.has(sid)) {
+        return
+      }
+      if (payload.turnId && currentTurnId && currentTurnId !== payload.turnId) return
       if (payload.turnId) activeTurnBySessionRef.current.set(sid, payload.turnId)
       lastTurnStatusBySessionRef.current.set(sid, {
         status: payload.status,
@@ -1058,6 +1150,11 @@ export function useChatStream({
   async function handleStop() {
     const sid = currentSessionIdRef.current ?? currentSessionId ?? null
     if (!sid) {
+      const pendingRequestOwner = chatRequestOwnerBySessionRef.current.get("__pending__")
+      if (pendingRequestOwner) {
+        userStoppedRequestIdsRef.current.add(pendingRequestOwner)
+        preparationAbortByRequestRef.current.get(pendingRequestOwner)?.abort()
+      }
       if (draftProjectBootstrap) {
         try {
           await getTransport().call("cancel_project_bootstrap", {
@@ -1066,16 +1163,36 @@ export function useChatStream({
         } catch (e) {
           logger.error("ui", "ChatScreen::stopBootstrap", "Failed to stop project task setup", e)
         }
+      }
+      if (pendingRequestOwner) {
+        if (!backendStartedRequestIdsRef.current.has(pendingRequestOwner)) return
+        try {
+          await getTransport().call("stop_chat", {
+            sessionId: null,
+            turnId: null,
+            clientRequestId: pendingRequestOwner,
+          })
+        } catch (e) {
+          logger.error("ui", "ChatScreen::stopPending", "Failed to stop pending chat", e)
+        }
         return
       }
       const active = Array.from(activeTurnBySessionRef.current.entries()).at(-1)
       if (!active) return
       const [activeSid, activeTurnId] = active
+      const requestOwner =
+        chatRequestOwnerBySessionRef.current.get(activeSid) ??
+        chatRequestOwnerBySessionRef.current.get("__pending__")
+      if (requestOwner) {
+        userStoppedRequestIdsRef.current.add(requestOwner)
+        preparationAbortByRequestRef.current.get(requestOwner)?.abort()
+      }
       setExecutionStateBySession((prev) => new Map(prev).set(activeSid, "cancelling"))
       try {
         await getTransport().call("stop_chat", {
           sessionId: activeSid,
           turnId: activeTurnId,
+          clientRequestId: requestOwner,
         })
       } catch (e) {
         logger.error("ui", "ChatScreen::stop", "Failed to stop chat", e)
@@ -1083,11 +1200,20 @@ export function useChatStream({
       return
     }
     const activeTurnId = activeTurnBySessionRef.current.get(sid) ?? null
+    const requestOwner = chatRequestOwnerBySessionRef.current.get(sid)
+    if (requestOwner) {
+      userStoppedRequestIdsRef.current.add(requestOwner)
+      preparationAbortByRequestRef.current.get(requestOwner)?.abort()
+    }
+    if (requestOwner && !activeTurnId && !backendStartedRequestIdsRef.current.has(requestOwner)) {
+      return
+    }
     setExecutionStateBySession((prev) => new Map(prev).set(sid, "cancelling"))
     try {
       await getTransport().call("stop_chat", {
         sessionId: sid,
         turnId: activeTurnId,
+        clientRequestId: requestOwner,
       })
     } catch (e) {
       logger.error("ui", "ChatScreen::stop", "Failed to stop chat", e)
@@ -1105,7 +1231,13 @@ export function useChatStream({
       sessionId: string,
       status?: ChatTurnStatus | null,
       interruptReason?: ChatTurnInterruptReason | null,
+      turnId?: string | null,
     ) => {
+      const currentTurnId = activeTurnBySessionRef.current.get(sessionId)
+      if (turnId && !currentTurnId && chatRequestOwnerBySessionRef.current.has(sessionId)) {
+        return false
+      }
+      if (turnId && currentTurnId && currentTurnId !== turnId) return false
       activeTurnBySessionRef.current.delete(sessionId)
       if (status) {
         lastTurnStatusBySessionRef.current.set(sessionId, {
@@ -1114,6 +1246,7 @@ export function useChatStream({
         })
         setExecutionStateBySession((prev) => new Map(prev).set(sessionId, status))
       }
+      return true
     },
     [],
   )
@@ -1125,14 +1258,15 @@ export function useChatStream({
   )
 
   const ensureAttachmentCount = useCallback(
-    async (attachments: ChatAttachment[], transport: Transport) => {
+    async (attachments: ChatAttachment[], transport: Transport, signal?: AbortSignal) => {
       if (attachments.length <= 64) return
-      await Promise.allSettled(
+      const cleanup = Promise.allSettled(
         attachments
           .map((attachment) => attachment.upload_id)
           .filter((id): id is string => !!id)
           .map((id) => transport.discardChatAttachmentUpload(id)),
       )
+      await awaitUnlessAborted(cleanup, signal)
       throw new Error(t("attachments.tooMany", "A message can contain at most 64 files"))
     },
     [t],
@@ -1146,8 +1280,11 @@ export function useChatStream({
       messageQuotesToSend: PendingMessageQuote[],
       targetSessionId: string | null,
       transport: Transport,
+      signal?: AbortSignal,
     ): Promise<ChatAttachment[]> => {
       const attachments: ChatAttachment[] = []
+
+      if (signal?.aborted) throw new ChatPreparationCancelledError()
 
       const sessionWorkingDir = sessions.find((s) => s.id === targetSessionId)?.workingDir ?? null
       const resolvedWorkingDir = targetSessionId ? sessionWorkingDir : draftWorkingDir
@@ -1156,7 +1293,10 @@ export function useChatStream({
         attachments.push(m)
       }
 
-      const planAttachments = await expandPlanMentionsToAttachments(text)
+      const planAttachments = await awaitUnlessAborted(
+        expandPlanMentionsToAttachments(text),
+        signal,
+      )
       for (const p of planAttachments) {
         attachments.push(p)
       }
@@ -1165,13 +1305,15 @@ export function useChatStream({
         throw new Error(t("attachments.tooMany", "A message can contain at most 64 files"))
       const unavailable = filesToSend.find((draft) => draft.status === "error")
       if (unavailable) {
-        throw new Error(
-          unavailable.error ||
-            t("attachments.uploadFailedShort", "Upload failed"),
-        )
+        throw new Error(unavailable.error || t("attachments.uploadFailedShort", "Upload failed"))
       }
       if (filesToSend.length > 0) {
-        const filesystemConfig = await readFilesystemConfig(transport).catch(() => null)
+        let filesystemConfig: Awaited<ReturnType<typeof readFilesystemConfig>> | null = null
+        try {
+          filesystemConfig = await awaitUnlessAborted(readFilesystemConfig(transport), signal)
+        } catch (error) {
+          if (isChatPreparationCancelled(error)) throw error
+        }
         if (filesystemConfig) {
           const configuredMaxBytes = attachmentBytesForConfig(filesystemConfig)
           const oversized = filesToSend.find((draft) => draft.file.size > configuredMaxBytes)
@@ -1191,24 +1333,31 @@ export function useChatStream({
       let cursor = 0
       let failure: unknown = null
       const worker = async () => {
-        while (!failure) {
+        while (!failure && !signal?.aborted) {
           const index = cursor
           cursor += 1
           if (index >= filesToSend.length) return
           try {
-            leases[index] = await transport.stageChatAttachment(filesToSend[index].file)
+            leases[index] = await awaitUnlessAborted(
+              transport.stageChatAttachment(filesToSend[index].file),
+              signal,
+              (lease) => transport.discardChatAttachmentUpload(lease.uploadId),
+            )
           } catch (error) {
             failure = error
           }
         }
       }
       await Promise.all(Array.from({ length: Math.min(3, filesToSend.length) }, () => worker()))
+      if (signal?.aborted && !failure) failure = new ChatPreparationCancelledError()
       if (failure) {
-        await Promise.allSettled(
+        const cleanup = Promise.allSettled(
           leases
             .filter((lease): lease is NonNullable<typeof lease> => !!lease)
             .map((lease) => transport.discardChatAttachmentUpload(lease.uploadId)),
         )
+        if (isChatPreparationCancelled(failure)) void cleanup
+        else await cleanup
         throw failure
       }
       for (let index = 0; index < filesToSend.length; index += 1) {
@@ -1407,6 +1556,35 @@ export function useChatStream({
     const messageQuotesToSend = [...draftMessageQuotes]
     const displayed = options?.displayText?.trim() || text
     const sendSessionId = options?.sessionIdOverride ?? currentSessionId
+    const chatRequestOwnerId = generateClientId()
+    const preparationAbort = new AbortController()
+    preparationAbortByRequestRef.current.set(chatRequestOwnerId, preparationAbort)
+    let chatRequestOwnerKey = sendSessionId ?? "__pending__"
+    const bindChatRequestOwner = (nextKey: string) => {
+      if (
+        chatRequestOwnerKey !== nextKey &&
+        chatRequestOwnerBySessionRef.current.get(chatRequestOwnerKey) === chatRequestOwnerId
+      ) {
+        chatRequestOwnerBySessionRef.current.delete(chatRequestOwnerKey)
+      }
+      chatRequestOwnerKey = nextKey
+      chatRequestOwnerBySessionRef.current.set(nextKey, chatRequestOwnerId)
+    }
+    const releaseChatRequestOwner = () => {
+      if (chatRequestOwnerBySessionRef.current.get(chatRequestOwnerKey) === chatRequestOwnerId) {
+        chatRequestOwnerBySessionRef.current.delete(chatRequestOwnerKey)
+      }
+    }
+    const releasePreparationLoading = () => {
+      if (chatRequestOwnerBySessionRef.current.get(chatRequestOwnerKey) === chatRequestOwnerId) {
+        setLoading(false)
+      }
+    }
+    bindChatRequestOwner(chatRequestOwnerKey)
+    // Attachment/mention preparation is part of the active send lifecycle.
+    // Expose Stop immediately instead of waiting until optimistic messages are
+    // created; handleStop aborts this request locally before startChat exists.
+    setLoading(true)
     if (options?.sessionIdOverride) {
       currentSessionIdRef.current = options.sessionIdOverride
       setCurrentSessionId(options.sessionIdOverride)
@@ -1433,12 +1611,32 @@ export function useChatStream({
             messageQuotesToSend,
             sendSessionId,
             sendTransport,
+            preparationAbort.signal,
           )
       if (getExtraAttachments && !options?.queuedRequestId) {
         attachments.push(...getExtraAttachments())
       }
-      await ensureAttachmentCount(attachments, sendTransport)
+      await ensureAttachmentCount(attachments, sendTransport, preparationAbort.signal)
     } catch (error) {
+      preparationAbortByRequestRef.current.delete(chatRequestOwnerId)
+      releasePreparationLoading()
+      releaseChatRequestOwner()
+      if (
+        isChatPreparationCancelled(error) ||
+        userStoppedRequestIdsRef.current.delete(chatRequestOwnerId)
+      ) {
+        userStoppedRequestIdsRef.current.delete(chatRequestOwnerId)
+        if (usesComposerDraft && sendingDraftIds.size > 0) {
+          setAttachedFiles((existing) =>
+            existing.map((draft) =>
+              sendingDraftIds.has(draft.id)
+                ? { ...draft, status: "ready", error: undefined }
+                : draft,
+            ),
+          )
+        }
+        return
+      }
       logger.error("ui", "useChatStream::attachment", "Attachment upload failed", error)
       toast.error(
         t("attachments.uploadFailed", "Files were not sent. {{error}}", {
@@ -1459,6 +1657,28 @@ export function useChatStream({
         )
       }
       options?.onPreparationError?.(error)
+      return
+    }
+    preparationAbortByRequestRef.current.delete(chatRequestOwnerId)
+    // Stop can arrive while files/quotes are still being staged, before the
+    // backend knows this request. In that window the request id is the local
+    // cancellation authority: discard leases and leave the composer intact.
+    if (userStoppedRequestIdsRef.current.delete(chatRequestOwnerId)) {
+      releasePreparationLoading()
+      void Promise.allSettled(
+        attachments
+          .map((attachment) => attachment.upload_id)
+          .filter((id): id is string => !!id)
+          .map((id) => sendTransport.discardChatAttachmentUpload(id)),
+      )
+      if (usesComposerDraft && sendingDraftIds.size > 0) {
+        setAttachedFiles((existing) =>
+          existing.map((draft) =>
+            sendingDraftIds.has(draft.id) ? { ...draft, status: "ready", error: undefined } : draft,
+          ),
+        )
+      }
+      releaseChatRequestOwner()
       return
     }
     const optimisticQuoteAttachments: MessageAttachment[] = quotesToSend.map((q) => ({
@@ -1610,6 +1830,7 @@ export function useChatStream({
         }
 
         targetSessionId = event.session_id
+        bindChatRequestOwner(event.session_id)
         // Bridge the ref lag: `setCurrentSessionId` below only updates
         // `currentSessionIdRef` after React commits, but the user is already on
         // this freshly-materialized session. Set it eagerly so the mark-as-read
@@ -1649,7 +1870,7 @@ export function useChatStream({
 
       const shouldDropStreamEvent = (event: Record<string, unknown>, sid: string): boolean => {
         const streamId = streamIdFromEvent(event)
-        if (streamId && endedStreamIdsRef.current.get(sid) === streamId) return true
+        if (isStreamEnded(endedStreamIdsRef.current, sid, streamId)) return true
 
         // Primary path bumps the seq cursor so identical events arriving
         // later via the EventBus reattach listener are dropped.
@@ -1739,11 +1960,13 @@ export function useChatStream({
 
       const modelOverride = modelOverrideFromManualSelection(manualModelOverrideRef?.current)
       const effectivePlanMode = options?.planMode ?? planMode
+      backendStartedRequestIdsRef.current.add(chatRequestOwnerId)
       await sendTransport.startChat(
         {
           message: text,
           attachments,
           sessionId: sendSessionId,
+          clientRequestId: chatRequestOwnerId,
           incognito: sendSessionId ? undefined : incognitoEnabled,
           sessionDefaults: sendSessionId
             ? undefined
@@ -1815,23 +2038,28 @@ export function useChatStream({
           .map((id) => sendTransport.discardChatAttachmentUpload(id)),
       )
       const sid = targetSessionId || "__pending__"
+      const ownsRequestLifecycleNow =
+        chatRequestOwnerBySessionRef.current.get(sid) === chatRequestOwnerId
+      const requestWasUserStopped = userStoppedRequestIdsRef.current.has(chatRequestOwnerId)
       const bootstrapFailedBeforeSession =
         !sendSessionId && sid === "__pending__" && !!draftProjectBootstrap
-      if (bootstrapFailedBeforeSession) {
+      if (requestWasUserStopped && isPreflightStopError(e)) {
+        updateSessionMessages(sid, (prev) =>
+          prev.filter(
+            (message) =>
+              message._clientId !== assistantPlaceholderClientId &&
+              message._clientId !== optimisticUserClientId,
+          ),
+        )
+        if (!options?.queuedRequestId) restoreUnsentDraft()
+      } else if (bootstrapFailedBeforeSession) {
         onProjectBootstrapFailure?.(e instanceof Error ? e.message : String(e))
         updateSessionMessages(sid, (prev) => {
-          const updated = [...prev]
-          const last = updated[updated.length - 1]
-          if (last?.role === "assistant" && !last.content && !last.toolCalls?.length) updated.pop()
-          const maybeUser = updated[updated.length - 1]
-          if (
-            maybeUser?.role === "user" &&
-            maybeUser.content === displayed &&
-            maybeUser.timestamp === now
-          ) {
-            updated.pop()
-          }
-          return updated
+          return prev.filter(
+            (message) =>
+              message._clientId !== assistantPlaceholderClientId &&
+              message._clientId !== optimisticUserClientId,
+          )
         })
         restoreUnsentDraft()
       } else if (
@@ -1843,27 +2071,11 @@ export function useChatStream({
         // errors may already have saved server-side, so keep those visible.
         keepExistingStreamLoading = true
         updateSessionMessages(sid, (prev) => {
-          const updated = [...prev]
-          const last = updated[updated.length - 1]
-          if (
-            last &&
-            last.role === "assistant" &&
-            !last.content &&
-            !last.toolCalls?.length &&
-            !last.contentBlocks?.length
-          ) {
-            updated.pop()
-          }
-          const maybeUser = updated[updated.length - 1]
-          if (
-            maybeUser &&
-            maybeUser.role === "user" &&
-            maybeUser.content === displayed &&
-            maybeUser.timestamp === now
-          ) {
-            updated.pop()
-          }
-          return updated
+          return prev.filter(
+            (message) =>
+              message._clientId !== assistantPlaceholderClientId &&
+              message._clientId !== optimisticUserClientId,
+          )
         })
         restoreUnsentDraft()
         try {
@@ -1884,7 +2096,7 @@ export function useChatStream({
             setExecutionStateBySession((prev) => new Map(prev).set(sid, state.status!))
           }
           const streamId = state.streamId || undefined
-          if (streamId) endedStreamIdsRef.current.delete(sid)
+          markStreamActive(endedStreamIdsRef.current, sid, streamId)
           const cursorKey = streamCursorKey(sid, streamId)
           if (!lastSeqRef.current.has(cursorKey)) {
             lastSeqRef.current.set(cursorKey, Number(state.lastSeq) || 0)
@@ -1899,11 +2111,13 @@ export function useChatStream({
         }
       } else {
         updateSessionMessages(sid, (prev) => {
-          const updated = [...prev]
-          const last = updated[updated.length - 1]
-          if (last && last.role === "assistant" && last.content === "" && !last.toolCalls?.length) {
-            updated.pop()
-          }
+          const updated = prev.filter(
+            (message) => message._clientId !== assistantPlaceholderClientId,
+          )
+          // A late failure from an older request is already represented by
+          // its durable terminal row.  Do not append that transient error
+          // after a newer turn's optimistic messages.
+          if (!ownsRequestLifecycleNow) return updated
           // isTurnError：可靠的失败信号（仅真抛错才 push，绝非 reconcile 未决的空成功）——
           // 让设计对话等消费端可给出一键重试，而不必用会误报的「空内容」启发式。
           updated.push({ role: "event", content: `${e}`, isTurnError: true })
@@ -1933,6 +2147,7 @@ export function useChatStream({
       }
       // Notify on error for non-current sessions
       if (
+        ownsRequestLifecycleNow &&
         !keepExistingStreamLoading &&
         targetSessionId &&
         currentSessionIdRef.current !== targetSessionId
@@ -1952,39 +2167,50 @@ export function useChatStream({
         }
       }
     } finally {
+      preparationAbortByRequestRef.current.delete(chatRequestOwnerId)
+      backendStartedRequestIdsRef.current.delete(chatRequestOwnerId)
       const sid = targetSessionId || "__pending__"
-      // Clean up empty assistant message if chat was stopped before any response arrived
+      const ownsRequestLifecycle =
+        chatRequestOwnerBySessionRef.current.get(sid) === chatRequestOwnerId
+      const wasUserStopped = userStoppedRequestIdsRef.current.delete(chatRequestOwnerId)
+      // Remove only this request's placeholder.  A watchdog can release the
+      // session before this promise settles; using "last empty assistant"
+      // here would delete a newer turn's placeholder.
       updateSessionMessages(sid, (prev) => {
-        const updated = [...prev]
-        const last = updated[updated.length - 1]
+        const index = prev.findIndex(
+          (message) => message._clientId === assistantPlaceholderClientId,
+        )
+        if (index < 0) return prev
+        const candidate = prev[index]
         if (
-          last &&
-          last.role === "assistant" &&
-          !last.content &&
-          !last.toolCalls?.length &&
-          !last.contentBlocks?.length
+          candidate.role === "assistant" &&
+          !candidate.content &&
+          !candidate.toolCalls?.length &&
+          !candidate.contentBlocks?.length
         ) {
-          updated.pop()
+          return [...prev.slice(0, index), ...prev.slice(index + 1)]
         }
-        return updated
+        return prev
       })
-      if (keepExistingStreamLoading && sid !== "__pending__") {
-        loadingSessionsRef.current.add(sid)
-        setLoadingSessionIds(new Set(loadingSessionsRef.current))
-        if (currentSessionIdRef.current === sid) {
-          setLoading(true)
-        }
-      } else {
-        loadingSessionsRef.current.delete(sid)
-        setLoadingSessionIds(new Set(loadingSessionsRef.current))
-        if (currentSessionIdRef.current === sid) {
-          setLoading(false)
+      if (ownsRequestLifecycle) {
+        if (keepExistingStreamLoading && sid !== "__pending__") {
+          loadingSessionsRef.current.add(sid)
+          setLoadingSessionIds(new Set(loadingSessionsRef.current))
+          if (currentSessionIdRef.current === sid) {
+            setLoading(true)
+          }
+        } else {
+          loadingSessionsRef.current.delete(sid)
+          setLoadingSessionIds(new Set(loadingSessionsRef.current))
+          if (currentSessionIdRef.current === sid) {
+            setLoading(false)
+          }
         }
       }
       // Notify on completion. Existing behavior: always notify for a
       // different session. For the active session, only surface an OS
       // notification when the app window is no longer foregrounded.
-      if (!keepExistingStreamLoading && chatResolved && targetSessionId) {
+      if (ownsRequestLifecycle && !keepExistingStreamLoading && chatResolved && targetSessionId) {
         const agent = agents.find((a) => a.id === currentAgentId)
         if (isAgentNotifyEnabled(agent?.notifyOnComplete)) {
           const status = lastTurnStatusBySessionRef.current.get(targetSessionId)?.status
@@ -2020,6 +2246,8 @@ export function useChatStream({
         const queue = await syncPendingSends(targetSessionId).catch(() => [])
         const queued = nextDispatchablePending(queue)
         if (
+          ownsRequestLifecycle &&
+          !wasUserStopped &&
           queued &&
           currentSessionIdRef.current === targetSessionId &&
           (queued.isPlanTrigger || queued.goalTrigger || autoSendPendingRef.current)
@@ -2035,6 +2263,7 @@ export function useChatStream({
           autoSendRef.current = true
         }
       }
+      if (ownsRequestLifecycle) releaseChatRequestOwner()
     }
   }
 

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -70,6 +70,7 @@ import {
 } from "../autoSendPendingPreference"
 import {
   awaitUnlessAborted,
+  beginChatBackendHandoff,
   ChatPreparationCancelledError,
   isChatPreparationCancelled,
   loadingStateAfterPreparationRelease,
@@ -1919,7 +1920,14 @@ export function useChatStream({
 
       const modelOverride = modelOverrideFromManualSelection(manualModelOverrideRef?.current)
       const effectivePlanMode = options?.planMode ?? planMode
-      backendStartedRequestIdsRef.current.add(chatRequestOwnerId)
+      // This synchronous check+mark is the handoff linearization point. Stop
+      // either cancelled the local request already, or it will observe backend
+      // ownership and send `stop_chat` (which can latch before turn_started).
+      beginChatBackendHandoff(
+        chatRequestOwnerId,
+        userStoppedRequestIdsRef.current,
+        backendStartedRequestIdsRef.current,
+      )
       await sendTransport.startChat(
         {
           message: text,
@@ -2002,7 +2010,12 @@ export function useChatStream({
       const requestWasUserStopped = userStoppedRequestIdsRef.current.has(chatRequestOwnerId)
       const bootstrapFailedBeforeSession =
         !sendSessionId && sid === "__pending__" && !!draftProjectBootstrap
-      if (requestWasUserStopped && isPreflightStopError(e)) {
+      if (
+        requestWasUserStopped &&
+        (isPreflightStopError(e) ||
+          isChatPreparationCancelled(e) ||
+          isActiveStreamError(e))
+      ) {
         updateSessionMessages(sid, (prev) =>
           prev.filter(
             (message) =>

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -68,60 +68,17 @@ import {
   AUTO_SEND_PENDING_EVENT,
   normalizeAutoSendPendingPreference,
 } from "../autoSendPendingPreference"
+import {
+  awaitUnlessAborted,
+  ChatPreparationCancelledError,
+  isChatPreparationCancelled,
+  validateChatAttachmentCount,
+} from "./chatPreparation"
 
 const ACTIVE_STREAM_ERROR_CODE = "active_stream"
 const QUEUED_MESSAGE_UNAVAILABLE_ERROR_CODE = "queued_message_unavailable"
 const CHAT_CANCELLED_DURING_PREFLIGHT_CODE = "chat_cancelled_during_preflight"
 const CHAT_NOTIFICATION_PREVIEW_MAX_CHARS = 220
-
-class ChatPreparationCancelledError extends Error {
-  constructor() {
-    super("Chat preparation cancelled by user")
-    this.name = "ChatPreparationCancelledError"
-  }
-}
-
-function isChatPreparationCancelled(error: unknown): boolean {
-  return error instanceof ChatPreparationCancelledError
-}
-
-function awaitUnlessAborted<T>(
-  promise: Promise<T>,
-  signal?: AbortSignal,
-  onLateResolve?: (value: T) => void | Promise<void>,
-): Promise<T> {
-  if (!signal) return promise
-  return new Promise<T>((resolve, reject) => {
-    let settled = false
-    const onAbort = () => {
-      if (settled) return
-      settled = true
-      signal.removeEventListener("abort", onAbort)
-      reject(new ChatPreparationCancelledError())
-    }
-    promise.then(
-      (value) => {
-        if (settled) {
-          if (signal.aborted && onLateResolve) {
-            void Promise.resolve(onLateResolve(value)).catch(() => {})
-          }
-          return
-        }
-        settled = true
-        signal.removeEventListener("abort", onAbort)
-        resolve(value)
-      },
-      (error) => {
-        if (settled) return
-        settled = true
-        signal.removeEventListener("abort", onAbort)
-        reject(error)
-      },
-    )
-    if (signal.aborted) onAbort()
-    else signal.addEventListener("abort", onAbort, { once: true })
-  })
-}
 
 function errorText(error: unknown): string {
   if (error instanceof Error) return error.message
@@ -1258,17 +1215,13 @@ export function useChatStream({
   )
 
   const ensureAttachmentCount = useCallback(
-    async (attachments: ChatAttachment[], transport: Transport, signal?: AbortSignal) => {
-      if (attachments.length <= 64) return
-      const cleanup = Promise.allSettled(
-        attachments
-          .map((attachment) => attachment.upload_id)
-          .filter((id): id is string => !!id)
-          .map((id) => transport.discardChatAttachmentUpload(id)),
-      )
-      await awaitUnlessAborted(cleanup, signal)
-      throw new Error(t("attachments.tooMany", "A message can contain at most 64 files"))
-    },
+    (attachments: ChatAttachment[], transport: Transport, signal?: AbortSignal) =>
+      validateChatAttachmentCount(
+        attachments,
+        transport,
+        t("attachments.tooMany", "A message can contain at most 64 files"),
+        signal,
+      ),
     [t],
   )
 
@@ -1394,7 +1347,7 @@ export function useChatStream({
         })
       }
 
-      await ensureAttachmentCount(attachments, transport)
+      await ensureAttachmentCount(attachments, transport, signal)
       return attachments
     },
     [draftWorkingDir, ensureAttachmentCount, quoteLineLabel, sessions, t],

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -72,6 +72,7 @@ import {
 import {
   awaitUnlessAborted,
   beginChatBackendHandoff,
+  deferActiveTurnRelease,
   ChatPreparationCancelledError,
   discardChatAttachmentUploads,
   isChatPreparationCancelled,
@@ -903,7 +904,13 @@ export function useChatStream({
         if (streamId) discardPendingStreamDeltas(sid, deltaBuffersRef, streamId)
         return
       }
-      if (payload?.turnId) activeTurnBySessionRef.current.delete(sid)
+      if (payload?.turnId) {
+        // Keep the identity until every listener for this event has run. The
+        // reattach listener owns loading teardown and calls handleTurnEnded;
+        // deleting synchronously here would make it reject the same terminal
+        // event as stale while the HTTP request owner is still present.
+        deferActiveTurnRelease(activeTurnBySessionRef.current, sid, payload.turnId)
+      }
       if (payload?.status) {
         lastTurnStatusBySessionRef.current.set(sid, {
           status: payload.status,

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -63,6 +63,7 @@ import {
   hasSendableChatPayload,
   nextDispatchablePending,
   shouldApplyPendingQueueSnapshot,
+  shouldReplayNextPending,
 } from "./pendingQueue"
 import {
   AUTO_SEND_PENDING_EVENT,
@@ -2215,9 +2216,10 @@ export function useChatStream({
       if (targetSessionId) {
         const queue = await syncPendingSends(targetSessionId).catch(() => [])
         const queued = nextDispatchablePending(queue)
+        const turnState = lastTurnStatusBySessionRef.current.get(targetSessionId)
         if (
           ownsRequestLifecycle &&
-          !wasUserStopped &&
+          shouldReplayNextPending(wasUserStopped, turnState) &&
           queued &&
           currentSessionIdRef.current === targetSessionId &&
           (queued.isPlanTrigger || queued.goalTrigger || autoSendPendingRef.current)

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -75,6 +75,7 @@ import {
   discardChatAttachmentUploads,
   isChatPreparationCancelled,
   loadingStateAfterPreparationRelease,
+  shouldRollbackNonPersistedStoppedSend,
   validateChatAttachmentCount,
 } from "./chatPreparation"
 
@@ -2003,11 +2004,12 @@ export function useChatStream({
       const ownsRequestLifecycleNow =
         chatRequestOwnerBySessionRef.current.get(sid) === chatRequestOwnerId
       const requestWasUserStopped = userStoppedRequestIdsRef.current.has(chatRequestOwnerId)
-      const stoppedBeforePersistence =
-        requestWasUserStopped &&
-        (isPreflightStopError(e) ||
-          isChatPreparationCancelled(e) ||
-          isActiveStreamError(e))
+      const stoppedBeforePersistence = shouldRollbackNonPersistedStoppedSend(
+        requestWasUserStopped,
+        isPreflightStopError(e),
+        isChatPreparationCancelled(e),
+        isActiveStreamError(e),
+      )
       await discardChatAttachmentUploads(attachments, sendTransport, !stoppedBeforePersistence)
       const bootstrapFailedBeforeSession =
         !sendSessionId && sid === "__pending__" && !!draftProjectBootstrap

--- a/src/components/chat/hooks/useChatStream.ts
+++ b/src/components/chat/hooks/useChatStream.ts
@@ -72,6 +72,7 @@ import {
   awaitUnlessAborted,
   beginChatBackendHandoff,
   ChatPreparationCancelledError,
+  discardChatAttachmentUploads,
   isChatPreparationCancelled,
   loadingStateAfterPreparationRelease,
   validateChatAttachmentCount,
@@ -1998,24 +1999,19 @@ export function useChatStream({
       if (options?.editMessageId != null) markDispatchAccepted()
       chatResolved = true
     } catch (e) {
-      await Promise.allSettled(
-        attachments
-          .map((attachment) => attachment.upload_id)
-          .filter((id): id is string => !!id)
-          .map((id) => sendTransport.discardChatAttachmentUpload(id)),
-      )
       const sid = targetSessionId || "__pending__"
       const ownsRequestLifecycleNow =
         chatRequestOwnerBySessionRef.current.get(sid) === chatRequestOwnerId
       const requestWasUserStopped = userStoppedRequestIdsRef.current.has(chatRequestOwnerId)
-      const bootstrapFailedBeforeSession =
-        !sendSessionId && sid === "__pending__" && !!draftProjectBootstrap
-      if (
+      const stoppedBeforePersistence =
         requestWasUserStopped &&
         (isPreflightStopError(e) ||
           isChatPreparationCancelled(e) ||
           isActiveStreamError(e))
-      ) {
+      await discardChatAttachmentUploads(attachments, sendTransport, !stoppedBeforePersistence)
+      const bootstrapFailedBeforeSession =
+        !sendSessionId && sid === "__pending__" && !!draftProjectBootstrap
+      if (stoppedBeforePersistence) {
         updateSessionMessages(sid, (prev) =>
           prev.filter(
             (message) =>

--- a/src/components/chat/hooks/useChatStreamReattach.test.tsx
+++ b/src/components/chat/hooks/useChatStreamReattach.test.tsx
@@ -5,7 +5,7 @@ import type { MutableRefObject } from "react"
 import { act, cleanup, render } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
-import type { Message } from "@/types/chat"
+import type { ChatTurnInterruptReason, ChatTurnStatus, Message } from "@/types/chat"
 import { useChatStreamReattach } from "./useChatStreamReattach"
 
 const mocks = vi.hoisted(() => {
@@ -20,21 +20,25 @@ const mocks = vi.hoisted(() => {
         listeners.set(name, handler)
         return () => listeners.delete(name)
       }),
-      call: vi.fn((name: string) =>
-        new Promise((resolve) => {
-          pending.set(name, resolve)
-        })),
+      call: vi.fn(
+        (name: string) =>
+          new Promise((resolve) => {
+            pending.set(name, resolve)
+          }),
+      ),
     },
-    reload: vi.fn(async (params: {
-      sessionId: string
-      sessionCacheRef: MutableRefObject<Map<string, Message[]>>
-      setMessages: (messages: Message[]) => void
-    }) => {
-      const next = mocks.dbMessages.map((message) => ({ ...message }))
-      params.sessionCacheRef.current.set(params.sessionId, next)
-      params.setMessages(next)
-      return true
-    }),
+    reload: vi.fn(
+      async (params: {
+        sessionId: string
+        sessionCacheRef: MutableRefObject<Map<string, Message[]>>
+        setMessages: (messages: Message[]) => void
+      }) => {
+        const next = mocks.dbMessages.map((message) => ({ ...message }))
+        params.sessionCacheRef.current.set(params.sessionId, next)
+        params.setMessages(next)
+        return true
+      },
+    ),
   }
 })
 
@@ -60,13 +64,26 @@ vi.mock("../chatUtils", async () => {
   return { ...actual, reloadAndMergeSessionMessages: mocks.reload }
 })
 
-function Harness({ onMessages }: { onMessages: (messages: Message[]) => void }) {
+function Harness({
+  onMessages,
+  onTurnStarted,
+  onTurnEnded,
+}: {
+  onMessages: (messages: Message[]) => void
+  onTurnStarted?: (sessionId: string, turnId: string) => void
+  onTurnEnded?: (
+    sessionId: string,
+    status?: ChatTurnStatus | null,
+    interruptReason?: ChatTurnInterruptReason | null,
+    turnId?: string | null,
+  ) => boolean
+}) {
   const [messages, setMessages] = useState<Message[]>([])
   const [, setLoading] = useState(false)
   const [, setLoadingSessionIds] = useState<Set<string>>(new Set())
   const currentSessionIdRef = useRef<string | null>("s1")
   const lastSeqRef = useRef(new Map<string, number>())
-  const endedStreamIdsRef = useRef(new Map<string, string>())
+  const endedStreamIdsRef = useRef(new Map<string, Set<string>>())
   const loadingSessionsRef = useRef(new Set<string>())
   const sessionCacheRef = useRef(new Map<string, Message[]>())
 
@@ -91,6 +108,8 @@ function Harness({ onMessages }: { onMessages: (messages: Message[]) => void }) 
     setLoadingSessionIds,
     sessionCacheRef,
     reloadSessions: async () => {},
+    onTurnStarted,
+    onTurnEnded,
   })
 
   useEffect(() => onMessages(messages), [messages, onMessages])
@@ -131,7 +150,13 @@ describe("useChatStreamReattach durable snapshot handshake", () => {
       },
     ]
     let latest: Message[] = []
-    render(<Harness onMessages={(messages) => { latest = messages }} />)
+    render(
+      <Harness
+        onMessages={(messages) => {
+          latest = messages
+        }}
+      />,
+    )
     const emit = mocks.listeners.get("chat:stream_delta")
     expect(emit).toBeTruthy()
 
@@ -189,7 +214,13 @@ describe("useChatStreamReattach durable snapshot handshake", () => {
 
   test("replays buffered deltas from a newer stream even below the old throughSeq", async () => {
     let latest: Message[] = []
-    render(<Harness onMessages={(messages) => { latest = messages }} />)
+    render(
+      <Harness
+        onMessages={(messages) => {
+          latest = messages
+        }}
+      />,
+    )
     const emit = mocks.listeners.get("chat:stream_delta")
     expect(emit).toBeTruthy()
 
@@ -231,13 +262,117 @@ describe("useChatStreamReattach durable snapshot handshake", () => {
     expect(latest.at(-1)?.content).toBe("old durable; new first token")
   })
 
+  test("does not let an older active snapshot replace a live newer turn", async () => {
+    let activeTurnId: string | null = null
+    const endedTurns: string[] = []
+    render(
+      <Harness
+        onMessages={() => {}}
+        onTurnStarted={(_sid, turnId) => {
+          activeTurnId = turnId
+        }}
+        onTurnEnded={(_sid, _status, _reason, turnId) => {
+          if (turnId && activeTurnId && turnId !== activeTurnId) return false
+          if (turnId) endedTurns.push(turnId)
+          activeTurnId = null
+          return true
+        }}
+      />,
+    )
+
+    await act(async () => {
+      mocks.listeners.get("chat:turn_started")?.({ sessionId: "s1", turnId: "turn-new" })
+      mocks.pending.get("get_session_stream_state")?.({
+        active: true,
+        lastSeq: 7,
+        acceptedSeq: 7,
+        durableSeq: 7,
+        committedSeq: 0,
+        persistenceRunId: "run-old",
+        streamId: "stream-old",
+        turnId: "turn-old",
+      })
+      mocks.pending.get("get_session_stream_snapshot")?.({
+        sessionId: "s1",
+        streamId: "stream-old",
+        turnId: "turn-old",
+        persistenceRunId: "run-old",
+        throughSeq: 7,
+        durableSeq: 7,
+        committedSeq: 0,
+        status: "running",
+        events: [],
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(activeTurnId).toBe("turn-new")
+
+    await act(async () => {
+      mocks.listeners.get("chat:stream_end")?.({
+        sessionId: "s1",
+        streamId: "stream-new",
+        turnId: "turn-new",
+        status: "completed",
+        persistenceStatus: "committed",
+      })
+    })
+
+    expect(activeTurnId).toBeNull()
+    expect(endedTurns).toContain("turn-new")
+  })
+
+  test("ignores an older terminal state after a live newer turn starts", async () => {
+    let activeTurnId: string | null = null
+    render(
+      <Harness
+        onMessages={() => {}}
+        onTurnStarted={(_sid, turnId) => {
+          activeTurnId = turnId
+        }}
+        onTurnEnded={(_sid, _status, _reason, turnId) => {
+          if (turnId && activeTurnId && turnId !== activeTurnId) return false
+          activeTurnId = null
+          return true
+        }}
+      />,
+    )
+
+    await act(async () => {
+      mocks.listeners.get("chat:turn_started")?.({ sessionId: "s1", turnId: "turn-new" })
+      mocks.pending.get("get_session_stream_state")?.({
+        active: false,
+        lastSeq: 7,
+        acceptedSeq: 7,
+        durableSeq: 7,
+        committedSeq: 7,
+        persistenceRunId: "run-old",
+        streamId: "stream-old",
+        turnId: null,
+        lastTerminalStatus: "interrupted",
+      })
+      mocks.pending.get("get_session_stream_snapshot")?.(null)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(activeTurnId).toBe("turn-new")
+  })
+
   test("does not replay a committed journal over canonical DB messages", async () => {
     mocks.dbMessages = [
       { role: "user", content: "question", dbId: 1 },
       { role: "assistant", content: "done", dbId: 2 },
     ]
     let latest: Message[] = []
-    render(<Harness onMessages={(messages) => { latest = messages }} />)
+    render(
+      <Harness
+        onMessages={(messages) => {
+          latest = messages
+        }}
+      />,
+    )
 
     await act(async () => {
       mocks.pending.get("get_session_stream_state")?.({
@@ -258,9 +393,7 @@ describe("useChatStreamReattach durable snapshot handshake", () => {
         durableSeq: 1,
         committedSeq: 1,
         status: "committed",
-        events: [
-          { seq: 1, event: JSON.stringify({ type: "text_delta", content: "done" }) },
-        ],
+        events: [{ seq: 1, event: JSON.stringify({ type: "text_delta", content: "done" }) }],
       })
       await Promise.resolve()
       await Promise.resolve()
@@ -273,7 +406,13 @@ describe("useChatStreamReattach durable snapshot handshake", () => {
 
   test("flushes the last durable RAF frame before a pending stream end", async () => {
     let latest: Message[] = []
-    render(<Harness onMessages={(messages) => { latest = messages }} />)
+    render(
+      <Harness
+        onMessages={(messages) => {
+          latest = messages
+        }}
+      />,
+    )
 
     await act(async () => {
       mocks.pending.get("get_session_stream_state")?.({
@@ -329,7 +468,13 @@ describe("useChatStreamReattach durable snapshot handshake", () => {
 
   test("does not let a stale snapshot revive a stream that ended during the handshake", async () => {
     let latest: Message[] = []
-    render(<Harness onMessages={(messages) => { latest = messages }} />)
+    render(
+      <Harness
+        onMessages={(messages) => {
+          latest = messages
+        }}
+      />,
+    )
 
     await act(async () => {
       // Let the staged DB baseline finish, while the state/snapshot calls are
@@ -382,5 +527,75 @@ describe("useChatStreamReattach durable snapshot handshake", () => {
     expect(latest).toHaveLength(2)
     expect(latest[0]?.content).toBe("question")
     expect(latest[1]?.content).toBe("safe tail")
+  })
+
+  test("ignores a delayed stream end from an older turn", async () => {
+    let latest: Message[] = []
+    render(
+      <Harness
+        onMessages={(messages) => {
+          latest = messages
+        }}
+        onTurnEnded={(_sid, _status, _reason, turnId) => turnId === "turn-new"}
+      />,
+    )
+
+    await act(async () => {
+      mocks.pending.get("get_session_stream_state")?.({
+        active: true,
+        lastSeq: 1,
+        acceptedSeq: 1,
+        durableSeq: 1,
+        committedSeq: 0,
+        persistenceRunId: "run-new",
+        streamId: "stream-new",
+        turnId: "turn-new",
+      })
+      mocks.pending.get("get_session_stream_snapshot")?.({
+        sessionId: "s1",
+        streamId: "stream-new",
+        turnId: "turn-new",
+        persistenceRunId: "run-new",
+        throughSeq: 1,
+        durableSeq: 1,
+        committedSeq: 0,
+        status: "running",
+        events: [{ seq: 1, event: JSON.stringify({ type: "text_delta", content: "new reply" }) }],
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+      flushAnimationFrames()
+    })
+
+    const reloadsBeforeEnd = mocks.reload.mock.calls.length
+    await act(async () => {
+      // A final old delta can already be sitting in its own rAF buffer when
+      // the delayed end arrives. The stale terminal must discard that buffer
+      // without touching the newer stream.
+      mocks.listeners.get("chat:stream_delta")?.({
+        sessionId: "s1",
+        streamId: "stream-old",
+        seq: 2,
+        event: JSON.stringify({ type: "text_delta", content: "old buffered tail" }),
+      })
+      mocks.listeners.get("chat:stream_end")?.({
+        sessionId: "s1",
+        streamId: "stream-old",
+        turnId: "turn-old",
+        status: "interrupted",
+        persistenceStatus: "committed",
+      })
+      // Frames that arrive after the old end are quarantined as well.
+      mocks.listeners.get("chat:stream_delta")?.({
+        sessionId: "s1",
+        streamId: "stream-old",
+        seq: 3,
+        event: JSON.stringify({ type: "text_delta", content: "old late tail" }),
+      })
+      flushAnimationFrames()
+    })
+
+    expect(latest.at(-1)?.content).toBe("new reply")
+    expect(mocks.reload).toHaveBeenCalledTimes(reloadsBeforeEnd)
   })
 })

--- a/src/components/chat/hooks/useChatStreamReattach.test.tsx
+++ b/src/components/chat/hooks/useChatStreamReattach.test.tsx
@@ -68,8 +68,10 @@ function Harness({
   onMessages,
   onTurnStarted,
   onTurnEnded,
+  initialMessages = [],
 }: {
   onMessages: (messages: Message[]) => void
+  initialMessages?: Message[]
   onTurnStarted?: (sessionId: string, turnId: string) => void
   onTurnEnded?: (
     sessionId: string,
@@ -78,14 +80,16 @@ function Harness({
     turnId?: string | null,
   ) => boolean
 }) {
-  const [messages, setMessages] = useState<Message[]>([])
+  const [messages, setMessages] = useState<Message[]>(initialMessages)
   const [, setLoading] = useState(false)
   const [, setLoadingSessionIds] = useState<Set<string>>(new Set())
   const currentSessionIdRef = useRef<string | null>("s1")
   const lastSeqRef = useRef(new Map<string, number>())
   const endedStreamIdsRef = useRef(new Map<string, Set<string>>())
   const loadingSessionsRef = useRef(new Set<string>())
-  const sessionCacheRef = useRef(new Map<string, Message[]>())
+  const sessionCacheRef = useRef(
+    new Map<string, Message[]>(initialMessages.length > 0 ? [["s1", initialMessages]] : []),
+  )
 
   const updateSessionMessages = (sessionId: string, updater: (prev: Message[]) => Message[]) => {
     setMessages((prev) => {
@@ -321,6 +325,75 @@ describe("useChatStreamReattach durable snapshot handshake", () => {
 
     expect(activeTurnId).toBeNull()
     expect(endedTurns).toContain("turn-new")
+  })
+
+  test("replays only the live turn stream when a stale snapshot handshake mixes generations", async () => {
+    let latest: Message[] = []
+    render(
+      <Harness
+        initialMessages={[
+          { role: "user", content: "new question" },
+          { role: "assistant", content: "", _clientId: "new-turn-placeholder" },
+        ]}
+        onMessages={(messages) => {
+          latest = messages
+        }}
+      />,
+    )
+
+    await act(async () => {
+      const emitDelta = mocks.listeners.get("chat:stream_delta")
+      emitDelta?.({
+        sessionId: "s1",
+        streamId: "stream-old",
+        seq: 8,
+        event: JSON.stringify({ type: "text_delta", content: "stale before; " }),
+      })
+      mocks.listeners.get("chat:turn_started")?.({
+        sessionId: "s1",
+        turnId: "turn-new",
+        streamId: "stream-new",
+      })
+      emitDelta?.({
+        sessionId: "s1",
+        streamId: "stream-old",
+        seq: 9,
+        event: JSON.stringify({ type: "text_delta", content: "stale after; " }),
+      })
+      emitDelta?.({
+        sessionId: "s1",
+        streamId: "stream-new",
+        seq: 1,
+        event: JSON.stringify({ type: "text_delta", content: "new reply" }),
+      })
+      mocks.pending.get("get_session_stream_state")?.({
+        active: true,
+        lastSeq: 9,
+        acceptedSeq: 9,
+        durableSeq: 9,
+        committedSeq: 0,
+        persistenceRunId: "run-old",
+        streamId: "stream-old",
+        turnId: "turn-old",
+      })
+      mocks.pending.get("get_session_stream_snapshot")?.({
+        sessionId: "s1",
+        streamId: "stream-old",
+        turnId: "turn-old",
+        persistenceRunId: "run-old",
+        throughSeq: 9,
+        durableSeq: 9,
+        committedSeq: 0,
+        status: "running",
+        events: [],
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+      flushAnimationFrames()
+    })
+
+    expect(latest.at(-1)?.role).toBe("assistant")
+    expect(latest.at(-1)?.content).toBe("new reply")
   })
 
   test("ignores an older terminal state after a live newer turn starts", async () => {

--- a/src/components/chat/hooks/useChatStreamReattach.ts
+++ b/src/components/chat/hooks/useChatStreamReattach.ts
@@ -117,6 +117,8 @@ interface SnapshotHandshake {
   stagedMessages: Message[] | null
   /** Most recent live turn_started observed after this handshake began. */
   liveTurnId: string | null
+  /** Stream generation paired with `liveTurnId` by chat:turn_started. */
+  liveStreamId: string | null
 }
 
 /**
@@ -188,10 +190,13 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
 
   useEffect(() => {
     const unlisten = getTransport().listen(EVENT_CHAT_TURN_STARTED, (raw) => {
-      const payload = raw as { sessionId?: string; turnId?: string } | null
+      const payload = raw as { sessionId?: string; turnId?: string; streamId?: string } | null
       if (!payload?.sessionId || !payload.turnId) return
       const handshake = snapshotHandshakeRef.current.get(payload.sessionId)
-      if (handshake) handshake.liveTurnId = payload.turnId
+      if (handshake) {
+        handshake.liveTurnId = payload.turnId
+        handshake.liveStreamId = payload.streamId ?? null
+      }
       onTurnStarted?.(payload.sessionId, payload.turnId)
     })
     return unlisten
@@ -230,6 +235,7 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
       ended: false,
       stagedMessages: null,
       liveTurnId: null,
+      liveStreamId: null,
     }
     handshakeRegistry.set(sid, handshake)
     const stagedSessionCacheRef = {
@@ -267,7 +273,18 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
           if (handshakeRegistry.get(sid) === handshake) {
             handshakeRegistry.delete(sid)
           }
-          handshake.deltas.sort((a, b) => a.seq - b.seq).forEach(applyStreamPayload)
+          const staleStreamId = snapshot?.streamId || state.streamId || null
+          handshake.deltas
+            // `turn_started` and stream deltas share the backend stream id.
+            // Once a newer turn has announced its generation, never replay an
+            // older stream's tail into that turn's optimistic assistant bubble.
+            .filter((delta) =>
+              handshake.liveStreamId
+                ? delta.streamId === handshake.liveStreamId
+                : !staleStreamId || delta.streamId !== staleStreamId,
+            )
+            .sort((a, b) => a.seq - b.seq)
+            .forEach(applyStreamPayload)
           if (!loadingSessionsRef.current.has(sid)) {
             loadingSessionsRef.current.add(sid)
             setLoadingSessionIds(new Set(loadingSessionsRef.current))

--- a/src/components/chat/hooks/useChatStreamReattach.ts
+++ b/src/components/chat/hooks/useChatStreamReattach.ts
@@ -10,8 +10,12 @@ import {
   discardPendingStreamDeltas,
   flushPendingStreamDeltas,
   handleStreamEvent,
+  isStreamEnded,
+  markStreamActive,
+  markStreamEnded,
   streamCursorKey,
   streamIdFromPayload,
+  type EndedStreamIds,
 } from "./useStreamEventHandler"
 
 // Backend constants: see `crates/ha-core/src/chat_engine/stream_broadcast.rs`.
@@ -44,7 +48,7 @@ export interface UseChatStreamReattachDeps {
   /** Per-session seq cursor shared with `useChatStream` for dedup. Owned by the
    *  parent (ChatScreen) so both hooks can see / update it. */
   lastSeqRef: React.MutableRefObject<Map<string, number>>
-  endedStreamIdsRef: React.MutableRefObject<Map<string, string>>
+  endedStreamIdsRef: React.MutableRefObject<EndedStreamIds>
   updateSessionMessages: (sessionId: string, updater: (prev: Message[]) => Message[]) => void
   setShowCodexAuthExpired: React.Dispatch<React.SetStateAction<boolean>>
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>
@@ -58,7 +62,8 @@ export interface UseChatStreamReattachDeps {
     sessionId: string,
     status?: ChatTurnStatus | null,
     interruptReason?: ChatTurnInterruptReason | null,
-  ) => void
+    turnId?: string | null,
+  ) => boolean
 }
 
 export interface SessionStreamState {
@@ -110,6 +115,8 @@ interface SnapshotHandshake {
   deltas: StreamDeltaPayload[]
   ended: boolean
   stagedMessages: Message[] | null
+  /** Most recent live turn_started observed after this handshake began. */
+  liveTurnId: string | null
 }
 
 /**
@@ -145,15 +152,15 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
 
   // Buffers are per-hook, not shared with useChatStream's primary path;
   // lastSeqRef dedup ensures each event hits at most one path. Within this
-  // hook they are keyed by session so overlapping background streams cannot
-  // mix pending text before the rAF flush runs.
+  // hook they are keyed by session + stream so an old stream cannot mix its
+  // pending text into a replacement turn before the rAF flush runs.
   const deltaBuffersRef = useRef(createStreamDeltaBuffers())
   const snapshotHandshakeRef = useRef(new Map<string, SnapshotHandshake>())
 
   const applyStreamPayload = (payload: StreamDeltaPayload) => {
     const sid = payload.sessionId
     const seq = payload.seq
-    if (payload.streamId && endedStreamIdsRef.current.get(sid) === payload.streamId) return
+    if (isStreamEnded(endedStreamIdsRef.current, sid, payload.streamId)) return
     const cursorKey = streamCursorKey(sid, payload.streamId)
     const prev = lastSeqRef.current.get(cursorKey) ?? 0
     if (seq <= prev) return
@@ -166,6 +173,12 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
       logger.warn("chat", "useChatStreamReattach::parse", "Failed to parse bus event", e)
       return
     }
+    // EventBus frames carry stream identity in the envelope, while the primary
+    // transport stamps it into the event. Normalize both paths so rAF buffers
+    // remain isolated by session + stream.
+    if (payload.streamId && !event._oc_stream_id) {
+      event._oc_stream_id = payload.streamId
+    }
     handleStreamEvent(event, sid, {
       updateSessionMessages,
       deltaBuffersRef,
@@ -177,6 +190,8 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
     const unlisten = getTransport().listen(EVENT_CHAT_TURN_STARTED, (raw) => {
       const payload = raw as { sessionId?: string; turnId?: string } | null
       if (!payload?.sessionId || !payload.turnId) return
+      const handshake = snapshotHandshakeRef.current.get(payload.sessionId)
+      if (handshake) handshake.liveTurnId = payload.turnId
       onTurnStarted?.(payload.sessionId, payload.turnId)
     })
     return unlisten
@@ -214,6 +229,7 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
       deltas: [],
       ended: false,
       stagedMessages: null,
+      liveTurnId: null,
     }
     handshakeRegistry.set(sid, handshake)
     const stagedSessionCacheRef = {
@@ -238,22 +254,60 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
       .then(([state, snapshot]) => {
         if (cancelled || handshake.ended) return
         if (!state) return
-        if (handshake.stagedMessages) {
-          sessionCacheRef.current.set(sid, handshake.stagedMessages)
-          setMessages(handshake.stagedMessages)
+        if (
+          handshake.liveTurnId &&
+          (!state.active ||
+            state.turnId !== handshake.liveTurnId ||
+            (snapshot !== null && snapshot.turnId !== handshake.liveTurnId))
+        ) {
+          // At least one state/snapshot response was captured before the live
+          // turn_started arrived. Whether that response describes an older
+          // active turn or an older terminal turn, it must not replace the
+          // live turn id or overwrite the new request's optimistic cache.
+          if (handshakeRegistry.get(sid) === handshake) {
+            handshakeRegistry.delete(sid)
+          }
+          handshake.deltas.sort((a, b) => a.seq - b.seq).forEach(applyStreamPayload)
+          if (!loadingSessionsRef.current.has(sid)) {
+            loadingSessionsRef.current.add(sid)
+            setLoadingSessionIds(new Set(loadingSessionsRef.current))
+          }
+          if (currentSessionIdRef.current === sid) setLoading(true)
+          return
         }
         if (state.turnId && state.active) {
           onTurnStarted?.(sid, state.turnId)
         } else {
-          onTurnEnded?.(
-            sid,
-            state.status ?? state.lastTerminalStatus ?? null,
-            state.interruptReason ?? null,
-          )
+          const appliesToCurrentTurn =
+            onTurnEnded?.(
+              sid,
+              state.status ?? state.lastTerminalStatus ?? null,
+              state.interruptReason ?? null,
+              state.turnId ?? null,
+            ) ?? true
+          if (!appliesToCurrentTurn) {
+            const staleStreamId = snapshot?.streamId || state.streamId || undefined
+            markStreamEnded(endedStreamIdsRef.current, sid, staleStreamId)
+            if (staleStreamId) {
+              discardPendingStreamDeltas(sid, deltaBuffersRef, staleStreamId)
+            }
+            if (handshakeRegistry.get(sid) === handshake) {
+              handshakeRegistry.delete(sid)
+            }
+            handshake.deltas
+              .filter((delta) => !staleStreamId || delta.streamId !== staleStreamId)
+              .sort((a, b) => a.seq - b.seq)
+              .forEach(applyStreamPayload)
+            return
+          }
+        }
+        if (handshake.stagedMessages) {
+          sessionCacheRef.current.set(sid, handshake.stagedMessages)
+          setMessages(handshake.stagedMessages)
         }
         const streamId = snapshot?.streamId || state.streamId || undefined
         if (snapshot) {
-          if (streamId) endedStreamIdsRef.current.delete(sid)
+          markStreamActive(endedStreamIdsRef.current, sid, streamId)
           const cursorKey = streamCursorKey(sid, streamId)
           // DB snapshot can lag accepted memory state. Rebuild from the
           // journal prefix instead of jumping to `lastSeq`.
@@ -305,9 +359,7 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
             // while the old stream's snapshot request is still in flight and
             // restart at seq=1; only apply the old snapshot watermark to
             // buffered frames from that same stream.
-            .filter(
-              (event) => event.streamId !== streamId || event.seq > snapshot.throughSeq,
-            )
+            .filter((event) => event.streamId !== streamId || event.seq > snapshot.throughSeq)
             .sort((a, b) => a.seq - b.seq)
             .forEach(applyStreamPayload)
         } else {
@@ -353,6 +405,22 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
       if (!payload?.sessionId) return
       const sid = payload.sessionId
       const streamId = payload.streamId || streamIdFromPayload(raw)
+      const appliesToCurrentTurn =
+        onTurnEnded?.(sid, payload.status, payload.interruptReason, payload.turnId) ?? true
+      if (!appliesToCurrentTurn) {
+        // Quarantine the old stream without touching the newer turn's state or
+        // rAF buffer. Handshake deltas retain stream identity, so remove only
+        // frames owned by this stale terminal event.
+        markStreamEnded(endedStreamIdsRef.current, sid, streamId)
+        if (streamId) {
+          discardPendingStreamDeltas(sid, deltaBuffersRef, streamId)
+          const handshake = snapshotHandshakeRef.current.get(sid)
+          if (handshake) {
+            handshake.deltas = handshake.deltas.filter((delta) => delta.streamId !== streamId)
+          }
+        }
+        return
+      }
       const handshake = snapshotHandshakeRef.current.get(sid)
       if (handshake) {
         handshake.ended = true
@@ -381,9 +449,7 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
           handshake.deltas.sort((a, b) => a.seq - b.seq).forEach(applyStreamPayload)
         }
       }
-      if (streamId) endedStreamIdsRef.current.set(sid, streamId)
-      onTurnEnded?.(sid, payload.status, payload.interruptReason)
-
+      markStreamEnded(endedStreamIdsRef.current, sid, streamId)
       // The backend deliberately delivers every durable delta before end, but
       // the most recent frame may still be waiting in our 30fps RAF merge
       // buffer. Flush it before cleanup; a `pending` persistence end does not
@@ -392,8 +458,9 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
         sid,
         { updateSessionMessages, deltaBuffersRef, setShowCodexAuthExpired },
         true,
+        streamId ?? null,
       )
-      discardPendingStreamDeltas(sid, deltaBuffersRef)
+      discardPendingStreamDeltas(sid, deltaBuffersRef, streamId ?? null)
       loadingSessionsRef.current.delete(sid)
       setLoadingSessionIds(new Set(loadingSessionsRef.current))
 
@@ -454,9 +521,16 @@ export function useChatStreamReattach(deps: UseChatStreamReattachDeps): void {
         if (recheck.active || !loadingSessionsRef.current.has(sid)) return
 
         // Terminal but the stream_end never landed → run the same teardown.
-        if (recheck.streamId) endedStreamIdsRef.current.set(sid, recheck.streamId)
-        onTurnEnded?.(sid, recheck.status ?? recheck.lastTerminalStatus ?? null, recheck.interruptReason ?? null)
-        discardPendingStreamDeltas(sid, deltaBuffersRef)
+        const appliesToCurrentTurn =
+          onTurnEnded?.(
+            sid,
+            recheck.status ?? recheck.lastTerminalStatus ?? null,
+            recheck.interruptReason ?? null,
+            recheck.turnId ?? null,
+          ) ?? true
+        if (!appliesToCurrentTurn) return
+        markStreamEnded(endedStreamIdsRef.current, sid, recheck.streamId)
+        discardPendingStreamDeltas(sid, deltaBuffersRef, recheck.streamId ?? null)
         loadingSessionsRef.current.delete(sid)
         setLoadingSessionIds(new Set(loadingSessionsRef.current))
         setLoading(false)

--- a/src/components/chat/hooks/useStreamEventHandler.test.ts
+++ b/src/components/chat/hooks/useStreamEventHandler.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest"
 import type { Message } from "@/types/chat"
-import { createStreamDeltaBuffers, handleStreamEvent } from "./useStreamEventHandler"
+import {
+  createStreamDeltaBuffers,
+  handleStreamEvent,
+  streamCursorKey,
+} from "./useStreamEventHandler"
 
 function createDeps(messagesRef: { current: Message[] }) {
   return {
@@ -310,12 +314,7 @@ describe("handleStreamEvent model recovery notices", () => {
       )
     }
 
-    expect(messagesRef.current.map((m) => m.role)).toEqual([
-      "user",
-      "event",
-      "event",
-      "assistant",
-    ])
+    expect(messagesRef.current.map((m) => m.role)).toEqual(["user", "event", "event", "assistant"])
     expect(parseEvent(messagesRef.current[1]).attempt).toBe(1)
     expect(parseEvent(messagesRef.current[2]).attempt).toBe(2)
   })
@@ -337,7 +336,8 @@ describe("handleStreamEvent durable attempt replacement", () => {
       ] satisfies Message[],
     }
     const deps = createDeps(messagesRef)
-    deps.deltaBuffersRef.current.pending.set("s1", {
+    const legacyCursor = streamCursorKey("s1", null)
+    deps.deltaBuffersRef.current.pending.set(legacyCursor, {
       text: "not-yet-rendered old bytes",
       thinking: "",
     })
@@ -353,7 +353,7 @@ describe("handleStreamEvent durable attempt replacement", () => {
     )
 
     expect(handled).toBe(true)
-    expect(deps.deltaBuffersRef.current.pending.has("s1")).toBe(false)
+    expect(deps.deltaBuffersRef.current.pending.has(legacyCursor)).toBe(false)
     expect(messagesRef.current[1]).toMatchObject({
       role: "assistant",
       content: "",

--- a/src/components/chat/hooks/useStreamEventHandler.ts
+++ b/src/components/chat/hooks/useStreamEventHandler.ts
@@ -29,6 +29,10 @@ export interface StreamDeltaBuffers {
   lastFlushAt: Map<string, number>
 }
 
+export type EndedStreamIds = Map<string, Set<string>>
+
+const MAX_ENDED_STREAMS_PER_SESSION = 8
+
 const LEGACY_STREAM_ID = "__legacy__"
 
 // 流式 flush 节流：把每帧（≈60fps）flush 降到 ~30fps。每次 flush 都触发末块
@@ -52,6 +56,46 @@ export function streamIdFromPayload(raw: unknown): string | undefined {
   return typeof value === "string" && value ? value : undefined
 }
 
+export function isStreamEnded(
+  ended: EndedStreamIds,
+  sessionId: string,
+  streamId?: string | null,
+): boolean {
+  return !!streamId && ended.get(sessionId)?.has(streamId) === true
+}
+
+export function markStreamEnded(
+  ended: EndedStreamIds,
+  sessionId: string,
+  streamId?: string | null,
+): void {
+  if (!streamId) return
+  let streams = ended.get(sessionId)
+  if (!streams) {
+    streams = new Set()
+    ended.set(sessionId, streams)
+  }
+  streams.delete(streamId)
+  streams.add(streamId)
+  while (streams.size > MAX_ENDED_STREAMS_PER_SESSION) {
+    const oldest = streams.values().next().value as string | undefined
+    if (!oldest) break
+    streams.delete(oldest)
+  }
+}
+
+export function markStreamActive(
+  ended: EndedStreamIds,
+  sessionId: string,
+  streamId?: string | null,
+): void {
+  if (!streamId) return
+  const streams = ended.get(sessionId)
+  if (!streams) return
+  streams.delete(streamId)
+  if (streams.size === 0) ended.delete(sessionId)
+}
+
 export function createStreamDeltaBuffers(): StreamDeltaBuffers {
   return {
     pending: new Map(),
@@ -63,15 +107,23 @@ export function createStreamDeltaBuffers(): StreamDeltaBuffers {
 export function discardPendingStreamDeltas(
   sid: string,
   deltaBuffersRef: React.MutableRefObject<StreamDeltaBuffers>,
+  streamId?: string | null,
 ): void {
   const state = deltaBuffersRef.current
-  const raf = state.rafs.get(sid)
-  if (raf !== undefined) {
-    cancelAnimationFrame(raf)
+  const keys =
+    streamId !== undefined
+      ? [streamCursorKey(sid, streamId)]
+      : new Set([...state.pending.keys(), ...state.rafs.keys(), ...state.lastFlushAt.keys()])
+  for (const key of keys) {
+    if (streamId === undefined && !key.startsWith(`${sid}\u0000`)) continue
+    const raf = state.rafs.get(key)
+    if (raf !== undefined) {
+      cancelAnimationFrame(raf)
+    }
+    state.rafs.delete(key)
+    state.pending.delete(key)
+    state.lastFlushAt.delete(key)
   }
-  state.rafs.delete(sid)
-  state.pending.delete(sid)
-  state.lastFlushAt.delete(sid)
 }
 
 export function discardAllPendingStreamDeltas(
@@ -89,12 +141,14 @@ export function discardAllPendingStreamDeltas(
 function pendingDeltasFor(
   deltaBuffersRef: React.MutableRefObject<StreamDeltaBuffers>,
   sid: string,
+  streamId?: string | null,
 ): { text: string; thinking: string } {
   const state = deltaBuffersRef.current
-  let pending = state.pending.get(sid)
+  const key = streamCursorKey(sid, streamId)
+  let pending = state.pending.get(key)
   if (!pending) {
     pending = { text: "", thinking: "" }
-    state.pending.set(sid, pending)
+    state.pending.set(key, pending)
   }
   return pending
 }
@@ -103,17 +157,19 @@ function takePendingStreamDeltas(
   sid: string,
   deltaBuffersRef: React.MutableRefObject<StreamDeltaBuffers>,
   cancelScheduled: boolean,
+  streamId?: string | null,
 ): { text: string; thinking: string } | null {
   const state = deltaBuffersRef.current
+  const key = streamCursorKey(sid, streamId)
   if (cancelScheduled) {
-    const raf = state.rafs.get(sid)
+    const raf = state.rafs.get(key)
     if (raf !== undefined) {
       cancelAnimationFrame(raf)
     }
   }
-  state.rafs.delete(sid)
-  const pending = state.pending.get(sid)
-  state.pending.delete(sid)
+  state.rafs.delete(key)
+  const pending = state.pending.get(key)
+  state.pending.delete(key)
   if (!pending || (!pending.text && !pending.thinking)) return null
   return pending
 }
@@ -122,10 +178,27 @@ export function flushPendingStreamDeltas(
   sid: string,
   deps: StreamEventHandlerDeps,
   cancelScheduled: boolean,
+  streamId?: string | null,
 ): void {
-  const pending = takePendingStreamDeltas(sid, deps.deltaBuffersRef, cancelScheduled)
+  if (streamId === undefined) {
+    const prefix = `${sid}\u0000`
+    const keys = [...deps.deltaBuffersRef.current.pending.keys()].filter((key) =>
+      key.startsWith(prefix),
+    )
+    for (const key of keys) {
+      const exactStreamId = key.slice(prefix.length)
+      flushPendingStreamDeltas(
+        sid,
+        deps,
+        cancelScheduled,
+        exactStreamId === LEGACY_STREAM_ID ? null : exactStreamId,
+      )
+    }
+    return
+  }
+  const pending = takePendingStreamDeltas(sid, deps.deltaBuffersRef, cancelScheduled, streamId)
   if (!pending) return
-  deps.deltaBuffersRef.current.lastFlushAt.set(sid, Date.now())
+  deps.deltaBuffersRef.current.lastFlushAt.set(streamCursorKey(sid, streamId), Date.now())
 
   const textChunk = pending.text
   const thinkingChunk = pending.thinking
@@ -200,23 +273,28 @@ function fallbackEventFromStreamEvent(event: Record<string, unknown>): FallbackE
   }
 }
 
-function schedulePendingStreamFlush(sid: string, deps: StreamEventHandlerDeps): void {
+function schedulePendingStreamFlush(
+  sid: string,
+  streamId: string | null,
+  deps: StreamEventHandlerDeps,
+): void {
   const state = deps.deltaBuffersRef.current
-  if (state.rafs.has(sid)) return
+  const key = streamCursorKey(sid, streamId)
+  if (state.rafs.has(key)) return
   const raf = requestAnimationFrame(() => {
     const s = deps.deltaBuffersRef.current
-    s.rafs.delete(sid)
+    s.rafs.delete(key)
     // Throttle to ~30fps: if the previous flush was < FLUSH_MIN_INTERVAL_MS ago,
     // wait one more frame instead of flushing now. Pending deltas keep
     // accumulating in the buffer, so nothing is lost — just coalesced.
-    const last = s.lastFlushAt.get(sid) ?? 0
+    const last = s.lastFlushAt.get(key) ?? 0
     if (Date.now() - last < FLUSH_MIN_INTERVAL_MS) {
-      schedulePendingStreamFlush(sid, deps)
+      schedulePendingStreamFlush(sid, streamId, deps)
       return
     }
-    flushPendingStreamDeltas(sid, deps, false)
+    flushPendingStreamDeltas(sid, deps, false, streamId)
   })
-  state.rafs.set(sid, raf)
+  state.rafs.set(key, raf)
 }
 
 function stringField(event: Record<string, unknown>, key: string): string {
@@ -298,13 +376,14 @@ export function handleStreamEvent(
   deps: StreamEventHandlerDeps,
 ): boolean {
   const { updateSessionMessages, deltaBuffersRef, setShowCodexAuthExpired } = deps
+  const eventStreamId = streamIdFromEvent(event) ?? null
 
   // A durable failover can happen after the failed attempt already rendered.
   // The backend journals this marker as the first event of the replacement
   // attempt, so clearing here is ordered and replay-safe. Never flush the old
   // rAF buffer: those bytes belong to the superseded attempt.
   if (event.type === "stream_attempt_started" && event.reset_superseded === true) {
-    discardPendingStreamDeltas(sid, deltaBuffersRef)
+    discardPendingStreamDeltas(sid, deltaBuffersRef, eventStreamId)
     updateSessionMessages(sid, (prev) => {
       const last = prev[prev.length - 1]
       if (!last || last.role !== "assistant") return prev
@@ -326,13 +405,13 @@ export function handleStreamEvent(
 
   // text_delta and thinking_delta: buffer and flush via rAF
   if (event.type === "text_delta" || event.type === "thinking_delta") {
-    const pending = pendingDeltasFor(deltaBuffersRef, sid)
+    const pending = pendingDeltasFor(deltaBuffersRef, sid, eventStreamId)
     if (event.type === "text_delta") {
       pending.text += stringField(event, "content") || stringField(event, "text")
     } else {
       pending.thinking += stringField(event, "content")
     }
-    schedulePendingStreamFlush(sid, deps)
+    schedulePendingStreamFlush(sid, eventStreamId, deps)
     return true
   }
 
@@ -351,14 +430,12 @@ export function handleStreamEvent(
   }
 
   if (event.type === "queued_user_message_inserted") {
-    flushPendingStreamDeltas(sid, deps, true)
+    flushPendingStreamDeltas(sid, deps, true, eventStreamId)
     const requestId = stringField(event, "request_id")
     const content = stringField(event, "content")
     const messageIdRaw = event.message_id
     const dbId =
-      typeof messageIdRaw === "number" && Number.isFinite(messageIdRaw)
-        ? messageIdRaw
-        : undefined
+      typeof messageIdRaw === "number" && Number.isFinite(messageIdRaw) ? messageIdRaw : undefined
     const attachmentsMeta =
       typeof event.attachments_meta === "string" ? event.attachments_meta : null
     const attachments = parseUserAttachmentsMeta(attachmentsMeta)
@@ -396,7 +473,7 @@ export function handleStreamEvent(
 
   // Flush pending thinking/text buffer before tool_call to preserve display order
   if (event.type === "tool_call") {
-    flushPendingStreamDeltas(sid, deps, true)
+    flushPendingStreamDeltas(sid, deps, true, eventStreamId)
   }
 
   // Handle tool_call, tool_result, model_fallback, codex_auth_expired via updateSessionMessages
@@ -508,11 +585,12 @@ export function handleStreamEvent(
           calls[idx] = { ...calls[idx], arguments: args }
         }
         const blocks: ContentBlock[] = [...(last.contentBlocks || [])]
-        const blockIdx = blocks.findIndex(
-          (b) => b.type === "tool_call" && b.tool.callId === callId,
-        )
+        const blockIdx = blocks.findIndex((b) => b.type === "tool_call" && b.tool.callId === callId)
         if (blockIdx >= 0) {
-          const block = blocks[blockIdx] as { type: "tool_call"; tool: { callId: string; name: string; arguments: string } }
+          const block = blocks[blockIdx] as {
+            type: "tool_call"
+            tool: { callId: string; name: string; arguments: string }
+          }
           blocks[blockIdx] = {
             type: "tool_call",
             tool: { ...block.tool, arguments: args },
@@ -533,13 +611,14 @@ export function handleStreamEvent(
         const toolMetadata = extractToolMetadata(event)
         const calls = [...(last.toolCalls || [])]
         const idx = calls.findIndex((c) => c.callId === event.call_id)
-        const resolvedDurationMs = (event.duration_ms as number | undefined) ?? (
-          idx >= 0 && calls[idx].startedAtMs ? Date.now() - calls[idx].startedAtMs! : undefined
-        )
+        const resolvedDurationMs =
+          (event.duration_ms as number | undefined) ??
+          (idx >= 0 && calls[idx].startedAtMs ? Date.now() - calls[idx].startedAtMs! : undefined)
         if (idx >= 0) {
-          const isError = typeof event.is_error === "boolean"
-            ? event.is_error as boolean
-            : hasToolError({ result: event.result as string | undefined })
+          const isError =
+            typeof event.is_error === "boolean"
+              ? (event.is_error as boolean)
+              : hasToolError({ result: event.result as string | undefined })
           calls[idx] = {
             ...calls[idx],
             result: event.result as string,
@@ -570,9 +649,10 @@ export function handleStreamEvent(
             tool: {
               ...block.tool,
               result: event.result as string,
-              isError: typeof event.is_error === "boolean"
-                ? event.is_error as boolean
-                : hasToolError({ result: event.result as string | undefined }),
+              isError:
+                typeof event.is_error === "boolean"
+                  ? (event.is_error as boolean)
+                  : hasToolError({ result: event.result as string | undefined }),
               ...(mediaItems && { mediaItems }),
               ...(resolvedDurationMs != null ? { durationMs: resolvedDurationMs } : {}),
               ...(toolMetadata ? { metadata: toolMetadata } : {}),

--- a/src/components/chat/subagent/SubagentSessionView.tsx
+++ b/src/components/chat/subagent/SubagentSessionView.tsx
@@ -65,7 +65,7 @@ export default function SubagentSessionView({
   const sessionsRef = useRef<SessionMeta[]>([])
   const currentSessionIdRef = useRef<string | null>(null)
   const lastSeqRef = useRef<Map<string, number>>(new Map())
-  const endedStreamIdsRef = useRef<Map<string, string>>(new Map())
+  const endedStreamIdsRef = useRef<Map<string, Set<string>>>(new Map())
   const loadingSessionsRef = useRef<Set<string>>(new Set())
   const sessionCacheRef = useRef<Map<string, Message[]>>(new Map())
   const loadedSessionIdRef = useRef<string | null>(null)
@@ -100,8 +100,9 @@ export default function SubagentSessionView({
   }, [])
 
   const handleTurnEnded = useCallback((sid: string, status?: ChatTurnStatus | null) => {
-    if (sid !== currentSessionIdRef.current) return
+    if (sid !== currentSessionIdRef.current) return false
     setExecutionState(status ?? null)
+    return true
   }, [])
 
   useChatStreamReattach({

--- a/src/components/design/chat/DesignChatPanel.tsx
+++ b/src/components/design/chat/DesignChatPanel.tsx
@@ -48,12 +48,7 @@ import {
   forkSessionRequestForMessage,
   type ForkComposerDraft,
 } from "@/components/chat/message/messageFork"
-import type {
-  ActiveModel,
-  ForkSessionResult,
-  Message,
-  PendingFileQuote,
-} from "@/types/chat"
+import type { ActiveModel, ForkSessionResult, Message, PendingFileQuote } from "@/types/chat"
 import type { DesignRecipe } from "@/types/design"
 import { useDesignChat } from "./useDesignChat"
 import { DesignConversationHistory } from "./DesignConversationHistory"
@@ -77,7 +72,8 @@ const DESIGN_STARTERS: {
     titleKey: "design.chat.starterOutlineTitle",
     titleFallback: "先规划大纲",
     promptKey: "design.chat.starterOutlinePrompt",
-    promptFallback: "先别急着做，请先给我一份结构大纲（分节 / 分页的标题与要点、叙事顺序），我确认后你再按大纲生成正式产物。",
+    promptFallback:
+      "先别急着做，请先给我一份结构大纲（分节 / 分页的标题与要点、叙事顺序），我确认后你再按大纲生成正式产物。",
   },
   {
     key: "palette",
@@ -275,7 +271,7 @@ export const DesignChatPanel = forwardRef<DesignChatPanelHandle, Props>(function
   // 跟随主聊天的「任务 / 气泡」显示模式与回合折叠偏好（设置页改动实时生效）。
   const { displayMode, autoCollapseCompletedTurns } = useChatDisplayPreferences()
   const seqRef = useRef<Map<string, number>>(new Map())
-  const endedRef = useRef<Map<string, string>>(new Map())
+  const endedRef = useRef<Map<string, Set<string>>>(new Map())
   const [messageTailVisible, setMessageTailVisible] = useState(true)
   useEmbeddedChatReadReceipt(
     isActive,
@@ -414,8 +410,7 @@ export const DesignChatPanel = forwardRef<DesignChatPanelHandle, Props>(function
             ? prev
             : [...prev, quote],
         ),
-      insertToken: (token) =>
-        stream.setInput((prev) => (prev.trim() ? `${prev} ${token}` : token)),
+      insertToken: (token) => stream.setInput((prev) => (prev.trim() ? `${prev} ${token}` : token)),
       addImageAttachment: (file) => {
         if (file.size > stream.maxChatAttachmentBytes) {
           toast.error(
@@ -497,11 +492,7 @@ export const DesignChatPanel = forwardRef<DesignChatPanelHandle, Props>(function
   const nextStepOverflowItems = showNextStep ? (
     <>
       {lastUserContent.trim() && (
-        <button
-          type="button"
-          className={FLOATING_MENU_ITEM_CLASS}
-          onClick={() => retryLastTurn()}
-        >
+        <button type="button" className={FLOATING_MENU_ITEM_CLASS} onClick={() => retryLastTurn()}>
           <RotateCcw className="h-3.5 w-3.5" />
           {t("design.chat.regenerate", "重新生成")}
         </button>
@@ -686,9 +677,7 @@ export const DesignChatPanel = forwardRef<DesignChatPanelHandle, Props>(function
               void getTransport()
                 .call("rename_session_cmd", { sessionId: sid, title })
                 .then(() => session.reloadThreads())
-                .catch((e) =>
-                  logger.error("ui", "DesignChat::rename", "rename thread failed", e),
-                )
+                .catch((e) => logger.error("ui", "DesignChat::rename", "rename thread failed", e))
             }}
             onArchive={(sid) => {
               void getTransport()
@@ -703,9 +692,7 @@ export const DesignChatPanel = forwardRef<DesignChatPanelHandle, Props>(function
                   if (session.currentSessionIdRef.current === sid) session.handleNewThread()
                   return session.reloadThreads()
                 })
-                .catch((e) =>
-                  logger.error("ui", "DesignChat::archive", "archive thread failed", e),
-                )
+                .catch((e) => logger.error("ui", "DesignChat::archive", "archive thread failed", e))
             }}
           />
         </div>
@@ -770,13 +757,18 @@ export const DesignChatPanel = forwardRef<DesignChatPanelHandle, Props>(function
         )}
       </div>
 
-      <ApprovalDialog requests={stream.approvalRequests} onRespond={stream.handleApprovalResponse} />
+      <ApprovalDialog
+        requests={stream.approvalRequests}
+        onRespond={stream.handleApprovalResponse}
+      />
 
       {/* 回合失败恢复条（P1-G）：末条是标记的失败事件时，给一键重试（重跑上一句 user prompt）。
           错误详情已由消息流里的 event 行呈现，本条只补此前缺失的「重试」出口。 */}
       {!session.loading && lastTurnFailed && !stream.input.trim() && lastUserContent.trim() && (
         <div className="flex items-center gap-2 px-3 pb-1.5">
-          <span className="text-xs text-destructive">{t("design.chat.turnFailed", "回合失败")}</span>
+          <span className="text-xs text-destructive">
+            {t("design.chat.turnFailed", "回合失败")}
+          </span>
           <button
             type="button"
             onClick={retryLastTurn}

--- a/src/components/knowledge/chat/KnowledgeChatPanel.tsx
+++ b/src/components/knowledge/chat/KnowledgeChatPanel.tsx
@@ -94,7 +94,7 @@ export const KnowledgeChatPanel = forwardRef<KnowledgeChatPanelHandle, Props>(
     // 跟随主聊天的「任务 / 气泡」显示模式与回合折叠偏好（设置页改动实时生效）。
     const { displayMode, autoCollapseCompletedTurns } = useChatDisplayPreferences()
     const seqRef = useRef<Map<string, number>>(new Map())
-    const endedRef = useRef<Map<string, string>>(new Map())
+    const endedRef = useRef<Map<string, Set<string>>>(new Map())
     const [messageTailVisible, setMessageTailVisible] = useState(true)
     useEmbeddedChatReadReceipt(
       isActive,

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -82,6 +82,9 @@ export interface ChatStartArgs {
   message: string;
   attachments: ReadonlyArray<ChatAttachment>;
   sessionId: string | null;
+  /** Opaque UI request identity used to stop a first turn before its lazy
+   *  session id has reached the frontend. */
+  clientRequestId?: string;
   incognito?: boolean;
   modelOverride?: string;
   /** Draft-only values snapshotted when the first turn creates the Session. */


### PR DESCRIPTION
## What changed

- route Desktop GUI Stop, HTTP Stop, IM `/stop`, Channel cancellation, and global Stop through shared core orchestration
- make preflight, provider/tool loops, approvals, questions, runtime jobs, subagents, and child processes observe the same cancellation lifecycle
- gate replacement turns while old-generation cleanup snapshots exact runtime identities
- bind watchdog recovery and frontend stream reconciliation to the exact turn/stream generation
- bound ACP ordinary inbound buffering while keeping `session/cancel` on an out-of-band control path
- document the unified transport and recovery contracts

## Why

Stop could become ineffective while a turn was in preflight, waiting for approval/input, executing tools, running subagents/processes, or recovering a stream. Delayed session-wide cleanup and watchdog work could also collide with a newly continued turn, while stale frontend stream events could overwrite the replacement response.

## User impact

GUI Stop and IM `/stop` now have the same behavior after entry-point resolution: cancellation is acknowledged promptly, partial durable output is preserved as interrupted, waits and owned runtime work are settled, and a later conversation can start without old cleanup or stream events corrupting it.

## Validation

- `cargo check -p ha-core`
- `cargo check -p ha-server`
- Tauri shell check with release-only external binaries disabled
- `pnpm typecheck`
- targeted Rust Stop/generation/watchdog persistence tests
- `pnpm vitest run src/components/chat/hooks/useChatStreamReattach.test.tsx` (8 tests)
- `cargo fmt --all -- --check`
- `git diff --check`
