### PR TITLE
🦭 fix(config): harden startup recovery and atomic persistence

### DIFF
--- a/crates/ha-base/src/platform/mod.rs
+++ b/crates/ha-base/src/platform/mod.rs
@@ -254,6 +254,59 @@ pub fn write_secure_file(path: &std::path::Path, bytes: &[u8]) -> std::io::Resul
     imp::write_secure_file(path, bytes)
 }
 
+/// Stream `source` into a credential-grade sibling temp file, `fsync` it, then
+/// atomically replace `target`. This keeps memory usage constant for unbounded
+/// inputs while preserving the old-or-new publication contract.
+pub fn copy_secure_file_atomic(
+    source: &std::path::Path,
+    target: &std::path::Path,
+) -> std::io::Result<u64> {
+    if source == target {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "source and target must differ",
+        ));
+    }
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let temp = target.with_extension(format!(
+        "tmp.{}.{}",
+        std::process::id(),
+        chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+    ));
+    let result = (|| {
+        let mut input = std::fs::File::open(source)?;
+        #[cfg(unix)]
+        let mut output = {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .mode(0o600)
+                .open(&temp)?
+        };
+        #[cfg(not(unix))]
+        let mut output = std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp)?;
+        let copied = std::io::copy(&mut input, &mut output)?;
+        output.sync_all()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o600))?;
+        }
+        imp::publish_atomic_file(&temp, target, true)?;
+        Ok(copied)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
+}
+
 /// Atomically replace `path` with `bytes` (temp in the same dir → fsync → rename),
 /// so a crash / power loss leaves either the old file intact or the new one
 /// complete — never a truncated file. Creates parent dirs if missing.
@@ -586,6 +639,31 @@ mod tests {
             .map(|entry| entry.unwrap().file_name())
             .collect::<Vec<_>>();
         assert_eq!(entries, vec![target.file_name().unwrap().to_os_string()]);
+    }
+
+    #[test]
+    fn copy_secure_file_atomic_streams_exact_bytes_without_temp_leaks() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source.bin");
+        let target = dir.path().join("target.json");
+        let bytes = vec![0x5a; 2 * 1024 * 1024 + 3];
+        std::fs::write(&source, &bytes).unwrap();
+
+        let copied = copy_secure_file_atomic(&source, &target).unwrap();
+
+        assert_eq!(copied, bytes.len() as u64);
+        assert_eq!(std::fs::read(&target).unwrap(), bytes);
+        let entries = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries.len(), 2);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600);
+        }
     }
 
     #[cfg(unix)]

--- a/crates/ha-base/src/platform/mod.rs
+++ b/crates/ha-base/src/platform/mod.rs
@@ -307,6 +307,26 @@ pub fn copy_secure_file_atomic(
     result
 }
 
+/// Move a fully-written file to a new path without replacing an existing
+/// destination. The directory entry change is atomic; on Unix both source and
+/// destination parent directories are fsynced before success is reported.
+///
+/// This is intended for cross-directory security transitions such as moving a
+/// malformed credential-bearing backup into quarantine. The paths must reside
+/// on the same filesystem.
+pub fn move_file_atomic(source: &std::path::Path, target: &std::path::Path) -> std::io::Result<()> {
+    if source == target {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "source and target must differ",
+        ));
+    }
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    imp::move_file_atomic(source, target)
+}
+
 /// Atomically replace `path` with `bytes` (temp in the same dir → fsync → rename),
 /// so a crash / power loss leaves either the old file intact or the new one
 /// complete — never a truncated file. Creates parent dirs if missing.
@@ -664,6 +684,30 @@ mod tests {
             let mode = std::fs::metadata(&target).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o600);
         }
+    }
+
+    #[test]
+    fn move_file_atomic_moves_without_clobbering() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_dir = dir.path().join("source");
+        let target_dir = dir.path().join("target");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::create_dir_all(&target_dir).unwrap();
+        let source = source_dir.join("config.json");
+        let target = target_dir.join("config.json");
+        std::fs::write(&source, b"secret").unwrap();
+
+        move_file_atomic(&source, &target).unwrap();
+
+        assert!(!source.exists());
+        assert_eq!(std::fs::read(&target).unwrap(), b"secret");
+
+        let replacement = source_dir.join("replacement.json");
+        std::fs::write(&replacement, b"replacement").unwrap();
+        let error = move_file_atomic(&replacement, &target).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(std::fs::read(&replacement).unwrap(), b"replacement");
+        assert_eq!(std::fs::read(&target).unwrap(), b"secret");
     }
 
     #[cfg(unix)]

--- a/crates/ha-base/src/platform/mod.rs
+++ b/crates/ha-base/src/platform/mod.rs
@@ -574,8 +574,18 @@ mod tests {
         let target = dir.path().join("secret.json");
         write_secure_file(&target, b"{}").unwrap();
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "{}");
-        write_secure_file(&target, b"{\"k\":1}").unwrap();
-        assert_eq!(std::fs::read_to_string(&target).unwrap(), "{\"k\":1}");
+        let replacement = r#"{"label":"服务器（测试）"}"#;
+        write_secure_file(&target, replacement.as_bytes()).unwrap();
+        let bytes = std::fs::read(&target).unwrap();
+        assert_eq!(bytes, replacement.as_bytes());
+        assert!(!bytes.starts_with(b"\xef\xbb\xbf"));
+
+        // The fully-written temp must be consumed by the atomic replacement.
+        let entries = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|entry| entry.unwrap().file_name())
+            .collect::<Vec<_>>();
+        assert_eq!(entries, vec![target.file_name().unwrap().to_os_string()]);
     }
 
     #[cfg(unix)]

--- a/crates/ha-base/src/platform/unix.rs
+++ b/crates/ha-base/src/platform/unix.rs
@@ -433,7 +433,7 @@ pub(super) fn publish_dir_atomic(source: &Path, target: &Path) -> io::Result<()>
             "staging source is not a directory",
         ));
     }
-    rename_dir_noreplace(source, target)?;
+    rename_noreplace(source, target)?;
     if let Some(parent) = target.parent() {
         fs::File::open(parent)?.sync_all()?;
     }
@@ -441,7 +441,7 @@ pub(super) fn publish_dir_atomic(source: &Path, target: &Path) -> io::Result<()>
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-fn rename_dir_noreplace(source: &Path, target: &Path) -> io::Result<()> {
+fn rename_noreplace(source: &Path, target: &Path) -> io::Result<()> {
     let source = std::ffi::CString::new(source.as_os_str().as_bytes())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "source path contains NUL"))?;
     let target = std::ffi::CString::new(target.as_os_str().as_bytes())
