### PR TITLE
chore: remove verified dead code

### DIFF
--- a/crates/ha-knowledge/src/tools/note.rs
+++ b/crates/ha-knowledge/src/tools/note.rs
@@ -7,7 +7,6 @@
 //! `knowledge:changed`.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::path::Path;
 
 use anyhow::{anyhow, bail, Result};
 use serde_json::Value;
@@ -1772,11 +1771,6 @@ fn append_under_heading(content: &str, heading: &str, line: &str) -> String {
             out
         }
     }
-}
-
-#[allow(dead_code)]
-fn _root_of(scope: &WorkspaceScope) -> &Path {
-    scope.root()
 }
 
 /// `folder/Note.md` → `Note` (stem, no extension), `/`-normalized.


### PR DESCRIPTION
## 死代码证据

- `crates/ha-knowledge/src/tools/note.rs` 中的私有函数 `_root_of` 被 `#[allow(dead_code)]` 显式压制编译器诊断。
- 全仓符号检索仅命中该定义，生产代码、测试、动态注册表和字符串引用均无调用。
- 函数仅原样转发 `WorkspaceScope::root()`，自首次引入以来没有接入调用链。

## 删除范围

- 删除私有 `_root_of` 转发函数。
- 删除因此不再使用的 `std::path::Path` 导入。
- 共 1 个文件、6 行删除；不修改公开 API、序列化结构、Tauri/HTTP 命令、MCP/ACP/Skill 注册、i18n、feature gate 或平台条件编译。

## 保留项

扫描中发现的兼容分支、序列化响应字段、平台条件字段、未来接线占位和公开再导出均因静态分析证据不足而保留，本 PR 不做顺手重构。

## 验证结果

- `cargo check -p ha-knowledge --all-targets --message-format short`
- `node scripts/analyze-crate-deps.mjs`
- `node scripts/analyze-crate-deps.mjs --tests`
- 正常 pre-push 全套门禁：`cargo fmt --check`、Clippy `-D warnings`、评测内部编译、`pnpm typecheck`、ESLint、更新器与 crate 边界守卫、Vitest（273 文件 / 1549 测试）、required Rust tests 与 doc-tests，全部通过。

## 风险与回滚

风险极低：仅删除无调用的私有恒等转发函数，不改变行为或数据。若需回滚，可对提交 `8ce1e2f67` 执行 `git revert`。