### PR TITLE
chore: remove verified dead code

### DIFF
--- a/crates/ha-core/src/agent/mod.rs
+++ b/crates/ha-core/src/agent/mod.rs
@@ -4565,17 +4565,6 @@ impl AssistantAgent {
         ))
     }
 
-    /// Build the "static" system prompt — excludes the dynamic awareness
-    /// suffix which providers append as a separate cache breakpoint.
-    ///
-    /// Currently unused but kept as the named dual of
-    /// [`Self::build_merged_system_prompt`]; compaction call sites use the
-    /// merged form and side-query shortcuts go through `CacheSafeParams`.
-    #[allow(dead_code)]
-    pub(crate) fn build_static_system_prompt(&self, model: &str, provider: &str) -> String {
-        self.build_full_system_prompt(model, provider)
-    }
-
     /// Build the trusted prompt used by the independent compaction call. Data
     /// lanes such as awareness/recall/notes are intentionally absent: placing
     /// them in the summarizer's system message would silently raise their
@@ -4721,12 +4710,6 @@ impl AssistantAgent {
             metadata_sink: None,
             effective_args_sink: None,
         }
-    }
-
-    /// Build a ToolExecContext without token usage info (backward-compatible wrapper).
-    #[allow(dead_code)]
-    pub(crate) fn tool_context(&self) -> crate::tool_defs::ToolExecContext {
-        self.tool_context_with_usage(None)
     }
 
     /// Get the context window size.

--- a/docs/architecture/core/tool-system.md
+++ b/docs/architecture/core/tool-system.md
@@ -975,7 +975,7 @@ Planning/Review 状态下 spawn 的子 Agent 自动把 `PLAN_MODE_DENIED_TOOLS` 
 | [`ha-core/src/tools/dispatch.rs`](../../../crates/ha-core/src/tools/dispatch.rs) | **注入决策单一入口**：`resolve_tool_fate()` / `all_dispatchable_tools()` / `is_globally_configured()` Tier 3 配置探针 |
 | [`ha-core/src/tools/definitions/registry.rs`](../../../crates/ha-core/src/tools/definitions/registry.rs) | `is_internal_tool()` / `background_policy_for_tool()` / `is_concurrent_safe()` —— ToolDefinition 元数据缓存 |
 | [`ha-core/src/tools/registry.rs`](../../../crates/ha-core/src/tools/registry.rs) · [`builtin_registry.rs`](../../../crates/ha-core/src/tools/builtin_registry.rs) | 执行分发注册表（名字 → handler）+ 冻结语义 + 全部内置条目 |
-| [`ha-core/src/agent/mod.rs`](../../../crates/ha-core/src/agent/mod.rs) | `build_tool_schemas()` / `build_full_system_prompt()` 共享 `resolve_tool_fate` 单一注入决策；`tool_context()` 构建 ToolExecContext |
+| [`ha-core/src/agent/mod.rs`](../../../crates/ha-core/src/agent/mod.rs) | `build_tool_schemas()` / `build_full_system_prompt()` 共享 `resolve_tool_fate` 单一注入决策；`tool_context_with_usage()` 构建 `ToolExecContext` |
 | [`ha-core/src/system_prompt/sections.rs`](../../../crates/ha-core/src/system_prompt/sections.rs) | `build_tools_section()` / `build_deferred_tools_section()` 渲染 eager 描述段 / deferred 一行索引 |
 | [`ha-core/src/tools/tool_search.rs`](../../../crates/ha-core/src/tools/tool_search.rs) | `tool_search`：按当前 Agent/Skill/Plan 限制过滤可发现工具 + v2 metadata 加权检索 |
 | [`ha-core/src/tools/execution.rs`](../../../crates/ha-core/src/tools/execution.rs) | 工具执行入口、审批门接线（`resolve_async`）、Plan Mode 路径检查、图片 marker 物化；普通文本交 PostToolUse 接纳 |


### PR DESCRIPTION
本次每周扫描清理 `AssistantAgent` 中两个没有调用方的内部包装方法，消除过时入口，保持现有提示词构建和工具上下文行为不变。

- 死代码证据：全仓（含隐藏配置、脚本、测试、评测、技能与文档）符号检索只命中两个方法的定义、一处旧文档引用及历史变更记录。临时移除这两处 `#[allow(dead_code)]` 后，`cargo check -p ha-core --all-targets --locked` 在库和测试目标中均报告 `build_static_system_prompt` 与 `tool_context` 从未使用。
- 删除范围：仅删除 `crates/ha-core/src/agent/mod.rs` 中 `build_static_system_prompt()` 和 `tool_context()` 及各自注释、抑制标记，共 17 行 Rust；将工具系统文档索引改为实际使用的 `tool_context_with_usage()`。
- 调用链与边界：两个方法均为 `pub(crate)` 固有方法，不是公共导出、trait 实现、注册入口或条件编译适配；一个仅转发 `build_full_system_prompt()`，另一个仅转发 `tool_context_with_usage(None)`。现有提示词、压缩和流式工具执行路径继续使用原有实现，无需改动调用方。
- 保留项：保留 `build_full_system_prompt()`、`build_merged_system_prompt()`、`tool_context_with_usage()`，保留历史 CHANGELOG。序列化字段、平台分支、明确标注的一次 minor 回滚兼容代码、动态注册及证据不足的公开方法均未删除。未触及配置、i18n、Tauri/HTTP/MCP/ACP/Skill 契约、版本号、凭据或用户数据。
- 验证：删除后 `cargo check -p ha-core --all-targets --locked` 无警告通过；`pnpm typecheck`、依赖分层守卫（生产与 `--tests`）、`check-agent-kernel-boundaries.mjs`、完整 diff 审查和 `git diff --check` 通过。正常 push 的完整 pre-push 已全部通过（格式检查、clippy、评测内部测试编译、TypeScript、ESLint、架构与版本守卫、Vitest 281 个文件 / 1,600 个测试、Rust 单元/集成/文档测试）；没有使用跳过开关或绕过钩子。
- 风险与回滚：变更只减少不可达包装方法，风险低；如需恢复，正常 revert 本 PR 的 squash 合并提交即可，无数据迁移或运行配置回滚。

基于最新 `origin/main` 的独立临时 worktree 和唯一任务分支执行；主工作区保持原分支、原提交且无未提交改动。
