### PR TITLE
🦭 fix(build): 对齐 tauri crate 与 @tauri-apps/api 版本并加守卫

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,6 +52,16 @@ jobs:
       - name: Updater endpoints sync check
         run: node scripts/verify-updater-endpoints.mjs
 
+      # The Tauri CLI refuses to build when the Rust `tauri` crate and the npm
+      # `@tauri-apps/api` package disagree on major.minor. Nothing else here
+      # catches that — clippy / cargo test / vitest never invoke `tauri build`
+      # — so it stays invisible until a tag is pushed and every release lane
+      # dies within minutes. v0.30.0 was lost that way: an incidental crate
+      # bump in #621 moved tauri 2.10.3 → 2.11.5 while the npm side stayed on
+      # 2.10.1, and four PRs merged green on top of it.
+      - name: Tauri crate ↔ npm api version sync
+        run: node scripts/verify-tauri-version-sync.mjs
+
       # Catch release.yml / update-*.yml path bugs at PR time instead of
       # at tag-push time. Covers the workspace target/ vs src-tauri/target/
       # mismatch that took down v0.2.0 release three times in a row, plus

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -76,6 +76,9 @@ echo "[pre-push] crate layering red line (test edges)"
   echo "[pre-push] verify-updater-endpoints (tauri.conf.json ↔ ha-updater ↔ mirror PUBLIC_BASE)"
   node scripts/verify-updater-endpoints.mjs
 
+  echo "[pre-push] verify-tauri-version-sync (tauri crate ↔ @tauri-apps/api)"
+  node scripts/verify-tauri-version-sync.mjs
+
 echo "[pre-push] vitest run"
 pnpm test
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -399,6 +399,7 @@ git cherry-pick --abort          # 整段放弃
 | 改 workflow job 名后没同步 ruleset | PR 卡在等一个已不存在的 job | 见 AGENTS.md "## 分支与发布" |
 | 改 `release.yml` 但没在 PR 阶段验证 | tag push 后跑真实 release 才 fail，删 tag 重打 + 又一轮 CI。v0.2.0 三次因此返工 | §4.1 |
 | 两条 build lane 同时上传 `latest.json` | 输的那条报 `422 already_exists` 整个 job 失败，它的平台条目从清单里整段消失 | §4.2 |
+| Rust `tauri` crate 与 npm `@tauri-apps/api` 的 major.minor 不一致 | Tauri CLI 拒绝构建，tag 一推四个平台全在几分钟内失败，只能删 tag 重打。CI 抓不到（clippy / cargo test / vitest 都不跑 `tauri build`） | `verify-tauri-version-sync.mjs`（CI + pre-push）。crate 侧常因 `cargo update` 被顺带抬版本，v0.30.0 即因此返工一轮 |
 
 ### 4.1 修改 release.yml 时的验证流程
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
     "@tailwindcss/vite": "^4.2.4",
-    "@tauri-apps/api": "^2.10.1",
+    "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-process": "^2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.5.1)(jiti@2.6.1))
       '@tauri-apps/api':
-        specifier: ^2.10.1
-        version: 2.10.1
+        specifier: ^2.11.1
+        version: 2.11.1
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.0
         version: 2.7.0
@@ -2221,8 +2221,8 @@ packages:
     peerDependencies:
       vite: ^8.0.10
 
-  '@tauri-apps/api@2.10.1':
-    resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
+  '@tauri-apps/api@2.11.1':
+    resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
 
   '@tauri-apps/cli-darwin-arm64@2.10.1':
     resolution: {integrity: sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ==}
@@ -7602,7 +7602,7 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 8.0.10(@types/node@25.5.1)(jiti@2.6.1)
 
-  '@tauri-apps/api@2.10.1': {}
+  '@tauri-apps/api@2.11.1': {}
 
   '@tauri-apps/cli-darwin-arm64@2.10.1':
     optional: true
@@ -7653,19 +7653,19 @@ snapshots:
 
   '@tauri-apps/plugin-dialog@2.7.0':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-process@2.3.1':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
-      '@tauri-apps/api': 2.10.1
+      '@tauri-apps/api': 2.11.1
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/scripts/verify-tauri-version-sync.mjs
+++ b/scripts/verify-tauri-version-sync.mjs
@@ -45,27 +45,41 @@ function lockedCrateVersion(crate) {
   return m[1];
 }
 
