### PR TITLE
🦭 fix(release): 修 latest.json 并发上传竞态并加平台完整性断言

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,8 +286,24 @@ jobs:
           rm -f "$cert" "$pem"
           security find-identity -v -p codesigning "$kc"
 
+      # ── Publish is racy across lanes; attempt 1 of 2 ──────────
+      # All four matrix lanes push assets to the SAME draft Release, and
+      # tauri-action's `uploadVersionJSON` is a read-modify-write on one
+      # shared `latest.json`: it lists assets, seeds `platforms` from the
+      # existing manifest, merges its own, deletes the old asset, uploads
+      # the new one. Two lanes that reach it together both see "no
+      # latest.json yet", both POST a create, and the loser dies on
+      # `422 already_exists` — v0.29.0's linux-arm64 lane, 87 min in, with
+      # every bundle already uploaded. Its `linux-aarch64*` entries were
+      # then simply absent from the shipped manifest.
+      #
+      # `continue-on-error` lets the retry below recover. A genuine build
+      # failure still fails the job: the gate step fails it outright when
+      # no bundles were produced, and otherwise the retry runs and fails.
       - name: Build & draft release
+        id: build_release
         if: github.event.inputs.dry_run != 'true'
+        continue-on-error: true
         uses: tauri-apps/tauri-action@v0.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -300,6 +316,55 @@ jobs:
           # secret is unset → Tauri falls back to ad-hoc (no behavior change).
           # No APPLE_ID/APPLE_TEAM_ID ⇒ sign-only, no notarization. See
           # docs/macos-self-signing.md.
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        with:
+          tagName: ${{ env.RELEASE_TAG }}
+          releaseName: "Hope Agent ${{ env.RELEASE_TAG }}"
+          releaseBody: ${{ steps.notes.outputs.body }}
+          releaseDraft: true
+          prerelease: false
+          includeUpdaterJson: true
+          args: ${{ matrix.args }}
+
+      # Retry only when attempt 1 got far enough to produce bundles — i.e.
+      # the compile finished and only publishing broke. Retrying then is
+      # cheap: the target dir is warm, so tauri re-bundles rather than
+      # rebuilding, and tauri-action is idempotent on a second pass
+      # (`uploadAssets` deletes an existing asset before re-uploading, and
+      # `uploadVersionJSON` now finds `latest.json` and takes the merge
+      # path instead of racing to create it).
+      #
+      # Without this gate a blind retry would double the cost of a real
+      # build failure — and this arm64 lane has been OOM-killed before (see
+      # the CARGO_PROFILE_RELEASE_CODEGEN_UNITS note at the top of the job).
+      # Failing here is also what keeps `continue-on-error` above honest:
+      # attempt 1's failure would otherwise pass silently.
+      - name: Gate publish retry
+        id: retry_gate
+        if: ${{ github.event.inputs.dry_run != 'true' && steps.build_release.outcome == 'failure' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle_dir=$(find target -type d -name bundle 2>/dev/null | head -1 || true)
+          if [ -n "$bundle_dir" ] && [ -n "$(find "$bundle_dir" -type f 2>/dev/null | head -1)" ]; then
+            echo "::notice::Bundles present in $bundle_dir — compile finished, so only the publish half failed (most likely the shared latest.json upload race). Retrying publish."
+          else
+            echo "::error::Build failed before producing any bundle — not retrying (a second attempt would just burn another full build). See the attempt-1 log above."
+            exit 1
+          fi
+
+      # ── Publish attempt 2 of 2 ────────────────────────────────
+      # Keep `env:` and `with:` byte-for-byte identical to attempt 1 above;
+      # they are duplicated only because a `uses:` step cannot be retried
+      # in place. Change one, change both.
+      - name: Build & draft release (publish retry)
+        if: ${{ steps.retry_gate.outcome == 'success' && steps.build_release.outcome == 'failure' && github.event.inputs.dry_run != 'true' }}
+        uses: tauri-apps/tauri-action@v0.6.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # See attempt 1 for why this identity is set this way.
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         with:
           tagName: ${{ env.RELEASE_TAG }}

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -398,6 +398,7 @@ git cherry-pick --abort          # 整段放弃
 | 新 minor 发完忘了切 `release/X.Y` | patch 修复无处落，紧急修复要回退 main 历史 | §2.3 publish 后立即切 |
 | 改 workflow job 名后没同步 ruleset | PR 卡在等一个已不存在的 job | 见 AGENTS.md "## 分支与发布" |
 | 改 `release.yml` 但没在 PR 阶段验证 | tag push 后跑真实 release 才 fail，删 tag 重打 + 又一轮 CI。v0.2.0 三次因此返工 | §4.1 |
+| 两条 build lane 同时上传 `latest.json` | 输的那条报 `422 already_exists` 整个 job 失败，它的平台条目从清单里整段消失 | §4.2 |
 
 ### 4.1 修改 release.yml 时的验证流程
 
@@ -416,6 +417,21 @@ git cherry-pick --abort          # 整段放弃
 跑法：[Actions → Release workflow](https://github.com/shiwenwen/hope-agent/actions/workflows/release.yml) → Run workflow → branch 选 PR 分支 → `tag` 填一个不存在的 sentinel 如 `v0.0.0-dryrun`（verify 步骤自动跳过）→ `dry_run` 勾 true。全平台 build 矩阵会跑（含 bare-binary path check 与 signer 验证），但跳过 draft Release 创建、bare-binary 上传、patch-manifest job。产物在 run 的 `Artifacts` 段下载。
 
 dry-run 不改任何 GitHub 状态：不打 tag、不建 Release、不碰 latest.json，失败重跑无副作用。
+
+### 4.2 `latest.json` 并发上传竞态
+
+4 条 build lane 往**同一个** draft Release 推产物，而 tauri-action 的 `uploadVersionJSON` 是对同一个 `latest.json` 做**读-改-写**：列 asset → 找到就下载、把已有 `platforms` 读进来 → 合并自己这条 lane 的 → 删旧 asset → 传新的。两条 lane 同时走到这里，都看到「还没有 latest.json」，于是都发 create，输的那条拿 `422 already_exists` 直接失败。
+
+v0.29.0 就是这样：linux-arm64 跑满 87 分钟、deb / rpm / AppImage 全都传完了，最后一步栽在这儿。后果不只是 job 红——**它的 `linux-aarch64*` 条目从清单里整段消失了**，而剩下三个平台的清单结构完全正常。上游 tauri-action 到 v1.0.0 都没修这个（v0.6.1 是 `--config`、v0.6.2 是 workspace root 探测）。
+
+两道防御：
+
+- **release.yml 自动重试一次**，但**只在已产出 bundle 时**重试。产出了 bundle 说明编译已完成、只是发布环节失败，此时 target 目录是热的，重试只重新打包不重新编译；重试对已存在 asset 是安全的（`uploadAssets` 先删后传，`uploadVersionJSON` 这次能找到 latest.json 因而走合并路径）。没产出 bundle 说明构建本身就挂了，闸门直接 `exit 1` —— 别让它盲目重试，arm64 lane 历史上被 OOM 杀过，那会把一次 90 分钟的失败变成 180 分钟。**这个 `exit 1` 同时是 `continue-on-error` 的诚实性保证**，去掉它首次失败就会静默通过。
+- **`patch-latest-json.mjs` 的 `--require` 现在同时断言 `platforms` 段**（原来只守 `bare_binary`）。任一平台的 `{os}-{arch}` 条目缺失或缺 `signature` / `url`，都在 publish 之前硬失败。
+
+重试是缓解不是根治——根因是 4 个写者共享一个清单，真正的结构性修法是让 `latest.json` 只由构建后的单一 job 生成。没做是因为那要复刻 tauri-action 的签名优先级与 bundle 命名规则（`-appimage` / `-deb` / `-rpm` / `-nsis` / `-app`、AppImage 的 `.sig` vs `.tar.gz.sig`），弄错就是**静默毁掉某平台的自动更新**，且只有真发一次版才验得出来。要做就单独开 PR、配 dry-run 验证，别夹在发版里。
+
+仍然撞上时：`gh run rerun <run-id> --failed` 重跑失败的 lane 即可，tauri-action 对已存在 asset 是先删后传，重跑幂等。
 
 ---
 

--- a/scripts/patch-latest-json.mjs
+++ b/scripts/patch-latest-json.mjs
@@ -9,15 +9,19 @@
 //   node scripts/patch-latest-json.mjs <latest.json> <artifacts-dir> <version>
 //                                      [--require=<platform,...>]
 //
-// `--require` names the platforms that MUST yield a bare_binary entry; a
-// missing one is a hard error instead of a warning. Without it the script
-// stays best-effort, which is what a single-platform backfill wants.
+// `--require` names the platforms that MUST end up complete: each one needs
+// both a bare_binary entry (built here) and a tauri-action `platforms` entry
+// (already on the manifest). A missing one is a hard error instead of a
+// warning. Without the flag the script stays best-effort, which is what a
+// single-platform backfill wants.
 //
 // Why this exists: every platform used to be skipped with a console.warn, so
 // a lost or half-uploaded artifact produced a manifest missing that
 // platform's bare_binary entry — CI green, and headless self-update for that
 // platform silently dead until someone noticed. release.yml now passes its
-// full build matrix, so the release fails loudly instead.
+// full build matrix, so the release fails loudly instead. The `platforms`
+// half of that check was added after v0.29.0, where a lost upload race cost
+// the manifest its entire `linux-aarch64*` set with nothing to catch it.
 //
 // It cannot simply require every platform in PLATFORM_MAP: `macos-x64` has
 // been a disabled lane since v0.2.0 (see release.yml matrix), so its artifact
@@ -120,6 +124,34 @@ for (const [platformDir, meta] of Object.entries(PLATFORM_MAP)) {
     extra_binaries: meta.extras,
   };
   console.log(`[patch-latest-json] added bare_binary entry for ${meta.key}`);
+}
+
+// The `platforms` section is tauri-action's output rather than ours, but
+// nothing guarded it until now and it is exactly as prone to silent loss as
+// bare_binary was. Every build lane read-modify-writes the one shared
+// latest.json on the draft Release, so a lane that loses that race drops its
+// own entries while the manifest still looks perfectly well-formed. v0.29.0
+// produced a draft whose manifest had no `linux-aarch64*` key at all — had it
+// been published, desktop auto-update on ARM64 Linux would have been silently
+// dead. `meta.key` is the same `{os}-{arch}` key the updater looks itself up
+// by, so requiring it here is the same contract `--require` already asserts
+// for bare_binary.
+const platforms = manifest.platforms || {};
+for (const platformDir of required) {
+  const { key } = PLATFORM_MAP[platformDir];
+  const entry = platforms[key];
+  if (!entry) {
+    const present = Object.keys(platforms).join(", ") || "none";
+    failures.push(
+      `${platformDir}: manifest has no platforms["${key}"] entry — that lane's latest.json upload was lost (present: ${present})`,
+    );
+    continue;
+  }
+  for (const field of ["signature", "url"]) {
+    if (!entry[field]) {
+      failures.push(`${platformDir}: platforms["${key}"] has no ${field}`);
+    }
+  }
 }
 
 // Merge mode: keep entries that already exist on the manifest (e.g.


### PR DESCRIPTION
## 背景

v0.29.0 的 `release.yml` 失败卡住发版。表面看是 linux-arm64 lane 挂了，实际不是编译问题——它跑满 87 分钟、deb / rpm / AppImage 全部上传成功，最后一步栽在：

```
Uploading latest.json...
##[error]Validation Failed: {"resource":"ReleaseAsset","code":"already_exists","field":"name"}
```

## 根因

4 条 build lane 往**同一个** draft Release 推产物，而 tauri-action 的 `uploadVersionJSON` 是对同一个 `latest.json` 做**读-改-写**：列 asset → 找到就下载、把已有 `platforms` 读进来 → 合并自己这条 lane 的 → 删旧 asset → 传新的。两条 lane 同时走到这里，都看到「还没有 latest.json」，于是都发 create，输的那条拿 422。

后果不只是 job 红——**arm64 的 `linux-aarch64*` 条目从清单里整段消失了**，而剩下三个平台的清单结构完全正常。这份清单一旦 publish，ARM64 Linux 桌面用户的自动更新就静默失效。

上游 tauri-action 到 v1.0.0 都没修这个（v0.6.1 是 `--config` 解析、v0.6.2 是 workspace root 探测），升级解决不了。

## 改动

**1. `release.yml` 失败后自动重试一次，但用「是否已产出 bundle」当闸门**

产出了 bundle ⇒ 编译已完成、只是发布环节失败，此时 target 目录是热的，重试只重新打包不重新编译；且重试对已存在 asset 是安全的（`uploadAssets` 先删后传，`uploadVersionJSON` 这次能找到 latest.json 因而走合并路径）。

没产出 bundle ⇒ 构建本身挂了，闸门直接 `exit 1`。**别让它盲目重试**——arm64 lane 历史上被 OOM 杀过，盲目重试会把一次 90 分钟的失败变成 180 分钟。这个 `exit 1` 同时是 `continue-on-error` 的诚实性保证，去掉它首次失败就会静默通过。

语义覆盖：

| 情形 | 结果 |
|---|---|
| 首次成功 | 闸门与重试都跳过 |
| 首次失败 + 有 bundle（竞态） | 闸门放行 → 重试 → 收敛 |
| 首次失败 + 无 bundle（真挂/OOM） | 闸门 `exit 1`，job 失败，不浪费第二次全量构建 |
| 重试也失败 | job 失败（重试步骤无 `continue-on-error`） |
| dry-run | 三步全跳过 |

**2. `patch-latest-json.mjs` 的 `--require` 现在同时断言 `platforms` 段**

原来只守 `bare_binary`，主 `platforms` 段完全裸奔——正是这次丢掉 `linux-aarch64` 却无人拦截的原因。现在任一平台的 `{os}-{arch}` 条目缺失或缺 `signature` / `url`，都在 publish 之前硬失败。

## 验证

用 v0.29.0 那份**真实残缺的** `latest.json` 跑新断言：

- 残缺清单 → `exit 1`，报 `linux-arm64: manifest has no platforms["linux-aarch64"] entry`
- 补上 `linux-aarch64` 后 → `exit 0`，`bare_binary` 正常写入且 `platforms` 段未被破坏
- `signature` 为空 → 拦住
- 不带 `--require` → 保持 best-effort，单平台回填场景不受影响

`node scripts/check-release-paths.mjs` 通过；`release.yml` YAML 解析通过，三步触发条件已核。

## 未做

重试是缓解不是根治。根因是 4 个写者共享一个清单，结构性修法是让 `latest.json` 只由构建后的单一 job 生成。没在本 PR 做，是因为那要复刻 tauri-action 的签名优先级与 bundle 命名规则（`-appimage` / `-deb` / `-rpm` / `-nsis` / `-app`、AppImage 的 `.sig` vs `.tar.gz.sig`），弄错就是静默毁掉某平台的自动更新，且只有真发一次版才验得出来。应单独开 PR 并配 dry-run 验证。