@@ -457,7 +457,7 @@ fn rename_dir_noreplace(source: &Path, target: &Path) -> io::Result<()> {
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
-fn rename_dir_noreplace(source: &Path, target: &Path) -> io::Result<()> {
+fn rename_noreplace(source: &Path, target: &Path) -> io::Result<()> {
     let source = std::ffi::CString::new(source.as_os_str().as_bytes())
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "source path contains NUL"))?;
     let target = std::ffi::CString::new(target.as_os_str().as_bytes())
@@ -486,14 +486,32 @@ fn rename_dir_noreplace(source: &Path, target: &Path) -> io::Result<()> {
     target_os = "linux",
     target_os = "android"
 )))]
-fn rename_dir_noreplace(source: &Path, target: &Path) -> io::Result<()> {
+fn rename_noreplace(source: &Path, target: &Path) -> io::Result<()> {
     if target.exists() {
         return Err(io::Error::new(
             io::ErrorKind::AlreadyExists,
-            "target directory already exists",
+            "target path already exists",
         ));
     }
     fs::rename(source, target)
+}
+
+pub(super) fn move_file_atomic(source: &Path, target: &Path) -> io::Result<()> {
+    rename_noreplace(source, target)?;
+    let target_parent = target
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    if let Some(parent) = target_parent {
+        fs::File::open(parent)?.sync_all()?;
+    }
+    let source_parent = source
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty());
+    match source_parent {
+        Some(parent) if Some(parent) != target_parent => fs::File::open(parent)?.sync_all()?,
+        _ => {}
+    }
+    Ok(())
 }
 
 /// Atomically create a user document without replacing an existing path.

--- a/crates/ha-base/src/platform/unix.rs
+++ b/crates/ha-base/src/platform/unix.rs
@@ -401,6 +401,14 @@ fn write_replace(path: &Path, bytes: &[u8], mode: u32) -> io::Result<()> {
         let _ = fs::remove_file(&tmp);
         return Err(e);
     }
+    // Persist the directory entry as well as the file contents. Without this,
+    // power loss can discard a rename that was already reported as successful.
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::File::open(parent)?.sync_all()?;
+    }
     Ok(())
 }
 
@@ -519,11 +527,18 @@ pub(super) fn write_atomic_create_new(path: &Path, bytes: &[u8]) -> io::Result<(
 
 pub(super) fn publish_atomic_file(source: &Path, target: &Path, overwrite: bool) -> io::Result<()> {
     if overwrite {
-        fs::rename(source, target)
+        fs::rename(source, target)?;
     } else {
         fs::hard_link(source, target)?;
-        fs::remove_file(source)
+        fs::remove_file(source)?;
     }
+    if let Some(parent) = target
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::File::open(parent)?.sync_all()?;
+    }
+    Ok(())
 }
 
 pub(super) fn run_hidden(cmd: &str, args: &[&str]) -> Option<std::process::Output> {

--- a/crates/ha-base/src/platform/windows.rs
+++ b/crates/ha-base/src/platform/windows.rs
@@ -463,31 +463,6 @@ pub(super) fn publish_atomic_file(source: &Path, target: &Path, overwrite: bool)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::ffi::OsString;
-    use std::os::windows::ffi::OsStringExt;
-
-    fn from_nul_terminated_wide(mut wide: Vec<u16>) -> OsString {
-        assert_eq!(wide.pop(), Some(0));
-        OsString::from_wide(&wide)
-    }
-
-    #[test]
-    fn move_file_paths_use_absolute_verbatim_form() {
-        let disk = from_nul_terminated_wide(
-            to_win32_verbatim_wide(Path::new(r"C:\hope-agent\config.json")).unwrap(),
-        );
-        assert_eq!(disk, OsString::from(r"\\?\C:\hope-agent\config.json"));
-
-        let unc = from_nul_terminated_wide(
-            to_win32_verbatim_wide(Path::new(r"\\server\share\config.json")).unwrap(),
-        );
-        assert_eq!(unc, OsString::from(r"\\?\UNC\server\share\config.json"));
-    }
-}
-
 pub(super) fn run_hidden(cmd: &str, args: &[&str]) -> Option<std::process::Output> {
     Command::new(cmd)
         .args(args)
@@ -654,4 +629,29 @@ pub(super) fn atomic_replace_binary(target: &Path, source: &Path) -> io::Result<
     };
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+
+    fn from_nul_terminated_wide(mut wide: Vec<u16>) -> OsString {
+        assert_eq!(wide.pop(), Some(0));
+        OsString::from_wide(&wide)
+    }
+
+    #[test]
+    fn move_file_paths_use_absolute_verbatim_form() {
+        let disk = from_nul_terminated_wide(
+            to_win32_verbatim_wide(Path::new(r"C:\hope-agent\config.json")).unwrap(),
+        );
+        assert_eq!(disk, OsString::from(r"\\?\C:\hope-agent\config.json"));
+
+        let unc = from_nul_terminated_wide(
+            to_win32_verbatim_wide(Path::new(r"\\server\share\config.json")).unwrap(),
+        );
+        assert_eq!(unc, OsString::from(r"\\?\UNC\server\share\config.json"));
+    }
 }

--- a/crates/ha-base/src/platform/windows.rs
+++ b/crates/ha-base/src/platform/windows.rs
@@ -463,6 +463,22 @@ pub(super) fn publish_atomic_file(source: &Path, target: &Path, overwrite: bool)
     }
 }
 