-function declaredNpmRange(pkg) {
-  const manifest = JSON.parse(
-    fs.readFileSync(path.join(root, "package.json"), "utf8"),
+// Read the RESOLVED version from pnpm-lock.yaml, not the range in
+// package.json. The declared range is not what gets installed: `^2.11.1`
+// happily admits 2.12.x, so a routine `pnpm update` could resolve the lockfile
+// onto a version the crate disagrees with while the floor still reads 2.11 —
+// and a floor-based check would wave it through, which is precisely the
+// release-breaking case this guard exists to catch. `--frozen-lockfile` CI
+// installs whatever the lockfile pins, so the lockfile is the truth.
+//
+// The importers block records both, e.g.
+//       '@tauri-apps/api':
+//         specifier: ^2.11.1
+//         version: 2.11.1
+function resolvedNpmVersion(pkg) {
+  const lock = fs.readFileSync(path.join(root, "pnpm-lock.yaml"), "utf8");
+  const re = new RegExp(
+    `'${pkg}':\\s*\\n\\s*specifier:\\s*(\\S+)\\s*\\n\\s*version:\\s*(\\S+)`,
   );
-  const range =
-    manifest.dependencies?.[pkg] ?? manifest.devDependencies?.[pkg];
-  if (!range) fail(`package.json does not depend on "${pkg}"`);
-  return range;
+  const m = lock.match(re);
+  if (!m) {
+    fail(
+      `pnpm-lock.yaml has no resolved importer entry for "${pkg}" — run \`pnpm install\` to refresh the lockfile`,
+    );
+  }
+  // Peer-resolved entries carry a suffix like `2.11.1(typescript@5.9.2)`.
+  return { specifier: m[1], version: m[2].replace(/\(.*$/, "") };
 }
 
 const majorMinor = (v) => v.split(".").slice(0, 2).join(".");
 
 const crateVersion = lockedCrateVersion("tauri");
-const npmRange = declaredNpmRange("@tauri-apps/api");
-// `^2.11.1` / `~2.11.1` / `2.11.1` all carry the floor we care about; the CLI
-// compares against whatever is installed, and the floor is what pins it.
-const npmFloor = npmRange.replace(/^[\^~>=\s]*/, "");
+const npm = resolvedNpmVersion("@tauri-apps/api");
 
-if (majorMinor(crateVersion) !== majorMinor(npmFloor)) {
+if (majorMinor(crateVersion) !== majorMinor(npm.version)) {
   fail(
-    `tauri crate (Cargo.lock) is ${crateVersion} but @tauri-apps/api (package.json) is ${npmRange}.\n` +
+    `tauri crate (Cargo.lock) is ${crateVersion} but @tauri-apps/api resolves to ${npm.version} (declared ${npm.specifier}).\n` +
       `  The Tauri CLI requires the same major.minor, so \`tauri build\` — and therefore the\n` +
       `  entire release workflow — will fail on every platform.\n` +
       `  Fix: set "@tauri-apps/api" to ^${majorMinor(crateVersion)}.x in package.json and run \`pnpm install\`.`,
@@ -73,5 +87,5 @@ if (majorMinor(crateVersion) !== majorMinor(npmFloor)) {
 }
 
 console.log(
-  `[verify-tauri-version-sync] OK — tauri ${crateVersion} ↔ @tauri-apps/api ${npmRange} (both ${majorMinor(crateVersion)}.x)`,
+  `[verify-tauri-version-sync] OK — tauri ${crateVersion} ↔ @tauri-apps/api ${npm.version} (declared ${npm.specifier}; both ${majorMinor(crateVersion)}.x)`,
 );

--- a/scripts/verify-tauri-version-sync.mjs
+++ b/scripts/verify-tauri-version-sync.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+//
+// Assert the Rust `tauri` crate and the npm `@tauri-apps/api` package agree on
+// major.minor.
+//
+// Why this exists: the Tauri CLI refuses to build when they disagree —
+//
+//   Found version mismatched Tauri packages. Make sure the NPM package and
+//   Rust crate versions are on the same major/minor releases:
+//   tauri (v2.11.5) : @tauri-apps/api (v2.10.1)
+//
+// — and nothing else in CI catches it, because `cargo clippy` / `cargo test` /
+// `vitest` never invoke `tauri build`. So the mismatch is invisible until a tag
+// is pushed and the real release workflow runs, at which point every platform
+// lane fails within minutes and the tag has to be deleted and re-cut.
+//
+// That is exactly what happened to v0.30.0: #621 bumped the locked `tauri`
+// crate 2.10.3 → 2.11.5 as an incidental dependency update, `@tauri-apps/api`
+// stayed pinned at 2.10.1, four PRs merged green on top of it, and the break
+// only surfaced during the release build.
+//
+// Patch versions are deliberately NOT compared — the CLI only requires
+// major/minor agreement, and demanding exact equality would fail on every
+// routine `cargo update`.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+
+function fail(msg) {
+  console.error(`[verify-tauri-version-sync] ${msg}`);
+  process.exit(1);
+}
+
+// Cargo.lock stores packages as `[[package]]` blocks; find the one whose name
+// is exactly `tauri` (not `tauri-build`, `tauri-utils`, …).
+function lockedCrateVersion(crate) {
+  const lock = fs.readFileSync(path.join(root, "Cargo.lock"), "utf8");
+  const re = new RegExp(
+    `\\[\\[package\\]\\]\\s*\\nname = "${crate}"\\s*\\nversion = "([^"]+)"`,
+  );
+  const m = lock.match(re);
+  if (!m) fail(`Cargo.lock has no [[package]] entry for "${crate}"`);
+  return m[1];
+}
+
+function declaredNpmRange(pkg) {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(root, "package.json"), "utf8"),
+  );
+  const range =
+    manifest.dependencies?.[pkg] ?? manifest.devDependencies?.[pkg];
+  if (!range) fail(`package.json does not depend on "${pkg}"`);
+  return range;
+}
+
+const majorMinor = (v) => v.split(".").slice(0, 2).join(".");
+
+const crateVersion = lockedCrateVersion("tauri");
+const npmRange = declaredNpmRange("@tauri-apps/api");
+// `^2.11.1` / `~2.11.1` / `2.11.1` all carry the floor we care about; the CLI
+// compares against whatever is installed, and the floor is what pins it.
+const npmFloor = npmRange.replace(/^[\^~>=\s]*/, "");
+
+if (majorMinor(crateVersion) !== majorMinor(npmFloor)) {
+  fail(
+    `tauri crate (Cargo.lock) is ${crateVersion} but @tauri-apps/api (package.json) is ${npmRange}.\n` +
+      `  The Tauri CLI requires the same major.minor, so \`tauri build\` — and therefore the\n` +
+      `  entire release workflow — will fail on every platform.\n` +
+      `  Fix: set "@tauri-apps/api" to ^${majorMinor(crateVersion)}.x in package.json and run \`pnpm install\`.`,
+  );
+}
+
+console.log(
+  `[verify-tauri-version-sync] OK — tauri ${crateVersion} ↔ @tauri-apps/api ${npmRange} (both ${majorMinor(crateVersion)}.x)`,
+);


### PR DESCRIPTION
## 背景

v0.30.0 发版构建（run 31158165952）**四个平台在开始后约 4 分钟全部失败**：

```
Found version mismatched Tauri packages. Make sure the NPM package and Rust crate versions are on the same major/minor releases:
tauri (v2.11.5) : @tauri-apps/api (v2.10.1)
```

## 根因

#621 拆 crate 时把 `Cargo.lock` 里的 `tauri` 从 **2.10.3 顺带抬到 2.11.5**（v0.29.0 那棵树还是 2.10.3），而 npm 侧的 `@tauri-apps/api` 仍停在 2.10.1。Tauri CLI 要求两者 major.minor 一致，否则拒绝构建。

**这个错配在 main 上躺了四个 PR 无人发现**——`clippy` / `cargo test` / `vitest` 都不调用 `tauri build`，所以 #632 的 9/9 全绿也照样漏过。只有真发版才撞得到，代价是一整轮构建加删 tag 重打。

好消息是失败得够早，**没有产生 draft release**，是干净的重来机会。另外 #631 新加的重试闸门按设计工作了：四条 lane 都没产出 bundle，闸门全部 `exit 1` 拒绝重试，没有白烧第二轮全量构建。

## 改动

- **`@tauri-apps/api` 下限抬到 `^2.11.1`**（最新可用版本，与 crate 侧 2.11.5 同 major.minor）。刻意改 `package.json` 的下限而不是只刷 lockfile，避免以后再悄悄解析回 2.10。
- **`@tauri-apps/cli` 保持 2.10.1 不动**：它不在该校验内（错误只列出 `tauri` ↔ `@tauri-apps/api`），且 v0.28 / v0.29 都由它打包，发版前不做无谓变更。
- **新增 [`scripts/verify-tauri-version-sync.mjs`](scripts/verify-tauri-version-sync.mjs)**，比对 `Cargo.lock` 的 `tauri` crate 与 `package.json` 的 `@tauri-apps/api` major.minor，挂进 `lint.yml` 与 `.husky/pre-push`。

  刻意**不比对 patch 版本**——CLI 只要求 major.minor 一致，比对 patch 会让每次例行 `cargo update` 都失败。

- `docs/release-process.md` 避坑表补一行。

## 验证

**没有靠版本号推断**——起了一次真实 `pnpm tauri build`，确认越过版本校验进入 `beforeBuildCommand` 与编译（正是上次栽掉那一步之后）：

```
Info Looking up installed tauri packages to check mismatched versions...
Running beforeBuildCommand `pnpm prepare:browser-host && ... && pnpm build`
Compiling proc-macro2 v1.0.107
```

守卫双向：

- 当前（已修）→ `exit 0`，`tauri 2.11.5 ↔ @tauri-apps/api ^2.11.1 (both 2.11.x)`
- 还原成 `^2.10.1` → `exit 1`，报出 crate/npm 两侧版本与修法

## 后续

本 PR 合并后删除现有 `v0.30.0` tag 并在新 main HEAD 重打（`package.json` 已是 0.30.0，无需再 bump）。