### PR TITLE
🦭 feat(chat): 增加置顶会话分组

### DIFF
--- a/crates/ha-core/src/session/db.rs
+++ b/crates/ha-core/src/session/db.rs
@@ -3240,6 +3240,7 @@ impl SessionDB {
             active_session_id,
             "s.updated_at DESC",
             false,
+            PinnedSessionFilter::All,
         )
     }
 
@@ -3255,6 +3256,7 @@ impl SessionDB {
         limit: Option<u32>,
         offset: Option<u32>,
         active_session_id: Option<&str>,
+        pinned_filter: PinnedSessionFilter,
     ) -> Result<(Vec<SessionMeta>, u32)> {
         self.list_sessions_paged_inner(
             agent_id,
@@ -3267,6 +3269,7 @@ impl SessionDB {
             // Cron run sessions are surfaced in the cron panel's "conversations"
             // timeline, never the main sidebar list.
             true,
+            pinned_filter,
         )
     }
 
@@ -3334,6 +3337,7 @@ impl SessionDB {
         active_session_id: Option<&str>,
         order_by: &str,
         exclude_cron: bool,
+        pinned_filter: PinnedSessionFilter,
     ) -> Result<(Vec<SessionMeta>, u32)> {
         // Sidebar list is a hot read during streaming — use the read pool so a
         // concurrent message-append write doesn't block it.
@@ -3375,6 +3379,16 @@ impl SessionDB {
             }
             ParentSessionFilter::Child => {
                 where_clauses.push("s.parent_session_id IS NOT NULL".to_string());
+            }
+        }
+
+        match pinned_filter {
+            PinnedSessionFilter::All => {}
+            PinnedSessionFilter::Pinned => {
+                where_clauses.push("s.pinned_at IS NOT NULL".to_string());
+            }
+            PinnedSessionFilter::Unpinned => {
+                where_clauses.push("s.pinned_at IS NULL".to_string());
             }
         }
 
@@ -5932,9 +5946,9 @@ impl SessionDB {
     }
 
     /// Return the first unread regular conversation in the sidebar's visual
-    /// order, plus its position inside that session group. Projects render
-    /// before unassigned sessions; active projects precede archived projects;
-    /// each group shares the pin/update ordering used by the list endpoint.
+    /// order, plus its position inside that session group. The cross-project
+    /// pinned group renders first, followed by active projects, archived
+    /// projects, and finally unassigned sessions.
     pub fn next_regular_unread_session(
         &self,
         active_session_id: Option<&str>,
@@ -5957,27 +5971,32 @@ impl SessionDB {
                         (s.project_id IS NOT NULL AND s.incognito = 0)
                     )
              ), ranked AS (
-                 SELECT id, project_id, is_unread,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY project_id
-                            ORDER BY pinned_at IS NULL ASC,
-                                     pinned_at DESC,
-                                     updated_at DESC,
-                                     id ASC
-                        ) - 1 AS list_offset
+                 SELECT id, project_id, pinned_at, is_unread,
+                        CASE WHEN pinned_at IS NOT NULL THEN
+                            ROW_NUMBER() OVER (
+                                PARTITION BY (pinned_at IS NOT NULL)
+                                ORDER BY pinned_at DESC, updated_at DESC, id ASC
+                            ) - 1
+                        ELSE
+                            ROW_NUMBER() OVER (
+                                PARTITION BY project_id, (pinned_at IS NULL)
+                                ORDER BY updated_at DESC, id ASC
+                            ) - 1
+                        END AS list_offset
                    FROM sidebar_sessions
              )
-             SELECT r.id, r.project_id, r.list_offset
+             SELECT r.id, r.project_id, r.pinned_at IS NOT NULL, r.list_offset
                FROM ranked r
                LEFT JOIN projects p ON p.id = r.project_id
               WHERE r.id != ?1 AND r.is_unread = 1
               ORDER BY CASE
-                           WHEN r.project_id IS NULL THEN 2
-                           WHEN COALESCE(p.archived, 0) = 0 THEN 0
-                           ELSE 1
+                           WHEN r.pinned_at IS NOT NULL THEN 0
+                           WHEN r.project_id IS NULL THEN 3
+                           WHEN COALESCE(p.archived, 0) = 0 THEN 1
+                           ELSE 2
                        END ASC,
-                       p.sort_order ASC,
-                       p.updated_at DESC,
+                       CASE WHEN r.pinned_at IS NULL THEN p.sort_order END ASC,
+                       CASE WHEN r.pinned_at IS NULL THEN p.updated_at END DESC,
                        r.list_offset ASC,
                        r.id ASC
               LIMIT 1",
@@ -5987,7 +6006,8 @@ impl SessionDB {
             Ok(UnreadSessionTarget {
                 session_id: row.get(0)?,
                 project_id: row.get(1)?,
-                list_offset: row.get(2)?,
+                pinned: row.get(2)?,
+                list_offset: row.get(3)?,
             })
         })
         .optional()
