### PR TITLE
🦭 feat: improve code and HTML file previews

### DIFF
--- a/docs/architecture/core/file-operations.md
+++ b/docs/architecture/core/file-operations.md
@@ -345,7 +345,7 @@ stateDiagram-v2
 
 [`FilePreviewPane`](../../../src/components/chat/project/file-browser/FilePreviewPane.tsx) 是统一预览视图，按 `fileKindOf` 结果分派（外壳 `FilePreviewPanel.tsx` 负责 target 切换与全屏，两者不是同一文件）：
 
-- code/text/Markdown：文本与语法高亮；Markdown 可切换渲染/源码。
+- code/text/Markdown：文本与语法高亮；Markdown 与普通 HTML 可切换渲染/源码。普通 HTML 默认显示高亮源码，渲染视图使用无脚本 sandbox，并注入与 Canvas 静态页面一致的离线 CSP（禁脚本、网络、frame、表单与 object）；受管 Artifact HTML 仍走独立的 `allow-scripts` 预览链路。
 - image/PDF/audio/video：浏览器原生预览。
 - Office：docx-preview / SheetJS / pptxviewjs 富预览，失败时回退后端抽取文本。
 - 二进制/失败状态：显示原因，并从同一能力层提供打开或下载。

--- a/docs/architecture/core/file-operations.md
+++ b/docs/architecture/core/file-operations.md
@@ -345,7 +345,7 @@ stateDiagram-v2
 
 [`FilePreviewPane`](../../../src/components/chat/project/file-browser/FilePreviewPane.tsx) 是统一预览视图，按 `fileKindOf` 结果分派（外壳 `FilePreviewPanel.tsx` 负责 target 切换与全屏，两者不是同一文件）：
 
-- code/text/Markdown：文本与语法高亮；Markdown 与普通 HTML 可切换渲染/源码。普通 HTML 默认显示高亮源码，渲染视图使用无脚本 sandbox，并注入与 Canvas 静态页面一致的离线 CSP（禁脚本、网络、frame、表单与 object）；受管 Artifact HTML 仍走独立的 `allow-scripts` 预览链路。
+- code/text/Markdown：文本与语法高亮；Markdown 与普通 HTML 可切换渲染/源码。普通 HTML 默认显示高亮源码，渲染视图会先移除脚本、refresh、外部资源和导航属性，再放进无脚本 sandbox 并注入与 Canvas 静态页面一致的离线 CSP；受管 Artifact HTML 仍走独立的 `allow-scripts` 预览链路。
 - image/PDF/audio/video：浏览器原生预览。
 - Office：docx-preview / SheetJS / pptxviewjs 富预览，失败时回退后端抽取文本。
 - 二进制/失败状态：显示原因，并从同一能力层提供打开或下载。

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "katex": "^0.16.38",
     "lucide-react": "^1.7.0",
     "mp4-muxer": "^5.2.2",
+    "parse5": "^8.0.1",
     "pptxviewjs": "^1.1.9",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       mp4-muxer:
         specifier: ^5.2.2
         version: 5.2.2
+      parse5:
+        specifier: ^8.0.1
+        version: 8.0.1
       pptxviewjs:
         specifier: ^1.1.9
         version: 1.1.9(chart.js@4.5.1)(jszip@3.10.1)

