### PR TITLE
feat(chat): 增加会话悬浮信息

### DIFF
--- a/src/components/chat/sidebar/SessionHoverCard.tsx
+++ b/src/components/chat/sidebar/SessionHoverCard.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from "react-i18next"
 
 import ChannelIcon from "@/components/common/ChannelIcon"
 import { useSessionGitControl } from "@/components/chat/workspace/useSessionGitControl"
+import { useWorkspaceEnvironment } from "@/components/chat/workspace/useWorkspaceEnvironment"
 import { TooltipContent } from "@/components/ui/tooltip"
 import { getTransport } from "@/lib/transport-provider"
 import { basename } from "@/lib/path"
@@ -67,16 +68,25 @@ export default function SessionHoverCard({
   formatRelativeTime,
 }: SessionHoverCardProps) {
   const { t } = useTranslation()
-  const workingDir = session.workingDir?.trim() || project?.workingDir?.trim() || null
-  const workingDirName = workingDir ? basename(workingDir) : null
+  const environmentState = useWorkspaceEnvironment(session.id)
+  const workingDir = environmentState.snapshot?.workingDir.path?.trim() || null
+  const workingDirName = workingDir
+    ? environmentState.snapshot?.workingDir.name || basename(workingDir)
+    : null
   const modelLabel = [session.providerName || session.providerId, session.modelId]
     .filter((value): value is string => Boolean(value))
     .join(" · ")
   const channelLabel = session.channelInfo
     ? `${session.channelInfo.channelId} · ${session.channelInfo.senderName || session.channelInfo.chatId}`
     : null
-  const gitState = useSessionGitControl(workingDir ? session.id : null)
+  const gitAvailable = Boolean(environmentState.snapshot?.git)
+  const gitState = useSessionGitControl(gitAvailable ? session.id : null)
   const gitSnapshot = gitState.snapshot
+  const gitUnavailable = Boolean(
+    environmentState.error ||
+    (environmentState.snapshot && workingDir && !environmentState.snapshot.git) ||
+    (workingDir && gitState.error),
+  )
 
   return (
     <TooltipContent
@@ -115,7 +125,14 @@ export default function SessionHoverCard({
           </div>
         )}
 
-        {workingDir && !gitSnapshot && !gitState.error && (
+        {environmentState.loading && !environmentState.snapshot && (
+          <div className="flex min-w-0 items-center gap-2.5 text-muted-foreground">
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+            <span className="truncate">{t("common.loading")}</span>
+          </div>
+        )}
+
+        {workingDir && gitAvailable && !gitSnapshot && !gitState.error && (
           <div className="flex min-w-0 items-center gap-2.5 text-muted-foreground">
             <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
             <span className="truncate">{t("common.loading")}</span>
@@ -173,7 +190,7 @@ export default function SessionHoverCard({
           </>
         )}
 
-        {workingDir && gitState.error && (
+        {gitUnavailable && (
           <div className="flex min-w-0 items-center gap-2.5 text-muted-foreground">
             <GitCompare className="h-4 w-4 shrink-0" />
             <span className="truncate">{t("workspace.environment.unavailable")}</span>

--- a/src/components/chat/sidebar/SessionHoverCard.tsx
+++ b/src/components/chat/sidebar/SessionHoverCard.tsx
@@ -1,0 +1,236 @@
+import {
+  Bot,
+  Cpu,
+  Folder,
+  FolderKanban,
+  GitBranch,
+  GitCompare,
+  HardDrive,
+  Loader2,
+  MessageSquare,
+  Network,
+  Timer,
+  Trees,
+} from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import ChannelIcon from "@/components/common/ChannelIcon"
+import { useSessionGitControl } from "@/components/chat/workspace/useSessionGitControl"
+import { TooltipContent } from "@/components/ui/tooltip"
+import { getTransport } from "@/lib/transport-provider"
+import { basename } from "@/lib/path"
+import type { AgentSummaryForSidebar, SessionMeta } from "@/types/chat"
+import type { ProjectMeta } from "@/types/project"
+
+interface SessionHoverCardProps {
+  session: SessionMeta
+  agent?: AgentSummaryForSidebar
+  parentSession?: SessionMeta
+  parentAgent?: AgentSummaryForSidebar
+  project?: ProjectMeta
+  formatRelativeTime: (dateStr: string) => string
+}
+
+function shortCheckoutPath(root: string, worktree: boolean): string {
+  const parts = root
+    .replace(/[\\/]+$/, "")
+    .split(/[\\/]/)
+    .filter(Boolean)
+  const visibleParts = worktree ? parts.slice(-2) : parts.slice(-1)
+  return visibleParts.join("/") || root
+}
+
+function AgentAvatar({ agent }: { agent?: AgentSummaryForSidebar }) {
+  return (
+    <span className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 text-[10px] text-primary">
+      {agent?.avatar ? (
+        <img
+          src={getTransport().resolveAssetUrl(agent.avatar) ?? agent.avatar}
+          className="h-full w-full object-cover"
+          alt=""
+        />
+      ) : agent?.emoji ? (
+        <span>{agent.emoji}</span>
+      ) : (
+        <Bot className="h-3 w-3" />
+      )}
+    </span>
+  )
+}
+
+export default function SessionHoverCard({
+  session,
+  agent,
+  parentSession,
+  parentAgent,
+  project,
+  formatRelativeTime,
+}: SessionHoverCardProps) {
+  const { t } = useTranslation()
+  const workingDir = session.workingDir?.trim() || project?.workingDir?.trim() || null
+  const workingDirName = workingDir ? basename(workingDir) : null
+  const modelLabel = [session.providerName || session.providerId, session.modelId]
+    .filter((value): value is string => Boolean(value))
+    .join(" · ")
+  const channelLabel = session.channelInfo
+    ? `${session.channelInfo.channelId} · ${session.channelInfo.senderName || session.channelInfo.chatId}`
+    : null
+  const gitState = useSessionGitControl(workingDir ? session.id : null)
+  const gitSnapshot = gitState.snapshot
+
+  return (
+    <TooltipContent
+      side="right"
+      align="start"
+      sideOffset={10}
+      collisionPadding={12}
+      className="w-[min(340px,calc(100vw-24px))] p-3.5 text-sm"
+    >
+      <div className="mb-3 flex items-start gap-3">
+        <p className="line-clamp-2 min-w-0 flex-1 break-words text-[15px] font-semibold leading-5 text-foreground">
+          {session.title || t("chat.newChat")}
+        </p>
+        <span className="shrink-0 text-xs font-normal text-muted-foreground">
+          {formatRelativeTime(session.updatedAt)}
+        </span>
+      </div>
+
+      <div className="space-y-2.5 text-[13px] text-foreground/90">
+        {project && (
+          <div className="flex min-w-0 items-center gap-2.5">
+            <FolderKanban className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">{project.name}</span>
+          </div>
+        )}
+
+        {workingDir && (
+          <div className="flex min-w-0 items-start gap-2.5">
+            <Folder className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+            <div className="min-w-0">
+              <p className="truncate">{workingDirName}</p>
+              {workingDirName !== workingDir && (
+                <p className="truncate text-[11px] text-muted-foreground">{workingDir}</p>
+              )}
+            </div>
+          </div>
+        )}
+
+        {workingDir && !gitSnapshot && !gitState.error && (
+          <div className="flex min-w-0 items-center gap-2.5 text-muted-foreground">
+            <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+            <span className="truncate">{t("common.loading")}</span>
+          </div>
+        )}
+
+        {gitSnapshot && (
+          <>
+            <div className="flex min-w-0 items-center gap-2.5">
+              {gitSnapshot.activeLocation === "worktree" ? (
+                <Trees className="h-4 w-4 shrink-0 text-muted-foreground" />
+              ) : (
+                <HardDrive className="h-4 w-4 shrink-0 text-muted-foreground" />
+              )}
+              <span className="shrink-0">
+                {gitSnapshot.activeLocation === "worktree"
+                  ? t("workspace.git.worktree")
+                  : t("workspace.git.localCheckout")}
+              </span>
+              <span className="truncate text-[11px] text-muted-foreground">
+                · {shortCheckoutPath(gitSnapshot.root, gitSnapshot.activeLocation === "worktree")}
+              </span>
+            </div>
+
+            <div className="flex min-w-0 items-center gap-2.5">
+              <GitBranch className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">
+                {gitSnapshot.branch || t("workspace.environment.status.detached")}
+              </span>
+            </div>
+
+            <div className="flex min-w-0 items-center gap-2.5">
+              <GitCompare className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className={gitSnapshot.status.clean ? "text-emerald-500" : "text-amber-500"}>
+                {gitSnapshot.status.clean
+                  ? t("workspace.environment.clean")
+                  : t("workspace.environment.changedFiles", {
+                      count: gitSnapshot.status.changedFiles,
+                    })}
+              </span>
+              {(gitSnapshot.status.linesAdded > 0 || gitSnapshot.status.linesRemoved > 0) && (
+                <span className="truncate text-[11px] tabular-nums">
+                  <span className="text-emerald-500">+{gitSnapshot.status.linesAdded}</span>
+                  <span className="ml-1 text-red-500">−{gitSnapshot.status.linesRemoved}</span>
+                </span>
+              )}
+              {gitSnapshot.status.conflictedFiles > 0 && (
+                <span className="truncate text-[11px] text-red-500">
+                  {t("workspace.environment.conflictCount", {
+                    count: gitSnapshot.status.conflictedFiles,
+                  })}
+                </span>
+              )}
+            </div>
+          </>
+        )}
+
+        {workingDir && gitState.error && (
+          <div className="flex min-w-0 items-center gap-2.5 text-muted-foreground">
+            <GitCompare className="h-4 w-4 shrink-0" />
+            <span className="truncate">{t("workspace.environment.unavailable")}</span>
+          </div>
+        )}
+
+        <div className="flex min-w-0 items-center gap-2.5">
+          <AgentAvatar agent={agent} />
+          <span className="truncate">{agent?.name || session.agentId}</span>
+        </div>
+
+        {modelLabel && (
+          <div className="flex min-w-0 items-center gap-2.5">
+            <Cpu className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">{modelLabel}</span>
+          </div>
+        )}
+
+        {session.parentSessionId && (
+          <div className="flex min-w-0 items-center gap-2.5">
+            <Network className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">
+              {t("chat.subagentFrom", {
+                agent: parentAgent?.name || parentSession?.agentId || session.parentSessionId,
+              })}
+            </span>
+          </div>
+        )}
+
+        {channelLabel && session.channelInfo && (
+          <div className="flex min-w-0 items-center gap-2.5">
+            <ChannelIcon
+              channelId={session.channelInfo.channelId}
+              className="h-4 w-4 shrink-0 text-muted-foreground"
+            />
+            <span className="truncate">{channelLabel}</span>
+          </div>
+        )}
+
+        {session.isCron && (
+          <div className="flex min-w-0 items-center gap-2.5">
+            <Timer className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">{t("chat.cronTrigger")}</span>
+          </div>
+        )}
+
+        <div className="flex min-w-0 items-center gap-2.5 text-muted-foreground">
+          <MessageSquare className="h-4 w-4 shrink-0" />
+          <span>{t("project.overview.messageCount", { count: session.messageCount })}</span>
+          {session.incognito && (
+            <>
+              <span aria-hidden="true">·</span>
+              <span>{t("chat.incognito")}</span>
+            </>
+          )}
+        </div>
+      </div>
+    </TooltipContent>
+  )
+}

--- a/src/components/chat/sidebar/SessionItem.tsx
+++ b/src/components/chat/sidebar/SessionItem.tsx
@@ -4,7 +4,7 @@ import { logger } from "@/lib/logger"
 import { useTranslation } from "react-i18next"
 import { cn } from "@/lib/utils"
 import { desktopUnreadCount, channelUnreadCount } from "@/lib/unread"
-import { IconTip } from "@/components/ui/tooltip"
+import { IconTip, Tooltip, TooltipTrigger } from "@/components/ui/tooltip"
 import { Input } from "@/components/ui/input"
 import {
   ContextMenu,
@@ -40,6 +40,8 @@ import type { ProjectMeta } from "@/types/project"
 import ChannelIcon from "@/components/common/ChannelIcon"
 import { INCOGNITO_BADGE_ICON_CLASSES } from "@/components/chat/input/incognitoStyles"
 import PendingCountdownRing from "./PendingCountdownRing"
+import SessionHoverCard from "./SessionHoverCard"
+import { useSessionHoverCard } from "./useSessionHoverCard"
 import type { SidebarDisplayMode } from "./types"
 
 interface SessionItemProps {
@@ -130,6 +132,14 @@ export default function SessionItem({
   const channelLabel = session.channelInfo
     ? `${session.channelInfo.channelId} · ${session.channelInfo.senderName || session.channelInfo.chatId}`
     : null
+  const hoverCard = useSessionHoverCard(renamingSessionId !== session.id)
+  const project = hoverCard.open
+    ? projects.find((candidate) => candidate.id === session.projectId)
+    : undefined
+  const parentSession = hoverCard.open
+    ? sessions.find((candidate) => candidate.id === session.parentSessionId)
+    : undefined
+  const parentAgent = parentSession ? getAgentInfo(parentSession.agentId) : undefined
 
   useEffect(() => {
     if (!revealSignal) return
@@ -160,9 +170,21 @@ export default function SessionItem({
   }, [session.id, displayUnreadCount, displayChannelUnreadCount, onMarkAllRead])
 
   return (
-    <ContextMenu>
-      <ContextMenuTrigger asChild>
-        <div
+    <ContextMenu
+      onOpenChange={(open) => {
+        if (open) hoverCard.close()
+      }}
+    >
+      <Tooltip
+        open={hoverCard.open}
+        onOpenChange={(open) => {
+          if (!open) hoverCard.close()
+        }}
+      >
+        <ContextMenuTrigger asChild>
+          <TooltipTrigger asChild>
+            <div
+          {...hoverCard.triggerProps}
           ref={rowRef}
           data-session-id={session.id}
           role="button"
@@ -177,10 +199,18 @@ export default function SessionItem({
                 ? "bg-amber-500/10 hover:bg-amber-500/15 border-l-2 border-l-amber-500 pl-[8px]"
                 : "hover:bg-secondary/40",
           )}
-          onClick={() => onSwitchSession(session.id)}
+          onClick={() => {
+            hoverCard.close()
+            onSwitchSession(session.id)
+          }}
           onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              hoverCard.close()
+              return
+            }
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault()
+              hoverCard.close()
               onSwitchSession(session.id)
             }
           }}
@@ -324,7 +354,14 @@ export default function SessionItem({
                 </span>
               )}
               {isCompact && renamingSessionId !== session.id && (
-                <span className="ml-auto flex shrink-0 items-center justify-end gap-1 pl-2 group-hover:pr-5">
+                <span
+                  className={cn(
+                    "ml-auto flex shrink-0 items-center justify-end gap-1 pl-2",
+                    onTogglePinned && !session.incognito
+                      ? "group-hover:pr-10"
+                      : "group-hover:pr-5",
+                  )}
+                >
                   {displayUnreadCount > 0 && (
                     <span
                       aria-hidden="true"
@@ -366,25 +403,6 @@ export default function SessionItem({
                           </span>
                         </IconTip>
                       )}
-                      {/* hover 时在原行右侧就地显示 agent 头像 + 名称（替换时间），不弹浮层 */}
-                      <span className="hidden min-w-0 items-center gap-1 group-hover:flex">
-                        <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary/10 text-[8px] text-primary">
-                          {agent?.avatar ? (
-                            <img
-                              src={getTransport().resolveAssetUrl(agent.avatar) ?? agent.avatar}
-                              className="h-full w-full object-cover"
-                              alt=""
-                            />
-                          ) : agent?.emoji ? (
-                            <span>{agent.emoji}</span>
-                          ) : (
-                            <Bot className="h-2 w-2" />
-                          )}
-                        </span>
-                        <span className="max-w-[88px] truncate text-[10px] font-normal text-muted-foreground/70">
-                          {agent?.name || session.agentId}
-                        </span>
-                      </span>
                       <span className="text-right text-[10px] font-normal text-muted-foreground/60 group-hover:hidden">
                         {formatRelativeTime(session.updatedAt)}
                       </span>
@@ -434,6 +452,31 @@ export default function SessionItem({
             )}
           </div>
 
+          {onTogglePinned && !session.incognito && (
+            <IconTip label={session.pinnedAt ? t("chat.unpinSession") : t("chat.pinSession")}>
+              <button
+                className={cn(
+                  "shrink-0 p-0.5 transition-colors",
+                  isCompact
+                    ? "absolute right-7 top-1/2 hidden -translate-y-1/2 text-muted-foreground/50 hover:!text-foreground group-hover:block"
+                    : "text-muted-foreground/0 group-hover:text-muted-foreground/40 hover:!text-foreground",
+                )}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  hoverCard.close()
+                  onTogglePinned(session.id, !session.pinnedAt)
+                }}
+                aria-label={session.pinnedAt ? t("chat.unpinSession") : t("chat.pinSession")}
+              >
+                {session.pinnedAt ? (
+                  <PinOff className="h-3.5 w-3.5" />
+                ) : (
+                  <Pin className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </IconTip>
+          )}
+
           {/* Incognito conversations intentionally cannot be retained. */}
           {!session.incognito && (
             <IconTip label={t("chat.archiveSession")}>
@@ -451,8 +494,20 @@ export default function SessionItem({
               </button>
             </IconTip>
           )}
-        </div>
-      </ContextMenuTrigger>
+            </div>
+          </TooltipTrigger>
+        </ContextMenuTrigger>
+        {hoverCard.open && (
+          <SessionHoverCard
+            session={session}
+            agent={agent}
+            parentSession={parentSession}
+            parentAgent={parentAgent}
+            project={project}
+            formatRelativeTime={formatRelativeTime}
+          />
+        )}
+      </Tooltip>
       <ContextMenuContent
         variant="floating"
         onCloseAutoFocus={(e) => {

--- a/src/components/chat/sidebar/useSessionHoverCard.ts
+++ b/src/components/chat/sidebar/useSessionHoverCard.ts
@@ -1,0 +1,77 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEvent,
+  type PointerEvent,
+} from "react"
+
+const HOVER_CARD_DELAY_MS = 450
+
+function targetSuppressesHoverCard(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    Boolean(target.closest("button, input, [data-ha-tip], [data-ha-title-tip]"))
+  )
+}
+
+/** Keeps the row-level card out of the way of its existing buttons and icon tips. */
+export function useSessionHoverCard(enabled: boolean) {
+  const [open, setOpen] = useState(false)
+  const timerRef = useRef<number | null>(null)
+
+  const close = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    setOpen(false)
+  }, [])
+
+  const schedule = useCallback(() => {
+    if (!enabled || open || timerRef.current !== null) return
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null
+      setOpen(true)
+    }, HOVER_CARD_DELAY_MS)
+  }, [enabled, open])
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+    },
+    [],
+  )
+
+  useEffect(() => {
+    if (!enabled) queueMicrotask(close)
+  }, [close, enabled])
+
+  const triggerProps = useMemo(
+    () => ({
+      onPointerEnter: (event: PointerEvent<HTMLElement>) => {
+        if (!targetSuppressesHoverCard(event.target)) schedule()
+      },
+      onPointerMove: (event: PointerEvent<HTMLElement>) => {
+        if (targetSuppressesHoverCard(event.target)) close()
+        else schedule()
+      },
+      onPointerLeave: close,
+      onFocus: (event: FocusEvent<HTMLElement>) => {
+        if (event.target !== event.currentTarget) {
+          close()
+          return
+        }
+        if (enabled) setOpen(true)
+      },
+      onBlur: (event: FocusEvent<HTMLElement>) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) close()
+      },
+    }),
+    [close, enabled, schedule],
+  )
+
+  return { open: enabled && open, close, triggerProps }
+}


### PR DESCRIPTION
## 变更

- 为会话列表增加延迟悬浮详情卡，展示标题、时间、项目、工作目录、模型及会话类型等上下文。
- 懒加载会话 Git 状态，展示 worktree / 本地 checkout、分支、改动文件数、增删行数和冲突数，并响应 Git 变更事件。
- 紧凑列表悬浮时不再显示 Agent 信息，新增置顶 / 取消置顶快捷按钮并保留归档操作。
- 支持键盘焦点、Escape 关闭，并避让已有按钮、输入框和图标提示。

## 背景

会话列表缺少快速判断任务工作区与 Git 状态的入口，需要进入会话后才能确认上下文。本改动参考 Codex 会话列表交互，在不切换会话的情况下提供可扫读详情。

## 影响

仅影响会话侧栏展示与交互；Git 信息按需加载，不改变会话或仓库状态。

## 验证

- pre-push `pnpm typecheck`
- pre-push ESLint（0 errors）
- pre-push Vitest：244 files / 1339 tests passed
- updater、crate layering 与 Tauri 版本同步守卫通过