@@ -8001,6 +8021,7 @@ mod tests {
             .expect("unread target");
         assert_eq!(target.session_id, project.id);
         assert_eq!(target.project_id.as_deref(), Some("project-a"));
+        assert!(!target.pinned);
         assert_eq!(target.list_offset, 0);
         assert_eq!(
             db.cron_unread_total().expect("cron unread total"),
@@ -8052,9 +8073,7 @@ mod tests {
         db.set_session_pinned(&read_pin.id, true)
             .expect("pin read session");
 
-        // Project groups render every visible row, not only rows eligible for
-        // the regular unread aggregate. Both of these rows must therefore
-        // occupy positions in the reveal target's list offset.
+        // Pinned rows from every ownership domain render in one shared group.
         let channel_pin = db
             .create_session_with_project("ha-main", Some("project-first"), None)
             .expect("pinned project channel");
@@ -8116,8 +8135,34 @@ mod tests {
             .next_regular_unread_session(None)
             .expect("locate unread")
             .expect("target");
+        assert_eq!(target.session_id, unassigned_unread.id);
+        assert!(target.pinned);
+        let (visible_pinned_rows, _) = db
+            .list_sessions_paged_for_sidebar(
+                None,
+                super::ProjectFilter::All,
+                super::ParentSessionFilter::All,
+                None,
+                None,
+                None,
+                super::PinnedSessionFilter::Pinned,
+            )
+            .expect("list pinned sidebar rows");
+        let pinned_visual_position = visible_pinned_rows
+            .iter()
+            .position(|session| session.id == target.session_id)
+            .expect("target visible in pinned list") as u32;
+        assert_eq!(target.list_offset, pinned_visual_position);
+
+        db.mark_session_read(&unassigned_unread.id)
+            .expect("mark pinned target read");
+        let target = db
+            .next_regular_unread_session(None)
+            .expect("locate project unread")
+            .expect("project target");
         assert_eq!(target.session_id, first_project_unread.id);
         assert_eq!(target.project_id.as_deref(), Some("project-first"));
+        assert!(!target.pinned);
         let (visible_project_rows, _) = db
             .list_sessions_paged_for_sidebar(
                 None,
@@ -8126,6 +8171,7 @@ mod tests {
                 None,
                 None,
                 None,
+                super::PinnedSessionFilter::Unpinned,
             )
             .expect("list project sidebar rows");
         let visual_position = visible_project_rows
@@ -8136,7 +8182,7 @@ mod tests {
             target.list_offset, visual_position,
             "every visible project row must occupy the same offset as the list endpoint"
         );
-        assert_eq!(target.list_offset, 3);
+        assert_eq!(target.list_offset, 0);
 
         let _ = std::fs::remove_file(&db_path);
     }
@@ -8183,6 +8229,7 @@ mod tests {
                 None,
                 None,
                 None,
+                super::PinnedSessionFilter::Unpinned,
             )
             .expect("list unassigned sidebar rows");
         let visual_position = visible_rows
@@ -8191,8 +8238,9 @@ mod tests {
             .expect("target visible in flat list") as u32;
 
         assert_eq!(target.session_id, unread.id);
+        assert!(!target.pinned);
         assert_eq!(target.list_offset, visual_position);
-        assert_eq!(target.list_offset, 1);
+        assert_eq!(target.list_offset, 0);
 
         let _ = std::fs::remove_file(&db_path);
     }
@@ -8323,6 +8371,7 @@ mod tests {
                 None,
                 None,
                 None,
+                super::PinnedSessionFilter::All,
             )
             .expect("list sessions");
         assert!(
@@ -8707,7 +8756,7 @@ mod tests {
     }
 
     #[test]
-    fn sidebar_pagination_filters_project_and_parent_before_limit() {
+    fn sidebar_pagination_filters_project_parent_and_pin_before_limit() {
         let db_path = temp_db_path("sidebar-filtered-pagination");
         let db = SessionDB::open(&db_path).expect("open session db");
         ensure_channel_conversations_table(&db);
@@ -8716,6 +8765,9 @@ mod tests {
         let child = db
             .create_session_with_parent("agent-a", Some(&root.id))
             .expect("child session");
+        let pinned_root = db.create_session("agent-a").expect("pinned root session");
+        db.set_session_pinned(&pinned_root.id, true)
+            .expect("pin root session");
         for _ in 0..3 {
             db.create_session_with_project("agent-a", Some("project-a"), None)
                 .expect("project session");
@@ -8729,11 +8781,12 @@ mod tests {
                 Some(1),
                 Some(0),
                 None,
+                super::PinnedSessionFilter::All,
             )
             .expect("list root sidebar sessions");
-        assert_eq!(root_total, 1);
+        assert_eq!(root_total, 2);
         assert_eq!(roots.len(), 1);
-        assert_eq!(roots[0].id, root.id);
+        assert_eq!(roots[0].id, pinned_root.id);
 
         let (children, child_total) = db
             .list_sessions_paged_for_sidebar(
@@ -8743,11 +8796,26 @@ mod tests {
                 Some(1),
                 Some(0),
                 None,
+                super::PinnedSessionFilter::All,
             )
             .expect("list child sidebar sessions");
         assert_eq!(child_total, 1);
         assert_eq!(children.len(), 1);
         assert_eq!(children[0].id, child.id);
+
+        let (unpinned_roots, unpinned_root_total) = db
+            .list_sessions_paged_for_sidebar(
+                Some("agent-a"),
+                super::ProjectFilter::Unassigned,
+                super::ParentSessionFilter::Root,
+                Some(1),
+                Some(0),
+                None,
+                super::PinnedSessionFilter::Unpinned,
+            )
+            .expect("list unpinned root sidebar sessions");
+        assert_eq!(unpinned_root_total, 1);
+        assert_eq!(unpinned_roots[0].id, root.id);
 
         let _ = std::fs::remove_file(&db_path);
     }
@@ -9928,6 +9996,17 @@ pub enum ParentSessionFilter {
     Root,
     /// Only sub-agent child sessions (`parent_session_id IS NOT NULL`).
     Child,
+}
+
+/// Filter sessions by whether the user has pinned them in the sidebar.
+#[derive(Debug, Clone, Copy)]
+pub enum PinnedSessionFilter {
+    /// Include both pinned and unpinned sessions.
+    All,
+    /// Only sessions with `pinned_at IS NOT NULL`.
+    Pinned,
+    /// Only sessions with `pinned_at IS NULL`.
+    Unpinned,
 }
 
 /// Filter for `search_messages` by session type.

--- a/crates/ha-core/src/session/mod.rs
+++ b/crates/ha-core/src/session/mod.rs
@@ -26,8 +26,8 @@ mod types;
 pub use artifacts::{aggregate_session_artifacts, FileArtifact, SessionArtifacts, UrlSource};
 pub(crate) use db::strip_fts_snippet_sentinels;
 pub use db::{
-    sanitize_fts_query, LastAssistantTokens, ParentSessionFilter, ProjectFilter, SessionDB,
-    SessionSearchResult, SessionTypeFilter,
+    sanitize_fts_query, LastAssistantTokens, ParentSessionFilter, PinnedSessionFilter,
+    ProjectFilter, SessionDB, SessionSearchResult, SessionTypeFilter,
 };
 pub use environment::build_git_snapshot; // pub：ha-vcs git_control 消费
 pub(crate) use environment::load_git_diff_for_root;

--- a/crates/ha-core/src/session/types.rs
+++ b/crates/ha-core/src/session/types.rs
@@ -357,8 +357,9 @@ impl From<SessionMeta> for ForkSessionResult {
 pub struct UnreadSessionTarget {
     pub session_id: String,
     pub project_id: Option<String>,
-    /// Zero-based position inside the target's sidebar session group using the
-    /// same pin/update ordering as the list endpoint.
+    /// Whether the target belongs to the sidebar's cross-project pinned group.
+    pub pinned: bool,
+    /// Zero-based position inside the target's sidebar session group.
     pub list_offset: u32,
 }
 

--- a/crates/ha-server/src/routes/projects.rs
+++ b/crates/ha-server/src/routes/projects.rs
@@ -16,7 +16,7 @@ use ha_core::project::{
     ProjectInstructionsDraft, ProjectInstructionsFile, ProjectMeta, ProjectOverviewSummary,
     StaleProjectInstructionsError, UpdateProjectInput,
 };
-use ha_core::session::{ParentSessionFilter, ProjectFilter, SessionMeta};
+use ha_core::session::{ParentSessionFilter, PinnedSessionFilter, ProjectFilter, SessionMeta};
 
 use crate::error::AppError;
 use crate::routes::sessions::PaginatedSessions;
@@ -112,6 +112,9 @@ pub struct ListProjectSessionsQuery {
     /// Currently-open session id; allowed in results even if incognito.
     #[serde(default)]
     pub active_session_id: Option<String>,
+    /// `true` selects pinned sessions; `false` selects unpinned sessions.
+    #[serde(default)]
+    pub pinned: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -388,6 +391,11 @@ pub async fn list_project_sessions(
         let limit = q.limit;
         let offset = q.offset;
         let active_session_id = q.active_session_id.clone();
+        let pinned_filter = match q.pinned {
+            Some(true) => PinnedSessionFilter::Pinned,
+            Some(false) => PinnedSessionFilter::Unpinned,
+            None => PinnedSessionFilter::All,
+        };
         ctx.session_db
             .run(move |db| {
                 db.list_sessions_paged_for_sidebar(
@@ -397,6 +405,7 @@ pub async fn list_project_sessions(
                     limit,
                     offset,
                     active_session_id.as_deref(),
+                    pinned_filter,
                 )
             })
             .await?

--- a/crates/ha-server/src/routes/sessions.rs
+++ b/crates/ha-server/src/routes/sessions.rs
@@ -34,6 +34,8 @@ pub struct ListSessionsQuery {
     pub unassigned: Option<bool>,
     /// `true` selects sub-agent child sessions; `false` selects top-level sessions.
     pub parent_session: Option<bool>,
+    /// `true` selects pinned sessions; `false` selects unpinned sessions.
+    pub pinned: Option<bool>,
     pub limit: Option<u32>,
     pub offset: Option<u32>,
     /// Currently-open session id; allowed to appear in results even if it is
@@ -699,6 +701,7 @@ pub async fn list_sessions(
         let project_id = q.project_id.clone();
         let agent_id = q.agent_id.clone();
         let parent_session = q.parent_session;
+        let pinned = q.pinned;
         let limit = q.limit;
         let offset = q.offset;
         let active_session_id = q.active_session_id.clone();
@@ -716,6 +719,11 @@ pub async fn list_sessions(
                     Some(false) => ha_core::session::ParentSessionFilter::Root,
                     None => ha_core::session::ParentSessionFilter::All,
                 };
+                let pinned_filter = match pinned {
+                    Some(true) => ha_core::session::PinnedSessionFilter::Pinned,
+                    Some(false) => ha_core::session::PinnedSessionFilter::Unpinned,
+                    None => ha_core::session::PinnedSessionFilter::All,
+                };
                 db.list_sessions_paged_for_sidebar(
                     agent_id.as_deref(),
                     project_filter,
@@ -723,6 +731,7 @@ pub async fn list_sessions(
                     limit,
                     offset,
                     active_session_id.as_deref(),
+                    pinned_filter,
                 )
             })
             .await?

--- a/docs/architecture/system/api-reference.md
+++ b/docs/architecture/system/api-reference.md
@@ -370,7 +370,7 @@ Pet 的主对话身份由 chat 请求可选 `uiSurface` 传播并落 `chat_turns
 | `save_project_instructions_cmd` | `PUT /api/projects/{id}/instructions` | ✅（owner 设置面，原子写入，不受通用文件写闸门影响） |
 | `delete_project_cmd` | `DELETE /api/projects/{id}` | ✅ |
 | `archive_project_cmd` | `POST /api/projects/{id}/archive` | ✅ |
-| `list_project_sessions_cmd` | `GET /api/projects/{id}/sessions` | ✅ |
+| `list_project_sessions_cmd` | `GET /api/projects/{id}/sessions?pinned=` | ✅（`pinned=true/false` 在分页前筛选置顶状态） |
 | `move_session_to_project_cmd` | `PATCH /api/sessions/{sessionId}/project` | ✅ |
 | `list_project_memories_cmd` | `GET /api/projects/{id}/memories` | ✅ |
 | `list_project_memory_files_cmd` | `GET /api/projects/{id}/memory-files` | ✅ |
@@ -515,7 +515,7 @@ KB 文件预览端点**仅面向用户本人，无 session 参数、无 owner fa
 
 | Tauri Command | HTTP | 状态 |
 |---|---|---|
-| `list_sessions_cmd` | `GET /api/sessions?agentId=&projectId=&unassigned=&parentSession=&limit=&offset=&activeSessionId=` | ✅（`parentSession=true/false` 分别只取子会话/顶层会话，过滤发生在分页前） |
+| `list_sessions_cmd` | `GET /api/sessions?agentId=&projectId=&unassigned=&parentSession=&pinned=&limit=&offset=&activeSessionId=` | ✅（`parentSession=true/false` 与 `pinned=true/false` 均在分页前筛选；置顶分组用 `pinned=true` 跨项目读取） |
 | `list_archived_sessions_cmd` | `GET /api/sessions/archived?limit=&offset=` | ✅（跨普通 / 项目 / IM / Subagent / Cron / Knowledge / Design 的归档管理列表） |
 | `create_session_cmd` | `POST /api/sessions` | ✅ |
 | `get_session_cmd` | `GET /api/sessions/{id}` | ✅ |

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -255,9 +255,15 @@ pub async fn list_project_sessions_cmd(
     limit: Option<u32>,
     offset: Option<u32>,
     active_session_id: Option<String>,
+    pinned: Option<bool>,
     state: State<'_, AppState>,
 ) -> Result<(Vec<SessionMeta>, u32), CmdError> {
-    use ha_core::session::{ParentSessionFilter, ProjectFilter};
+    use ha_core::session::{ParentSessionFilter, PinnedSessionFilter, ProjectFilter};
+    let pinned_filter = match pinned {
+        Some(true) => PinnedSessionFilter::Pinned,
+        Some(false) => PinnedSessionFilter::Unpinned,
+        None => PinnedSessionFilter::All,
+    };
     let (mut sessions, total) = state
         .session_db
         .run(move |db| {
@@ -268,6 +274,7 @@ pub async fn list_project_sessions_cmd(
                 limit,
                 offset,
                 active_session_id.as_deref(),
+                pinned_filter,
             )
         })
         .await?;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,6 +1,6 @@
 use crate::commands::CmdError;
 use crate::session;
-use crate::session::{ParentSessionFilter, ProjectFilter};
+use crate::session::{ParentSessionFilter, PinnedSessionFilter, ProjectFilter};
 use crate::AppState;
 use tauri::State;
 
@@ -70,6 +70,7 @@ pub async fn list_sessions_cmd(
     project_id: Option<String>,
     unassigned: Option<bool>,
     parent_session: Option<bool>,
+    pinned: Option<bool>,
     limit: Option<u32>,
     offset: Option<u32>,
     active_session_id: Option<String>,
@@ -92,6 +93,11 @@ pub async fn list_sessions_cmd(
                 Some(false) => ParentSessionFilter::Root,
                 None => ParentSessionFilter::All,
             };
+            let pinned_filter = match pinned {
+                Some(true) => PinnedSessionFilter::Pinned,
+                Some(false) => PinnedSessionFilter::Unpinned,
+                None => PinnedSessionFilter::All,
+            };
             db.list_sessions_paged_for_sidebar(
                 agent_id.as_deref(),
                 project_filter,
@@ -99,6 +105,7 @@ pub async fn list_sessions_cmd(
                 limit,
                 offset,
                 active_session_id.as_deref(),
+                pinned_filter,
             )
         })
         .await?;

--- a/src/components/chat/hooks/useChatSession.ts
+++ b/src/components/chat/hooks/useChatSession.ts
@@ -24,6 +24,11 @@ import type {
   AgentSummaryForSidebar,
   SubagentEvent,
 } from "@/types/chat"
+import {
+  dispatchSessionPinChange,
+  sessionWithPinnedState,
+  sortSessionsForSidebar,
+} from "../sessionPinEvents"
 import type { AgentConfig } from "@/components/settings/types"
 import { confirmDiscardDirtyFileEditors } from "../files/fileDirtyRegistry"
 
@@ -88,7 +93,7 @@ export interface UseChatSessionReturn {
   // Handlers
   reloadSessions: () => Promise<void>
   reloadAgents: () => Promise<void>
-  handleToggleSessionPinned: (sessionId: string, pinned: boolean) => Promise<void>
+  handleToggleSessionPinned: (session: SessionMeta, pinned: boolean) => Promise<void>
   handleReorderAgents: (agentIds: string[]) => Promise<void>
   handleSwitchSession: (
     sessionId: string,
@@ -117,15 +122,6 @@ interface UseChatSessionOptions {
   activeSessionReadable: boolean
   /** Ref form for transport callbacks that must avoid stale render closures. */
   activeSessionReadableRef: React.MutableRefObject<boolean>
-}
-
-function sortSessionsForSidebar(sessions: SessionMeta[]): SessionMeta[] {
-  return sessions.slice().sort((a, b) => {
-    const aPinned = a.pinnedAt ? Date.parse(a.pinnedAt) || 0 : 0
-    const bPinned = b.pinnedAt ? Date.parse(b.pinnedAt) || 0 : 0
-    if (aPinned !== bPinned) return bPinned - aPinned
-    return (Date.parse(b.updatedAt) || 0) - (Date.parse(a.updatedAt) || 0)
-  })
 }
 
 export function useChatSession({
@@ -505,20 +501,19 @@ export function useChatSession({
   }, [])
 
   const handleToggleSessionPinned = useCallback(
-    async (sessionId: string, pinned: boolean) => {
-      const pinnedAt = pinned ? new Date().toISOString() : null
-      setSessions((prev) =>
-        sortSessionsForSidebar(
-          prev.map((session) => (session.id === sessionId ? { ...session, pinnedAt } : session)),
-        ),
-      )
+    async (session: SessionMeta, pinned: boolean) => {
+      const optimisticSession = sessionWithPinnedState(session, pinned)
+      dispatchSessionPinChange(optimisticSession, "optimistic")
       try {
-        await getTransport().call("set_session_pinned_cmd", { sessionId, pinned })
+        await getTransport().call("set_session_pinned_cmd", { sessionId: session.id, pinned })
+        dispatchSessionPinChange(optimisticSession, "refresh")
         await reloadSessions()
       } catch (e) {
         logger.error("ui", "ChatScreen::pinSession", "Failed to update session pin", e)
         toast.error(t("common.saveFailed"), { description: String(e) })
+        dispatchSessionPinChange(session, "rollback")
         await reloadSessions()
+        dispatchSessionPinChange(session, "refresh")
       }
     },
     [reloadSessions, t],

--- a/src/components/chat/project/ProjectSection.tsx
+++ b/src/components/chat/project/ProjectSection.tsx
@@ -104,13 +104,13 @@ interface ProjectSectionProps {
   onCommitRename: () => void
   onCancelRename: () => void
   onMoveSessionToProject?: (sessionId: string, projectId: string | null) => void
-  onToggleSessionPinned?: (sessionId: string, pinned: boolean) => void
+  onToggleSessionPinned?: (session: SessionMeta, pinned: boolean) => void
   getAgentInfo: (agentId: string) => AgentSummaryForSidebar | undefined
   formatRelativeTime: (dateStr: string) => string
   displayMode: SidebarDisplayMode
   motionDisabled?: boolean
-  /** Whether the sticky Agent header occupies the 32px row above Projects. */
-  hasAgentHeader?: boolean
+  /** Number of sticky 32px section headers rendered above Projects. */
+  stickyHeaderCount?: number
   unreadFocusTarget?: (UnreadSessionTarget & { signal: number }) | null
 }
 
@@ -146,7 +146,7 @@ export default function ProjectSection(props: ProjectSectionProps) {
     onAddProject,
     onReorderProjects,
     motionDisabled = false,
-    hasAgentHeader = false,
+    stickyHeaderCount = 0,
     unreadFocusTarget,
   } = props
   const visibleProjects = useMemo(() => projects.filter((p) => !p.archived), [projects])
@@ -185,7 +185,7 @@ export default function ProjectSection(props: ProjectSectionProps) {
 
   // A reveal target temporarily forces its containing tree path open without
   // mutating the user's persisted expansion preferences from an effect.
-  const unreadProjectId = unreadFocusTarget?.projectId ?? null
+  const unreadProjectId = unreadFocusTarget?.pinned ? null : (unreadFocusTarget?.projectId ?? null)
   const projectsExpanded = expanded || unreadProjectId !== null
   const archivedProjectsExpanded =
     archivedExpanded ||
@@ -265,7 +265,7 @@ export default function ProjectSection(props: ProjectSectionProps) {
         onToggle={() => setExpanded(!expanded)}
         className={cn(
           "sticky z-20 mb-0 flex h-8 items-center border-b border-border/50 bg-surface-panel px-3",
-          hasAgentHeader ? "top-8" : "top-0",
+          stickyHeaderCount === 0 ? "top-0" : stickyHeaderCount === 1 ? "top-8" : "top-16",
         )}
         action={
           <IconTip label={t("project.newProject")}>
@@ -456,14 +456,14 @@ function ProjectGroup({
   const projectUnreadCount = project.unreadCount
 
   // Fingerprint of the project's slice of the live global session array. Any
-  // visible change (create / delete / rename / reorder / read / pin) flips it
+  // visible change (create / delete / rename / reorder / read) flips it
   // and triggers the independent per-project refetch below.
   const changeSignal = useMemo(
     () =>
       projectSessions
         .map(
           (s) =>
-            `${s.id}:${s.updatedAt}:${s.pinnedAt ?? ""}:${s.unreadCount}:${s.title ?? ""}:${s.pendingInteractionCount}`,
+            `${s.id}:${s.updatedAt}:${s.unreadCount}:${s.title ?? ""}:${s.pendingInteractionCount}`,
         )
         .join("|"),
     [projectSessions],
@@ -484,9 +484,13 @@ function ProjectGroup({
     changeSignal,
     sessionCount: project.sessionCount,
     ensureSessionId:
-      unreadFocusTarget?.projectId === project.id ? unreadFocusTarget.sessionId : null,
+      !unreadFocusTarget?.pinned && unreadFocusTarget?.projectId === project.id
+        ? unreadFocusTarget.sessionId
+        : null,
     ensureSessionOffset:
-      unreadFocusTarget?.projectId === project.id ? unreadFocusTarget.listOffset : null,
+      !unreadFocusTarget?.pinned && unreadFocusTarget?.projectId === project.id
+        ? unreadFocusTarget.listOffset
+        : null,
   })
   const showPaginationFooter = childTotal > PROJECT_SESSION_PAGE_SIZE
   const ProjectToggleIcon = groupExpanded ? FolderOpen : Folder
@@ -688,9 +692,9 @@ function ProjectGroup({
                 <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
               </div>
             ) : childSessions.length === 0 ? (
-              archivedView ? (
+              archivedView || project.sessionCount > 0 ? (
                 <div className="px-2 py-1 text-[11px] text-muted-foreground/60">
-                  {t("project.sessionsInProject", { count: 0 })}
+                  {t("project.sessionsInProject", { count: project.sessionCount })}
                 </div>
               ) : (
                 <button

--- a/src/components/chat/project/hooks/useProjectSessions.test.tsx
+++ b/src/components/chat/project/hooks/useProjectSessions.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+import type { SessionMeta } from "@/types/chat"
+import { dispatchSessionPinChange, sessionWithPinnedState } from "../../sessionPinEvents"
+import { useProjectSessions } from "./useProjectSessions"
+
+const transportMock = vi.hoisted(() => ({ call: vi.fn() }))
+
+vi.mock("@/lib/transport-provider", () => ({
+  getTransport: () => transportMock,
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn() },
+}))
+
+function session(id: string, projectId: string): SessionMeta {
+  return {
+    id,
+    title: id,
+    agentId: "agent-a",
+    createdAt: "2026-08-07T00:00:00Z",
+    updatedAt: "2026-08-07T00:00:00Z",
+    messageCount: 1,
+    unreadCount: 0,
+    channelUnreadCount: 0,
+    hasError: false,
+    pendingInteractionCount: 0,
+    isCron: false,
+    incognito: false,
+    projectId,
+  }
+}
+
+describe("useProjectSessions pin changes", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    transportMock.call.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  test("patches only the owning project and refreshes after persistence", async () => {
+    const projectSession = session("project-session", "project-a")
+    transportMock.call.mockResolvedValueOnce([[projectSession], 1])
+    const { result } = renderHook(() =>
+      useProjectSessions({
+        projectId: "project-a",
+        expanded: true,
+        changeSignal: "",
+        sessionCount: 1,
+      }),
+    )
+
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync()
+    })
+    expect(result.current.sessions.map((item) => item.id)).toEqual([projectSession.id])
+    expect(result.current.total).toBe(1)
+
+    const callsBeforeUnrelatedEvent = transportMock.call.mock.calls.length
+    act(() => {
+      dispatchSessionPinChange(
+        sessionWithPinnedState(session("other", "project-b"), true),
+        "refresh",
+      )
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+    expect(transportMock.call).toHaveBeenCalledTimes(callsBeforeUnrelatedEvent)
+
+    act(() => {
+      dispatchSessionPinChange(sessionWithPinnedState(projectSession, true), "optimistic")
+    })
+    expect(result.current.sessions).toEqual([])
+    expect(result.current.total).toBe(0)
+    expect(transportMock.call).toHaveBeenCalledTimes(callsBeforeUnrelatedEvent)
+
+    transportMock.call.mockResolvedValueOnce([[], 0])
+    act(() => {
+      dispatchSessionPinChange(sessionWithPinnedState(projectSession, true), "refresh")
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150)
+    })
+    expect(transportMock.call).toHaveBeenCalledTimes(callsBeforeUnrelatedEvent + 1)
+    expect(result.current.sessions).toEqual([])
+    expect(result.current.total).toBe(0)
+  })
+})

--- a/src/components/chat/project/hooks/useProjectSessions.ts
+++ b/src/components/chat/project/hooks/useProjectSessions.ts
@@ -14,7 +14,7 @@
  * Realtime freshness piggybacks on the shared global `sessions` array that the
  * ChatScreen keeps live (full reloads + incremental patches). `changeSignal` is a
  * fingerprint of this project's slice of that array; when it changes — a session
- * was created / renamed / reordered / read / pinned — we refetch the window.
+ * was created / renamed / reordered / read — we refetch the window.
  * `sessionCount` (live from `ProjectMeta`) is a backstop for membership changes
  * that don't surface in the global window (e.g. moving an old session in).
  */
@@ -25,6 +25,11 @@ import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import type { SessionMeta } from "@/types/chat"
 import { PROJECT_SESSION_PAGE_SIZE } from "../../hooks/constants"
+import {
+  SESSION_PIN_CHANGED_EVENT,
+  sortSessionsForSidebar,
+  type SessionPinChangeDetail,
+} from "../../sessionPinEvents"
 
 export interface UseProjectSessionsParams {
   projectId: string
@@ -69,6 +74,7 @@ export function useProjectSessions({
   const [windowSize, setWindowSize] = useState(PROJECT_SESSION_PAGE_SIZE)
   const [loading, setLoading] = useState(false)
   const [loadingMore, setLoadingMore] = useState(false)
+  const [pinChangeSignal, setPinChangeSignal] = useState(0)
 
   // Tracks whether we've ever loaded so re-expanding shows stale rows instead
   // of a spinner while the background refetch lands.
@@ -115,6 +121,7 @@ export function useProjectSessions({
               id: projectId,
               limit: requestedLimit,
               offset: 0,
+              pinned: false,
             },
           )
           if (cancelled || seq !== reqSeqRef.current) return
@@ -146,6 +153,7 @@ export function useProjectSessions({
     windowSize,
     changeSignal,
     sessionCount,
+    pinChangeSignal,
     ensureSessionId,
     ensureSessionOffset,
   ])
@@ -170,6 +178,31 @@ export function useProjectSessions({
     window.addEventListener("hope:session-renamed", onRenamed)
     return () => window.removeEventListener("hope:session-renamed", onRenamed)
   }, [])
+
+  // Pin changes carry their owning project so one toggle patches only the
+  // affected expanded group. The optimistic/rollback phases update the visible
+  // rows immediately; refresh runs only after the persistence attempt settles.
+  useEffect(() => {
+    const onPinned = (event: Event) => {
+      const detail = (event as CustomEvent<SessionPinChangeDetail>).detail
+      if (!expanded || detail?.session.projectId !== projectId) return
+      if (detail.phase === "refresh") {
+        setPinChangeSignal((value) => value + 1)
+        return
+      }
+
+      const changed = detail.session
+      setSessions((prev) => {
+        const withoutChanged = prev.filter((session) => session.id !== changed.id)
+        return changed.pinnedAt
+          ? withoutChanged
+          : sortSessionsForSidebar([...withoutChanged, changed]).slice(0, windowSize)
+      })
+      setTotal((prev) => Math.max(0, prev + (changed.pinnedAt ? -1 : 1)))
+    }
+    window.addEventListener(SESSION_PIN_CHANGED_EVENT, onPinned)
+    return () => window.removeEventListener(SESSION_PIN_CHANGED_EVENT, onPinned)
+  }, [expanded, projectId, windowSize])
 
   const showMore = useCallback(() => {
     setLoadingMore(true)

--- a/src/components/chat/sessionPinEvents.ts
+++ b/src/components/chat/sessionPinEvents.ts
@@ -1,0 +1,38 @@
+import type { SessionMeta } from "@/types/chat"
+
+export const SESSION_PIN_CHANGED_EVENT = "hope:session-pinned"
+
+export type SessionPinChangePhase = "optimistic" | "rollback" | "refresh"
+
+export interface SessionPinChangeDetail {
+  session: SessionMeta
+  phase: SessionPinChangePhase
+}
+
+export function dispatchSessionPinChange(session: SessionMeta, phase: SessionPinChangePhase) {
+  window.dispatchEvent(
+    new CustomEvent<SessionPinChangeDetail>(SESSION_PIN_CHANGED_EVENT, {
+      detail: { session, phase },
+    }),
+  )
+}
+
+export function sessionWithPinnedState(
+  session: SessionMeta,
+  pinned: boolean,
+  pinnedAt = new Date().toISOString(),
+): SessionMeta {
+  return {
+    ...session,
+    pinnedAt: pinned ? session.pinnedAt || pinnedAt : null,
+  }
+}
+
+export function sortSessionsForSidebar(sessions: SessionMeta[]): SessionMeta[] {
+  return sessions.slice().sort((a, b) => {
+    const aPinned = a.pinnedAt ? Date.parse(a.pinnedAt) || 0 : 0
+    const bPinned = b.pinnedAt ? Date.parse(b.pinnedAt) || 0 : 0
+    if (aPinned !== bPinned) return bPinned - aPinned
+    return (Date.parse(b.updatedAt) || 0) - (Date.parse(a.updatedAt) || 0)
+  })
+}

--- a/src/components/chat/sidebar/AgentSection.tsx
+++ b/src/components/chat/sidebar/AgentSection.tsx
@@ -37,6 +37,8 @@ interface AgentSectionProps {
   panelWidth: number
   displayMode: SidebarDisplayMode
   motionDisabled?: boolean
+  /** Number of sticky 32px section headers rendered above this section. */
+  stickyHeaderCount?: number
 }
 
 const AGENT_CARD_MIN_WIDTH_PX = 156
@@ -227,6 +229,7 @@ export default function AgentSection({
   panelWidth,
   displayMode,
   motionDisabled = false,
+  stickyHeaderCount = 0,
 }: AgentSectionProps) {
   const { t } = useTranslation()
   const clickTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -265,7 +268,10 @@ export default function AgentSection({
         count={agents.length}
         expanded={agentsExpanded}
         onToggle={() => setAgentsExpanded(!agentsExpanded)}
-        className="sticky top-0 z-20 mb-0 flex h-8 items-center border-b border-border/50 bg-surface-panel px-3"
+        className={cn(
+          "sticky z-20 mb-0 flex h-8 items-center border-b border-border/50 bg-surface-panel px-3",
+          stickyHeaderCount === 0 ? "top-0" : stickyHeaderCount === 1 ? "top-8" : "top-16",
+        )}
       />
       <AnimatedCollapse
         open={agentsExpanded}

--- a/src/components/chat/sidebar/ChatSidebar.tsx
+++ b/src/components/chat/sidebar/ChatSidebar.tsx
@@ -31,6 +31,7 @@ import { sortSessionSearchResults } from "../chatUtils"
 import { SEARCH_LIMIT } from "../hooks/constants"
 import AgentSection from "./AgentSection"
 import SessionList from "./SessionList"
+import PinnedSection from "./PinnedSection"
 import ProjectSection from "../project/ProjectSection"
 import { GLOBAL_SESSION_SEARCH_TYPES } from "./sessionListModel"
 import { useSidebarSessionPagination } from "./useSidebarSessionPagination"
@@ -189,7 +190,7 @@ export default function ChatSidebar({
           setUnreadRevealTarget(null)
           return
         }
-        if (target.projectId) setProjectsExpanded(true)
+        if (target.projectId && !target.pinned) setProjectsExpanded(true)
         setUnreadRevealTarget({ ...target, signal: unreadFocusSignal })
       })
       .catch((error) => {
@@ -293,6 +294,7 @@ export default function ChatSidebar({
   // metadata cache; it is deliberately not the flat list's rendering source.
   const {
     sessionsByFilter,
+    pinnedSessions,
     loading: sidebarSessionsLoading,
     loadingMoreByFilter,
     hasMoreByFilter,
@@ -303,10 +305,14 @@ export default function ChatSidebar({
     currentSessionId,
     enabled: !sessionsLoading,
     refreshSignal: sessions,
-    ensureSessionId: unreadRevealTarget?.projectId ? null : (unreadRevealTarget?.sessionId ?? null),
-    ensureSessionOffset: unreadRevealTarget?.projectId
-      ? null
-      : (unreadRevealTarget?.listOffset ?? null),
+    ensureSessionId:
+      unreadRevealTarget?.pinned || unreadRevealTarget?.projectId
+        ? null
+        : (unreadRevealTarget?.sessionId ?? null),
+    ensureSessionOffset:
+      unreadRevealTarget?.pinned || unreadRevealTarget?.projectId
+        ? null
+        : (unreadRevealTarget?.listOffset ?? null),
   })
   const filteredSessions = sessionsByFilter[sessionFilter]
 
@@ -481,7 +487,9 @@ export default function ChatSidebar({
 
   const showAgentSection = agents.length > 1
   const showProjectSection = projects.length > 0 || !!onAddProject
-  const stickySidebarHeaderCount = Number(showAgentSection) + Number(showProjectSection)
+  const showPinnedSection = pinnedSessions.length > 0
+  const stickySidebarHeaderCount =
+    Number(showPinnedSection) + Number(showAgentSection) + Number(showProjectSection)
 
   const sessionListNode = (
     <SessionList
@@ -709,6 +717,34 @@ export default function ChatSidebar({
                 sessionListNode
               ) : (
                 <>
+                  {showPinnedSection && (
+                    <PinnedSection
+                      pinnedSessions={pinnedSessions}
+                      sessions={sessions}
+                      projects={projects}
+                      currentSessionId={currentSessionId}
+                      readableSessionId={readableSessionId}
+                      loadingSessionIds={loadingSessionIds}
+                      onSwitchSession={onSwitchSession}
+                      onArchiveClick={handleArchiveClick}
+                      onMarkAllRead={handleSidebarUnreadChanged}
+                      renamingSessionId={renamingSessionId}
+                      renameValue={renameValue}
+                      renameInputRef={renameInputRef}
+                      onStartRename={startRename}
+                      onRenameValueChange={setRenameValue}
+                      onCommitRename={commitRename}
+                      onCancelRename={cancelRename}
+                      onMoveToProject={handleSidebarMoveSession}
+                      onToggleSessionPinned={onToggleSessionPinned}
+                      getAgentInfo={getAgentInfo}
+                      formatRelativeTime={formatRelativeTime}
+                      displayMode={sidebarDisplayMode}
+                      motionDisabled={sidebarMotionDisabled}
+                      unreadFocusTarget={unreadRevealTarget}
+                    />
+                  )}
+
                   {/* Collapsible Agents section */}
                   {showAgentSection && (
                     <AgentSection
@@ -723,6 +759,7 @@ export default function ChatSidebar({
                       panelWidth={panelWidth}
                       displayMode={sidebarDisplayMode}
                       motionDisabled={sidebarMotionDisabled}
+                      stickyHeaderCount={Number(showPinnedSection)}
                     />
                   )}
 
@@ -759,7 +796,7 @@ export default function ChatSidebar({
                       formatRelativeTime={formatRelativeTime}
                       displayMode={sidebarDisplayMode}
                       motionDisabled={sidebarMotionDisabled}
-                      hasAgentHeader={showAgentSection}
+                      stickyHeaderCount={Number(showPinnedSection) + Number(showAgentSection)}
                       unreadFocusTarget={unreadRevealTarget}
                     />
                   )}

--- a/src/components/chat/sidebar/PinnedSection.tsx
+++ b/src/components/chat/sidebar/PinnedSection.tsx
@@ -1,0 +1,143 @@
+import { useCallback, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { AnimatedCollapse } from "@/components/ui/animated-presence"
+import { cn } from "@/lib/utils"
+import type { AgentSummaryForSidebar, SessionMeta, UnreadSessionTarget } from "@/types/chat"
+import type { ProjectMeta } from "@/types/project"
+import SessionItem from "./SessionItem"
+import SidebarSectionHeader from "./SidebarSectionHeader"
+import type { SidebarDisplayMode } from "./types"
+
+const PINNED_EXPANDED_STORAGE_KEY = "hope.chatSidebarPinnedExpanded"
+
+function readExpanded(): boolean {
+  try {
+    if (typeof window === "undefined") return true
+    const raw = window.localStorage.getItem(PINNED_EXPANDED_STORAGE_KEY)
+    return raw === null ? true : raw === "true"
+  } catch {
+    return true
+  }
+}
+
+interface PinnedSectionProps {
+  pinnedSessions: SessionMeta[]
+  sessions: SessionMeta[]
+  projects: ProjectMeta[]
+  currentSessionId: string | null
+  readableSessionId: string | null
+  loadingSessionIds: Set<string>
+  onSwitchSession: (sessionId: string) => void
+  onArchiveClick: (sessionId: string, event: React.MouseEvent) => void
+  onMarkAllRead?: () => void
+  renamingSessionId: string | null
+  renameValue: string
+  renameInputRef: React.RefObject<HTMLInputElement | null>
+  onStartRename: (sessionId: string, currentTitle: string) => void
+  onRenameValueChange: (value: string) => void
+  onCommitRename: () => void
+  onCancelRename: () => void
+  onMoveToProject?: (sessionId: string, projectId: string | null) => void
+  onToggleSessionPinned?: (session: SessionMeta, pinned: boolean) => void
+  getAgentInfo: (agentId: string) => AgentSummaryForSidebar | undefined
+  formatRelativeTime: (dateStr: string) => string
+  displayMode: SidebarDisplayMode
+  motionDisabled?: boolean
+  unreadFocusTarget?: (UnreadSessionTarget & { signal: number }) | null
+}
+
+export default function PinnedSection({
+  pinnedSessions,
+  sessions,
+  projects,
+  currentSessionId,
+  readableSessionId,
+  loadingSessionIds,
+  onSwitchSession,
+  onArchiveClick,
+  onMarkAllRead,
+  renamingSessionId,
+  renameValue,
+  renameInputRef,
+  onStartRename,
+  onRenameValueChange,
+  onCommitRename,
+  onCancelRename,
+  onMoveToProject,
+  onToggleSessionPinned,
+  getAgentInfo,
+  formatRelativeTime,
+  displayMode,
+  motionDisabled = false,
+  unreadFocusTarget,
+}: PinnedSectionProps) {
+  const { t } = useTranslation()
+  const [expanded, setExpandedState] = useState(readExpanded)
+  const visibleExpanded = expanded || unreadFocusTarget?.pinned === true
+  const sessionContext = useMemo(() => {
+    const byId = new Map(sessions.map((session) => [session.id, session]))
+    for (const session of pinnedSessions) byId.set(session.id, session)
+    return [...byId.values()]
+  }, [pinnedSessions, sessions])
+
+  const setExpanded = useCallback((next: boolean) => {
+    setExpandedState(next)
+    try {
+      window.localStorage.setItem(PINNED_EXPANDED_STORAGE_KEY, String(next))
+    } catch {
+      // localStorage may be unavailable in restricted browser modes.
+    }
+  }, [])
+
+  return (
+    <div className="contents">
+      <SidebarSectionHeader
+        title={t("chat.pinnedSessions")}
+        count={pinnedSessions.length}
+        expanded={visibleExpanded}
+        onToggle={() => setExpanded(!expanded)}
+        className="sticky top-0 z-20 mb-0 flex h-8 items-center border-b border-border/50 bg-surface-panel px-3"
+      />
+      <AnimatedCollapse open={visibleExpanded} durationMs={motionDisabled ? 0 : undefined}>
+        <div
+          className={cn("px-2 pb-1 pt-1", displayMode === "compact" ? "space-y-1" : "space-y-0.5")}
+        >
+          {pinnedSessions.map((session) => (
+            <SessionItem
+              key={session.id}
+              session={session}
+              sessions={sessionContext}
+              agent={getAgentInfo(session.agentId)}
+              showSubagentBadge
+              projects={projects}
+              isActive={session.id === currentSessionId}
+              isReadable={session.id === readableSessionId}
+              isLoading={loadingSessionIds.has(session.id)}
+              renamingSessionId={renamingSessionId}
+              renameValue={renameValue}
+              renameInputRef={renameInputRef}
+              onSwitchSession={onSwitchSession}
+              onArchiveClick={onArchiveClick}
+              onStartRename={onStartRename}
+              onRenameValueChange={onRenameValueChange}
+              onCommitRename={onCommitRename}
+              onCancelRename={onCancelRename}
+              onMarkAllRead={onMarkAllRead}
+              onMoveToProject={onMoveToProject}
+              onTogglePinned={onToggleSessionPinned}
+              getAgentInfo={getAgentInfo}
+              formatRelativeTime={formatRelativeTime}
+              displayMode={displayMode}
+              revealSignal={
+                unreadFocusTarget?.pinned && unreadFocusTarget.sessionId === session.id
+                  ? unreadFocusTarget.signal
+                  : undefined
+              }
+            />
+          ))}
+        </div>
+      </AnimatedCollapse>
+    </div>
+  )
+}

--- a/src/components/chat/sidebar/SessionItem.tsx
+++ b/src/components/chat/sidebar/SessionItem.tsx
@@ -65,7 +65,7 @@ interface SessionItemProps {
   onCommitRename: () => void
   onCancelRename: () => void
   onMarkAllRead?: () => void
-  onTogglePinned?: (sessionId: string, pinned: boolean) => void
+  onTogglePinned?: (session: SessionMeta, pinned: boolean) => void
   /**
    * Move this session to a project (or remove from current project when
    * `projectId` is `null`). Only rendered when this callback is provided.
@@ -464,7 +464,7 @@ export default function SessionItem({
                 onClick={(e) => {
                   e.stopPropagation()
                   hoverCard.close()
-                  onTogglePinned(session.id, !session.pinnedAt)
+                  onTogglePinned(session, !session.pinnedAt)
                 }}
                 aria-label={session.pinnedAt ? t("chat.unpinSession") : t("chat.pinSession")}
               >
@@ -518,7 +518,7 @@ export default function SessionItem({
         }}
       >
         {onTogglePinned && (
-          <ContextMenuItem onClick={() => onTogglePinned(session.id, !session.pinnedAt)}>
+          <ContextMenuItem onClick={() => onTogglePinned(session, !session.pinnedAt)}>
             {session.pinnedAt ? (
               <PinOff className="h-4 w-4 mr-2" />
             ) : (

--- a/src/components/chat/sidebar/SessionList.tsx
+++ b/src/components/chat/sidebar/SessionList.tsx
@@ -64,7 +64,7 @@ interface SessionListProps {
   // Projects — drives the per-session "Move to project" submenu
   projects?: ProjectMeta[]
   onMoveToProject?: (sessionId: string, projectId: string | null) => void
-  onToggleSessionPinned?: (sessionId: string, pinned: boolean) => void
+  onToggleSessionPinned?: (session: SessionMeta, pinned: boolean) => void
   displayMode: SidebarDisplayMode
   /** Number of visible 32px sticky section headers above the filter tabs. */
   stickyHeaderCount?: number
@@ -140,7 +140,13 @@ export default function SessionList({
         <div
           className={cn(
             "sticky z-20 flex items-center gap-0.5 px-3 py-1.5 border-b border-border/40 bg-surface-panel overflow-x-auto scrollbar-none",
-            stickyHeaderCount === 0 ? "top-0" : stickyHeaderCount === 1 ? "top-8" : "top-16",
+            stickyHeaderCount === 0
+              ? "top-0"
+              : stickyHeaderCount === 1
+                ? "top-8"
+                : stickyHeaderCount === 2
+                  ? "top-16"
+                  : "top-24",
           )}
         >
           {(["session", "subagent"] as const).map((filter) => {

--- a/src/components/chat/sidebar/sessionListModel.test.ts
+++ b/src/components/chat/sidebar/sessionListModel.test.ts
@@ -63,6 +63,7 @@ describe("sidebar session list model", () => {
     session("project", { projectId: "project-a" }),
     session("subagent", { parentSessionId: "parent" }),
     session("project-subagent", { projectId: "project-a", parentSessionId: "parent" }),
+    session("pinned", { pinnedAt: "2026-07-12T01:00:00Z" }),
     session("cron", { isCron: true }),
     session("other-agent", { agentId: "agent-b" }),
   ]
@@ -95,6 +96,7 @@ describe("sidebar session list model", () => {
       limit: 50,
       offset: 50,
       activeSessionId: "active",
+      pinned: false,
     })
     expect(sidebarSessionPageArgs("subagent", null, 0, 50)).toEqual({
       unassigned: true,
@@ -103,6 +105,7 @@ describe("sidebar session list model", () => {
       limit: 50,
       offset: 0,
       activeSessionId: undefined,
+      pinned: false,
     })
   })
 

--- a/src/components/chat/sidebar/sessionListModel.ts
+++ b/src/components/chat/sidebar/sessionListModel.ts
@@ -18,6 +18,7 @@ export function sidebarSessionPageArgs(
   return {
     unassigned: true,
     parentSession: filter === "subagent",
+    pinned: false,
     agentId: selectedAgentId ?? undefined,
     limit,
     offset,
@@ -37,7 +38,7 @@ export function filterSessionsForSidebarTab(
 ): SessionMeta[] {
   return sessions.filter((session) => {
     if (selectedAgentId !== null && session.agentId !== selectedAgentId) return false
-    if (session.isCron || session.projectId) return false
+    if (session.isCron || session.projectId || session.pinnedAt) return false
 
     return filter === "subagent" ? !!session.parentSessionId : !session.parentSessionId
   })

--- a/src/components/chat/sidebar/types.ts
+++ b/src/components/chat/sidebar/types.ts
@@ -38,7 +38,7 @@ export interface ChatSidebarProps {
   onNewChat: (agentId: string, opts?: { incognito?: boolean }) => void
   onArchiveSession: (sessionId: string) => void | Promise<void>
   onEditAgent?: (agentId: string) => void
-  onToggleSessionPinned?: (sessionId: string, pinned: boolean) => void
+  onToggleSessionPinned?: (session: SessionMeta, pinned: boolean) => void
   onReorderAgents?: (agentIds: string[]) => void
   onReorderProjects?: (projectIds: string[]) => void
   onMarkAllRead?: () => void

--- a/src/components/chat/sidebar/useSidebarSessionPagination.test.tsx
+++ b/src/components/chat/sidebar/useSidebarSessionPagination.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+import type { SessionMeta } from "@/types/chat"
+import { dispatchSessionPinChange, sessionWithPinnedState } from "../sessionPinEvents"
+import { useSidebarSessionPagination } from "./useSidebarSessionPagination"
+
+const transportMock = vi.hoisted(() => ({ call: vi.fn() }))
+
+vi.mock("@/lib/transport-provider", () => ({
+  getTransport: () => transportMock,
+}))
+
+vi.mock("@/lib/logger", () => ({
+  logger: { error: vi.fn() },
+}))
+
+function session(id: string, patch: Partial<SessionMeta> = {}): SessionMeta {
+  return {
+    id,
+    title: id,
+    agentId: "agent-a",
+    createdAt: "2026-08-07T00:00:00Z",
+    updatedAt: "2026-08-07T00:00:00Z",
+    messageCount: 1,
+    unreadCount: 0,
+    channelUnreadCount: 0,
+    hasError: false,
+    pendingInteractionCount: 0,
+    isCron: false,
+    incognito: false,
+    ...patch,
+  }
+}
+
+describe("useSidebarSessionPagination pin changes", () => {
+  beforeEach(() => {
+    transportMock.call.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  test("moves a row between the rendered lists without querying before persistence", async () => {
+    const regular = session("regular")
+    transportMock.call.mockImplementation((_command: string, args: Record<string, unknown>) => {
+      if (args.pinned === true) return Promise.resolve([[], 0])
+      if (args.parentSession === false) return Promise.resolve([[regular], 1])
+      return Promise.resolve([[], 0])
+    })
+    const refreshSignal: SessionMeta[] = []
+    const { result } = renderHook(() =>
+      useSidebarSessionPagination({
+        selectedAgentId: null,
+        currentSessionId: null,
+        enabled: true,
+        refreshSignal,
+      }),
+    )
+
+    await waitFor(() => expect(result.current.sessionsByFilter.session).toHaveLength(1))
+    const callsBeforePin = transportMock.call.mock.calls.length
+
+    act(() => {
+      dispatchSessionPinChange(sessionWithPinnedState(regular, true), "optimistic")
+    })
+    expect(result.current.sessionsByFilter.session).toEqual([])
+    expect(result.current.pinnedSessions.map((item) => item.id)).toEqual([regular.id])
+    expect(transportMock.call).toHaveBeenCalledTimes(callsBeforePin)
+
+    act(() => {
+      dispatchSessionPinChange(regular, "rollback")
+    })
+    expect(result.current.pinnedSessions).toEqual([])
+    expect(result.current.sessionsByFilter.session.map((item) => item.id)).toEqual([regular.id])
+  })
+})

--- a/src/components/chat/sidebar/useSidebarSessionPagination.ts
+++ b/src/components/chat/sidebar/useSidebarSessionPagination.ts
@@ -3,6 +3,11 @@ import { getTransport } from "@/lib/transport-provider"
 import { logger } from "@/lib/logger"
 import type { SessionMeta } from "@/types/chat"
 import { SESSION_PAGE_SIZE } from "../hooks/constants"
+import {
+  SESSION_PIN_CHANGED_EVENT,
+  sortSessionsForSidebar,
+  type SessionPinChangeDetail,
+} from "../sessionPinEvents"
 import type { SessionFilterType } from "./types"
 import { filterSessionsForSidebarTab, sidebarSessionPageArgs } from "./sessionListModel"
 
@@ -36,6 +41,7 @@ export function useSidebarSessionPagination({
   ensureSessionOffset,
 }: UseSidebarSessionPaginationParams) {
   const [sessionsByFilter, setSessionsByFilter] = useState<SessionsByFilter>(emptySessions)
+  const [pinnedSessions, setPinnedSessions] = useState<SessionMeta[]>([])
   const [totalsByFilter, setTotalsByFilter] = useState<NumberByFilter>(emptyNumbers)
   const [loading, setLoading] = useState(true)
   const [loadingMoreByFilter, setLoadingMoreByFilter] = useState<BooleanByFilter>(emptyBooleans)
@@ -54,6 +60,7 @@ export function useSidebarSessionPagination({
       queryKeyRef.current = queryKey
       loadedRowsRef.current = emptyNumbers()
       setSessionsByFilter(emptySessions())
+      setPinnedSessions([])
       setTotalsByFilter(emptyNumbers())
     }
     setLoading(true)
@@ -61,53 +68,60 @@ export function useSidebarSessionPagination({
     setLoadingMoreByFilter(emptyBooleans())
 
     try {
-      const pages = await Promise.all(
-        FILTERS.map(async (filter) => {
-          let [rows, total] = await getTransport().call<[SessionMeta[], number]>(
-            "list_sessions_cmd",
-            sidebarSessionPageArgs(
-              filter,
-              selectedAgentId,
-              0,
-              SESSION_PAGE_SIZE,
-              activeSessionIdRef.current,
-            ),
-          )
-
-          // A second click may target a row outside the first page. The backend
-          // returns its exact visual-order offset, so one prefix request replaces
-          // a sequential page-by-page scan while preserving a contiguous list.
-          if (
-            filter === "session" &&
-            ensureSessionId &&
-            !rows.some((session) => session.id === ensureSessionId) &&
-            rows.length < total
-          ) {
-            const requiredLimit = Math.min(
-              total,
-              Math.max(SESSION_PAGE_SIZE, Math.floor(ensureSessionOffset ?? 0) + 1),
+      const [pages, [pinnedRows]] = await Promise.all([
+        Promise.all(
+          FILTERS.map(async (filter) => {
+            let [rows, total] = await getTransport().call<[SessionMeta[], number]>(
+              "list_sessions_cmd",
+              sidebarSessionPageArgs(
+                filter,
+                selectedAgentId,
+                0,
+                SESSION_PAGE_SIZE,
+                activeSessionIdRef.current,
+              ),
             )
-            if (requiredLimit > rows.length) {
-              ;[rows, total] = await getTransport().call<[SessionMeta[], number]>(
-                "list_sessions_cmd",
-                sidebarSessionPageArgs(
-                  filter,
-                  selectedAgentId,
-                  0,
-                  requiredLimit,
-                  activeSessionIdRef.current,
-                ),
+
+            // A second click may target a row outside the first page. The backend
+            // returns its exact visual-order offset, so one prefix request replaces
+            // a sequential page-by-page scan while preserving a contiguous list.
+            if (
+              filter === "session" &&
+              ensureSessionId &&
+              !rows.some((session) => session.id === ensureSessionId) &&
+              rows.length < total
+            ) {
+              const requiredLimit = Math.min(
+                total,
+                Math.max(SESSION_PAGE_SIZE, Math.floor(ensureSessionOffset ?? 0) + 1),
               )
+              if (requiredLimit > rows.length) {
+                ;[rows, total] = await getTransport().call<[SessionMeta[], number]>(
+                  "list_sessions_cmd",
+                  sidebarSessionPageArgs(
+                    filter,
+                    selectedAgentId,
+                    0,
+                    requiredLimit,
+                    activeSessionIdRef.current,
+                  ),
+                )
+              }
             }
-          }
-          return {
-            filter,
-            rows: filterSessionsForSidebarTab(rows, filter, selectedAgentId),
-            loadedRows: rows.length,
-            total,
-          }
+            return {
+              filter,
+              rows: filterSessionsForSidebarTab(rows, filter, selectedAgentId),
+              loadedRows: rows.length,
+              total,
+            }
+          }),
+        ),
+        getTransport().call<[SessionMeta[], number]>("list_sessions_cmd", {
+          agentId: selectedAgentId ?? undefined,
+          pinned: true,
+          activeSessionId: activeSessionIdRef.current ?? undefined,
         }),
-      )
+      ])
       if (generation !== generationRef.current) return
 
       const nextSessions = emptySessions()
@@ -120,6 +134,7 @@ export function useSidebarSessionPagination({
       }
       loadedRowsRef.current = nextLoadedRows
       setSessionsByFilter(nextSessions)
+      setPinnedSessions(pinnedRows)
       setTotalsByFilter(nextTotals)
     } catch (error) {
       if (generation === generationRef.current) {
@@ -141,6 +156,40 @@ export function useSidebarSessionPagination({
       generationRef.current += 1
     }
   }, [reload, refreshSignal])
+
+  useEffect(() => {
+    const onPinChanged = (event: Event) => {
+      const detail = (event as CustomEvent<SessionPinChangeDetail>).detail
+      if (!detail?.session || detail.phase === "refresh") return
+      const changed = detail.session
+      if (selectedAgentId !== null && changed.agentId !== selectedAgentId) return
+
+      setPinnedSessions((prev) => {
+        const withoutChanged = prev.filter((session) => session.id !== changed.id)
+        return changed.pinnedAt
+          ? sortSessionsForSidebar([...withoutChanged, changed])
+          : withoutChanged
+      })
+
+      setSessionsByFilter((prev) => {
+        const next: SessionsByFilter = {
+          session: prev.session.filter((session) => session.id !== changed.id),
+          subagent: prev.subagent.filter((session) => session.id !== changed.id),
+        }
+        if (changed.pinnedAt) return next
+
+        const targetFilter: SessionFilterType = changed.parentSessionId ? "subagent" : "session"
+        if (filterSessionsForSidebarTab([changed], targetFilter, selectedAgentId).length === 0) {
+          return next
+        }
+        next[targetFilter] = sortSessionsForSidebar([...next[targetFilter], changed])
+        return next
+      })
+    }
+
+    window.addEventListener(SESSION_PIN_CHANGED_EVENT, onPinChanged)
+    return () => window.removeEventListener(SESSION_PIN_CHANGED_EVENT, onPinChanged)
+  }, [selectedAgentId])
 
   const loadMore = useCallback(
     async (filter: SessionFilterType) => {
@@ -205,6 +254,7 @@ export function useSidebarSessionPagination({
 
   return {
     sessionsByFilter,
+    pinnedSessions,
     loading,
     loadingMoreByFilter,
     hasMoreByFilter,

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -638,6 +638,7 @@
     "markAllRead": "تحديد الكل كمقروء",
     "markAsRead": "تحديد كمقروء",
     "pinSession": "تثبيت",
+    "pinnedSessions": "المثبتة",
     "unpinSession": "إلغاء التثبيت",
     "minutesAgo": "منذ {{count}} دقيقة",
     "modelsCount": "{{count}} نماذج",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -638,6 +638,7 @@
     "markAllRead": "Mark all as read",
     "markAsRead": "Mark as read",
     "pinSession": "Pin",
+    "pinnedSessions": "Pinned",
     "unpinSession": "Unpin",
     "minutesAgo": "{{count}}min ago",
     "modelsCount": "{{count}} models",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -638,6 +638,7 @@
     "markAllRead": "Marcar todo como leído",
     "markAsRead": "Marcar como leído",
     "pinSession": "Fijar",
+    "pinnedSessions": "Fijadas",
     "unpinSession": "Desfijar",
     "minutesAgo": "hace {{count}}min",
     "modelsCount": "{{count}} modelos",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -638,6 +638,7 @@
     "markAllRead": "すべて既読にする",
     "markAsRead": "既読にする",
     "pinSession": "ピン留め",
+    "pinnedSessions": "ピン留め",
     "unpinSession": "ピン留め解除",
     "minutesAgo": "{{count}}分前",
     "modelsCount": "{{count}} モデル",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -638,6 +638,7 @@
     "markAllRead": "모두 읽음으로 표시",
     "markAsRead": "읽음으로 표시",
     "pinSession": "고정",
+    "pinnedSessions": "고정",
     "unpinSession": "고정 해제",
     "minutesAgo": "{{count}}분 전",
     "modelsCount": "모델 {{count}}개",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -638,6 +638,7 @@
     "markAllRead": "Tanda semua sebagai dibaca",
     "markAsRead": "Tandakan sebagai dibaca",
     "pinSession": "Semat",
+    "pinnedSessions": "Disemat",
     "unpinSession": "Nyahsemat",
     "minutesAgo": "{{count}} minit lalu",
     "modelsCount": "{{count}} model",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -638,6 +638,7 @@
     "markAllRead": "Marcar tudo como lido",
     "markAsRead": "Marcar como lido",
     "pinSession": "Fixar",
+    "pinnedSessions": "Fixadas",
     "unpinSession": "Desafixar",
     "minutesAgo": "{{count}}min atrás",
     "modelsCount": "{{count}} modelos",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -638,6 +638,7 @@
     "markAllRead": "Отметить всё как прочитанное",
     "markAsRead": "Отметить как прочитанное",
     "pinSession": "Закрепить",
+    "pinnedSessions": "Закреплённые",
     "unpinSession": "Открепить",
     "minutesAgo": "{{count}} мин назад",
     "modelsCount": "{{count}} моделей",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -638,6 +638,7 @@
     "markAllRead": "Tümünü okundu olarak işaretle",
     "markAsRead": "Okundu olarak işaretle",
     "pinSession": "Sabitle",
+    "pinnedSessions": "Sabitlenenler",
     "unpinSession": "Sabitlemeyi kaldır",
     "minutesAgo": "{{count}} dk önce",
     "modelsCount": "{{count}} model",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -638,6 +638,7 @@
     "markAllRead": "Đánh dấu tất cả là đã đọc",
     "markAsRead": "Đánh dấu là đã đọc",
     "pinSession": "Ghim",
+    "pinnedSessions": "Đã ghim",
     "unpinSession": "Bỏ ghim",
     "minutesAgo": "{{count}} phút trước",
     "modelsCount": "{{count}} mô hình",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -638,6 +638,7 @@
     "markAllRead": "全部已讀",
     "markAsRead": "標記已讀",
     "pinSession": "置頂",
+    "pinnedSessions": "置頂",
     "unpinSession": "取消置頂",
     "minutesAgo": "{{count}}分鐘前",
     "modelsCount": "{{count}} 個模型",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -638,6 +638,7 @@
     "markAllRead": "全部已读",
     "markAsRead": "标记已读",
     "pinSession": "置顶",
+    "pinnedSessions": "置顶",
     "unpinSession": "取消置顶",
     "minutesAgo": "{{count}}分钟前",
     "modelsCount": "{{count}} 个模型",

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -626,7 +626,9 @@ export interface ForkSessionResult extends SessionMeta {
 export interface UnreadSessionTarget {
   sessionId: string
   projectId?: string | null
-  /** Zero-based position within its project or the unassigned session list. */
+  /** Whether the target belongs to the cross-project pinned group. */
+  pinned: boolean
+  /** Zero-based position within the target sidebar group. */
   listOffset: number
 }
 


### PR DESCRIPTION
## 改动说明

- 在会话侧栏顶部增加独立的「置顶」分组，仅在存在置顶会话时展示
- 置顶会话跨项目、普通会话、频道会话和 Subagent 汇总，并从原分组移除以避免重复
- 后端分页接口增加置顶状态过滤，未读定位顺序与新侧栏视觉顺序保持一致
- 置顶/取消置顶采用乐观更新，失败自动回滚，持久化后执行精确刷新
- 兼容主分支新增的会话悬浮信息与悬浮置顶入口
- 补齐所有语言文案、HTTP/Tauri 接口文档和回归测试

## 背景与影响

此前置顶会话仍散落在各项目或普通列表中，用户无法集中查看。新的独立分组提供统一入口，同时保留分页、项目导航、未读跳转和远程 HTTP 模式的一致行为。

修复过程中还处理了旧项目会话的刷新竞态、全置顶项目的错误空状态，以及一次置顶触发所有展开项目重新请求的问题。

## 验证

- `pnpm typecheck`
- `pnpm exec vitest run src/components/chat/sidebar/useSidebarSessionPagination.test.tsx src/components/chat/project/hooks/useProjectSessions.test.tsx src/components/chat/sidebar/sessionListModel.test.ts`
- 相关前端文件 ESLint
- `node scripts/sync-i18n.mjs --check`
- 定向 Rust session 测试及 `cargo check -p ha-core` / `cargo check -p ha-server`