--- a/src/components/chat/project/file-browser/FilePreviewPane.test.tsx
+++ b/src/components/chat/project/file-browser/FilePreviewPane.test.tsx
@@ -88,7 +88,19 @@ describe("FilePreviewPane", () => {
   })
 
   test("toggles ordinary HTML between highlighted source and an offline preview", async () => {
-    const content = '<main id="preview">Hello</main><script>window.previewRan = true</script>'
+    const content = `<!doctype html>
+      <html>
+        <head><meta http-equiv="refresh" content="0;url=https://evil.test/refresh"></head>
+        <body>
+          <main id="preview">Hello</main>
+          <noscript><meta http-equiv="refresh" content="0;url=https://evil.test/noscript"></noscript>
+          <a href="https://evil.test/link" target="_top">Leave</a>
+          <form action="https://evil.test/form"><button formaction="https://evil.test/button">Send</button></form>
+          <img src="https://evil.test/image.png" onerror="window.previewRan = true">
+          <img alt="inline" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==">
+          <script>window.location.href = "https://evil.test/script"</script>
+        </body>
+      </html>`
     const source = {
       name: "preview.html",
       mime: "text/html",
@@ -120,13 +132,18 @@ describe("FilePreviewPane", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "fileBrowser.rendered" }))
 
-    const frame = screen.getByTitle("preview.html")
+    const frame = await screen.findByTitle("preview.html")
     const srcDoc = frame.getAttribute("srcdoc") ?? ""
-    expect(srcDoc).toContain(content)
+    expect(srcDoc).toContain('<main id="preview">Hello</main>')
     expect(srcDoc).toContain("default-src 'none'")
     expect(srcDoc).toContain("script-src 'none'")
     expect(srcDoc).toContain("connect-src 'none'")
-    expect(srcDoc.indexOf("Content-Security-Policy")).toBeLessThan(srcDoc.indexOf(content))
+    expect(srcDoc).not.toContain("https://evil.test")
+    expect(srcDoc).not.toContain("<script")
+    expect(srcDoc).not.toContain('http-equiv="refresh"')
+    expect(srcDoc).not.toContain("onerror=")
+    expect(srcDoc).not.toContain("target=")
+    expect(srcDoc).toContain('alt="inline" src="data:image/gif;base64,')
     expect(frame.getAttribute("sandbox")).toBe("")
     expect(frame.getAttribute("referrerpolicy")).toBe("no-referrer")
 

--- a/src/components/chat/project/file-browser/FilePreviewPane.test.tsx
+++ b/src/components/chat/project/file-browser/FilePreviewPane.test.tsx
@@ -19,6 +19,40 @@ afterEach(() => {
 })
 
 describe("FilePreviewPane", () => {
+  test("renders code previews with inline syntax colors", async () => {
+    const source = {
+      name: "example.ts",
+      mime: "text/typescript",
+      readText: vi.fn(async () => ({
+        relPath: "example.ts",
+        content: "const answer = 42",
+        isBinary: false,
+        mime: "text/typescript",
+        totalLines: 1,
+        sizeBytes: 17,
+        truncated: false,
+        contentHash: null,
+        isUtf8: true,
+        lineEnding: "lf" as const,
+        hasUtf8Bom: false,
+      })),
+      extractDoc: vi.fn(),
+      rawUrl: vi.fn(),
+    } satisfies PreviewSource
+
+    const { container } = render(
+      <TooltipProvider>
+        <FilePreviewPane source={source} />
+      </TooltipProvider>,
+    )
+
+    await waitFor(() => {
+      const tokens = [...container.querySelectorAll<HTMLElement>(".shiki .line > span")]
+      expect(tokens.length).toBeGreaterThan(1)
+      expect(new Set(tokens.map((token) => token.style.color)).size).toBeGreaterThan(1)
+    })
+  })
+
   test("shows a persistent open action in the preview header", () => {
     const onOpen = vi.fn()
     const source: PreviewSource = {
@@ -51,6 +85,53 @@ describe("FilePreviewPane", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "fileActions.open" }))
     expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  test("toggles ordinary HTML between highlighted source and an offline preview", async () => {
+    const content = '<main id="preview">Hello</main><script>window.previewRan = true</script>'
+    const source = {
+      name: "preview.html",
+      mime: "text/html",
+      readText: vi.fn(async () => ({
+        relPath: "preview.html",
+        content,
+        isBinary: false,
+        mime: "text/html",
+        totalLines: 1,
+        sizeBytes: content.length,
+        truncated: false,
+        contentHash: null,
+        isUtf8: true,
+        lineEnding: "lf" as const,
+        hasUtf8Bom: false,
+      })),
+      extractDoc: vi.fn(),
+      rawUrl: vi.fn(),
+    } satisfies PreviewSource
+
+    const { container } = render(
+      <TooltipProvider>
+        <FilePreviewPane source={source} />
+      </TooltipProvider>,
+    )
+
+    await waitFor(() => expect(container.querySelector(".shiki")).not.toBeNull())
+    expect(screen.queryByTitle("preview.html")).toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "fileBrowser.rendered" }))
+
+    const frame = screen.getByTitle("preview.html")
+    const srcDoc = frame.getAttribute("srcdoc") ?? ""
+    expect(srcDoc).toContain(content)
+    expect(srcDoc).toContain("default-src 'none'")
+    expect(srcDoc).toContain("script-src 'none'")
+    expect(srcDoc).toContain("connect-src 'none'")
+    expect(srcDoc.indexOf("Content-Security-Policy")).toBeLessThan(srcDoc.indexOf(content))
+    expect(frame.getAttribute("sandbox")).toBe("")
+    expect(frame.getAttribute("referrerpolicy")).toBe("no-referrer")
+
+    fireEvent.click(screen.getByRole("button", { name: "fileBrowser.viewSource" }))
+    await waitFor(() => expect(container.querySelector(".shiki")).not.toBeNull())
   })
 
   test("renders managed Artifact HTML from its raw URL without reading it as code", async () => {

--- a/src/components/chat/project/file-browser/FilePreviewPane.tsx
+++ b/src/components/chat/project/file-browser/FilePreviewPane.tsx
@@ -1,8 +1,9 @@
 /**
  * Read-only preview for a workspace file, dispatched by file kind:
- * code/text (Shiki, direct), markdown (rendered + view-source), image
+ * code/text (Shiki, direct), markdown and HTML (rendered + view-source), image
  * (`<img>`), PDF (`<iframe>`), Office (extracted text + images), and a binary
- * placeholder for everything else.
+ * placeholder for everything else. Ordinary HTML renders in a script-free
+ * sandbox; managed HTML artifacts use their dedicated script-enabled path.
  *
  * Selecting text in a code/text/markdown-source preview reveals a "quote to
  * chat" action capturing the file path + exact line range + content.
@@ -31,6 +32,23 @@ type Loaded =
   | { kind: "code" | "text" | "markdown" | "binary"; data: FileTextContent }
   | { kind: "image" | "pdf" | "audio" | "video" | "managed_html"; url: string | null }
   | { kind: "office" }
+
+const OFFLINE_HTML_PREVIEW_CSP =
+  "default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'; script-src 'none'; font-src data:; connect-src 'none'; frame-src 'none'; object-src 'none'; form-action 'none'; base-uri 'none'"
+
+/**
+ * Put the offline policy before any caller-controlled markup so the browser
+ * applies it before discovering subresources. A leading doctype stays first;
+ * the HTML parser places the following meta element in its generated head.
+ * Keep this aligned with Canvas' static renderer; the iframe sandbox remains
+ * the second boundary.
+ */
+function buildOfflineHtmlPreview(source: string): string {
+  const policy = `<meta http-equiv="Content-Security-Policy" content="${OFFLINE_HTML_PREVIEW_CSP}">`
+  const doctype = /^\s*<!doctype[^>]*>/i.exec(source)
+  const offset = doctype?.[0].length ?? 0
+  return `${source.slice(0, offset)}${policy}${source.slice(offset)}`
+}
 
 export interface FilePreviewPaneProps {
   /** The file to preview (memoize this — it drives the load effect), or `null`. */
@@ -72,14 +90,21 @@ export function FilePreviewPane({
   useEffect(() => {
     let cancelled = false
     let leasedRawUrl: string | null = null
-    setViewSource(false)
     if (!source) {
+      setViewSource(false)
       setLoaded(null)
       return
     }
     setLoading(true)
     setError(null)
     const kind = fileKindOf(source.name, source.mime, source.language)
+    // Preserve the existing highlighted-source default for ordinary HTML.
+    // Managed HTML artifacts follow their dedicated renderer below.
+    setViewSource(
+      source.presentation !== "managed_html" &&
+        kind === "code" &&
+        shikiLang(source.name, source.language) === "html",
+    )
     void (async () => {
       try {
         if (source.presentation === "managed_html") {
@@ -122,7 +147,12 @@ export function FilePreviewPane({
     }
   }, [source])
 
-  const effectiveViewSource = viewSource || (!!highlightLines && loaded?.kind === "markdown")
+  const isHtmlPreview =
+    loaded?.kind === "code" && shikiLang(source?.name ?? "", source?.language) === "html"
+  const supportsRenderedView = loaded?.kind === "markdown" || isHtmlPreview
+  const effectiveViewSource =
+    viewSource ||
+    (!!highlightLines && (loaded?.kind === "markdown" || isHtmlPreview))
 
   const handleQuoteSelection = useCallback(
     (sel: CodeSelection) => {
@@ -164,14 +194,14 @@ export function FilePreviewPane({
           ) : null}
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-0.5">
-          {loaded?.kind === "markdown" ? (
+          {supportsRenderedView ? (
             <div className="inline-flex items-center rounded-md border border-border/60 p-0.5">
               <button
                 type="button"
                 onClick={() => setViewSource(false)}
                 className={cn(
                   "rounded px-2 py-0.5 text-xs transition-colors",
-                  !viewSource
+                  !effectiveViewSource
                     ? "bg-secondary text-foreground"
                     : "text-muted-foreground hover:text-foreground",
                 )}
@@ -183,7 +213,7 @@ export function FilePreviewPane({
                 onClick={() => setViewSource(true)}
                 className={cn(
                   "rounded px-2 py-0.5 text-xs transition-colors",
-                  viewSource
+                  effectiveViewSource
                     ? "bg-secondary text-foreground"
                     : "text-muted-foreground hover:text-foreground",
                 )}
@@ -403,6 +433,22 @@ function PreviewBody({
       <div className="px-4 py-3">
         <MarkdownRenderer content={loaded.data.content} />
       </div>
+    )
+  }
+
+  if (
+    loaded.kind === "code" &&
+    shikiLang(source.name, source.language) === "html" &&
+    !viewSource
+  ) {
+    return (
+      <iframe
+        title={source.name}
+        srcDoc={buildOfflineHtmlPreview(loaded.data.content)}
+        sandbox=""
+        referrerPolicy="no-referrer"
+        className="h-full w-full border-0 bg-white dark:bg-surface-app"
+      />
     )
   }
 

--- a/src/components/chat/project/file-browser/FilePreviewPane.tsx
+++ b/src/components/chat/project/file-browser/FilePreviewPane.tsx
@@ -24,6 +24,7 @@ import type { PreviewSource } from "@/components/chat/files/previewSource"
 import type { PendingFileQuote } from "@/types/chat"
 import { OfficeRichPreview } from "@/components/chat/files/office/OfficeRichPreview"
 import { BinaryPlaceholder } from "./BinaryPlaceholder"
+import { buildOfflineHtmlPreview } from "./offlineHtmlPreview"
 import { ShikiCodeView, type CodeSelection } from "./ShikiCodeView"
 
 export type QuotePayload = PendingFileQuote
@@ -32,23 +33,6 @@ type Loaded =
   | { kind: "code" | "text" | "markdown" | "binary"; data: FileTextContent }
   | { kind: "image" | "pdf" | "audio" | "video" | "managed_html"; url: string | null }
   | { kind: "office" }
-
-const OFFLINE_HTML_PREVIEW_CSP =
-  "default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'; script-src 'none'; font-src data:; connect-src 'none'; frame-src 'none'; object-src 'none'; form-action 'none'; base-uri 'none'"
-
-/**
- * Put the offline policy before any caller-controlled markup so the browser
- * applies it before discovering subresources. A leading doctype stays first;
- * the HTML parser places the following meta element in its generated head.
- * Keep this aligned with Canvas' static renderer; the iframe sandbox remains
- * the second boundary.
- */
-function buildOfflineHtmlPreview(source: string): string {
-  const policy = `<meta http-equiv="Content-Security-Policy" content="${OFFLINE_HTML_PREVIEW_CSP}">`
-  const doctype = /^\s*<!doctype[^>]*>/i.exec(source)
-  const offset = doctype?.[0].length ?? 0
-  return `${source.slice(0, offset)}${policy}${source.slice(offset)}`
-}
 
 export interface FilePreviewPaneProps {
   /** The file to preview (memoize this — it drives the load effect), or `null`. */
@@ -442,12 +426,10 @@ function PreviewBody({
     !viewSource
   ) {
     return (
-      <iframe
-        title={source.name}
-        srcDoc={buildOfflineHtmlPreview(loaded.data.content)}
-        sandbox=""
-        referrerPolicy="no-referrer"
-        className="h-full w-full border-0 bg-white dark:bg-surface-app"
+      <OfflineHtmlPreview
+        name={source.name}
+        sizeBytes={loaded.data.sizeBytes}
+        content={loaded.data.content}
       />
     )
   }
@@ -468,4 +450,63 @@ function PreviewBody({
   }
 
   return null
+}
+
+function OfflineHtmlPreview({
+  name,
+  sizeBytes,
+  content,
+}: {
+  name: string
+  sizeBytes: number
+  content: string
+}) {
+  const [result, setResult] = useState<{
+    content: string
+    html: string | null
+    error: string | null
+  } | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    void buildOfflineHtmlPreview(content).then(
+      (html) => {
+        if (!cancelled) setResult({ content, html, error: null })
+      },
+      (error: unknown) => {
+        if (!cancelled) {
+          setResult({
+            content,
+            html: null,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      },
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [content])
+
+  if (result?.content !== content) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+      </div>
+    )
+  }
+
+  if (!result.html) {
+    return <BinaryPlaceholder name={name} sizeBytes={sizeBytes} note={result.error ?? undefined} />
+  }
+
+  return (
+    <iframe
+      title={name}
+      srcDoc={result.html}
+      sandbox=""
+      referrerPolicy="no-referrer"
+      className="h-full w-full border-0 bg-white dark:bg-surface-app"
+    />
+  )
 }

--- a/src/components/chat/project/file-browser/ShikiCodeView.tsx
+++ b/src/components/chat/project/file-browser/ShikiCodeView.tsx
@@ -93,7 +93,6 @@ export function ShikiCodeView({
       codeToHtml(content, {
         lang: l,
         themes: { light: "github-light", dark: "github-dark" },
-        defaultColor: false,
         transformers: [lineData],
       })
     void render(lang)

--- a/src/components/chat/project/file-browser/offlineHtmlPreview.ts
+++ b/src/components/chat/project/file-browser/offlineHtmlPreview.ts
@@ -1,0 +1,139 @@
+import type { DefaultTreeAdapterTypes } from "parse5"
+
+const OFFLINE_HTML_PREVIEW_CSP =
+  "default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'; script-src 'none'; font-src data:; connect-src 'none'; frame-src 'none'; object-src 'none'; form-action 'none'; base-uri 'none'"
+
+const REMOVED_ELEMENTS = new Set([
+  "base",
+  "embed",
+  "frame",
+  "frameset",
+  "iframe",
+  "object",
+  "portal",
+  "script",
+])
+
+const REMOVED_ATTRIBUTES = new Set([
+  "action",
+  "download",
+  "formaction",
+  "formtarget",
+  "manifest",
+  "ping",
+  "srcdoc",
+  "srcset",
+  "target",
+])
+
+const OFFLINE_URL_ATTRIBUTES = new Set([
+  "background",
+  "href",
+  "longdesc",
+  "poster",
+  "src",
+  "usemap",
+])
+
+type ParentNode = DefaultTreeAdapterTypes.ParentNode
+type ChildNode = DefaultTreeAdapterTypes.ChildNode
+type Element = DefaultTreeAdapterTypes.Element
+
+function isElement(node: ChildNode): node is Element {
+  return "tagName" in node
+}
+
+function isOfflineUrl(value: string): boolean {
+  const normalized = value.trim().toLowerCase()
+  return (
+    normalized.startsWith("#") || normalized.startsWith("blob:") || normalized.startsWith("data:")
+  )
+}
+
+function sanitizeAttributes(element: Element): void {
+  const tagName = element.tagName.toLowerCase()
+  element.attrs = element.attrs.filter((attribute) => {
+    const name = attribute.name.toLowerCase()
+    if (name.startsWith("on") || REMOVED_ATTRIBUTES.has(name)) return false
+
+    if (OFFLINE_URL_ATTRIBUTES.has(name)) {
+      // Anchors and image-map areas can navigate the preview even when an
+      // iframe has an empty sandbox. Keep their text/shape but remove href.
+      if (name === "href" && (tagName === "a" || tagName === "area")) return false
+      return isOfflineUrl(attribute.value)
+    }
+
+    return true
+  })
+}
+
+function sanitizeChildren(parent: ParentNode): void {
+  const retained: ChildNode[] = []
+
+  for (const child of parent.childNodes) {
+    if (!isElement(child)) {
+      retained.push(child)
+      continue
+    }
+
+    const tagName = child.tagName.toLowerCase()
+    const isHttpEquivMeta =
+      tagName === "meta" &&
+      child.attrs.some((attribute) => attribute.name.toLowerCase() === "http-equiv")
+    if (REMOVED_ELEMENTS.has(tagName) || isHttpEquivMeta) {
+      child.parentNode = null
+      continue
+    }
+
+    sanitizeAttributes(child)
+    sanitizeChildren(child)
+    if (tagName === "template" && "content" in child) {
+      sanitizeChildren(child.content)
+    }
+    retained.push(child)
+  }
+
+  parent.childNodes = retained
+}
+
+function findElement(parent: ParentNode, tagName: string): Element | null {
+  for (const child of parent.childNodes) {
+    if (!isElement(child)) continue
+    if (child.tagName.toLowerCase() === tagName) return child
+    const nested = findElement(child, tagName)
+    if (nested) return nested
+  }
+  return null
+}
+
+/**
+ * Build a static, offline document for an ordinary HTML file preview.
+ *
+ * Parsing happens only after the user switches to rendered mode, so parse5 is
+ * kept out of the initial file-browser chunk. The sanitizer removes every
+ * script/navigation primitive before serialization; CSP and the iframe's
+ * empty sandbox remain independent execution/network boundaries.
+ */
+export async function buildOfflineHtmlPreview(source: string): Promise<string> {
+  const { defaultTreeAdapter, html, parse, serialize } = await import("parse5")
+  // The iframe has scripting disabled, so parse noscript contents as markup as
+  // the browser will; otherwise a refresh meta nested there could evade the walk.
+  const document = parse(source, { scriptingEnabled: false })
+  sanitizeChildren(document)
+
+  const head = findElement(document, "head")
+  if (!head) throw new Error("HTML preview has no document head")
+
+  const policy = defaultTreeAdapter.createElement("meta", html.NS.HTML, [
+    { name: "http-equiv", value: "Content-Security-Policy" },
+    { name: "content", value: OFFLINE_HTML_PREVIEW_CSP },
+  ])
+  const firstChild = head.childNodes[0]
+  if (firstChild) {
+    defaultTreeAdapter.insertBefore(head, policy, firstChild)
+  } else {
+    defaultTreeAdapter.appendChild(head, policy)
+  }
+
+  return serialize(document)
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1007,8 +1007,10 @@ html[data-focus-indicators="enhanced"]
 }
 
 /* Direct Shiki file preview (file browser): dual theme + gutter line numbers.
- * Shiki is rendered with defaultColor:false, so each token carries
- * --shiki-light / --shiki-dark CSS vars that we switch on the `.dark` root. */
+ * Shiki emits an inline light `color` as a fail-safe plus `--shiki-dark`; the
+ * dark rule below switches tokens when the app theme is dark. Keeping a real
+ * inline color prevents the whole preview becoming monochrome when WebView
+ * style ordering drops the light custom-property override. */
 .hope-shiki-view {
   font-size: 0.8125rem;
   line-height: 1.5;
@@ -1046,10 +1048,6 @@ html[data-focus-indicators="enhanced"]
   color: color-mix(in srgb, var(--color-muted-foreground) 65%, transparent);
   background: var(--color-background);
   user-select: none;
-}
-.hope-shiki-view .shiki,
-.hope-shiki-view .shiki span {
-  color: var(--shiki-light);
 }
 .dark .hope-shiki-view .shiki,
 .dark .hope-shiki-view .shiki span {


### PR DESCRIPTION
## Summary

- restore reliable Shiki token colors in file content previews
- add Rendered / View source switching for ordinary `.html` and `.htm` files
- keep ordinary HTML source-first and render it in an offline, script-free sandbox
- preserve the dedicated script-enabled path for managed Canvas/Artifact HTML
- document the preview security boundary and add regression coverage

## Root cause

The Shiki renderer used `defaultColor: false`, which made light-theme token colors depend entirely on CSS custom-property overrides. In affected WebView style ordering, those overrides were lost and every token fell back to the same color.

## User impact

Code previews retain syntax colors consistently. HTML files can now be inspected as highlighted source or rendered safely without scripts, network access, nested frames, forms, or objects.

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run src/components/chat/project/file-browser/FilePreviewPane.test.tsx`
- pre-push: ESLint, updater/config guards, crate-layering guards
- pre-push: 257 Vitest files / 1441 tests passed
- `git diff --check`