### PR TITLE
Inject project ID into the system prompt

### DIFF
--- a/crates/ha-core/src/system_prompt/build.rs
+++ b/crates/ha-core/src/system_prompt/build.rs
@@ -312,13 +312,11 @@ pub(crate) fn build_with_resolved_session(
     ));
 
     // ⑦b Current Project — injected before Memory so the LLM knows which
-    // project context it's in before reading project-scoped memories.
-    // Only in non-openclaw mode (openclaw already uses a "Project Context"
-    // heading for its 4-file markdown pack).
-    if !definition.config.openclaw_mode {
-        if let Some(proj) = project {
-            sections.push(build_project_context_section(proj));
-        }
+    // project context it's in before reading project-scoped memories. This is
+    // also required in OpenClaw mode: its earlier "Project Context" section
+    // describes the 4-file agent pack, not the current Hope Agent project.
+    if let Some(proj) = project {
+        sections.push(build_project_context_section(proj));
     }
 
     // ⑦d User-selected working directory for this session. Injected after
@@ -2429,6 +2427,49 @@ mod memory_section_tests {
             out.contains("Your avatar image is at: https://example.com/a.png"),
             "openclaw-mode prompt should include avatar line: {out}"
         );
+    }
+
+    #[test]
+    fn project_identity_injected_in_openclaw_mode() {
+        let mut definition = mk_definition();
+        definition.config.openclaw_mode = true;
+        let project = Project {
+            id: "openclaw-project-123".to_string(),
+            name: "OpenClaw Project".to_string(),
+            description: None,
+            logo: None,
+            color: None,
+            default_agent_id: None,
+            default_model_id: None,
+            working_dir: None,
+            created_at: 0,
+            updated_at: 0,
+            sort_order: 0,
+            archived: false,
+        };
+        let budget = MemoryBudgetConfig::default();
+        let out = build(
+            &definition,
+            Some("gpt-5.4"),
+            Some("OpenAI"),
+            &[],
+            &budget,
+            None,
+            None,
+            None,
+            Some(&project),
+            None,
+            false,
+            None,
+            None,
+            SessionMode::Default,
+            ExecutionMode::Off,
+            crate::workflow_mode::WorkflowMode::Off,
+        );
+
+        assert!(out.contains("# Project Context"));
+        assert!(out.contains("# Current Project"));
+        assert!(out.contains("Project ID: `openclaw-project-123`"));
     }
 
     #[test]

--- a/crates/ha-core/src/system_prompt/sections.rs
+++ b/crates/ha-core/src/system_prompt/sections.rs
@@ -607,8 +607,8 @@ pub(super) fn build_acp_section() -> String {
 // ── Project sections ────────────────────────────────────────────
 
 /// Build a "Current Project" section describing the project this session
-/// belongs to: name and optional description. Project instructions are loaded
-/// exclusively from the working directory's `AGENTS.md` by
+/// belongs to: name, stable id, and optional description. Project instructions
+/// are loaded exclusively from the working directory's `AGENTS.md` by
 /// `build_session_working_dir_section`.
 ///
 /// Injected into the system prompt right before the Memory section so the
@@ -620,6 +620,7 @@ pub(super) fn build_project_context_section(project: &Project) -> String {
         "You are currently working inside project **{}**.\n",
         project.name
     ));
+    out.push_str(&format!("Project ID: `{}`\n", project.id));
 
     if let Some(desc) = project
         .description
@@ -895,5 +896,34 @@ mod runtime_control_prompt_tests {
             .expect("team key actions");
         assert!(key_actions.contains("`pause`"));
         assert!(key_actions.contains("`resume`"));
+    }
+}
+
+#[cfg(test)]
+mod project_context_prompt_tests {
+    use crate::project::Project;
+
+    #[test]
+    fn current_project_section_includes_project_id() {
+        let project = Project {
+            id: "project-123".to_string(),
+            name: "Hope Agent".to_string(),
+            description: Some("Local AI assistant".to_string()),
+            logo: None,
+            color: None,
+            default_agent_id: None,
+            default_model_id: None,
+            working_dir: None,
+            created_at: 0,
+            updated_at: 0,
+            sort_order: 0,
+            archived: false,
+        };
+
+        let section = super::build_project_context_section(&project);
+
+        assert!(section.contains("project **Hope Agent**"));
+        assert!(section.contains("Project ID: `project-123`"));
+        assert!(section.contains("Description: Local AI assistant"));
     }
 }

