### PR TITLE
ci: raise Node heap for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
     name: build (${{ matrix.platform }})
     env:
       RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
+      # v0.35.0 的 macOS lane 在 beforeBuildCommand 的 `tsc -b` 碰到 Node
+      # 默认约 2 GiB old-space 上限；给前端构建留足堆，同时保持在 7 GiB runner 内。
+      NODE_OPTIONS: "--max-old-space-size=4096"
       # 仅 release-tag / dispatch 构建串行化 codegen，换取最小 / 最快二进制（叠加
       # 根 Cargo.toml 的 lto="thin" / strip）。Docker（docker.yml 走 Dockerfile，
       # 不读此 env）与日常 dev 不受影响。


### PR DESCRIPTION
## Summary

- raise the release job Node old-space limit to 4 GiB
- prevent the macOS v0.35.0 lane from failing in `tsc -b` at the default ~2 GiB heap limit

## Failure evidence

Release run 32592634653 failed before bundle creation with Node `FATAL ERROR: Ineffective mark-compacts near heap limit` and exit code 134. The run was cancelled after the deterministic failure; no draft Release was created.

## Validation

- `pnpm check:release-paths`
- `git diff --check`
- full pre-push gate