+pub(super) fn move_file_atomic(source: &Path, target: &Path) -> io::Result<()> {
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+    extern "system" {
+        fn MoveFileExW(source: *const u16, target: *const u16, flags: u32) -> i32;
+    }
+    let source = to_win32_verbatim_wide(source)?;
+    let target = to_win32_verbatim_wide(target)?;
+    // Omitting MOVEFILE_REPLACE_EXISTING preserves the no-clobber contract.
+    let result = unsafe { MoveFileExW(source.as_ptr(), target.as_ptr(), MOVEFILE_WRITE_THROUGH) };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
 pub(super) fn run_hidden(cmd: &str, args: &[&str]) -> Option<std::process::Output> {
     Command::new(cmd)
         .args(args)

--- a/crates/ha-base/src/platform/windows.rs
+++ b/crates/ha-base/src/platform/windows.rs
@@ -8,6 +8,46 @@ use std::time::Duration;
 
 const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
+/// Convert a filesystem path to the absolute Win32 verbatim form accepted by
+/// raw `*W` APIs. Rust's `std::fs` adds long-path handling internally, but a
+/// direct `MoveFileExW` call must supply the `\\?\` / `\\?\UNC\` prefix itself.
+fn to_win32_verbatim_wide(path: &Path) -> io::Result<Vec<u16>> {
+    use std::os::windows::ffi::OsStrExt;
+
+    const BACKSLASH: u16 = b'\\' as u16;
+    const FORWARD_SLASH: u16 = b'/' as u16;
+    const QUESTION: u16 = b'?' as u16;
+    const DOT: u16 = b'.' as u16;
+    let absolute = std::path::absolute(path)?;
+    let mut path_wide = absolute
+        .as_os_str()
+        .encode_wide()
+        .map(|unit| {
+            if unit == FORWARD_SLASH {
+                BACKSLASH
+            } else {
+                unit
+            }
+        })
+        .collect::<Vec<_>>();
+    let already_verbatim_or_device = path_wide
+        .starts_with(&[BACKSLASH, BACKSLASH, QUESTION, BACKSLASH])
+        || path_wide.starts_with(&[BACKSLASH, BACKSLASH, DOT, BACKSLASH]);
+    if !already_verbatim_or_device {
+        if path_wide.starts_with(&[BACKSLASH, BACKSLASH]) {
+            let mut verbatim = r"\\?\UNC\".encode_utf16().collect::<Vec<_>>();
+            verbatim.extend_from_slice(&path_wide[2..]);
+            path_wide = verbatim;
+        } else {
+            let mut verbatim = r"\\?\".encode_utf16().collect::<Vec<_>>();
+            verbatim.extend_from_slice(&path_wide);
+            path_wide = verbatim;
+        }
+    }
+    path_wide.push(0);
+    Ok(path_wide)
+}
+
 pub(super) fn terminate_process_tree(pid: u32) {
     let _ = Command::new("taskkill")
         .args(["/F", "/T", "/PID", &pid.to_string()])
@@ -402,20 +442,13 @@ pub(super) fn publish_atomic_file(source: &Path, target: &Path, overwrite: bool)
         return fs::remove_file(source);
     }
 
-    use std::os::windows::ffi::OsStrExt;
-    fn to_wide(path: &Path) -> Vec<u16> {
-        path.as_os_str()
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect()
-    }
     const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
     const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
     extern "system" {
         fn MoveFileExW(source: *const u16, target: *const u16, flags: u32) -> i32;
     }
-    let source = to_wide(source);
-    let target = to_wide(target);
+    let source = to_win32_verbatim_wide(source)?;
+    let target = to_win32_verbatim_wide(target)?;
     let result = unsafe {
         MoveFileExW(
             source.as_ptr(),
@@ -427,6 +460,31 @@ pub(super) fn publish_atomic_file(source: &Path, target: &Path, overwrite: bool)
         Err(io::Error::last_os_error())
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+
+    fn from_nul_terminated_wide(mut wide: Vec<u16>) -> OsString {
+        assert_eq!(wide.pop(), Some(0));
+        OsString::from_wide(&wide)
+    }
+
+    #[test]
+    fn move_file_paths_use_absolute_verbatim_form() {
+        let disk = from_nul_terminated_wide(
+            to_win32_verbatim_wide(Path::new(r"C:\hope-agent\config.json")).unwrap(),
+        );
+        assert_eq!(disk, OsString::from(r"\\?\C:\hope-agent\config.json"));
+
+        let unc = from_nul_terminated_wide(
+            to_win32_verbatim_wide(Path::new(r"\\server\share\config.json")).unwrap(),
+        );
+        assert_eq!(unc, OsString::from(r"\\?\UNC\server\share\config.json"));
     }
 }
 

--- a/crates/ha-base/src/platform/windows.rs
+++ b/crates/ha-base/src/platform/windows.rs
@@ -300,8 +300,8 @@ pub(super) fn try_acquire_exclusive_lock(path: &Path) -> io::Result<Option<fs::F
 }
 
 /// Shared atomic-replace core: write `bytes` to a sibling temp (same dir), fsync,
-/// then rename over the target. Windows `rename` fails if the destination exists,
-/// so it is removed first; the temp is cleaned up on a rename failure.
+/// then replace the target with one `MoveFileExW` operation. The temp is cleaned
+/// up on a publication failure.
 fn write_replace(path: &Path, bytes: &[u8]) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -323,11 +323,10 @@ fn write_replace(path: &Path, bytes: &[u8]) -> io::Result<()> {
     // lives under the user profile so by default only the owning user
     // and SYSTEM/Administrators can read. Hardening to an explicit DACL
     // (strip inherited ACEs, grant only the owner) is a future pass.
-    // Windows rename fails if the destination exists; remove first.
-    if path.exists() {
-        let _ = fs::remove_file(path);
-    }
-    if let Err(e) = fs::rename(&tmp, path) {
+    // Publish in one Win32 rename operation. Removing the destination first
+    // leaves a crash window where config.json is missing; MoveFileExW with
+    // REPLACE_EXISTING keeps the old-or-new atomic replacement contract.
+    if let Err(e) = publish_atomic_file(&tmp, path, true) {
         let _ = fs::remove_file(&tmp);
         return Err(e);
     }
@@ -340,7 +339,7 @@ pub(super) fn write_secure_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
 
 /// Atomic write for user documents (knowledge-base notes). On Windows there is no
 /// Unix-style mode to preserve — NTFS DACL inheritance applies — so this shares
-/// the same temp + remove-dest + rename path as `write_secure_file`.
+/// the same temp + atomic-replace path as `write_secure_file`.
 pub(super) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
     write_replace(path, bytes)
 }

--- a/crates/ha-core/src/backup.rs
+++ b/crates/ha-core/src/backup.rs
@@ -26,9 +26,7 @@ pub fn create_backup() -> Result<String, String> {
         let src = root.join(file);
         if src.exists() {
             let dst = backup_dir.join(file);
-            let copy_result = std::fs::read(&src)
-                .and_then(|bytes| crate::platform::write_secure_file(&dst, &bytes));
-            if let Err(e) = copy_result {
+            if let Err(e) = crate::platform::copy_secure_file_atomic(&src, &dst) {
                 app_warn!("backup", "create", "Failed to copy {}: {}", file, e);
             }
         }

--- a/crates/ha-core/src/backup.rs
+++ b/crates/ha-core/src/backup.rs
@@ -811,7 +811,7 @@ fn quarantine_unparseable_legacy_token_backup(
     // Claim the exact directory entry in one operation. Copying first and
     // deleting `path` later could unlink a replacement published by another
     // Hope Agent process between those two operations.
-    std::fs::rename(path, &quarantined)
+    crate::platform::move_file_atomic(path, &quarantined)
         .map_err(|error| format!("Cannot move {:?} to {:?}: {error}", path, quarantined))?;
     let claimed_bytes = match std::fs::read(&quarantined) {
         Ok(bytes) => bytes,
@@ -848,11 +848,10 @@ fn quarantine_unparseable_legacy_token_backup(
 }
 
 /// Restore a quarantined file without overwriting a concurrently published
-/// replacement. A hard link claims the absent original name atomically; only
-/// then is the quarantine name removed.
+/// replacement. The platform move is no-clobber and durably records removal
+/// from quarantine as well as publication at the original path.
 fn restore_quarantined_backup(quarantined: &Path, original: &Path) -> std::io::Result<()> {
-    std::fs::hard_link(quarantined, original)?;
-    std::fs::remove_file(quarantined)
+    crate::platform::move_file_atomic(quarantined, original)
 }
 
 fn format_quarantine_rollback_error(

--- a/crates/ha-core/src/backup.rs
+++ b/crates/ha-core/src/backup.rs
@@ -472,6 +472,9 @@ mod tests {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
+                let quarantine_mode =
+                    std::fs::metadata(&quarantine).unwrap().permissions().mode() & 0o777;
+                assert_eq!(quarantine_mode, 0o700);
                 let mode = std::fs::metadata(&quarantined[0])
                     .unwrap()
                     .permissions()
@@ -791,6 +794,15 @@ fn quarantine_unparseable_legacy_token_backup(
             "Refusing credential quarantine directory {:?}",
             quarantine_dir
         ));
+    }
+    // A moved file keeps its original mode. Tighten the directory before the
+    // rename so even a crash before the file-level 0600 rewrite cannot expose
+    // a historical 0644 Owner Token to another local user.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&quarantine_dir, std::fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("Cannot secure {:?}: {error}", quarantine_dir))?;
     }
 
     let quarantine_id = uuid::Uuid::new_v4().simple();

--- a/crates/ha-core/src/backup.rs
+++ b/crates/ha-core/src/backup.rs
@@ -26,7 +26,9 @@ pub fn create_backup() -> Result<String, String> {
         let src = root.join(file);
         if src.exists() {
             let dst = backup_dir.join(file);
-            if let Err(e) = std::fs::copy(&src, &dst) {
+            let copy_result = std::fs::read(&src)
+                .and_then(|bytes| crate::platform::write_secure_file(&dst, &bytes));
+            if let Err(e) = copy_result {
                 app_warn!("backup", "create", "Failed to copy {}: {}", file, e);
             }
         }
@@ -419,6 +421,115 @@ mod tests {
             "current"
         );
     }
+
+    #[test]
+    fn legacy_token_scrub_accepts_bom_and_preserves_utf8() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("config.json");
+        let body = r#"{"server":{"apiKey":"legacy-token"},"label":"服务器（测试）"}"#;
+        let bytes = [b"\xef\xbb\xbf".as_slice(), body.as_bytes()].concat();
+        std::fs::write(&path, bytes).unwrap();
+
+        scrub_legacy_server_token_file(&path).unwrap();
+
+        let rewritten = std::fs::read(&path).unwrap();
+        assert!(!rewritten.starts_with(b"\xef\xbb\xbf"));
+        let value: serde_json::Value = serde_json::from_slice(&rewritten).unwrap();
+        assert_eq!(value["label"], "服务器（测试）");
+        assert!(value["server"].get("apiKey").is_none());
+    }
+
+    #[test]
+    fn unparseable_backup_is_quarantined_without_stopping_the_scan() {
+        let temp = tempfile::tempdir().unwrap();
+        crate::test_support::with_env_vars(&[("HA_DATA_DIR", temp.path())], || {
+            let autosave = paths::autosave_dir().unwrap();
+            std::fs::create_dir_all(&autosave).unwrap();
+            let malformed_path =
+                autosave.join("2026-08-08T00-00-00-000__config__server__test.json");
+            let malformed = b"{\"server\":{\"apiKey\":\"legacy-token\"},\"label\":\xe4";
+            std::fs::write(&malformed_path, malformed).unwrap();
+
+            let valid_path = autosave.join("2026-08-08T00-00-01-000__config__server__test.json");
+            std::fs::write(
+                &valid_path,
+                br#"{"server":{"apiKey":"second-token"},"theme":"dark"}"#,
+            )
+            .unwrap();
+
+            scrub_legacy_server_tokens().unwrap();
+
+            assert!(!malformed_path.exists());
+            let quarantine = paths::credentials_dir().unwrap().join("quarantine");
+            let quarantined = std::fs::read_dir(&quarantine)
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .collect::<Vec<_>>();
+            assert_eq!(quarantined.len(), 1);
+            assert_eq!(std::fs::read(&quarantined[0]).unwrap(), malformed);
+            assert_eq!(
+                quarantined[0].extension().and_then(|ext| ext.to_str()),
+                Some("corrupt")
+            );
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mode = std::fs::metadata(&quarantined[0])
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777;
+                assert_eq!(mode, 0o600);
+            }
+
+            let valid: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&valid_path).unwrap()).unwrap();
+            assert_eq!(valid["theme"], "dark");
+            assert!(valid["server"].get("apiKey").is_none());
+        });
+    }
+
+    #[test]
+    fn quarantine_failure_is_fail_closed_and_preserves_the_backup() {
+        let temp = tempfile::tempdir().unwrap();
+        crate::test_support::with_env_vars(&[("HA_DATA_DIR", temp.path())], || {
+            let autosave = paths::autosave_dir().unwrap();
+            std::fs::create_dir_all(&autosave).unwrap();
+            let malformed_path =
+                autosave.join("2026-08-08T00-00-00-000__config__server__test.json");
+            let malformed = b"{\"server\":{\"apiKey\":\"legacy-token\"}";
+            std::fs::write(&malformed_path, malformed).unwrap();
+
+            let credentials = paths::credentials_dir().unwrap();
+            std::fs::create_dir_all(&credentials).unwrap();
+            std::fs::write(credentials.join("quarantine"), b"not a directory").unwrap();
+
+            let error = scrub_legacy_server_tokens().unwrap_err();
+            assert!(error.contains("Cannot quarantine unparseable config backup"));
+            assert_eq!(std::fs::read(&malformed_path).unwrap(), malformed);
+        });
+    }
+
+    #[test]
+    fn quarantine_detects_a_concurrent_replacement_and_restores_it() {
+        let temp = tempfile::tempdir().unwrap();
+        crate::test_support::with_env_vars(&[("HA_DATA_DIR", temp.path())], || {
+            let autosave = paths::autosave_dir().unwrap();
+            std::fs::create_dir_all(&autosave).unwrap();
+            let path = autosave.join("2026-08-08T00-00-00-000__config__server__test.json");
+            let stale_bytes = b"{\"server\":{\"apiKey\":\"stale-token\"}";
+            let replacement = br#"{"theme":"dark"}"#;
+            std::fs::write(&path, replacement).unwrap();
+
+            let error = quarantine_unparseable_legacy_token_backup(&path, stale_bytes)
+                .expect_err("a changed source must not be quarantined as the stale parse result");
+
+            assert!(error.contains("changed while it was being quarantined"));
+            assert_eq!(std::fs::read(&path).unwrap(), replacement);
+            let quarantine = paths::credentials_dir().unwrap().join("quarantine");
+            assert_eq!(std::fs::read_dir(quarantine).unwrap().count(), 0);
+        });
+    }
 }
 
 // ── Auto-Snapshot on every config write ────────────────────────────
@@ -616,8 +727,34 @@ fn scrub_legacy_server_token_file(path: &Path) -> Result<(), String> {
         ));
     }
     let bytes = std::fs::read(path).map_err(|error| format!("Cannot read {:?}: {error}", path))?;
