### PR TITLE
fix: restore packaged file preview highlighting

### DIFF
--- a/docs/architecture/core/file-operations.md
+++ b/docs/architecture/core/file-operations.md
@@ -346,7 +346,7 @@ stateDiagram-v2
 
 [`FilePreviewPane`](../../../src/components/chat/project/file-browser/FilePreviewPane.tsx) 是统一预览视图，按 `fileKindOf` 结果分派（外壳 `FilePreviewPanel.tsx` 负责单个 target 与全屏，`useFilePreview.ts` 负责工作台多标签；三者不是同一个文件）：
 
-- code/text/Markdown：文本与语法高亮；Markdown 与普通 HTML 可切换渲染/源码。普通 HTML 默认显示高亮源码，渲染视图会先移除脚本、refresh、外部资源和导航属性，再放进无脚本 sandbox 并注入与 Canvas 静态页面一致的离线 CSP；受管 Artifact HTML 仍走独立的 `allow-scripts` 预览链路。
+- code/text/Markdown：文本与语法高亮；文件预览的 Shiki 固定使用 JavaScript 正则引擎，不依赖生产 Tauri CSP 禁止的运行时 WASM 编译。Markdown 与普通 HTML 可切换渲染/源码。普通 HTML 默认显示高亮源码，渲染视图会先移除脚本、refresh、外部资源和导航属性，再放进无脚本 sandbox 并注入与 Canvas 静态页面一致的离线 CSP；受管 Artifact HTML 仍走独立的 `allow-scripts` 预览链路。
 - image/PDF/audio/video：浏览器原生预览。
 - managed HTML / Artifact：受限沙箱 iframe 预览。
 - Office：docx-preview / SheetJS / pptxviewjs 富预览，失败时回退后端抽取文本。

--- a/src/components/chat/project/file-browser/ShikiCodeView.tsx
+++ b/src/components/chat/project/file-browser/ShikiCodeView.tsx
@@ -17,12 +17,19 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { codeToHtml, type ShikiTransformer } from "shiki"
+import {
+  createHighlighter,
+  createJavaScriptRegexEngine,
+  type BundledLanguage,
+  type Highlighter,
+  type ShikiTransformer,
+} from "shiki"
 import { Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import { useTranslation } from "react-i18next"
 
 import { SelectionActionMenu } from "@/components/common/SelectionActionMenu"
+import { logger } from "@/lib/logger"
 import { cn } from "@/lib/utils"
 import { useSelectionActionMenu } from "./useSelectionActionMenu"
 
@@ -35,6 +42,45 @@ export interface CodeSelection {
 /** Above this size we skip Shiki's synchronous tokenizer and show plain
  *  monospace text, so a huge file can't block the UI thread. */
 const MAX_HIGHLIGHT_BYTES = 400_000
+const SHIKI_THEMES = ["github-light", "github-dark"] as const
+
+/**
+ * Tauri's production CSP deliberately omits `wasm-unsafe-eval`. Shiki's
+ * bundled shortcut uses the Oniguruma WASM engine by default, so it works in
+ * jsdom/dev but fails in the packaged WebView and poisons the shortcut's
+ * singleton promise. Use Shiki's JavaScript regex engine for this surface so
+ * highlighting stays offline and CSP-safe without weakening the app policy.
+ */
+let previewHighlighterPromise: Promise<Highlighter> | null = null
+
+function getPreviewHighlighter(): Promise<Highlighter> {
+  if (!previewHighlighterPromise) {
+    const pending = createHighlighter({
+      engine: createJavaScriptRegexEngine(),
+      langs: [],
+      themes: [...SHIKI_THEMES],
+    })
+    previewHighlighterPromise = pending.catch((error) => {
+      // A transient chunk-load failure must not permanently disable every
+      // later preview in this renderer process.
+      previewHighlighterPromise = null
+      throw error
+    })
+  }
+  return previewHighlighterPromise
+}
+
+async function renderHighlightedCode(content: string, lang: string): Promise<string> {
+  const highlighter = await getPreviewHighlighter()
+  if (lang !== "text" && !highlighter.getLoadedLanguages().includes(lang)) {
+    await highlighter.loadLanguage(lang as BundledLanguage)
+  }
+  return highlighter.codeToHtml(content, {
+    lang: lang as BundledLanguage,
+    themes: { light: SHIKI_THEMES[0], dark: SHIKI_THEMES[1] },
+    transformers: [lineData],
+  })
+}
 
 const lineData: ShikiTransformer = {
   name: "line-data",
@@ -72,21 +118,29 @@ export function ShikiCodeView({
   useEffect(() => {
     if (tooLarge) return
     let cancelled = false
-    const render = (l: string) =>
-      codeToHtml(content, {
-        lang: l,
-        themes: { light: "github-light", dark: "github-dark" },
-        transformers: [lineData],
-      })
-    void render(lang)
-      .catch(() => render("text")) // unknown grammar → plaintext
+    let syntaxError: unknown = null
+    void renderHighlightedCode(content, lang)
+      .catch((error) => {
+        syntaxError = error
+        return renderHighlightedCode(content, "text")
+      }) // unknown grammar → Shiki plaintext (retains line numbers)
       .then((out) => {
         if (cancelled) return
+        if (syntaxError) {
+          logger.warn("ui", "ShikiCodeView::render", "syntax grammar failed; used plaintext", {
+            lang,
+            error: syntaxError instanceof Error ? syntaxError.message : String(syntaxError),
+          })
+        }
         setHtml(out)
         setLoading(false)
       })
-      .catch(() => {
+      .catch((error) => {
         if (cancelled) return
+        logger.error("ui", "ShikiCodeView::render", "code preview highlighting failed", {
+          lang,
+          error: error instanceof Error ? error.message : String(error),
+        })
         setHtml(null)
         setLoading(false)
       })


### PR DESCRIPTION
## 问题

正式 Tauri 包中的文件预览会静默退化为无颜色、无行号的纯文本。文件类型识别仍然正确；实际原因是 Shiki 默认 Oniguruma/WASM 引擎需要运行时 WASM 编译，而生产 CSP 未放行 `wasm-unsafe-eval`。首次初始化失败后，语法与纯文本兜底都会复用失败的单例。

## 修复

- 文件预览改用 Shiki 的 JavaScript 正则引擎，保持现有 Tauri CSP 不变
- 未知语法继续回退到 Shiki 纯文本输出，保留行号
- 高亮器初始化失败后允许后续重试，避免 renderer 生命周期内永久失效
- 补充不含文件内容的最小错误日志与架构说明

## 验证

- `pnpm typecheck`
- CSP 冒烟：强制 `WebAssembly.instantiate` 失败时，JSON 仍生成多 token 颜色且 WASM 调用数为 0
- pre-push 全套门禁通过：TypeScript、ESLint、架构/更新器守卫、Vitest（273 文件 / 1549 测试）