### PR TITLE
fix(chat): 修复历史模型降级事件展示

### DIFF
--- a/src/components/chat/fallbackEvent.ts
+++ b/src/components/chat/fallbackEvent.ts
@@ -1,0 +1,36 @@
+import type { FallbackEvent } from "@/types/chat"
+
+function pickString(event: Record<string, unknown>, key: string): string | undefined {
+  const value = event[key]
+  return typeof value === "string" ? value : undefined
+}
+
+function pickNumber(event: Record<string, unknown>, key: string): number | undefined {
+  const value = event[key]
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value === "string") {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return undefined
+}
+
+/** Normalize both live and persisted model-fallback payloads for one renderer. */
+export function fallbackEventFromPayload(event: Record<string, unknown>): FallbackEvent {
+  const model =
+    pickString(event, "model") ??
+    pickString(event, "model_id") ??
+    pickString(event, "to_model") ??
+    ""
+  return {
+    type: pickString(event, "type"),
+    model,
+    from_model: pickString(event, "from_model"),
+    reason: pickString(event, "reason"),
+    error: pickString(event, "error"),
+    attempt: pickNumber(event, "attempt"),
+    total: pickNumber(event, "total"),
+    provider_id: pickString(event, "provider_id"),
+    model_id: pickString(event, "model_id"),
+  }
+}

--- a/src/components/chat/hooks/useStreamEventHandler.ts
+++ b/src/components/chat/hooks/useStreamEventHandler.ts
@@ -1,5 +1,5 @@
 import type React from "react"
-import type { ContentBlock, FallbackEvent, MediaItem, Message, ToolMetadata } from "@/types/chat"
+import type { ContentBlock, MediaItem, Message, ToolMetadata } from "@/types/chat"
 import {
   contextCompactionData,
   isContextCompactionPayload,
@@ -8,6 +8,7 @@ import {
   shouldReplaceContextCompactionNotice,
 } from "../contextCompactionEvents"
 import { mergeUsageFromEvent, parseUserAttachmentsMeta } from "../chatUtils"
+import { fallbackEventFromPayload } from "../fallbackEvent"
 import { hasToolError } from "../message/executionStatus"
 
 /** Extract a structured tool_metadata payload from a stream event when present. */
@@ -237,40 +238,6 @@ export function flushPendingStreamDeltas(
     }
     return updated
   })