-    let mut value: serde_json::Value = serde_json::from_slice(&bytes)
-        .map_err(|error| format!("Cannot parse {:?}: {error}", path))?;
+    // Match the live config parser: Windows editors commonly prefix JSON with
+    // EF BB BF, which is valid UTF-8 text but rejected by serde_json itself.
+    let json = bytes.strip_prefix(b"\xef\xbb\xbf").unwrap_or(&bytes);
+    let mut value: serde_json::Value = match serde_json::from_slice(json) {
+        Ok(value) => value,
+        Err(parse_error) => {
+            // The file may still contain a plaintext legacy Owner Token. Move
+            // it out of the portable backup tree into the credential area,
+            // but never let one unusable rollback snapshot brick startup.
+            let quarantined = quarantine_unparseable_legacy_token_backup(path, &bytes).map_err(
+                |quarantine_error| {
+                    format!(
+                        "Cannot quarantine unparseable config backup {:?} (parse: {}; quarantine: {})",
+                        path, parse_error, quarantine_error
+                    )
+                },
+            )?;
+            app_warn!(
+                "backup",
+                "scrub_legacy_server_token",
+                "Quarantined unparseable config backup {} as {}: {}",
+                path.display(),
+                quarantined.display(),
+                parse_error
+            );
+            return Ok(());
+        }
+    };
     let Some(server) = value
         .as_object_mut()
         .and_then(|root| root.get_mut("server"))
