### PR TITLE
fix(web): normalize HTTP transport response contracts

### DIFF
--- a/src/lib/transport-http.test.ts
+++ b/src/lib/transport-http.test.ts
@@ -182,10 +182,10 @@ test("HttpTransport mints a path-bound ticket for session file previews", async 
 
 test("HttpTransport uses the protected direct session route when authentication is disabled", async () => {
   fetchMock.mockResolvedValueOnce(
-    new Response(
-      JSON.stringify({ authRequired: false, ticket: null, expiresInSecs: null }),
-      { status: 200, headers: { "content-type": "application/json" } },
-    ),
+    new Response(JSON.stringify({ authRequired: false, ticket: null, expiresInSecs: null }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
   )
   const transport = new HttpTransport("http://localhost:8420")
 
@@ -708,6 +708,223 @@ test("HttpTransport.try_restore_session unwraps HTTP restored payload", async ()
   const restored = await transport.call<boolean>("try_restore_session")
 
   expect(restored).toBe(true)
+})
+
+test("HttpTransport unwraps Agent markdown and template content like Tauri", async () => {
+  const transport = new HttpTransport("http://localhost:8420")
+
+  fetchMock
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ content: "# Agent instructions" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ content: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ content: "# Built-in template" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+
+  await expect(
+    transport.call<string | null>("get_agent_markdown", {
+      id: "agent-1",
+      file: "agent.md",
+    }),
+  ).resolves.toBe("# Agent instructions")
+  await expect(
+    transport.call<string | null>("get_agent_markdown", {
+      id: "agent-1",
+      file: "persona.md",
+    }),
+  ).resolves.toBeNull()
+  await expect(
+    transport.call<string>("get_agent_template", { name: "agent", locale: "zh" }),
+  ).resolves.toBe("# Built-in template")
+
+  expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+    "http://localhost:8420/api/agents/agent-1/markdown?file=agent.md",
+    "http://localhost:8420/api/agents/agent-1/markdown?file=persona.md",
+    "http://localhost:8420/api/agents/template?name=agent&locale=zh",
+  ])
+})
+
+test.each([
+  {
+    command: "get_system_prompt",
+    args: { agentId: "agent-1" },
+    payload: { system_prompt: "# System prompt" },
+    expected: "# System prompt",
+  },
+  {
+    command: "render_persona_to_soul_md",
+    args: { id: "agent-1", persona: {} },
+    payload: { content: "# Soul" },
+    expected: "# Soul",
+  },
+  {
+    command: "read_log_file_cmd",
+    args: { filename: "app.log" },
+    payload: { content: "log line" },
+    expected: "log line",
+  },
+  {
+    command: "get_log_file_path_cmd",
+    args: undefined,
+    payload: { path: "/tmp/app.log" },
+    expected: "/tmp/app.log",
+  },
+  {
+    command: "export_logs_cmd",
+    args: { filter: {}, format: "json" },
+    payload: { data: "[]" },
+    expected: "[]",
+  },
+  {
+    command: "install_skill_dependency",
+    args: { skillName: "demo", specIndex: 0 },
+    payload: { ok: true, output: "installed" },
+    expected: "installed",
+  },
+  {
+    command: "channel_validate_credentials",
+    args: { channelId: "telegram", credentials: {}, settings: {} },
+    payload: { info: "Hope Bot" },
+    expected: "Hope Bot",
+  },
+  {
+    command: "create_backup_cmd",
+    args: undefined,
+    payload: { name: "backup.zip" },
+    expected: "backup.zip",
+  },
+])(
+  "HttpTransport unwraps $command string payload like Tauri",
+  async ({ command, args, payload, expected }) => {
+    const transport = new HttpTransport("http://localhost:8420")
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+
+    await expect(
+      transport.call<string>(command, args as Record<string, unknown> | undefined),
+    ).resolves.toBe(expected)
+  },
+)
+
+test.each([
+  {
+    command: "get_agent_memory_md",
+    args: { id: "agent-1" },
+    payload: { content: "# Agent memory" },
+    expected: "# Agent memory",
+  },
+  {
+    command: "get_global_memory_md",
+    args: undefined,
+    payload: { content: null },
+    expected: null,
+  },
+])(
+  "HttpTransport unwraps $command optional content like Tauri",
+  async ({ command, args, payload, expected }) => {
+    const transport = new HttpTransport("http://localhost:8420")
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+
+    await expect(
+      transport.call<string | null>(command, args as Record<string, unknown> | undefined),
+    ).resolves.toBe(expected)
+  },
+)
+
+test.each([
+  ["get_skill_env_check", { enabled: false }, false],
+  ["get_skills_auto_review_enabled", { enabled: true }, true],
+  ["get_skills_auto_review_promotion", { auto: false }, false],
+])("HttpTransport unwraps %s boolean payload like Tauri", async (command, payload, expected) => {
+  const transport = new HttpTransport("http://localhost:8420")
+  fetchMock.mockResolvedValue(
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  )
+
+  await expect(transport.call<boolean>(command)).resolves.toBe(expected)
+})
+
+test.each(["test_provider", "test_model"])(
+  "HttpTransport preserves the %s JSON-string contract",
+  async (command) => {
+    const transport = new HttpTransport("http://localhost:8420")
+    const payload = { success: false, message: "connection failed", latencyMs: 12 }
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+
+    const args = command === "test_provider" ? { config: {} } : { config: {}, modelId: "m1" }
+    await expect(transport.call<string>(command, args)).resolves.toBe(JSON.stringify(payload))
+  },
+)
+
+test.each(["test_provider", "test_model"])(
+  "HttpTransport rejects a scalar %s error like Tauri",
+  async (command) => {
+    const transport = new HttpTransport("http://localhost:8420")
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify("Client error: invalid user agent"), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+
+    const args = command === "test_provider" ? { config: {} } : { config: {}, modelId: "m1" }
+    await expect(transport.call<string>(command, args)).rejects.toThrow(
+      "Client error: invalid user agent",
+    )
+  },
+)
+
+test("HttpTransport aligns proxy probe success and failure with Tauri", async () => {
+  const transport = new HttpTransport("http://localhost:8420")
+  fetchMock
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, message: "Proxy connected" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+    .mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: false, message: "Proxy unavailable" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    )
+
+  await expect(transport.call<string>("test_proxy", { config: {} })).resolves.toBe(
+    "Proxy connected",
+  )
+  await expect(transport.call<string>("test_proxy", { config: {} })).rejects.toThrow(
+    "Proxy unavailable",
+  )
 })
 
 test("HttpTransport unwraps the Git auto-merge input for the HTTP owner API", async () => {

--- a/src/lib/transport-http.ts
+++ b/src/lib/transport-http.ts
@@ -1853,6 +1853,16 @@ function normalizeCommandResponse(command: string, value: unknown): unknown {
     const paginated = value as { sessions: unknown; total: unknown }
     return [paginated.sessions, paginated.total]
   }
+  if (command === "test_provider" || command === "test_model") {
+    // HTTP parses the core JSON string before returning it; Tauri passes that
+    // JSON string through. A non-JSON core error becomes a JSON string scalar
+    // over HTTP, which must reject just like the Tauri command instead of being
+    // interpreted as a successful plain-text result by parseTestResult().
+    if (typeof value === "string") throw new Error(value)
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return JSON.stringify(value)
+    }
+  }
   if (value && typeof value === "object" && !Array.isArray(value)) {
     const record = value as Record<string, unknown>
     switch (command) {
@@ -1861,6 +1871,43 @@ function normalizeCommandResponse(command: string, value: unknown): unknown {
       case "get_plan_content":
       case "load_plan_version_content":
         return record.content
+      case "get_agent_markdown":
+      case "get_agent_memory_md":
+      case "get_global_memory_md":
+        // HTTP wraps the optional file contents as `{ content }`, while the
+        // Tauri command returns `Option<String>` directly. Preserve `null` so
+        // callers can distinguish a missing file from an intentionally empty one.
+        return record.content ?? null
+      case "get_agent_template":
+      case "render_persona_to_soul_md":
+      case "read_log_file_cmd":
+        // HTTP wraps required text responses as `{ content }`; Tauri returns
+        // the string directly.
+        return record.content ?? ""
+      case "get_system_prompt":
+        return record.system_prompt ?? ""
+      case "get_log_file_path_cmd":
+        return record.path ?? ""
+      case "export_logs_cmd":
+        return record.data ?? ""
+      case "install_skill_dependency":
+        return record.output ?? ""
+      case "channel_validate_credentials":
+        return record.info ?? ""
+      case "create_backup_cmd":
+        return record.name ?? ""
+      case "get_skill_env_check":
+      case "get_skills_auto_review_enabled":
+        return record.enabled ?? false
+      case "get_skills_auto_review_promotion":
+        return record.auto ?? false
+      case "test_proxy":
+        // The HTTP route reports probe failures in a 200 response, whereas the
+        // Tauri command rejects. Keep callers' success/error branches aligned.
+        if (record.success === false) {
+          throw new Error(String(record.message ?? "Proxy test failed"))
+        }
+        return record.message ?? ""
       case "get_plan_file_path":
         return record.filePath
       case "get_plan_checkpoint":


### PR DESCRIPTION
## What changed

- unwrap HTTP response envelopes for Agent markdown/templates, memory files, system prompts, logs, Skills, Channel validation, and backup creation
- preserve Tauri-compatible boolean and string return contracts in Web mode
- normalize Provider/Model test payloads back to JSON strings and reject scalar errors
- align proxy probe failures with the Tauri rejected-promise behavior
- add regression coverage for all normalized response shapes

## Root cause

The Axum routes return JSON envelopes such as `{ content }`, `{ enabled }`, or `{ message }`, while the matching Tauri commands return scalar values directly. `HttpTransport` forwarded those envelopes unchanged, so Web-mode callers received objects where they expected strings or booleans. For Agent markdown this made `value.length` undefined and caused the reported `toLocaleString` crash.

## User impact

Web Agent settings no longer crash when loading Agent markdown. Related HTTP-only settings and diagnostics now receive the same effective values as the desktop transport.

## Validation

- `pnpm exec vitest run src/lib/transport-http.test.ts` (43/43)
- `pnpm typecheck`
- Prettier check for the changed files
- `git diff --check`

Fixes #612