--- a/docs/architecture/core/project.md
+++ b/docs/architecture/core/project.md
@@ -322,7 +322,7 @@ flowchart TD
     CP --> WD --> MEM -.其余静态段.-> TAIL
 ```
 
-- **`# Current Project`**（[`system_prompt/sections.rs`](../../../crates/ha-core/src/system_prompt/sections.rs)）：注入在 Memory 段**之前**。包含项目名称、稳定的 `Project ID` 与可选 `Description`，并在长期记忆开启时尾随一句提示——本会话 `save_memory` 默认落 project scope（想逃出项目边界要显式传 `scope='global'` 或 `'agent'`）。它不再承载任何数据库指令。
+- **`# Current Project`**（[`system_prompt/sections.rs`](../../../crates/ha-core/src/system_prompt/sections.rs)）：注入在 Memory 段**之前**。包含项目名称、稳定的 `Project ID` 与可选 `Description`，并在长期记忆开启时尾随一句提示——本会话 `save_memory` 默认落 project scope（想逃出项目边界要显式传 `scope='global'` 或 `'agent'`）。OpenClaw 模式同样注入此段；其更早的 `# Project Context` 只描述四文件 Agent pack，不能替代当前 HA 项目身份。它不再承载任何数据库指令。
 - **`# Working Directory`**（详见 [prompt-system.md](prompt-system.md)）：路径声明 + `## Working Directory Instructions` 子节，紧跟在 Project 段之后、Memory 段之前。项目工作目录始终有根 `AGENTS.md`，由既有 working-dir instruction loader 读取并按 20,000 字符上限注入——这也是项目指令的唯一入口。通用非项目工作目录仍保留 `AGENTS.md` 优先、`CLAUDE.md` fallback 的发现规则。
 - **`# Files in Working Directory`**（清单由 [`system_prompt/sections.rs`](../../../crates/ha-core/src/system_prompt/sections.rs) 的 `build_working_dir_files_section` 构建，在 `build.rs` 末尾 emit）：**独立顶层段，emit 在整个 prompt 最末**（在 Memory / 天气等所有静态段之后）。顶层文件清单——非递归、只列名、名称排序、跳过隐藏项与 `.git` / `node_modules`、上限 100 条、每轮刷新。刻意拆成尾块：文件增删只 bust 这一块，不波及前面的静态前缀缓存；同一目录状态产出 byte-identical 文本。模型靠普通 `read` 工具按需读文件。
 

--- a/docs/architecture/core/project.md
+++ b/docs/architecture/core/project.md
@@ -313,7 +313,7 @@ flowchart LR
 ```mermaid
 flowchart TD
     subgraph PREFIX["稳定前缀（内容稳定 → cache 命中）"]
-        CP["# Current Project<br/>名称 + Description + save_memory 提示"]
+        CP["# Current Project<br/>名称 + Project ID + Description + save_memory 提示"]
         WD["# Working Directory<br/>路径 + AGENTS.md 指令注入"]
         MEM["# Memory 段 / Project Core Memory 索引"]
     end
@@ -322,7 +322,7 @@ flowchart TD
     CP --> WD --> MEM -.其余静态段.-> TAIL
 ```
 
-- **`# Current Project`**（[`system_prompt/sections.rs`](../../../crates/ha-core/src/system_prompt/sections.rs)）：注入在 Memory 段**之前**。只含项目名称与可选 `Description`，并在长期记忆开启时尾随一句提示——本会话 `save_memory` 默认落 project scope（想逃出项目边界要显式传 `scope='global'` 或 `'agent'`）。它不再承载任何数据库指令。
+- **`# Current Project`**（[`system_prompt/sections.rs`](../../../crates/ha-core/src/system_prompt/sections.rs)）：注入在 Memory 段**之前**。包含项目名称、稳定的 `Project ID` 与可选 `Description`，并在长期记忆开启时尾随一句提示——本会话 `save_memory` 默认落 project scope（想逃出项目边界要显式传 `scope='global'` 或 `'agent'`）。它不再承载任何数据库指令。
 - **`# Working Directory`**（详见 [prompt-system.md](prompt-system.md)）：路径声明 + `## Working Directory Instructions` 子节，紧跟在 Project 段之后、Memory 段之前。项目工作目录始终有根 `AGENTS.md`，由既有 working-dir instruction loader 读取并按 20,000 字符上限注入——这也是项目指令的唯一入口。通用非项目工作目录仍保留 `AGENTS.md` 优先、`CLAUDE.md` fallback 的发现规则。
 - **`# Files in Working Directory`**（清单由 [`system_prompt/sections.rs`](../../../crates/ha-core/src/system_prompt/sections.rs) 的 `build_working_dir_files_section` 构建，在 `build.rs` 末尾 emit）：**独立顶层段，emit 在整个 prompt 最末**（在 Memory / 天气等所有静态段之后）。顶层文件清单——非递归、只列名、名称排序、跳过隐藏项与 `.git` / `node_modules`、上限 100 条、每轮刷新。刻意拆成尾块：文件增删只 bust 这一块，不波及前面的静态前缀缓存；同一目录状态产出 byte-identical 文本。模型靠普通 `read` 工具按需读文件。
 


### PR DESCRIPTION
## What changed

- add the stable project ID to the `# Current Project` system-prompt section
- add a unit test covering the injected project name, ID, and description
- update the project architecture documentation to reflect the prompt contract

## Why

Project-bound conversations previously exposed the project name and description, while the ID was only available indirectly through backend state or the default workspace path. Tools and agent workflows that need an exact `project_id` should receive it explicitly and consistently.

## Impact

When a session is attached to a project, the model now sees the exact `Project ID: <id>` value alongside the existing project name. Routing, permissions, memory scope, and working-directory behavior are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p ha-core --tests`