@@ -635,4 +772,90 @@ fn scrub_legacy_server_token_file(path: &Path) -> Result<(), String> {
     // posture while replacing the file atomically.
     crate::platform::write_secure_file(path, &data)
         .map_err(|error| format!("Cannot rewrite {:?}: {error}", path))
+}
+
+/// Preserve an unparseable backup under the credential boundary before
+/// removing it from the portable backup tree. The opaque random filename
+/// avoids exposing a credential-derived content fingerprint in logs.
+fn quarantine_unparseable_legacy_token_backup(
+    path: &Path,
+    bytes: &[u8],
+) -> Result<PathBuf, String> {
+    let quarantine_dir = paths::credentials_dir()
+        .map_err(|error| error.to_string())?
+        .join("quarantine");
+    std::fs::create_dir_all(&quarantine_dir)
+        .map_err(|error| format!("Cannot create {:?}: {error}", quarantine_dir))?;
+    let quarantine_metadata = std::fs::symlink_metadata(&quarantine_dir)
+        .map_err(|error| format!("Cannot inspect {:?}: {error}", quarantine_dir))?;
+    if quarantine_metadata.file_type().is_symlink() || !quarantine_metadata.is_dir() {
+        return Err(format!(
+            "Refusing credential quarantine directory {:?}",
+            quarantine_dir
+        ));
+    }
+
+    let quarantine_id = uuid::Uuid::new_v4().simple();
+    let quarantined =
+        quarantine_dir.join(format!("legacy-config-backup-{quarantine_id}.json.corrupt"));
+    // Claim the exact directory entry in one operation. Copying first and
+    // deleting `path` later could unlink a replacement published by another
+    // Hope Agent process between those two operations.
+    std::fs::rename(path, &quarantined)
+        .map_err(|error| format!("Cannot move {:?} to {:?}: {error}", path, quarantined))?;
+    let claimed_bytes = match std::fs::read(&quarantined) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            let rollback = restore_quarantined_backup(&quarantined, path);
+            return Err(format_quarantine_rollback_error(
+                format!("Cannot verify {:?}: {error}", quarantined),
+                rollback,
+                &quarantined,
+                path,
+            ));
+        }
+    };
+    if claimed_bytes != bytes {
+        let rollback = restore_quarantined_backup(&quarantined, path);
+        return Err(format_quarantine_rollback_error(
+            format!("Backup {:?} changed while it was being quarantined", path),
+            rollback,
+            &quarantined,
+            path,
+        ));
+    }
+    if let Err(error) = crate::platform::write_secure_file(&quarantined, &claimed_bytes) {
+        let rollback = restore_quarantined_backup(&quarantined, path);
+        return Err(match rollback {
+            Ok(()) => format!("Cannot secure {:?}: {error}; move rolled back", quarantined),
+            Err(rollback_error) => format!(
+                "Cannot secure {:?}: {error}; cannot roll back to {:?}: {rollback_error}",
+                quarantined, path
+            ),
+        });
+    }
+    Ok(quarantined)
+}
+
+/// Restore a quarantined file without overwriting a concurrently published
+/// replacement. A hard link claims the absent original name atomically; only
+/// then is the quarantine name removed.
+fn restore_quarantined_backup(quarantined: &Path, original: &Path) -> std::io::Result<()> {
+    std::fs::hard_link(quarantined, original)?;
+    std::fs::remove_file(quarantined)
+}
+
+fn format_quarantine_rollback_error(
+    error: String,
+    rollback: std::io::Result<()>,
+    quarantined: &Path,
+    original: &Path,
+) -> String {
+    match rollback {
+        Ok(()) => format!("{error}; move rolled back"),
+        Err(rollback_error) => format!(
+            "{error}; cannot roll back {:?} to {:?}: {rollback_error}",
+            quarantined, original
+        ),
+    }
 }