-}
-
-function pickString(event: Record<string, unknown>, key: string): string | undefined {
-  const v = event[key]
-  return typeof v === "string" ? v : undefined
-}
-
-function pickNumber(event: Record<string, unknown>, key: string): number | undefined {
-  const v = event[key]
-  if (typeof v === "number" && Number.isFinite(v)) return v
-  if (typeof v === "string") {
-    const parsed = Number(v)
-    if (Number.isFinite(parsed)) return parsed
-  }
-  return undefined
-}
-
-function fallbackEventFromStreamEvent(event: Record<string, unknown>): FallbackEvent {
-  const model =
-    pickString(event, "model") ??
-    pickString(event, "model_id") ??
-    pickString(event, "to_model") ??
-    ""
-  return {
-    type: pickString(event, "type"),
-    model,
-    from_model: pickString(event, "from_model"),
-    reason: pickString(event, "reason"),
-    error: pickString(event, "error"),
-    attempt: pickNumber(event, "attempt"),
-    total: pickNumber(event, "total"),
-    provider_id: pickString(event, "provider_id"),
-    model_id: pickString(event, "model_id"),
-  }
 }
 
 function schedulePendingStreamFlush(
@@ -669,7 +636,7 @@ export function handleStreamEvent(
       case "model_fallback": {
         updated[updated.length - 1] = {
           ...last,
-          fallbackEvent: fallbackEventFromStreamEvent(event),
+          fallbackEvent: fallbackEventFromPayload(event),
         }
         break
       }

--- a/src/components/chat/message/MessageBubble.event.test.tsx
+++ b/src/components/chat/message/MessageBubble.event.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import type { Message } from "@/types/chat"
+import MessageBubble from "./MessageBubble"
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock("@/components/common/ProviderIcon", () => ({
+  default: () => <span data-testid="provider-icon" />,
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function renderEventMessage(content: Record<string, unknown>) {
+  const msg: Message = {
+    role: "event",
+    content: JSON.stringify(content),
+  }
+
+  return render(
+    <MessageBubble
+      msg={msg}
+      index={0}
+      isLast={false}
+      loading={false}
+      executionState={null}
+      agents={[]}
+      isHovered={false}
+      onHover={() => {}}
+      onContextMenu={() => {}}
+      isCopied={false}
+      onCopy={() => {}}
+      sessionId="session-1"
+    />,
+  )
+}
+
+describe("MessageBubble persisted events", () => {
+  test("renders a persisted model fallback with the fallback banner", () => {
+    const payload = {
+      type: "model_fallback",
+      model: "OpenAI / gpt-5.1",
+      from_model: "Codex / gpt-5.2-codex",
+      provider_id: "openai",
+      model_id: "gpt-5.1",
+      reason: "auth_error",
+      attempt: 2,
+      total: 3,
+      error: "authentication failed",
+    }
+
+    const { container } = renderEventMessage(payload)
+
+    expect(screen.getByText("chat.fallbackTitle")).toBeTruthy()
+    expect(screen.getByText("gpt-5.2-codex")).toBeTruthy()
+    expect(screen.getByText("gpt-5.1")).toBeTruthy()
+    expect(screen.getByText("2/3")).toBeTruthy()
+    expect(container.textContent).not.toContain(JSON.stringify(payload))
+
+    fireEvent.click(screen.getByRole("button"))
+    expect(screen.getByText("authentication failed")).toBeTruthy()
+  })
+})

--- a/src/components/chat/message/MessageBubble.tsx
+++ b/src/components/chat/message/MessageBubble.tsx
@@ -55,6 +55,7 @@ import RoundLimitReachedBanner from "@/components/chat/RoundLimitReachedBanner"
 import MessageUrlPreviews from "./MessageUrlPreviews"
 import { AssistantContentBlocks } from "./MessageContent"
 import { PlanCommentBubble } from "./PlanCommentBubble"
+import { fallbackEventFromPayload } from "../fallbackEvent"
 import type {
   ChatDisplayMode,
   ContentRenderMode,
@@ -1787,6 +1788,9 @@ function MessageBubbleInner({
     }
     if (eventPayload?.type === "profile_rotation") {
       return <ProfileRotationBanner event={eventPayload as ProfileRotationEvent} />
+    }
+    if (eventPayload?.type === "model_fallback") {
+      return <FallbackBanner event={fallbackEventFromPayload(eventPayload)} />
     }
     if (eventPayload?.type === "model_retry" || eventPayload?.type === "model_chain_retry") {
       return (


### PR DESCRIPTION
## 变更内容

- 为持久化的 `model_fallback` 事件补齐专用降级横幅渲染
- 统一流式事件与历史事件的 fallback payload 解析逻辑
- 添加历史降级事件回归测试，防止折叠后重新展开时显示原始 JSON

## 根因

流式过程中，`model_fallback` 会挂载到当前 assistant 消息并使用 `FallbackBanner`；会话完成后，该事件以 `role=event` 持久化，但历史事件渲染分支未处理 `model_fallback`，导致折叠区重新展开时退化为普通 JSON 文本。

## 用户影响

完成后的模型降级过程重新展开时，会继续显示与流式阶段一致的模型降级横幅及详情，不再暴露原始事件 JSON。

## 验证

- `pnpm exec vitest run src/components/chat/message/MessageBubble.event.test.tsx src/components/chat/hooks/useStreamEventHandler.test.ts`
- `pnpm typecheck`
- `pnpm exec prettier --check src/components/chat/fallbackEvent.ts src/components/chat/hooks/useStreamEventHandler.ts src/components/chat/message/MessageBubble.tsx src/components/chat/message/MessageBubble.event.test.tsx`
- `git diff --check`