### PR TITLE
feat(updater): 支持远端服务更新提示

### DIFF
--- a/crates/ha-server/src/lib.rs
+++ b/crates/ha-server/src/lib.rs
@@ -271,6 +271,11 @@ fn build_router_with_cors(
     // Protected API routes
     let api = Router::new()
         .route("/server/status", get(routes::server_status::server_status))
+        .route("/app-update/status", get(routes::app_update::status))
+        .route("/app-update/check", post(routes::app_update::check))
+        .route("/app-update/prepare", post(routes::app_update::prepare))
+        .route("/app-update/confirm", post(routes::app_update::confirm))
+        .route("/app-update/jobs/{job_id}", get(routes::app_update::job))
         .route(
             "/auth/token/rotate",
             post(routes::auth::rotate_server_owner_token),

--- a/crates/ha-server/src/routes/app_update.rs
+++ b/crates/ha-server/src/routes/app_update.rs
@@ -1,0 +1,75 @@
+//! Owner-only HTTP surface for updating the service process itself.
+
+use axum::extract::Path;
+use axum::{Extension, Json};
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::middleware::AuthState;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PrepareInstallBody {
+    current_version: String,
+    target_version: String,
+    server_instance_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfirmInstallBody {
+    plan_id: String,
+}
+
+pub async fn status() -> Result<Json<ha_updater::remote_update::RemoteUpdateStatus>, AppError> {
+    Ok(Json(ha_updater::remote_update::status().await?))
+}
+
+pub async fn check() -> Result<Json<ha_updater::remote_update::RemoteUpdateStatus>, AppError> {
+    Ok(Json(ha_updater::remote_update::check_now().await?))
+}
+
+pub async fn prepare(
+    Extension(auth): Extension<AuthState>,
+    Json(body): Json<PrepareInstallBody>,
+) -> Result<Json<ha_updater::remote_update::RemoteInstallPlan>, AppError> {
+    require_explicit_owner_auth(&auth)?;
+    let plan = ha_updater::remote_update::prepare_install(
+        &body.current_version,
+        &body.target_version,
+        &body.server_instance_id,
+    )
+    .await
+    .map_err(|error| AppError::conflict_with_code("stale_update_plan", error.to_string()))?;
+    Ok(Json(plan))
+}
+
+pub async fn confirm(
+    Extension(auth): Extension<AuthState>,
+    Json(body): Json<ConfirmInstallBody>,
+) -> Result<Json<ha_updater::remote_update::RemoteUpdateJob>, AppError> {
+    require_explicit_owner_auth(&auth)?;
+    let job = ha_updater::remote_update::confirm_install(&body.plan_id)
+        .await
+        .map_err(|error| AppError::conflict_with_code("update_not_started", error.to_string()))?;
+    Ok(Json(job))
+}
+
+pub async fn job(
+    Path(job_id): Path<String>,
+) -> Result<Json<ha_updater::remote_update::RemoteUpdateJob>, AppError> {
+    let job = ha_updater::remote_update::job_status(&job_id)
+        .await?
+        .ok_or_else(|| AppError::not_found("update job not found"))?;
+    Ok(Json(job))
+}
+
+fn require_explicit_owner_auth(auth: &AuthState) -> Result<(), AppError> {
+    if auth.auth_required() {
+        Ok(())
+    } else {
+        Err(AppError::forbidden(
+            "远程服务端更新要求启用 Server Owner Token",
+        ))
+    }
+}

--- a/crates/ha-server/src/routes/mod.rs
+++ b/crates/ha-server/src/routes/mod.rs
@@ -3,6 +3,7 @@ pub mod helpers;
 
 pub mod acp;
 pub mod agents;
+pub mod app_update;
 pub mod artifacts;
 pub mod attachments;
 pub mod auth;

--- a/crates/ha-server/src/web_assets.rs
+++ b/crates/ha-server/src/web_assets.rs
@@ -151,9 +151,23 @@ fn build_response(path: &str, asset: Asset, headers: &HeaderMap) -> Response<Bod
     let mime = HeaderValue::from_str(mime.as_ref())
         .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream"));
 
+    // The HTML entry point must be revalidated after a server self-update so
+    // it can reference the new content-hashed bundles. Vite assets are safe to
+    // cache forever because their filenames change with their contents.
+    let cache_control = if path == "index.html" {
+        "no-cache"
+    } else if path.starts_with("assets/") {
+        "public, max-age=31536000, immutable"
+    } else {
+        "no-cache"
+    };
     let builder = Response::builder()
         .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, mime);
+        .header(header::CONTENT_TYPE, mime)
+        .header(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static(cache_control),
+        );
 
     if !asset.compressed {
         return builder

--- a/crates/ha-updater/src/auto_check.rs
+++ b/crates/ha-updater/src/auto_check.rs
@@ -116,6 +116,14 @@ async fn run_check_once(cfg: &AutoUpdateConfig) {
             return;
         }
     };
+    if let Err(e) = super::remote_update::record_check(outcome.clone(), manifest.clone()).await {
+        app_warn!(
+            "self_update",
+            "auto_check",
+            "failed to persist remote update snapshot: {}",
+            e
+        );
+    }
     if !outcome.has_update {
         app_debug!(
             "self_update",
@@ -187,6 +195,14 @@ async fn run_check_once(cfg: &AutoUpdateConfig) {
                 );
                 if let Some(bus) = ha_core::get_event_bus() {
                     bus.emit("app_update:staged", json!({ "version": staged_version }));
+                }
+                if let Err(e) = super::remote_update::record_staged(staged_version).await {
+                    app_warn!(
+                        "self_update",
+                        "auto_check",
+                        "failed to persist staged update snapshot: {}",
+                        e
+                    );
                 }
             }
             Err(e) => app_warn!(

--- a/crates/ha-updater/src/download.rs
+++ b/crates/ha-updater/src/download.rs
@@ -281,6 +281,10 @@ async fn ssrf_check(url: &str) -> Result<()> {
 }
 
 fn emit_progress(job_id: &str, label: &str, written: u64, total: Option<u64>, phase: &str) {
+    let percent = total
+        .map(|t| ((written * 100) / t.max(1)) as u32)
+        .unwrap_or(0);
+    super::remote_update::record_progress_sync(job_id, phase, Some(percent));
     if let Some(bus) = ha_core::get_event_bus() {
         bus.emit(
             "app_update:progress",
@@ -290,9 +294,7 @@ fn emit_progress(job_id: &str, label: &str, written: u64, total: Option<u64>, ph
                 "phase": phase,
                 "written": written,
                 "total": total,
-                "percent": total
-                    .map(|t| ((written * 100) / t.max(1)) as u32)
-                    .unwrap_or(0),
+                "percent": percent,
             }),
         );
     }

--- a/crates/ha-updater/src/lib.rs
+++ b/crates/ha-updater/src/lib.rs
@@ -43,6 +43,7 @@ pub mod download;
 pub mod keys;
 pub mod manifest;
 pub mod package_manager;
+pub mod remote_update;
 pub mod self_contained;
 pub mod service_control;
 pub mod signature;
@@ -96,7 +97,7 @@ pub fn wire() {
 }
 
 pub use config::AutoUpdateConfig;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use source_detector::InstallSource;
 
@@ -147,7 +148,7 @@ pub struct CheckOutcome {
     pub bare_binary_available: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RecommendedPath {
     /// Desktop is in the foreground — route to `tauri-plugin-updater`.

--- a/crates/ha-updater/src/remote_update.rs
+++ b/crates/ha-updater/src/remote_update.rs
@@ -1,0 +1,596 @@
+//! Owner-plane update lifecycle for a remotely connected Web / desktop UI.
+//!
+//! The browser never supplies a command, URL, artifact, or filesystem path.
+//! It may only confirm a short-lived, process-bound plan produced from a
+//! freshly verified release manifest. Durable job state lives under the
+//! updater data directory so the new process can reconcile an interrupted
+//! connection after a service restart.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use anyhow::{Context, Result};
+use chrono::{Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::manifest::Manifest;
+use crate::source_detector::InstallSource;
+use crate::{CheckOutcome, RecommendedPath};
+
+const STATE_FILE: &str = "remote-update-state.json";
+const PLAN_TTL_MINUTES: i64 = 5;
+const MAX_JOBS: usize = 8;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteUpdateSnapshot {
+    pub server_instance_id: String,
+    pub current_version: String,
+    pub latest_version: String,
+    pub has_update: bool,
+    pub install_source: String,
+    pub recommended_path: RecommendedPath,
+    pub capability: RemoteUpdateCapability,
+    pub notes: Option<String>,
+    pub pub_date: Option<String>,
+    pub bare_binary_available: bool,
+    pub staged_version: Option<String>,
+    pub checked_at: String,
+    pub manual_instructions: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteUpdateCapability {
+    Automatic,
+    DockerRedeploy,
+    Manual,
+    DesktopOnly,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteUpdateJob {
+    pub job_id: String,
+    pub from_version: String,
+    pub target_version: String,
+    pub path: RecommendedPath,
+    pub status: RemoteJobStatus,
+    pub phase: String,
+    pub percent: Option<u32>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RemoteJobStatus {
+    Running,
+    AwaitingRestart,
+    Succeeded,
+    Failed,
+}
+
+impl RemoteJobStatus {
+    fn terminal(self) -> bool {
+        matches!(self, Self::Succeeded | Self::Failed)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteUpdateStatus {
+    pub server_instance_id: String,
+    pub current_version: String,
+    pub snapshot: Option<RemoteUpdateSnapshot>,
+    pub active_job: Option<RemoteUpdateJob>,
+    pub recent_jobs: Vec<RemoteUpdateJob>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteInstallPlan {
+    pub plan_id: Option<String>,
+    pub server_instance_id: String,
+    pub current_version: String,
+    pub target_version: String,
+    pub path: RecommendedPath,
+    pub capability: RemoteUpdateCapability,
+    pub expires_at: Option<String>,
+    pub confirmation: String,
+    pub manual_instructions: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingPlan {
+    public: RemoteInstallPlan,
+    source: InstallSource,
+    manifest: Manifest,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PersistedState {
+    snapshot: Option<RemoteUpdateSnapshot>,
+    jobs: Vec<RemoteUpdateJob>,
+}
+
+#[derive(Default)]
+struct RuntimeState {
+    persisted: PersistedState,
+    plans: HashMap<String, PendingPlan>,
+}
+
+fn runtime() -> &'static Mutex<RuntimeState> {
+    static RUNTIME: OnceLock<Mutex<RuntimeState>> = OnceLock::new();
+    RUNTIME.get_or_init(|| Mutex::new(RuntimeState::default()))
+}
+
+fn server_instance_id() -> &'static str {
+    static ID: OnceLock<String> = OnceLock::new();
+    ID.get_or_init(|| uuid::Uuid::new_v4().to_string())
+}
+
+fn now() -> String {
+    Utc::now().to_rfc3339()
+}
+
+fn state_path() -> Result<std::path::PathBuf> {
+    Ok(ha_core::paths::updater_dir()?.join(STATE_FILE))
+}
+
+async fn ensure_loaded() -> Result<()> {
+    static LOADED: AtomicBool = AtomicBool::new(false);
+    static LOAD_LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+    if LOADED.load(Ordering::Acquire) {
+        return Ok(());
+    }
+    let _guard = LOAD_LOCK
+        .get_or_init(|| tokio::sync::Mutex::new(()))
+        .lock()
+        .await;
+    if LOADED.load(Ordering::Acquire) {
+        return Ok(());
+    }
+    let loaded = ha_core::blocking::run_blocking(|| -> Result<PersistedState> {
+        let path = state_path()?;
+        if !path.exists() {
+            return Ok(PersistedState::default());
+        }
+        let bytes = std::fs::read(&path)
+            .with_context(|| format!("read remote update state {}", path.display()))?;
+        serde_json::from_slice(&bytes).context("parse remote update state")
+    })
+    .await?;
+    {
+        let mut g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+        g.persisted = loaded;
+        reconcile_after_restart(&mut g.persisted);
+    }
+    LOADED.store(true, Ordering::Release);
+    persist().await
+}
+
+fn reconcile_after_restart(state: &mut PersistedState) {
+    let current = ha_core::app_init::app_version();
+    let stamp = now();
+    if let Some(snapshot) = state.snapshot.as_mut() {
+        snapshot.server_instance_id = server_instance_id().into();
+        snapshot.current_version = current.into();
+        if snapshot.latest_version.trim_start_matches('v') == current.trim_start_matches('v') {
+            snapshot.has_update = false;
+        }
+    }
+    for job in &mut state.jobs {
+        if job.target_version.trim_start_matches('v') == current.trim_start_matches('v') {
+            if job.status != RemoteJobStatus::Succeeded {
+                job.updated_at = stamp.clone();
+                job.status = RemoteJobStatus::Succeeded;
+                job.phase = "done".into();
+                job.percent = Some(100);
+                job.error = None;
+            }
+            continue;
+        }
+        if job.status.terminal() {
+            continue;
+        }
+        job.updated_at = stamp.clone();
+        job.status = RemoteJobStatus::Failed;
+        job.phase = "restart_failed".into();
+        job.error = Some(format!(
+            "服务已重新启动，但运行版本仍为 {current}；请检查服务管理器或手动恢复"
+        ));
+    }
+}
+
+async fn persist() -> Result<()> {
+    let bytes = {
+        let g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+        serde_json::to_vec_pretty(&g.persisted).context("serialize remote update state")?
+    };
+    ha_core::blocking::run_blocking(move || -> Result<()> {
+        let path = state_path()?;
+        ha_core::platform::write_atomic(&path, &bytes)
+            .with_context(|| format!("write remote update state {}", path.display()))
+    })
+    .await
+}
+
+fn capability(outcome: &CheckOutcome) -> (RemoteUpdateCapability, Option<String>) {
+    match (&outcome.install_source, outcome.recommended_path) {
+        (InstallSource::Docker, _) => (
+            RemoteUpdateCapability::DockerRedeploy,
+            Some(format!(
+                "此服务运行在 Docker 中。请拉取包含 Hope Agent {} 的新镜像并重新创建容器；服务端不会在容器内替换二进制。",
+                outcome.latest_version
+            )),
+        ),
+        (_, RecommendedPath::SelfContained | RecommendedPath::PackageManager) => {
+            (RemoteUpdateCapability::Automatic, None)
+        }
+        (_, RecommendedPath::Tauri) => (
+            RemoteUpdateCapability::DesktopOnly,
+            Some("该服务来自桌面应用包，请在服务器本机更新桌面应用。".into()),
+        ),
+        _ => (
+            RemoteUpdateCapability::Manual,
+            Some(format!(
+                "当前安装方式不支持远程自动更新，请在服务器上手动安装 Hope Agent {}。",
+                outcome.latest_version
+            )),
+        ),
+    }
+}
+
+fn snapshot_from(outcome: &CheckOutcome, staged_version: Option<String>) -> RemoteUpdateSnapshot {
+    let (capability, manual_instructions) = capability(outcome);
+    RemoteUpdateSnapshot {
+        server_instance_id: server_instance_id().to_string(),
+        current_version: outcome.current_version.clone(),
+        latest_version: outcome.latest_version.clone(),
+        has_update: outcome.has_update,
+        install_source: outcome.install_source.label().into(),
+        recommended_path: outcome.recommended_path,
+        capability,
+        notes: outcome.notes.clone(),
+        pub_date: outcome.pub_date.clone(),
+        bare_binary_available: outcome.bare_binary_available,
+        staged_version,
+        checked_at: now(),
+        manual_instructions,
+    }
+}
+
+pub async fn status() -> Result<RemoteUpdateStatus> {
+    ensure_loaded().await?;
+    let g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+    let active_job = g
+        .persisted
+        .jobs
+        .iter()
+        .rev()
+        .find(|job| !job.status.terminal())
+        .cloned();
+    Ok(RemoteUpdateStatus {
+        server_instance_id: server_instance_id().into(),
+        current_version: ha_core::app_init::app_version().into(),
+        snapshot: g.persisted.snapshot.clone(),
+        active_job,
+        recent_jobs: g.persisted.jobs.iter().rev().cloned().collect(),
+    })
+}
+
+pub async fn check_now() -> Result<RemoteUpdateStatus> {
+    ensure_loaded().await?;
+    let (outcome, manifest) = crate::check_update_full().await?;
+    record_check(outcome, manifest).await?;
+    status().await
+}
+
+pub async fn record_check(outcome: CheckOutcome, _manifest: Manifest) -> Result<()> {
+    ensure_loaded().await?;
+    {
+        let mut g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+        let staged = g
+            .persisted
+            .snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.staged_version.clone())
+            .filter(|version| version == &outcome.latest_version);
+        g.persisted.snapshot = Some(snapshot_from(&outcome, staged));
+    }
+    persist().await
+}
+
+pub async fn record_staged(version: String) -> Result<()> {
+    ensure_loaded().await?;
+    {
+        let mut g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(snapshot) = g.persisted.snapshot.as_mut() {
+            snapshot.staged_version = Some(version);
+        }
+    }
+    persist().await
+}
+
+pub async fn prepare_install(
+    expected_current_version: &str,
+    target_version: &str,
+    expected_server_instance_id: &str,
+) -> Result<RemoteInstallPlan> {
+    ensure_loaded().await?;
+    if expected_server_instance_id != server_instance_id() {
+        anyhow::bail!("服务已重新启动，请刷新更新状态后重试");
+    }
+    let (outcome, manifest) = crate::check_update_full().await?;
+    if outcome.current_version != expected_current_version {
+        anyhow::bail!("服务版本已变化，请刷新更新状态后重试");
+    }
+    if !outcome.has_update || outcome.latest_version != target_version {
+        anyhow::bail!("目标版本已变化或当前已是最新版本，请重新检查");
+    }
+    let (capability, manual_instructions) = capability(&outcome);
+    let executable = capability == RemoteUpdateCapability::Automatic;
+    let plan_id = executable.then(|| uuid::Uuid::new_v4().to_string());
+    let expires_at =
+        executable.then(|| (Utc::now() + Duration::minutes(PLAN_TTL_MINUTES)).to_rfc3339());
+    let confirmation = if executable {
+        format!(
+            "将远程服务端从 {} 更新到 {}。服务会短暂断开，正在运行的远程任务可能被中止。",
+            outcome.current_version, outcome.latest_version
+        )
+    } else {
+        manual_instructions.clone().unwrap_or_default()
+    };
+    let public = RemoteInstallPlan {
+        plan_id: plan_id.clone(),
+        server_instance_id: server_instance_id().into(),
+        current_version: outcome.current_version.clone(),
+        target_version: outcome.latest_version.clone(),
+        path: outcome.recommended_path,
+        capability,
+        expires_at,
+        confirmation,
+        manual_instructions,
+    };
+    {
+        let mut g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+        let staged = g
+            .persisted
+            .snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.staged_version.clone())
+            .filter(|version| version == &outcome.latest_version);
+        g.persisted.snapshot = Some(snapshot_from(&outcome, staged));
+        if let Some(id) = plan_id {
+            g.plans.retain(|_, plan| {
+                plan.public
+                    .expires_at
+                    .as_deref()
+                    .and_then(|stamp| stamp.parse::<chrono::DateTime<Utc>>().ok())
+                    .is_some_and(|stamp| stamp > Utc::now())
+            });
+            g.plans.insert(
+                id,
+                PendingPlan {
+                    public: public.clone(),
+                    source: outcome.install_source,
+                    manifest,
+                },
+            );
+        }
+    }
+    persist().await?;
+    Ok(public)
+}
+
+pub async fn confirm_install(plan_id: &str) -> Result<RemoteUpdateJob> {
+    ensure_loaded().await?;
+    let (job, plan, pruned_jobs) = {
+        let mut g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+        if g.persisted.jobs.iter().any(|job| !job.status.terminal()) {
+            anyhow::bail!("已有服务端更新任务正在执行");
+        }
+        let plan = g
+            .plans
+            .remove(plan_id)
+            .ok_or_else(|| anyhow::anyhow!("安装计划不存在、已使用或已过期"))?;
+        let expires_at = plan
+            .public
+            .expires_at
+            .as_deref()
+            .and_then(|stamp| stamp.parse::<chrono::DateTime<Utc>>().ok())
+            .ok_or_else(|| anyhow::anyhow!("安装计划不可执行"))?;
+        if expires_at <= Utc::now() || plan.public.server_instance_id != server_instance_id() {
+            anyhow::bail!("安装计划已过期，请重新检查");
+        }
+        if plan.public.capability != RemoteUpdateCapability::Automatic {
+            anyhow::bail!("当前安装方式不支持远程自动更新");
+        }
+        // Execution-layer Docker guard. A stale/malformed plan must never turn
+        // a container deployment into an in-container binary replacement.
+        if matches!(
+            crate::source_detector::detect_install_source(),
+            InstallSource::Docker
+        ) {
+            anyhow::bail!("Docker 部署禁止在容器内替换二进制；请重新拉取镜像");
+        }
+        let stamp = now();
+        let job = RemoteUpdateJob {
+            job_id: format!("remote_{}", uuid::Uuid::new_v4().simple()),
+            from_version: plan.public.current_version.clone(),
+            target_version: plan.public.target_version.clone(),
+            path: plan.public.path,
+            status: RemoteJobStatus::Running,
+            phase: "queued".into(),
+            percent: Some(0),
+            created_at: stamp.clone(),
+            updated_at: stamp,
+            error: None,
+        };
+        g.persisted.jobs.push(job.clone());
+        let pruned_jobs = if g.persisted.jobs.len() > MAX_JOBS {
+            let drain = g.persisted.jobs.len() - MAX_JOBS;
+            g.persisted.jobs.drain(0..drain).collect()
+        } else {
+            Vec::new()
+        };
+        (job, plan, pruned_jobs)
+    };
+    if let Err(error) = persist().await {
+        let mut g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+        g.persisted.jobs.retain(|item| item.job_id != job.job_id);
+        if !pruned_jobs.is_empty() {
+            let mut restored = pruned_jobs;
+            restored.append(&mut g.persisted.jobs);
+            g.persisted.jobs = restored;
+        }
+        g.plans.insert(plan_id.to_string(), plan.clone());
+        return Err(error);
+    }
+    let returned = job.clone();
+    tokio::spawn(async move {
+        execute(job, plan).await;
+    });
+    Ok(returned)
+}
+
+async fn execute(job: RemoteUpdateJob, plan: PendingPlan) {
+    let result: Result<()> = async {
+        match plan.public.path {
+            RecommendedPath::SelfContained => {
+                crate::self_contained::install(
+                    &job.job_id,
+                    Some(&job.target_version),
+                    Some(plan.manifest),
+                )
+                .await?;
+                // The service manager normally terminates us before this line.
+                // If it returns first (or no managed service exists), keep the
+                // durable state at awaiting_restart; only the new process may
+                // claim success after its version matches the target.
+                return Ok(());
+            }
+            RecommendedPath::PackageManager => {
+                crate::self_contained::emit_phase(
+                    &job.job_id,
+                    crate::self_contained::Phase::Downloading,
+                );
+                let source = plan.source;
+                let outcome = ha_core::blocking::run_blocking(move || {
+                    crate::package_manager::upgrade(&source)
+                })
+                .await?;
+                if !outcome.success {
+                    anyhow::bail!(
+                        "package manager upgrade failed: {}\n{}",
+                        outcome.command,
+                        ha_core::truncate_utf8(&outcome.stderr, 1024)
+                    );
+                }
+                mark_restart_pending(&job.job_id).await?;
+                crate::self_contained::emit_phase(
+                    &job.job_id,
+                    crate::self_contained::Phase::Restarting,
+                );
+                crate::service_control::restart_service()?;
+                return Ok(());
+            }
+            _ => anyhow::bail!("安装计划的更新路径不可远程执行"),
+        }
+    }
+    .await;
+
+    match result {
+        Ok(()) => {}
+        Err(error) => {
+            app_warn!(
+                "self_update",
+                "remote_install",
+                "remote update job {} failed: {error:#}",
+                job.job_id
+            );
+            finish_job(
+                &job.job_id,
+                RemoteJobStatus::Failed,
+                Some(error.to_string()),
+            )
+            .await;
+        }
+    }
+}
+
+pub async fn mark_restart_pending(job_id: &str) -> Result<()> {
+    {
+        let mut g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+        if let Some(job) = g.persisted.jobs.iter_mut().find(|job| job.job_id == job_id) {
+            job.status = RemoteJobStatus::AwaitingRestart;
+            job.phase = "restarting".into();
+            job.updated_at = now();
+        } else {
+            return Ok(());
+        }
+    }
+    persist().await
+}
+
+async fn finish_job(job_id: &str, status: RemoteJobStatus, error: Option<String>) {
+    let snapshot = {
+        let mut g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+        let Some(job) = g.persisted.jobs.iter_mut().find(|job| job.job_id == job_id) else {
+            return;
+        };
+        job.status = status;
+        job.phase = if status == RemoteJobStatus::Succeeded {
+            "done".into()
+        } else {
+            "failed".into()
+        };
+        job.percent = (status == RemoteJobStatus::Succeeded).then_some(100);
+        job.error = error.clone();
+        job.updated_at = now();
+        job.clone()
+    };
+    if let Err(error) = persist().await {
+        app_error!(
+            "self_update",
+            "remote_install",
+            "failed to persist terminal state for {}: {error:#}",
+            job_id
+        );
+    }
+    if let Some(bus) = ha_core::get_event_bus() {
+        bus.emit(
+            "app_update:completed",
+            serde_json::json!({
+                "job_id": job_id,
+                "status": status,
+                "error": error,
+                "targetVersion": snapshot.target_version,
+                "remote": true,
+            }),
+        );
+    }
+}
+
+pub fn record_progress_sync(job_id: &str, phase: &str, percent: Option<u32>) {
+    let mut g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+    if let Some(job) = g.persisted.jobs.iter_mut().find(|job| job.job_id == job_id) {
+        job.phase = phase.into();
+        job.percent = percent.or(job.percent);
+        job.updated_at = now();
+    }
+}
+
+pub async fn job_status(job_id: &str) -> Result<Option<RemoteUpdateJob>> {
+    ensure_loaded().await?;
+    let g = runtime().lock().unwrap_or_else(|p| p.into_inner());
+    Ok(g.persisted
+        .jobs
+        .iter()
+        .find(|job| job.job_id == job_id)
+        .cloned())
+}

--- a/crates/ha-updater/src/remote_update.rs
+++ b/crates/ha-updater/src/remote_update.rs
@@ -462,7 +462,7 @@ async fn execute(job: RemoteUpdateJob, plan: PendingPlan) {
     let result: Result<()> = async {
         match plan.public.path {
             RecommendedPath::SelfContained => {
-                crate::self_contained::install(
+                crate::self_contained::install_for_remote(
                     &job.job_id,
                     Some(&job.target_version),
                     Some(plan.manifest),

--- a/crates/ha-updater/src/remote_update.rs
+++ b/crates/ha-updater/src/remote_update.rs
@@ -472,7 +472,7 @@ async fn execute(job: RemoteUpdateJob, plan: PendingPlan) {
                 // If it returns first (or no managed service exists), keep the
                 // durable state at awaiting_restart; only the new process may
                 // claim success after its version matches the target.
-                return Ok(());
+                Ok(())
             }
             RecommendedPath::PackageManager => {
                 crate::self_contained::emit_phase(
@@ -497,7 +497,7 @@ async fn execute(job: RemoteUpdateJob, plan: PendingPlan) {
                     crate::self_contained::Phase::Restarting,
                 );
                 crate::service_control::restart_service()?;
-                return Ok(());
+                Ok(())
             }
             _ => anyhow::bail!("安装计划的更新路径不可远程执行"),
         }

--- a/crates/ha-updater/src/self_contained.rs
+++ b/crates/ha-updater/src/self_contained.rs
@@ -230,6 +230,26 @@ pub async fn install(
     target_version: Option<&str>,
     preloaded_manifest: Option<Manifest>,
 ) -> Result<InstallOutcome> {
+    install_with_restart_requirement(job_id, target_version, preloaded_manifest, false).await
+}
+
+/// Install a remote-owner update. Unlike tool-driven updates, the durable
+/// remote job must become terminal when the service manager rejects restart;
+/// otherwise it would block every later remote update attempt.
+pub async fn install_for_remote(
+    job_id: &str,
+    target_version: Option<&str>,
+    preloaded_manifest: Option<Manifest>,
+) -> Result<InstallOutcome> {
+    install_with_restart_requirement(job_id, target_version, preloaded_manifest, true).await
+}
+
+async fn install_with_restart_requirement(
+    job_id: &str,
+    target_version: Option<&str>,
+    preloaded_manifest: Option<Manifest>,
+    require_restart_success: bool,
+) -> Result<InstallOutcome> {
     let StagedBuild {
         extracted,
         extras,
@@ -315,12 +335,18 @@ pub async fn install(
     // `exit(0)`, and systemd's `Restart=on-failure` would NOT pull
     // us back up after a clean exit — the service would stay
     // stopped with the new binary in place.
-    let restart = service_control::restart_service().ok();
+    let restart_result = service_control::restart_service();
 
     backup::prune();
     // The swap consumed the staged build; drop it so it isn't "reused" later.
     super::staging::prune(None);
     emit_phase(job_id, Phase::Done);
+
+    let restart = if require_restart_success {
+        Some(restart_result.context("restart updated service")?)
+    } else {
+        restart_result.ok()
+    };
 
     Ok(InstallOutcome {
         from_version,

--- a/crates/ha-updater/src/self_contained.rs
+++ b/crates/ha-updater/src/self_contained.rs
@@ -71,6 +71,7 @@ impl Phase {
 }
 
 pub fn emit_phase(job_id: &str, phase: Phase) {
+    super::remote_update::record_progress_sync(job_id, phase.as_str(), None);
     if let Some(bus) = ha_core::get_event_bus() {
         bus.emit(
             "app_update:progress",
@@ -302,6 +303,10 @@ pub async fn install(
     }
 
     emit_phase(job_id, Phase::Restarting);
+    // Persist the restart boundary for owner-plane jobs before this process can
+    // be terminated by the service manager. Tool-driven jobs are not present
+    // in the durable tracker, so this is a cheap no-op for them.
+    super::remote_update::mark_restart_pending(job_id).await?;
     // NOTE: do NOT call `stop_if_running` here — `restart_service`
     // already does atomic kill+restart on every platform
     // (launchctl kickstart -k / systemctl --user restart / schtasks

--- a/docs/architecture/infra/self-update.md
+++ b/docs/architecture/infra/self-update.md
@@ -176,7 +176,7 @@ GUI 入口在「设置 → 关于 → 自动更新」，命令 `get_auto_update_
 - `prepare` 会重新拉 manifest，并创建 5 分钟有效、绑定当前 `serverInstanceId` 的一次性 plan。`confirm` 只接受 `planId`；客户端不能提交下载 URL、命令、安装路径或 package-manager 参数。服务端版本变化、进程重启、plan 复用或过期均 fail closed。
 - `prepare` / `confirm` 即使位于 Bearer 保护路由内，仍要求 Server Owner Token **确实启用**；危险逃生模式下的无鉴权 HTTP 服务不得远程触发自更新。
 - Docker 在推荐层和执行层双重拒绝容器内 binary swap，仅返回拉取新镜像并重建容器的说明。其它 `ManualPrompt` 也只展示指引，不提供一键执行。
-- SelfContained 在调用 service restart 前持久化 `awaiting_restart`。新进程启动后若运行版本等于 job 目标版本，将任务协调为 `succeeded`；否则记为 `failed/restart_failed`，保留恢复线索。
+- SelfContained 在调用 service restart 前持久化 `awaiting_restart`。服务管理器拒绝重启时立即记为 `failed`；新进程启动后若运行版本等于 job 目标版本，将任务协调为 `succeeded`；否则记为 `failed/restart_failed`，保留恢复线索。
 - 前端用公共 `/api/health` 的 `version` 验证重启结果。Tauri remote 只恢复 HTTP/WS 连接，不 relaunch 本机应用；由同一 server 提供静态资源的同源 Web 在目标版本上线后 reload，`index.html` 使用 `Cache-Control: no-cache`，哈希 asset 使用 immutable cache。
 - Tauri 首屏前从本地 `UserConfig` 恢复已保存的 remote transport；远端不可用时留在 embedded IPC，让用户仍可进入设置修复连接。
 

--- a/docs/architecture/infra/self-update.md
+++ b/docs/architecture/infra/self-update.md
@@ -162,6 +162,24 @@ GUI 入口在「设置 → 关于 → 自动更新」，命令 `get_auto_update_
 
 **桌面重启选择前置**：发现新版后 UI 提供两选项——「更新并重启」（装完自动 `relaunch()`）与「仅更新（稍后重启）」（装完停在「已就绪」态等用户显式点重启）。**绝不无条件自动重启**，避免打断进行中的对话。
 
+## Web / 远程桌面统一服务端更新
+
+[`remote_update`](../../../crates/ha-updater/src/remote_update.rs) 给 HTTP owner 平面提供与本机桌面 bundle updater **相互独立**的服务端更新目标：
+
+| 前端形态         | 本机桌面更新 | 所连接服务端更新            |
+| ---------------- | ------------ | --------------------------- |
+| Web              | —            | 提醒、确认、进度、重启恢复  |
+| Tauri + embedded | 有           | —（同一进程，避免重复展示） |
+| Tauri + remote   | 有           | 提醒、确认、进度、重启恢复  |
+
+- 状态写入 `~/.hope-agent/updater/remote-update-state.json`。WebSocket 事件只作低延迟提示；首次连接、重连或 lag 后，前端必重读 `GET /api/app-update/status`，不能把 EventBus 当真相源。
+- `prepare` 会重新拉 manifest，并创建 5 分钟有效、绑定当前 `serverInstanceId` 的一次性 plan。`confirm` 只接受 `planId`；客户端不能提交下载 URL、命令、安装路径或 package-manager 参数。服务端版本变化、进程重启、plan 复用或过期均 fail closed。
+- `prepare` / `confirm` 即使位于 Bearer 保护路由内，仍要求 Server Owner Token **确实启用**；危险逃生模式下的无鉴权 HTTP 服务不得远程触发自更新。
+- Docker 在推荐层和执行层双重拒绝容器内 binary swap，仅返回拉取新镜像并重建容器的说明。其它 `ManualPrompt` 也只展示指引，不提供一键执行。
+- SelfContained 在调用 service restart 前持久化 `awaiting_restart`。新进程启动后若运行版本等于 job 目标版本，将任务协调为 `succeeded`；否则记为 `failed/restart_failed`，保留恢复线索。
+- 前端用公共 `/api/health` 的 `version` 验证重启结果。Tauri remote 只恢复 HTTP/WS 连接，不 relaunch 本机应用；由同一 server 提供静态资源的同源 Web 在目标版本上线后 reload，`index.html` 使用 `Cache-Control: no-cache`，哈希 asset 使用 immutable cache。
+- Tauri 首屏前从本地 `UserConfig` 恢复已保存的 remote transport；远端不可用时留在 embedded IPC，让用户仍可进入设置修复连接。
+
 ## 下载健壮性（重试 + 断点续传）
 
 [`download::download_to`](../../../crates/ha-updater/src/download.rs) 只负责取字节（验签是调用方的事），但取得够稳：

--- a/docs/architecture/system/api-reference.md
+++ b/docs/architecture/system/api-reference.md
@@ -6,12 +6,12 @@
 
 Hope Agent 前端通过 `Transport` 抽象层和后端通信，内部根据运行环境自动在 Tauri IPC 和 HTTP/WebSocket 之间切换。本文档把两条通道上的**每一条接口**列成一一对应的表格，并标记对齐状态。
 
-## 数据来源（截至 2026-08-02）
+## 数据来源（截至 2026-08-05）
 
 | 源 | 位置 | 数量 |
 |---|---|---|
 | Tauri 命令 | `src-tauri/src/lib.rs` 的 `tauri::generate_handler!` | **1128** |
-| HTTP 路由 | `crates/ha-server/src/lib.rs` 的 `.route(...)` | **1059** |
+| HTTP 路由 | `crates/ha-server/src/lib.rs` 的 `.route(...)` | **1068** |
 | 前端 COMMAND_MAP | `src/lib/transport-http.ts::COMMAND_MAP` | **1108** |
 | WebSocket 端点 | `crates/ha-server/src/ws/` | **1** |
 | EventBus 事件 | 全代码 `emit_event` 调用 | **59+** |
@@ -21,7 +21,7 @@ Hope Agent 前端通过 `Transport` 抽象层和后端通信，内部根据运�
 | 分类 | 数量 | 说明 |
 |---|---|---|
 | ✅ 两端完全对齐（在 COMMAND_MAP 中） | 1108 | 常规请求/响应命令，以及 HTTP-only 的 bound raw ticket 命令 |
-| 🔧 特殊处理（不在 COMMAND_MAP 但 HTTP 已实现，走专用 Transport 方法） | 15 | multipart/二进制流/保存对话框类接口，以及 HTTP-only 的短时 transport ticket 基础设施 |
+| 🔧 特殊处理（不在 COMMAND_MAP 但 HTTP 已实现，走专用 Transport 方法） | 16 | multipart/二进制流/保存对话框类接口、HTTP-only 的短时 transport ticket 基础设施，以及远程服务端更新控制面 |
 | 🖥️ Desktop-only / Tauri-only（HTTP 无对应） | 10 | macOS / legacy 系统权限探测（5 条）+ `project_fs_resolve` / `kb_file_resolve_cmd`（`convertFileSrc`）+ Dock / tray 未读提示 + browser-side save-as |
 | ❌ HTTP 路由存在但 COMMAND_MAP 漏写 | 0 | — |
 | ❌ HTTP 路由完全缺失 | 0 | — |
@@ -83,6 +83,17 @@ Tauri ↔ COMMAND_MAP 差集为 22 条合法非通用映射命令：5 条 Deskto
 | `approval_required` | tools/approval.rs | `{ requestId, command, cwd, sessionId }` |
 | `ask_user_request` | tools/ask_user_question.rs | 结构化问答组 |
 | `session_pending_interactions_changed` | 审批 + ask_user 合流 | `{ sessionId, count }` |
+
+### 系统更新
+
+| 事件名 | 触发点 | Payload 关键字段 |
+|---|---|---|
+| `app_update:available` | headless 自动检查发现新版 | `{ currentVersion, version, notes?, pubDate?, recommendedPath }` |
+| `app_update:staged` | SelfContained 静默预下载完成 | `{ version }` |
+| `app_update:progress` | 下载字节或安装阶段变化 | `{ job_id, phase, label, percent?, written?, total? }` |
+| `app_update:completed` | 更新任务终态 | `{ job_id, status, error?, targetVersion?, remote? }` |
+
+事件只负责低延迟提示，不重放。Web / 远程桌面首次连接、重连或 lag 后必须重读 `GET /api/app-update/status`；跨服务重启的状态以 `~/.hope-agent/updater/remote-update-state.json` 为准。
 
 ### 计划模式
 
@@ -1348,11 +1359,16 @@ Agent 执行准入采用两层 guard：Desktop / HTTP / Channel / Cron 等调用
 | `save_notification_config` | `PUT /api/config/notification` | ✅ |
 | `get_auto_update_config` | `GET /api/config/auto-update` | ✅ |
 | `set_auto_update_config` | `PUT /api/config/auto-update` | ✅ |
+| — | `GET /api/app-update/status` | HTTP-only：读取远程服务更新快照、活动任务与最近任务 |
+| — | `POST /api/app-update/check` | HTTP-only：立即检查远程服务更新并持久化快照 |
+| — | `POST /api/app-update/prepare` | HTTP-only、Owner Token 必须启用：创建 5 分钟、进程绑定的一次性安装计划 |
+| — | `POST /api/app-update/confirm` | HTTP-only、Owner Token 必须启用：消费一次性计划并启动持久化更新任务；请求体只含 `planId` |
+| — | `GET /api/app-update/jobs/{jobId}` | HTTP-only：按 ID 重读持久化任务，供断线/重启恢复 |
 | `get_startup_notification_config` | `GET /api/config/startup-notification` | ✅ |
 | `save_startup_notification_config` | `PUT /api/config/startup-notification` | ✅ |
 | `get_server_config` | `GET /api/config/server` | ✅ |
 | `save_server_config` | `PUT /api/config/server` | ✅ |
-| `get_server_runtime_status` | `GET /api/server/status` | ✅ (免鉴权) — 返回 `{ boundAddr, startedAt, uptimeSecs, startupError, eventsWsCount, chatWsCount, localDesktopClient, activeChatStreams, activeChatCounts: { desktop, http, channel, total } }`。`activeChatStreams` 是 `activeChatCounts.total` 的 back-compat 别名（在跑的 `run_chat_engine` 数量）。`chatWsCount` 当前仍是独立的 `Arc<AtomicU32>` 计数器（`crates/ha-core/src/server_status.rs::chat_ws_counter`），per-session chat WS 端点已下线但 counter 字段未拆——历史遗留，目前没有 handler 在递增，实测恒为 0。`localDesktopClient` 在 Tauri 命令恒 `true`（桌面 webview 通过 IPC 与后端通信，不走 WS），HTTP 路由恒 `false`，前端把它计入"活跃连接" |
+| `get_server_runtime_status` | `GET /api/server/status` | ✅（Owner 保护面）— 返回 `{ boundAddr, startedAt, uptimeSecs, startupError, eventsWsCount, chatWsCount, localDesktopClient, activeChatStreams, activeChatCounts: { desktop, http, channel, total } }`。`activeChatStreams` 是 `activeChatCounts.total` 的 back-compat 别名（在跑的 `run_chat_engine` 数量）。`chatWsCount` 当前仍是独立的 `Arc<AtomicU32>` 计数器（`crates/ha-core/src/server_status.rs::chat_ws_counter`），per-session chat WS 端点已下线但 counter 字段未拆——历史遗留，目前没有 handler 在递增，实测恒为 0。`localDesktopClient` 在 Tauri 命令恒 `true`（桌面 webview 通过 IPC 与后端通信，不走 WS），HTTP 路由恒 `false`，前端把它计入"活跃连接" |
 | `get_proxy_config` | `GET /api/config/proxy` | ✅ |
 | `save_proxy_config` | `PUT /api/config/proxy` | ✅ |
 | `get_shortcut_config` | `GET /api/config/shortcuts` | ✅ |
@@ -1788,7 +1804,7 @@ Context / Cache 共用单 SQL `get_session_last_assistant_token_row`，避免渲
 
 ## 已知不对齐项
 
-截至 2026-08-02 三端差集为 26 条：§7.3 的 6 条 Desktop-only 系统权限命令、§7.3.1 的 12 条 HTTP 已实现但走专用 Transport 方法、3 条 HTTP-only transport ticket 基础设施，以及 `project_fs_resolve` / `kb_file_resolve_cmd` / `set_dock_badge_cmd` / `set_tray_unread_cmd` / `save_exported_file` 5 条 Tauri-only 命令。没有“HTTP 漏写 COMMAND_MAP”或“HTTP 路由缺失”的破口；COMMAND_MAP 每一条顶层命令都能在 `tauri::generate_handler!` 找到对应命令。
+截至 2026-08-05 三端差集为 31 条：§7.3 的 6 条 Desktop-only 系统权限命令、§7.3.1 的 12 条 HTTP 已实现但走专用 Transport 方法、3 条 HTTP-only transport ticket 基础设施、5 条 HTTP-only 远程服务更新端点，以及 `project_fs_resolve` / `kb_file_resolve_cmd` / `set_dock_badge_cmd` / `set_tray_unread_cmd` / `save_exported_file` 5 条 Tauri-only 命令。没有“HTTP 漏写 COMMAND_MAP”或“HTTP 路由缺失”的破口；COMMAND_MAP 每一条顶层命令都能在 `tauri::generate_handler!` 找到对应命令。
 
 ### §7.3 Desktop-only（Tauri 专属，合法缺失，6 条）
 
@@ -1858,7 +1874,7 @@ awk 'BEGIN{flag=0} /tauri::generate_handler!\[/{flag=1;next} flag&&/^[[:space:]]
     src-tauri/src/lib.rs | grep -vE '^[[:space:]]*//|^[[:space:]]*$' | \
     grep -oE '::[a-z_][a-zA-Z0-9_]*,?[[:space:]]*$' | tr -d ':, ' | sort -u | wc -l
 
-# 2. HTTP 路由总数（截至 2026-08-02：1058）
+# 2. HTTP 路由总数（截至 2026-08-05：1068）
 grep -cE '^[[:space:]]+\.route\(' crates/ha-server/src/lib.rs
 
 # 3. COMMAND_MAP 条目数（截至 2026-07-30：1107，不含闭合 `}` 的行）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { PortalScopeProvider } from "@/components/ui/portal-scope"
 import { LightboxProvider } from "@/components/common/ImageLightbox"
 import ErrorBoundary from "@/components/common/ErrorBoundary"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+import ServerUpdateNotice from "@/components/common/ServerUpdateNotice"
 import ProviderSetup from "@/components/settings/ProviderSetup"
 import type { SettingsSection } from "@/components/settings/types"
 import type { AgentTab } from "@/components/settings/agent-panel/types"
@@ -1622,6 +1623,7 @@ export default function App() {
                   </div>
                 </div>
               )}
+              <ServerUpdateNotice />
             </div>
           </div>
         </LightboxProvider>

--- a/src/components/common/ServerUpdateNotice.tsx
+++ b/src/components/common/ServerUpdateNotice.tsx
@@ -1,0 +1,251 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Download, Loader2, RefreshCw, Server, X } from "lucide-react"
+import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+import {
+  checkServerUpdate,
+  confirmServerUpdate,
+  prepareServerUpdate,
+  useServerUpdateStore,
+  type ServerInstallPlan,
+} from "@/lib/serverUpdater"
+
+export default function ServerUpdateNotice({
+  variant = "notice",
+}: {
+  variant?: "notice" | "panel"
+}) {
+  const { t } = useTranslation()
+  const { target, status, autoUpdatePolicy, checking, error } = useServerUpdateStore()
+  const [dismissed, setDismissed] = useState<string | null>(null)
+  const [plan, setPlan] = useState<ServerInstallPlan | null>(null)
+  const [preparing, setPreparing] = useState(false)
+  const [confirming, setConfirming] = useState(false)
+  const available = status?.snapshot
+  const job = status?.activeJob
+  const latestJob = status?.recentJobs[0]
+  const failedJob = latestJob?.status === "failed" ? latestJob : undefined
+  const identity = target
+    ? failedJob
+      ? `${target}|failed|${failedJob.jobId}`
+      : available
+        ? `${target}|${available.latestVersion}`
+        : target
+    : null
+
+  if (!target) return null
+  if (variant === "notice") {
+    if (autoUpdatePolicy?.notify !== true) return null
+    if (!job && ((!available?.hasUpdate && !failedJob) || dismissed === identity)) return null
+  }
+
+  async function prepare() {
+    setPreparing(true)
+    try {
+      setPlan(await prepareServerUpdate())
+    } catch {
+      // The shared store renders the server's structured error below the card.
+    } finally {
+      setPreparing(false)
+    }
+  }
+
+  async function confirm() {
+    if (!plan?.planId) return
+    setConfirming(true)
+    try {
+      await confirmServerUpdate(plan.planId)
+      setPlan(null)
+    } catch {
+      // Keep the confirmation open so the user can review/retry.
+    } finally {
+      setConfirming(false)
+    }
+  }
+
+  const manual = plan && plan.capability !== "automatic"
+  const confirmationText = plan
+    ? plan.capability === "docker_redeploy"
+      ? t("askUserDialog.appUpdate.manual.dockerText", {
+          from: plan.currentVersion,
+          to: plan.targetVersion,
+        })
+      : manual
+        ? t("askUserDialog.appUpdate.manual.text", {
+            from: plan.currentVersion,
+            to: plan.targetVersion,
+            installSource: available?.installSource,
+          })
+        : t(
+            plan.path === "package_manager"
+              ? "askUserDialog.appUpdate.install.text.packageManager"
+              : "askUserDialog.appUpdate.install.text.selfContained",
+            {
+              from: plan.currentVersion,
+              to: plan.targetVersion,
+              installSource: available?.installSource,
+              notes: available?.notes ? `\n\n${available.notes}` : "",
+            },
+          )
+    : ""
+
+  return (
+    <>
+      <div
+        className={
+          variant === "notice"
+            ? "fixed bottom-6 right-6 z-50 w-[380px] animate-in slide-in-from-bottom-5 fade-in duration-300"
+            : "w-full"
+        }
+      >
+        <div
+          className={
+            variant === "notice"
+              ? "relative rounded-2xl border border-sky-500/25 bg-card p-4 shadow-xl dark:bg-zinc-900/95"
+              : "relative rounded-[24px] border border-sky-500/20 bg-card px-6 py-5"
+          }
+        >
+          {variant === "notice" && !job && (
+            <button
+              type="button"
+              aria-label={t("common.close")}
+              className="absolute right-3 top-3 rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+              onClick={() => setDismissed(identity)}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+          <div className="flex items-start gap-3.5 pr-5">
+            <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-sky-500/10 text-sky-600 dark:text-sky-400">
+              <Server className="h-5 w-5" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-medium uppercase tracking-wide text-sky-600 dark:text-sky-400">
+                Hope Agent Server · {new URL(target).host}
+              </p>
+              <p className="mt-1 text-sm font-semibold text-foreground">
+                {failedJob && !job
+                  ? t("about.updateInstallFailed")
+                  : job
+                    ? job.status === "awaiting_restart"
+                      ? t("about.updateInstalled")
+                      : t("about.updateInstalling", { version: job.targetVersion })
+                    : available?.hasUpdate
+                      ? t("about.updateAvailable", { version: available.latestVersion })
+                      : t("about.updateUpToDate", { version: status?.currentVersion })}
+              </p>
+              {job ? (
+                <div className="mt-3">
+                  <div className="flex justify-between text-[11px] text-muted-foreground">
+                    <span>{job.phase}</span>
+                    {job.percent != null && <span>{job.percent}%</span>}
+                  </div>
+                  <Progress
+                    value={job.percent}
+                    indeterminate={job.percent == null}
+                    className="mt-1.5 bg-sky-500/15 [&>div]:bg-sky-500"
+                  />
+                </div>
+              ) : available?.hasUpdate ? (
+                <>
+                  {available?.notes && (
+                    <div className="update-notes-markdown mt-2 max-h-28 overflow-auto text-xs leading-relaxed text-muted-foreground">
+                      <MarkdownRenderer content={available.notes} />
+                    </div>
+                  )}
+                  <div className="mt-4 flex justify-end gap-2">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-8 rounded-full text-xs"
+                      disabled={checking}
+                      onClick={() => void checkServerUpdate().catch(() => undefined)}
+                    >
+                      <RefreshCw
+                        className={`mr-1.5 h-3.5 w-3.5 ${checking ? "animate-spin" : ""}`}
+                      />
+                      {t("about.updateCheck")}
+                    </Button>
+                    <Button
+                      size="sm"
+                      className="h-8 rounded-full bg-sky-600 px-4 text-xs text-white hover:bg-sky-700"
+                      disabled={preparing}
+                      onClick={() => void prepare()}
+                    >
+                      {preparing ? (
+                        <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <Download className="mr-1.5 h-3.5 w-3.5" />
+                      )}
+                      {t("about.updateShort")}
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className="mt-4 flex justify-end">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-8 rounded-full text-xs"
+                    disabled={checking}
+                    onClick={() => void checkServerUpdate().catch(() => undefined)}
+                  >
+                    <RefreshCw className={`mr-1.5 h-3.5 w-3.5 ${checking ? "animate-spin" : ""}`} />
+                    {checking ? t("about.updateChecking") : t("about.updateCheck")}
+                  </Button>
+                </div>
+              )}
+              {failedJob?.error && !job && (
+                <p className="mt-2 break-words text-[11px] text-destructive">{failedJob.error}</p>
+              )}
+              {error && <p className="mt-2 break-words text-[11px] text-destructive">{error}</p>}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <AlertDialog open={Boolean(plan)} onOpenChange={(open) => !open && setPlan(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("askUserDialog.appUpdate.install.header", {
+                from: plan?.currentVersion,
+                to: plan?.targetVersion,
+              })}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="whitespace-pre-wrap">
+              {confirmationText}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("common.cancel")}</AlertDialogCancel>
+            {!manual && (
+              <AlertDialogAction
+                disabled={confirming}
+                onClick={(event) => {
+                  event.preventDefault()
+                  void confirm()
+                }}
+              >
+                {confirming && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {t("askUserDialog.appUpdate.install.confirm")}
+              </AlertDialogAction>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}

--- a/src/components/onboarding/steps/ModeStep.tsx
+++ b/src/components/onboarding/steps/ModeStep.tsx
@@ -6,8 +6,9 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
   confirmTransportChange,
-  getTransport,
+  getClientUserConfig,
   prepareRemoteTransport,
+  saveClientUserConfig,
 } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 
@@ -74,15 +75,12 @@ export function RemoteConnectPanel({
       const finalKey = remoteApiKey.trim() || null
       const prepared = await prepareRemoteTransport(trimmedUrl, finalKey)
       try {
-        const current = getTransport()
-        const full = await current.call<Record<string, unknown>>("get_user_config")
-        await current.call("save_user_config", {
-          config: {
-            ...full,
-            serverMode: "remote",
-            remoteServerUrl: trimmedUrl,
-            remoteApiKey: finalKey,
-          },
+        const full = await getClientUserConfig()
+        await saveClientUserConfig({
+          ...full,
+          serverMode: "remote",
+          remoteServerUrl: trimmedUrl,
+          remoteApiKey: finalKey,
         })
         prepared.activate()
       } catch (error) {

--- a/src/components/settings/AboutPanel.tsx
+++ b/src/components/settings/AboutPanel.tsx
@@ -20,13 +20,14 @@ import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
 import { DeferredNumberInput } from "@/components/ui/deferred-number-input"
 import MarkdownRenderer from "@/components/common/MarkdownRenderer"
+import ServerUpdateNotice from "@/components/common/ServerUpdateNotice"
 import { HOPE_AGENT_URLS, useAppVersion } from "@/lib/appMeta"
 import { openHelpWindow } from "@/lib/manual/openHelpWindow"
 import {
   checkForDesktopUpdate,
   getAutoUpdateConfig,
-  invalidateAutoUpdateConfig,
   isDesktopUpdaterAvailable,
+  setAutoUpdateConfig,
   setPendingUpdate as setGlobalPendingUpdate,
   subscribeManualCheckRequests,
   type AutoUpdateConfig,
@@ -107,8 +108,7 @@ export default function AboutPanel({ onOpenUpdateHistory }: { onOpenUpdateHistor
     setAutoCfg(next)
     setAutoSaving(true)
     try {
-      await getTransport().call("set_auto_update_config", { config: next })
-      invalidateAutoUpdateConfig()
+      await setAutoUpdateConfig(next)
       setAutoSaveStatus("saved")
       setTimeout(() => setAutoSaveStatus("idle"), 2000)
     } catch (err) {
@@ -450,6 +450,8 @@ export default function AboutPanel({ onOpenUpdateHistory }: { onOpenUpdateHistor
             </div>
           </div>
         </section>
+
+        <ServerUpdateNotice variant="panel" />
 
         {autoCfg && (
           <section className="rounded-[24px] border border-border/70 bg-card px-6 py-5">

--- a/src/components/settings/ServerPanel.tsx
+++ b/src/components/settings/ServerPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, type ReactNode } from "react"
 import {
+  getClientUserConfig,
   getTransport,
   isCurrentHttpTransportFor,
   useTransport,
@@ -8,6 +9,7 @@ import {
   activateCurrentHttpOwnerToken,
   confirmTransportChange,
   prepareRemoteTransport,
+  saveClientUserConfig,
   switchToEmbedded,
   type PreparedRemoteTransport,
 } from "@/lib/transport-provider"
@@ -153,7 +155,7 @@ export default function ServerPanel() {
     let cancelled = false
 
     Promise.all([
-      getTransport().call<Record<string, unknown>>("get_user_config"),
+      getClientUserConfig(),
       getTransport().call<Record<string, unknown>>("get_server_config"),
     ])
       .then(([userCfg, serverCfg]) => {
@@ -313,14 +315,12 @@ export default function ServerPanel() {
       // Persist connection preferences only after the new server credential
       // is active locally and the remote destination has accepted it. A failed
       // validation must leave durable mode, URL, and credential unchanged.
-      const full = await getTransport().call<Record<string, unknown>>("get_user_config")
-      await getTransport().call("save_user_config", {
-        config: {
-          ...full,
-          serverMode: config.serverMode,
-          remoteServerUrl: config.remoteServerUrl || null,
-          remoteApiKey: effectiveRemoteApiKey,
-        },
+      const full = await getClientUserConfig()
+      await saveClientUserConfig({
+        ...full,
+        serverMode: config.serverMode,
+        remoteServerUrl: config.remoteServerUrl || null,
+        remoteApiKey: effectiveRemoteApiKey,
       })
 
       // Switch transport based on mode
@@ -436,10 +436,8 @@ export default function ServerPanel() {
       try {
         await activateCurrentHttpOwnerToken(result.token)
         if (config.serverMode === "remote") {
-          const full = await getTransport().call<Record<string, unknown>>("get_user_config")
-          await getTransport().call("save_user_config", {
-            config: { ...full, remoteApiKey: result.token },
-          })
+          const full = await getClientUserConfig()
+          await saveClientUserConfig({ ...full, remoteApiKey: result.token })
           setConfig((previous) => ({ ...previous, remoteApiKey: result.token }))
           setSavedSnapshot((previous) => {
             const snapshot = JSON.parse(previous || JSON.stringify(config)) as ServerConfig

--- a/src/components/settings/provider-setup/RemoteConnectDialog.tsx
+++ b/src/components/settings/provider-setup/RemoteConnectDialog.tsx
@@ -12,8 +12,9 @@ import {
 } from "@/components/ui/dialog"
 import {
   confirmTransportChange,
-  getTransport,
+  getClientUserConfig,
   prepareRemoteTransport,
+  saveClientUserConfig,
 } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import { Globe, Loader2, Wifi } from "lucide-react"
@@ -82,15 +83,12 @@ export function RemoteConnectDialog({
       const finalKey = apiKey.trim() || null
       const prepared = await prepareRemoteTransport(finalUrl, finalKey)
       try {
-        const current = getTransport()
-        const full = await current.call<Record<string, unknown>>("get_user_config")
-        await current.call("save_user_config", {
-          config: {
-            ...full,
-            serverMode: "remote",
-            remoteServerUrl: finalUrl,
-            remoteApiKey: finalKey,
-          },
+        const full = await getClientUserConfig()
+        await saveClientUserConfig({
+          ...full,
+          serverMode: "remote",
+          remoteServerUrl: finalUrl,
+          remoteApiKey: finalKey,
         })
         prepared.activate()
       } catch (error) {

--- a/src/lib/desktopUpdater.ts
+++ b/src/lib/desktopUpdater.ts
@@ -1,5 +1,6 @@
 import { isTauriMode } from "@/lib/transport"
 import { getTransport } from "@/lib/transport-provider"
+import { TauriTransport } from "@/lib/transport-tauri"
 import { logger } from "@/lib/logger"
 import { APP_VERSION } from "@/lib/appMeta"
 
@@ -52,11 +53,16 @@ function clampAutoUpdateIntervalHours(value: unknown): number {
 
 let _autoUpdateConfig: AutoUpdateConfig | null = null
 
+function desktopConfigTransport() {
+  // A remote-connected Tauri shell still updates the local native bundle.
+  return isTauriMode() ? new TauriTransport() : getTransport()
+}
+
 /** Fetch (and cache) the auto-update config. Falls back to defaults on error. */
 export async function getAutoUpdateConfig(force = false): Promise<AutoUpdateConfig> {
   if (_autoUpdateConfig && !force) return _autoUpdateConfig
   try {
-    const cfg = await getTransport().call<AutoUpdateConfig>("get_auto_update_config")
+    const cfg = await desktopConfigTransport().call<AutoUpdateConfig>("get_auto_update_config")
     _autoUpdateConfig = { ...DEFAULT_AUTO_UPDATE_CONFIG, ...cfg }
   } catch {
     _autoUpdateConfig = { ...DEFAULT_AUTO_UPDATE_CONFIG }
@@ -67,6 +73,11 @@ export async function getAutoUpdateConfig(force = false): Promise<AutoUpdateConf
 /** Invalidate the cached config (call after a settings save). */
 export function invalidateAutoUpdateConfig(): void {
   _autoUpdateConfig = null
+}
+
+export async function setAutoUpdateConfig(config: AutoUpdateConfig): Promise<void> {
+  await desktopConfigTransport().call("set_auto_update_config", { config })
+  invalidateAutoUpdateConfig()
 }
 
 /**

--- a/src/lib/serverUpdater.ts
+++ b/src/lib/serverUpdater.ts
@@ -1,0 +1,329 @@
+import { useEffect, useSyncExternalStore } from "react"
+import { isTauriMode, TRANSPORT_EVENT_RESYNC_REQUIRED } from "@/lib/transport"
+import { getActiveHttpTransport, useTransportRevision } from "@/lib/transport-provider"
+import type { HttpTransport } from "@/lib/transport-http"
+import { logger } from "@/lib/logger"
+
+export type ServerUpdateCapability = "automatic" | "docker_redeploy" | "manual" | "desktop_only"
+
+export type ServerUpdateJobStatus = "running" | "awaiting_restart" | "succeeded" | "failed"
+
+export interface ServerUpdateSnapshot {
+  serverInstanceId: string
+  currentVersion: string
+  latestVersion: string
+  hasUpdate: boolean
+  installSource: string
+  recommendedPath: "tauri" | "package_manager" | "self_contained" | "manual_prompt"
+  capability: ServerUpdateCapability
+  notes?: string | null
+  pubDate?: string | null
+  bareBinaryAvailable: boolean
+  stagedVersion?: string | null
+  checkedAt: string
+  manualInstructions?: string | null
+}
+
+export interface ServerUpdateJob {
+  jobId: string
+  fromVersion: string
+  targetVersion: string
+  path: ServerUpdateSnapshot["recommendedPath"]
+  status: ServerUpdateJobStatus
+  phase: string
+  percent?: number | null
+  createdAt: string
+  updatedAt: string
+  error?: string | null
+}
+
+export interface ServerUpdateStatus {
+  serverInstanceId: string
+  currentVersion: string
+  snapshot?: ServerUpdateSnapshot | null
+  activeJob?: ServerUpdateJob | null
+  recentJobs: ServerUpdateJob[]
+}
+
+export interface ServerInstallPlan {
+  planId?: string | null
+  serverInstanceId: string
+  currentVersion: string
+  targetVersion: string
+  path: ServerUpdateSnapshot["recommendedPath"]
+  capability: ServerUpdateCapability
+  expiresAt?: string | null
+  confirmation: string
+  manualInstructions?: string | null
+}
+
+export interface ServerAutoUpdatePolicy {
+  checkEnabled: boolean
+  notify: boolean
+}
+
+interface StoreSnapshot {
+  target: string | null
+  status: ServerUpdateStatus | null
+  autoUpdatePolicy: ServerAutoUpdatePolicy | null
+  loading: boolean
+  checking: boolean
+  error: string | null
+}
+
+let snapshot: StoreSnapshot = {
+  target: null,
+  status: null,
+  autoUpdatePolicy: null,
+  loading: false,
+  checking: false,
+  error: null,
+}
+const listeners = new Set<() => void>()
+let boundTransport: HttpTransport | null = null
+let cleanupEvents: (() => void) | null = null
+let refreshPromise: Promise<ServerUpdateStatus | null> | null = null
+
+function emit(patch: Partial<StoreSnapshot>) {
+  snapshot = { ...snapshot, ...patch }
+  for (const listener of listeners) listener()
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+function getSnapshot() {
+  return snapshot
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function refreshStatus(check = false): Promise<ServerUpdateStatus | null> {
+  const transport = boundTransport
+  if (!transport) return null
+  if (refreshPromise && !check) return refreshPromise
+  const request = (async () => {
+    emit(check ? { checking: true, error: null } : { loading: true, error: null })
+    try {
+      const status = await transport.requestAppUpdate<ServerUpdateStatus>(
+        check ? "/api/app-update/check" : "/api/app-update/status",
+        check ? { method: "POST" } : undefined,
+      )
+      if (boundTransport === transport) emit({ status })
+      return status
+    } catch (error) {
+      if (boundTransport === transport) emit({ error: describeError(error) })
+      throw error
+    } finally {
+      if (boundTransport === transport) emit(check ? { checking: false } : { loading: false })
+    }
+  })()
+  if (!check) refreshPromise = request
+  try {
+    return await request
+  } finally {
+    if (refreshPromise === request) refreshPromise = null
+  }
+}
+
+async function refreshAutoUpdatePolicy(): Promise<ServerAutoUpdatePolicy | null> {
+  const transport = boundTransport
+  if (!transport) return null
+  try {
+    const config = await transport.call<ServerAutoUpdatePolicy>("get_auto_update_config")
+    if (typeof config.checkEnabled !== "boolean" || typeof config.notify !== "boolean") {
+      throw new Error("Invalid server auto-update policy")
+    }
+    const policy = { checkEnabled: config.checkEnabled, notify: config.notify }
+    if (boundTransport === transport) emit({ autoUpdatePolicy: policy })
+    return policy
+  } catch (error) {
+    if (boundTransport === transport) emit({ autoUpdatePolicy: null })
+    throw error
+  }
+}
+
+function bindToActiveTransport() {
+  const transport = getActiveHttpTransport()
+  if (transport === boundTransport) return
+  cleanupEvents?.()
+  cleanupEvents = null
+  boundTransport = transport
+  refreshPromise = null
+  if (!transport) {
+    emit({
+      target: null,
+      status: null,
+      autoUpdatePolicy: null,
+      loading: false,
+      checking: false,
+      error: null,
+    })
+    return
+  }
+  emit({
+    target: transport.getBaseUrl(),
+    status: null,
+    autoUpdatePolicy: null,
+    loading: true,
+    error: null,
+  })
+  const refreshStatusFromEvent = () => {
+    void refreshStatus().catch((error) => {
+      logger.warn("updater", "serverUpdater::refresh", "server update status failed", error)
+    })
+  }
+  const refreshPolicyFromEvent = () => {
+    void refreshAutoUpdatePolicy().catch((error) => {
+      logger.warn("updater", "serverUpdater::policy", "server update policy failed", error)
+    })
+  }
+  const refreshAllFromEvent = () => {
+    refreshStatusFromEvent()
+    refreshPolicyFromEvent()
+  }
+  const unlisten = [
+    transport.listen(TRANSPORT_EVENT_RESYNC_REQUIRED, refreshAllFromEvent),
+    transport.listen("config:changed", refreshPolicyFromEvent),
+    transport.listen("app_update:available", refreshStatusFromEvent),
+    transport.listen("app_update:staged", refreshStatusFromEvent),
+    transport.listen("app_update:completed", refreshStatusFromEvent),
+    transport.listen("app_update:progress", (payload) => {
+      if (!payload || typeof payload !== "object") return
+      const event = payload as { job_id?: string; phase?: string; percent?: number }
+      const status = snapshot.status
+      if (!status?.activeJob || status.activeJob.jobId !== event.job_id) return
+      emit({
+        status: {
+          ...status,
+          activeJob: {
+            ...status.activeJob,
+            phase: event.phase ?? status.activeJob.phase,
+            percent: event.percent ?? status.activeJob.percent,
+          },
+        },
+      })
+    }),
+  ]
+  cleanupEvents = () => unlisten.forEach((off) => off())
+  void (async () => {
+    const [status, policy] = await Promise.all([
+      refreshStatus().catch((error) => {
+        logger.warn("updater", "serverUpdater::bind", "initial server update status failed", error)
+        return null
+      }),
+      refreshAutoUpdatePolicy().catch((error) => {
+        logger.warn("updater", "serverUpdater::bind", "initial server update policy failed", error)
+        return null
+      }),
+    ])
+    // Establish an initial snapshot only when the remote server permits
+    // automatic checks. Manual checks remain available from the panel.
+    if (boundTransport === transport && status && !status.snapshot && policy?.checkEnabled) {
+      await refreshStatus(true).catch((error) => {
+        logger.warn("updater", "serverUpdater::bind", "initial server update check failed", error)
+      })
+    }
+  })()
+}
+
+export function useServerUpdateStore(): StoreSnapshot {
+  const revision = useTransportRevision()
+  useEffect(() => bindToActiveTransport(), [revision])
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+export async function checkServerUpdate(): Promise<ServerUpdateStatus | null> {
+  bindToActiveTransport()
+  return refreshStatus(true)
+}
+
+export async function prepareServerUpdate(): Promise<ServerInstallPlan> {
+  bindToActiveTransport()
+  const transport = boundTransport
+  const current = snapshot.status
+  const available = current?.snapshot
+  if (!transport || !current || !available?.hasUpdate) {
+    throw new Error("No server update is available")
+  }
+  // Manual/Docker paths are informational only. The durable status already
+  // carries the server-selected capability, so showing its instructions does
+  // not need to create an executable plan (or require update authority).
+  if (available.capability !== "automatic") {
+    return {
+      planId: null,
+      serverInstanceId: current.serverInstanceId,
+      currentVersion: current.currentVersion,
+      targetVersion: available.latestVersion,
+      path: available.recommendedPath,
+      capability: available.capability,
+      expiresAt: null,
+      confirmation: available.manualInstructions ?? "",
+      manualInstructions: available.manualInstructions,
+    }
+  }
+  try {
+    return await transport.requestAppUpdate<ServerInstallPlan>("/api/app-update/prepare", {
+      method: "POST",
+      body: {
+        currentVersion: current.currentVersion,
+        targetVersion: available.latestVersion,
+        serverInstanceId: current.serverInstanceId,
+      },
+    })
+  } catch (error) {
+    emit({ error: describeError(error) })
+    throw error
+  }
+}
+
+export async function confirmServerUpdate(planId: string): Promise<ServerUpdateJob> {
+  const transport = boundTransport
+  if (!transport) throw new Error("Server connection changed")
+  let job: ServerUpdateJob
+  try {
+    job = await transport.requestAppUpdate<ServerUpdateJob>("/api/app-update/confirm", {
+      method: "POST",
+      body: { planId },
+    })
+  } catch (error) {
+    emit({ error: describeError(error) })
+    throw error
+  }
+  const current = snapshot.status
+  if (current) emit({ status: { ...current, activeJob: job } })
+  void verifyRestart(transport, job.targetVersion)
+  return job
+}
+
+async function verifyRestart(transport: HttpTransport, targetVersion: string) {
+  const deadline = Date.now() + 2 * 60_000
+  while (Date.now() < deadline && boundTransport === transport) {
+    try {
+      const health = await transport.probeHealth(AbortSignal.timeout(5_000))
+      if (health.version.replace(/^v/, "") === targetVersion.replace(/^v/, "")) {
+        await refreshStatus().catch(() => null)
+        const sameOrigin =
+          typeof window !== "undefined" &&
+          new URL(transport.getBaseUrl()).origin === window.location.origin
+        if (!isTauriMode() && sameOrigin) {
+          window.setTimeout(() => window.location.reload(), 600)
+        }
+        return
+      }
+      const durable = await refreshStatus().catch(() => null)
+      if (durable?.recentJobs[0]?.status === "failed") return
+    } catch {
+      // Expected while the service manager replaces/restarts the process.
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 1500))
+  }
+  if (boundTransport === transport) {
+    emit({ error: `Server did not come back on version ${targetVersion}` })
+    await refreshStatus().catch(() => null)
+  }
+}

--- a/src/lib/transport-http.ts
+++ b/src/lib/transport-http.ts
@@ -2117,6 +2117,61 @@ export class HttpTransport implements Transport {
     return this.baseUrl === normalizeHttpBaseUrl(candidate)
   }
 
+  /** Stable target used by the remote-service updater and its reconnect UI. */
+  getBaseUrl(): string {
+    return this.baseUrl
+  }
+
+  /**
+   * Owner-plane request for the server process updater. This deliberately
+   * accepts only the fixed app-update API family: callers cannot turn it into
+   * an arbitrary authenticated fetch primitive.
+   */
+  async requestAppUpdate<T>(
+    path: string,
+    init: { method?: "GET" | "POST"; body?: unknown; signal?: AbortSignal } = {},
+  ): Promise<T> {
+    if (!/^\/api\/app-update(?:\/|$)/.test(path)) {
+      throw new Error("Only /api/app-update requests are allowed")
+    }
+    const auth = this.authSnapshot()
+    const headers: Record<string, string> = {}
+    if (auth.apiKey) headers.Authorization = `Bearer ${auth.apiKey}`
+    let body: string | undefined
+    if (init.body !== undefined) {
+      headers["Content-Type"] = "application/json"
+      body = JSON.stringify(init.body)
+    }
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method: init.method ?? "GET",
+      headers,
+      body,
+      signal: init.signal,
+      credentials: "same-origin",
+      cache: "no-store",
+    })
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "")
+      this.handleAuthFailure(response.status, auth.revision)
+      throw new HttpTransportResponseError(
+        response.status,
+        `[HttpTransport] ${init.method ?? "GET"} ${path} returned ${response.status}: ${detail}`,
+      )
+    }
+    return (await response.json()) as T
+  }
+
+  /** Public health probe used to verify the target version after restart. */
+  async probeHealth(signal?: AbortSignal): Promise<{ status: string; version: string }> {
+    const response = await fetch(`${this.baseUrl}/api/health`, {
+      signal,
+      credentials: "same-origin",
+      cache: "no-store",
+    })
+    if (!response.ok) throw new Error(`Health probe failed (${response.status})`)
+    return (await response.json()) as { status: string; version: string }
+  }
+
   /** Update the API key at runtime. */
   setApiKey(key: string | null): void {
     this.credentialRevision += 1

--- a/src/lib/transport-provider.ts
+++ b/src/lib/transport-provider.ts
@@ -166,6 +166,23 @@ export function isCurrentHttpTransportFor(baseUrl: string): boolean {
   return instance instanceof HttpTransport && instance.matchesBaseUrl(baseUrl);
 }
 
+/** Active remote/server transport, or null while the desktop uses local IPC. */
+export function getActiveHttpTransport(): HttpTransport | null {
+  const active = getTransport();
+  return active instanceof HttpTransport ? active : null;
+}
+
+/** Connection preferences belong to the local desktop shell, not its remote backend. */
+export async function getClientUserConfig(): Promise<Record<string, unknown>> {
+  const transport = isTauriMode() ? new TauriTransport() : getTransport();
+  return transport.call<Record<string, unknown>>("get_user_config");
+}
+
+export async function saveClientUserConfig(config: Record<string, unknown>): Promise<void> {
+  const transport = isTauriMode() ? new TauriTransport() : getTransport();
+  await transport.call("save_user_config", { config });
+}
+
 export interface PreparedRemoteTransport {
   /** Publish the already-validated client as the application singleton. */
   activate(): void;
@@ -224,6 +241,24 @@ export async function prepareRemoteTransport(
       next.dispose();
     },
   };
+}
+
+let remoteRestoreStarted = false;
+
+/** Restore the desktop's saved remote connection before the first React render. */
+export async function restoreConfiguredRemoteTransport(): Promise<boolean> {
+  if (!isTauriMode() || remoteRestoreStarted) return instance instanceof HttpTransport;
+  remoteRestoreStarted = true;
+  const local = new TauriTransport();
+  const config = await local.call<Record<string, unknown>>("get_user_config");
+  if (config.serverMode !== "remote") return false;
+  const baseUrl =
+    typeof config.remoteServerUrl === "string" ? config.remoteServerUrl.trim() : "";
+  if (!baseUrl) return false;
+  const apiKey = typeof config.remoteApiKey === "string" ? config.remoteApiKey : null;
+  const prepared = await prepareRemoteTransport(baseUrl, apiKey);
+  prepared.activate();
+  return true;
 }
 
 /**

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ import {
   listenEnhancedFocusIndicators,
   loadEnhancedFocusIndicators,
 } from "./lib/focus-indicator-preference"
+import { restoreConfiguredRemoteTransport } from "./lib/transport-provider"
 
 discardTokenFromUrl()
 installDesktopContextMenuGuard()
@@ -48,6 +49,11 @@ if (windowType === "pet") {
 // await 当前一种 locale，毫秒级本地资源）。i18nReady 内部已 try/catch，chunk 失败
 // 也会 resolve（回退 en），渲染绝不会被卡死。
 void i18nReady.finally(async () => {
+  try {
+    await restoreConfiguredRemoteTransport()
+  } catch (error) {
+    logger.warn("transport", "main::restoreRemote", "saved remote server is unavailable", error)
+  }
   await loadEnhancedFocusIndicators()
   listenEnhancedFocusIndicators()
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -49,11 +49,6 @@ if (windowType === "pet") {
 // await 当前一种 locale，毫秒级本地资源）。i18nReady 内部已 try/catch，chunk 失败
 // 也会 resolve（回退 en），渲染绝不会被卡死。
 void i18nReady.finally(async () => {
-  try {
-    await restoreConfiguredRemoteTransport()
-  } catch (error) {
-    logger.warn("transport", "main::restoreRemote", "saved remote server is unavailable", error)
-  }
   await loadEnhancedFocusIndicators()
   listenEnhancedFocusIndicators()
 
@@ -116,4 +111,15 @@ void i18nReady.finally(async () => {
       </AuthGate>
     </StrictMode>,
   )
+
+  // A saved remote server may be offline. Defer its network handshake until
+  // after the first paint so the local desktop UI and connection settings stay
+  // available instead of leaving the window blank while it times out.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      void restoreConfiguredRemoteTransport().catch((error) => {
+        logger.warn("transport", "main::restoreRemote", "saved remote server is unavailable", error)
+      })
+    })
+  })
 })


### PR DESCRIPTION
## 变更内容

- 为远程 Web 与远程桌面连接提供统一的服务端更新状态、检查、确认安装与进度提示。
- 新增受鉴权保护的服务端更新 HTTP 端点及可恢复的持久化任务状态。
- 在关于页保留手动检查入口；全局浮层严格遵守远端服务的 `notify` 和 `checkEnabled` 配置。

## 原因与影响

此前更新提示只覆盖本地桌面包，部署在服务器上的服务端没有统一的发现和安装引导。本 PR 让远程连接客户端能够提示服务端更新，并针对 Docker、手动安装、包管理器和自包含二进制给出安全的处理路径。

服务端重启后会校正更新任务终态；持久化失败会回滚计划和任务，避免遗留无法重试的“运行中”任务。

## 验证

- `cargo check -p ha-server`
- `pnpm typecheck`
- `cargo fmt --all -- --check`
- `prettier --check src/lib/serverUpdater.ts src/components/common/ServerUpdateNotice.tsx`
- `git diff --check`