--- a/crates/ha-core/src/config/autosave.rs
+++ b/crates/ha-core/src/config/autosave.rs
@@ -105,11 +105,11 @@ pub fn snapshot_before_write(src: &Path, kind: &str) {
     let safe_src = sanitize_slug(&reason.source);
     let filename = format!("{}__{}__{}__{}.json", ts, kind, safe_cat, safe_src);
     let dst = dir.join(&filename);
-    // Publish only after the source has been read completely. The legacy-token
-    // scrubber runs in other Hope Agent processes and must never observe the
-    // half-written destination that `fs::copy` exposes while it is in flight.
-    let snapshot_result =
-        std::fs::read(src).and_then(|bytes| crate::platform::write_secure_file(&dst, &bytes));
+    // Stream into a credential-grade sibling temp and publish only after the
+    // copy is complete. Config/user JSON can contain unbounded strings and
+    // vectors, so buffering another full copy here would amplify peak memory
+    // on every settings write.
+    let snapshot_result = crate::platform::copy_secure_file_atomic(src, &dst);
     if let Err(e) = snapshot_result {
         app_warn!(
             "backup",

--- a/crates/ha-core/src/config/autosave.rs
+++ b/crates/ha-core/src/config/autosave.rs
@@ -1,4 +1,4 @@
-//! Autosave 快照原语：每次 config / user_config 写盘前把旧文件拷进
+//! Autosave 快照原语：每次 config / user_config 写盘前把旧文件原子发布到
 //! `backups/autosave/`，任何设置改动都可回滚。
 //!
 //! **为什么住在 config 而不是 backup**：写前快照是 config 写路径的安全网，
@@ -105,7 +105,12 @@ pub fn snapshot_before_write(src: &Path, kind: &str) {
     let safe_src = sanitize_slug(&reason.source);
     let filename = format!("{}__{}__{}__{}.json", ts, kind, safe_cat, safe_src);
     let dst = dir.join(&filename);
-    if let Err(e) = std::fs::copy(src, &dst) {
+    // Publish only after the source has been read completely. The legacy-token
+    // scrubber runs in other Hope Agent processes and must never observe the
+    // half-written destination that `fs::copy` exposes while it is in flight.
+    let snapshot_result =
+        std::fs::read(src).and_then(|bytes| crate::platform::write_secure_file(&dst, &bytes));
+    if let Err(e) = snapshot_result {
         app_warn!(
             "backup",
             "autosave",
@@ -163,4 +168,44 @@ fn rotate_autosaves(dir: &Path, keep: usize) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_is_atomically_published_with_exact_utf8_bytes() {
+        let temp = tempfile::tempdir().unwrap();
+        crate::test_support::with_env_vars(&[("HA_DATA_DIR", temp.path())], || {
+            let source = temp.path().join("config.json");
+            let content = r#"{"label":"服务器（测试）"}"#;
+            std::fs::write(&source, content.as_bytes()).unwrap();
+            let _reason = scope_save_reason("server", "test");
+
+            snapshot_before_write(&source, "config");
+
+            let autosave = paths::autosave_dir().unwrap();
+            let snapshots = std::fs::read_dir(&autosave)
+                .unwrap()
+                .map(|entry| entry.unwrap().path())
+                .collect::<Vec<_>>();
+            assert_eq!(snapshots.len(), 1);
+            assert_eq!(
+                snapshots[0].extension().and_then(|ext| ext.to_str()),
+                Some("json")
+            );
+            assert_eq!(std::fs::read(&snapshots[0]).unwrap(), content.as_bytes());
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mode = std::fs::metadata(&snapshots[0])
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777;
+                assert_eq!(mode, 0o600);
+            }
+        });
+    }
 }

--- a/crates/ha-core/src/config/persistence.rs
+++ b/crates/ha-core/src/config/persistence.rs
@@ -750,7 +750,10 @@ fn save_config_with_change(
     super::autosave::snapshot_before_write(&path, "config");
 
     let data = serde_json::to_string_pretty(config)?;
-    std::fs::write(&path, data)?;
+    // Serialize completely before touching the destination, then fsync and
+    // atomically replace it. A crash can expose the old or the new UTF-8 JSON,
+    // never a half-written multibyte character or truncated document.
+    crate::platform::write_secure_file(&path, data.as_bytes())?;
 
     // Atomically publish the new snapshot so subsequent cached_config() calls
     // see the refreshed state without touching disk.

--- a/docs/architecture/infra/backup-autosave.md
+++ b/docs/architecture/infra/backup-autosave.md
@@ -76,7 +76,7 @@ flowchart TB
 
 `create_backup` 在 `backups/backup_{UTC 时间戳}/`（格式 `%Y-%m-%dT%H-%M-%S`）下逐项复制：
 
-- 顶层文件 `config.json` / `user.json` / `memory.md`（存在才拷）；
+- 顶层文件 `config.json` / `user.json` / `memory.md`（存在才拷；流式写入同目录临时文件、`fsync` 后原子发布，故无大小上限的旧 `memory.md` 不会被整体读入内存）；
 - `credentials/auth.json`（OAuth 凭据）；
 - `agents/` 整目录递归复制（含各 Agent 的 Core Memory）；
 - 全局 `memory/` 目录递归复制（全局 Core Memory）；

--- a/docs/architecture/infra/backup-autosave.md
+++ b/docs/architecture/infra/backup-autosave.md
@@ -159,7 +159,7 @@ flowchart TB
 
 ## 备份文件里的凭据洗刷
 
-配置备份是普通的回滚数据，**可能被拷到别的机器**，因此其中不能残留敏感凭据。历史上 server Owner Token 曾以 `server.apiKey` 存在 `config.json` 里，凭据迁移到独立凭据库后，`scrub_legacy_server_tokens`（在 `backup.rs`）会**清扫所有历史备份**——遍历 `backups/autosave/*__config__*.json` 与每个 `backups/backup_*/config.json`，剥掉 `server.apiKey`，回写时用 `write_secure_file` 保持 0600 权限。解析与活动配置一样容忍 UTF-8 BOM；若文件已经损坏到无法解析，原始字节会以 0600 原子移入 `credentials/quarantine/legacy-config-backup-<id>.json.corrupt` 并告警，成功隔离后不再让一个不可用的回滚点阻断整次启动；隔离失败或并发检测到文件已变化则 fail closed、保留原文件并报错。它由凭据迁移路径（`server_auth::clear_legacy_config_token`）调用，且**拒绝跟随符号链接**：备份树是数据，不是改写树外任意文件的授权。
+配置备份是普通的回滚数据，**可能被拷到别的机器**，因此其中不能残留敏感凭据。历史上 server Owner Token 曾以 `server.apiKey` 存在 `config.json` 里，凭据迁移到独立凭据库后，`scrub_legacy_server_tokens`（在 `backup.rs`）会**清扫所有历史备份**——遍历 `backups/autosave/*__config__*.json` 与每个 `backups/backup_*/config.json`，剥掉 `server.apiKey`，回写时用 `write_secure_file` 保持 0600 权限。解析与活动配置一样容忍 UTF-8 BOM；若文件已经损坏到无法解析，隔离目录会先强制为 0700，原始字节再以 0600 原子移入 `credentials/quarantine/legacy-config-backup-<id>.json.corrupt` 并告警，成功隔离后不再让一个不可用的回滚点阻断整次启动；隔离失败或并发检测到文件已变化则 fail closed、保留原文件并报错。它由凭据迁移路径（`server_auth::clear_legacy_config_token`）调用，且**拒绝跟随符号链接**：备份树是数据，不是改写树外任意文件的授权。
 
 与之配套，`config::clear_legacy_server_token_without_backup` 在清除**活动** config 里的旧 token 时**刻意跳过 autosave**——否则会把带密的 config 拷进普通 autosave 树，等于把刚要清掉的密又留了一份。
 

--- a/docs/architecture/infra/backup-autosave.md
+++ b/docs/architecture/infra/backup-autosave.md
@@ -14,7 +14,7 @@ Backup / Autosave 是一张**配置安全网**。它不持有任何业务数据�
 - **一次手滑改坏配置**——比如把某项设置改错，事后想撤销；
 - **崩溃循环导致配置损坏**——比如 `config.json` 写到一半进程崩溃、下次启动读不出来。
 
-关键想法是用**两套预算独立、粒度不同的备份**分别覆盖这两类事故，而不是共用一套。**配置 autosave** 走细粒度：每次配置写盘前自动拷一份旧文件，单文件（`config.json` 或 `user.json`）粒度，保留最近 50 份，专供撤销某一次设置编辑。**全量备份** 走粗粒度：在崩溃诊断命中阈值、删除 Agent 前或用户手动时，把整套配置目录连同 Core Memory 一起快照，保留最近 5 份，用于崩溃自愈与整体回滚。逐项对照见下节《两套备份的分工》。
+关键想法是用**两套预算独立、粒度不同的备份**分别覆盖这两类事故，而不是共用一套。**配置 autosave** 走细粒度：每次配置写盘前完整读取旧文件，再原子发布单文件快照（`config.json` 或 `user.json`），保留最近 50 份，专供撤销某一次设置编辑。**全量备份** 走粗粒度：在崩溃诊断命中阈值、删除 Agent 前或用户手动时，把整套配置目录连同 Core Memory 一起快照，保留最近 5 份，用于崩溃自愈与整体回滚。逐项对照见下节《两套备份的分工》。
 
 两套都落在 `~/.hope-agent/backups/` 下，都以**「失败永不阻塞合法写」**为铁律实现：备份只是安全网，绝不能因为安全网破损而拦住用户的正常配置写。核心逻辑集中在 `ha-core`（零 Tauri 依赖），桌面 / server 只做薄壳转发。
 
@@ -30,7 +30,7 @@ flowchart TB
       GD["guardian.set_enabled_in_config<br/>raw JSON 旁路"]
     end
     subgraph fine["细粒度 · autosave（config::autosave）"]
-      SBW["snapshot_before_write<br/>写盘前拷旧文件"]
+      SBW["snapshot_before_write<br/>写盘前原子发布旧文件"]
       ADIR[("backups/autosave/*.json<br/>保留 50")]
     end
     subgraph crash["粗粒度 · 全量备份（backup.rs）"]
@@ -109,7 +109,7 @@ flowchart TB
 `snapshot_before_write(src, kind)` 是配置 autosave 的**唯一入口**（`kind ∈ "config" | "user"`）：
 
 1. 若 `src` 文件**不存在**（首次保存，无旧文件可拷）→ 早退，但**仍消费掉 reason 标签**（防止标签泄漏给下一次无关写）。
-2. `src` 存在 → 经 `take_save_reason` 取出并清空 reason 标签，把 `src` 复制进 `autosave_dir`，文件名编码 `{timestamp}__{kind}__{category}__{source}.json`，末尾 `rotate_autosaves` 轮转。
+2. `src` 存在 → 经 `take_save_reason` 取出并清空 reason 标签，完整读取 `src` 后以 `write_secure_file` 原子发布进 `autosave_dir`（不会暴露半写入的最终 `.json`），文件名编码 `{timestamp}__{kind}__{category}__{source}.json`，末尾 `rotate_autosaves` 轮转。
 3. **过程中任何错误只 `app_warn`，绝不向上传播**——合法写永远优先于快照成功。
 
 ### reason 标签机制（thread-local）
@@ -122,7 +122,7 @@ flowchart LR
     B --> C["snapshot_before_write<br/>take_save_reason 消费标签"]
     C --> D{"src 存在?"}
     D -- 否 --> E["早退<br/>但仍消费标签"]
-    D -- 是 --> F["拷成 {ts}__{kind}__{cat}__{src}.json"]
+    D -- 是 --> F["原子发布为 {ts}__{kind}__{cat}__{src}.json"]
     B --> G["guard Drop<br/>清空 thread-local（已消费则 no-op）"]
 ```
 
@@ -159,7 +159,7 @@ flowchart TB
 
 ## 备份文件里的凭据洗刷
 
-配置备份是普通的回滚数据，**可能被拷到别的机器**，因此其中不能残留敏感凭据。历史上 server Owner Token 曾以 `server.apiKey` 存在 `config.json` 里，凭据迁移到独立凭据库后，`scrub_legacy_server_tokens`（在 `backup.rs`）会**清扫所有历史备份**——遍历 `backups/autosave/*__config__*.json` 与每个 `backups/backup_*/config.json`，剥掉 `server.apiKey`，回写时用 `write_secure_file` 保持 0600 权限。它由凭据迁移路径（`server_auth::clear_legacy_config_token`）调用，且**拒绝跟随符号链接**：备份树是数据，不是改写树外任意文件的授权。
+配置备份是普通的回滚数据，**可能被拷到别的机器**，因此其中不能残留敏感凭据。历史上 server Owner Token 曾以 `server.apiKey` 存在 `config.json` 里，凭据迁移到独立凭据库后，`scrub_legacy_server_tokens`（在 `backup.rs`）会**清扫所有历史备份**——遍历 `backups/autosave/*__config__*.json` 与每个 `backups/backup_*/config.json`，剥掉 `server.apiKey`，回写时用 `write_secure_file` 保持 0600 权限。解析与活动配置一样容忍 UTF-8 BOM；若文件已经损坏到无法解析，原始字节会以 0600 原子移入 `credentials/quarantine/legacy-config-backup-<id>.json.corrupt` 并告警，成功隔离后不再让一个不可用的回滚点阻断整次启动；隔离失败或并发检测到文件已变化则 fail closed、保留原文件并报错。它由凭据迁移路径（`server_auth::clear_legacy_config_token`）调用，且**拒绝跟随符号链接**：备份树是数据，不是改写树外任意文件的授权。
 
 与之配套，`config::clear_legacy_server_token_without_backup` 在清除**活动** config 里的旧 token 时**刻意跳过 autosave**——否则会把带密的 config 拷进普通 autosave 树，等于把刚要清掉的密又留了一份。
 
@@ -229,7 +229,7 @@ autosave 文件名带毫秒（`%3f`），避免同一秒内多次写盘碰撞；
 - **回滚前自快照不可省**：`restore_autosave` 覆盖前先对当前态自快照，保证回滚动作本身也可逆——这一步是闭环可逆性的关键。
 - **符号链接一律不跟随**：`copy_dir_recursive` 遇符号链接跳过并 warn；`create_backup` / `restore_backup` / `scrub_legacy_server_tokens` 的源与目标都先 `symlink_metadata` 校验，拒绝非目录 / 符号链接。备份树是数据，不能被篡改的链接诱导去读写树外文件。
 - **Core Memory 恢复走原子替换**：`replace_dir_from_backup` 先把整份目录暂存到目标旁边，再原子 `rename` 就位、失败回滚——一份被篡改 / 半截失败的备份因此绝不会把当前可用的 Core Memory 目录删空。
-- **备份里不留凭据**：`scrub_legacy_server_tokens` 清扫历史备份中的旧 `server.apiKey`；`clear_legacy_server_token_without_backup` 刻意跳过 autosave，避免把带密 config 拷进快照树。
+- **备份里不留凭据**：`scrub_legacy_server_tokens` 清扫历史备份中的旧 `server.apiKey`；BOM 正常剥除，无法可靠解析的文件只有成功原子移入凭据隔离区后才退出普通备份枚举，隔离失败或并发变化均 fail closed；`clear_legacy_server_token_without_backup` 刻意跳过 autosave，避免把带密 config 拷进快照树。
 - **guardian.enabled 刻意绕过 mutate_config**：它是 `AppConfig` schema 之外的 raw JSON 字段，走不了 `mutate_config`，故意直接读写；写前仍手动 `scope_save_reason` + `snapshot_before_write` 守住 rollback 契约。
 - **预算分离有意为之**：`MAX_BACKUPS` / `MAX_AUTOSAVES` 各算各的，防一阵设置编辑的 autosave 洪水把用户上一次手动全量备份挤掉。
 - **轮转依赖时间序前缀**：轮转判「最旧」靠文件名 / 目录名字典序 == 时间序，改时间戳格式会破坏这一前提。

--- a/docs/architecture/infra/config-system.md
+++ b/docs/architecture/infra/config-system.md
@@ -60,7 +60,7 @@ mutate_config(("canvas", "settings-ui"), |cfg| {
 
 ### 异步上下文用 `mutate_config_async`
 
-`mutate_config` 是同步函数，它持锁期间会做真实的阻塞 IO（写前校验读、autosave 拷贝、`fs::write`）。若在 async fn 里 inline 调用，它会把一个 tokio worker 钉死到 IO 完成；若 home 目录被杀软扫描或云同步拖慢，被钉住的 worker 越积越多，runtime 会饿死。**async 上下文必须改用 `mutate_config_async`**——它把整套克隆→改→存→发布搬到 tokio 的 blocking 线程池，只占用可消耗的辅助线程。这也是后端"阻塞 IO 红线"在配置写路径上的落点。
+`mutate_config` 是同步函数，它持锁期间会做真实的阻塞 IO（写前校验读、autosave 拷贝、临时文件写入与原子替换）。若在 async fn 里 inline 调用，它会把一个 tokio worker 钉死到 IO 完成；若 home 目录被杀软扫描或云同步拖慢，被钉住的 worker 越积越多，runtime 会饿死。**async 上下文必须改用 `mutate_config_async`**——它把整套克隆→改→存→发布搬到 tokio 的 blocking 线程池，只占用可消耗的辅助线程。这也是后端"阻塞 IO 红线"在配置写路径上的落点。
 
 ## 并发模型
 
@@ -81,7 +81,7 @@ flowchart LR
 - **读者从不阻塞**：`ArcSwap` 允许无限个并发 reader，读路径永不等待写路径。
 - **写者互斥**：全局 `Mutex<()>` 保证临界区串行化。它防的是 lost-update——两个请求同时"读-改-写"，后写的会用自己那份陈旧快照覆盖先写的结果。写锁强制"读到的一定是最新快照"。
 - **快照原子性**：`store(Arc::new(new))` 是一次 release store。任何 `cached_config()` 调用要么看到旧快照、要么看到新快照，绝不会看到半更新状态。
-- **持锁时间可控**：写锁只覆盖一次配置克隆 + 闭包执行 + 序列化 + 一次 `fs::write` + 一次 Arc swap。磁盘 IO 虽是阻塞的，但写入频率极低（用户点保存），不会拖垮 runtime 的其它 worker。
+- **持锁时间可控**：写锁只覆盖一次配置克隆 + 闭包执行 + 序列化 + 一次安全原子写 + 一次 Arc swap。磁盘 IO 虽是阻塞的，但写入频率极低（用户点保存），不会拖垮 runtime 的其它 worker。
 
 ### 为什么坚持单一真相源
 
@@ -107,7 +107,7 @@ sequenceDiagram
     M->>A: load_config() 克隆最新快照
     M->>M: f(&mut cfg)（校验失败即在此返回 Err）
     M->>D: autosave 旧文件 → backups/autosave/
-    M->>D: 写入新 config.json
+    M->>D: 同目录临时文件 fsync → 原子替换 config.json
     M->>A: store 新 Arc（原子发布）
     M->>S: post_save：同步 terminal 远程写开关 + emit config:changed
     M->>S: config_changed hook（观察型）
@@ -118,6 +118,7 @@ sequenceDiagram
 几个要点：
 
 - **autosave 在覆盖前**：写盘之前先把"旧"文件拷进 `backups/autosave/`，所以每一次设置改动都可回滚。快照失败只 warn，绝不阻塞用户写入。
+- **磁盘发布也是原子的**：新 JSON 先完整序列化并写入同目录临时文件，`fsync` 后才替换目标；Windows 使用 `MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH)`，崩溃时只能观察到旧文件或新文件，不会留下半个 UTF-8 字符或截断 JSON。
 - **发布在落盘后**：先写磁盘、再 `store` 新快照，保证内存里能被读到的一定是已经持久化过的状态。
 - **副作用经注入执行**：`post_save` 与 `config_changed` hook 不写死在 persistence 里，而是在装配期一次性注册（见[备份 / 回滚联动](#备份--回滚联动)）；未注册时（测试 / 纯 CLI）自动跳过。
 


### PR DESCRIPTION
Fixes #640

## What changed

- make legacy server-token backup scrubbing accept UTF-8 BOMs
- move malformed config backups into a credential-scoped, 0600 quarantine instead of aborting startup
- fail closed and preserve the original backup when quarantine fails or a concurrent writer replaces the file
- publish config, autosave, and top-level backup files atomically
- use `MoveFileExW(REPLACE_EXISTING | WRITE_THROUGH)` on Windows instead of deleting the destination before rename
- document the recovery and atomic-write contracts

## Root cause

The supported managed credential format is currently `{"version":1,"token":"...","createdAt":...}`; the reported `version: 2` / `ownerToken` shape is not the application contract. The startup failure occurred while clearing the legacy token from ordinary config backups: a BOM-prefixed or malformed backup made the scrub pass return an error. Separately, direct writes and copies could expose truncated JSON to another process or after a crash.

## User impact

Upgrades no longer get stuck on an unusable historical rollback file once it has been securely quarantined, and config persistence now has an old-or-new atomicity guarantee so partial UTF-8/JSON is not published.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p ha-base -p ha-core --tests`
