### PR TITLE
fix(release): support GitHub asset API URLs in R2 mirror

### DIFF
--- a/.github/workflows/mirror-release-r2.yml
+++ b/.github/workflows/mirror-release-r2.yml
@@ -372,6 +372,15 @@ jobs:
           # per-version prefix — so move it out of the asset set.
           test -f "$WORK/assets/latest.json" || { echo "::error::release $TAG has no latest.json"; exit 1; }
           mv "$WORK/assets/latest.json" "$WORK/manifest/latest.json"
+          # tauri-action v1 writes numeric GitHub asset API URLs into
+          # latest.json. Resolve those IDs to filenames from this exact tag's
+          # Release metadata, then let the offline rewrite script validate and
+          # consume the map. Never infer names from signatures or network
+          # redirects.
+          gh api "repos/${{ github.repository }}/releases/tags/$TAG" \
+            --jq '[.assets[] | {key: .url, value: .name}] | from_entries' \
+            > "$WORK/manifest/asset-map.json"
+          jq -e 'type == "object" and length >= 20' "$WORK/manifest/asset-map.json" >/dev/null
           echo "--- assets to mirror ---"
           ls -la "$WORK/assets/"
           count=$(find "$WORK/assets" -type f | wc -l | tr -d ' ')
@@ -390,6 +399,7 @@ jobs:
           mkdir -p "$WORK/out"
           node scripts/rewrite-manifest-for-mirror.mjs \
             "$WORK/manifest/latest.json" "$TAG" "$PUBLIC_BASE" \
+            --asset-map="$WORK/manifest/asset-map.json" \
             --out="$WORK/out/latest.json" --docs-out="$WORK/out/notes-docs.txt"
 
       - name: Assert the notes link only mirrored docs

--- a/scripts/__tests__/workflow-supply-chain.test.mjs
+++ b/scripts/__tests__/workflow-supply-chain.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict"
-import { readFileSync, readdirSync } from "node:fs"
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
 import { spawnSync } from "node:child_process"
+import os from "node:os"
+import path from "node:path"
 import { fileURLToPath } from "node:url"
 import test from "node:test"
 import { inspectWorkflow } from "../check-workflow-supply-chain.mjs"
@@ -97,5 +99,73 @@ test("endpoint resolver diagnoses the boolean key/account mixup without receivin
     })
     assert.equal(result.status, status, result.stderr)
     if (same === "true") assert.ok(result.stdout.includes("equals R2_ACCESS_KEY_ID"))
+  }
+})
+
+function runManifestRewrite({ platformUrl, assetMap }) {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), "hope-agent-mirror-manifest-"))
+  const manifestPath = path.join(tempRoot, "latest.json")
+  const outputPath = path.join(tempRoot, "rewritten.json")
+  const assetMapPath = path.join(tempRoot, "asset-map.json")
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      version: "0.40.0",
+      notes: "[English](https://github.com/shiwenwen/hope-agent/blob/v0.40.0/docs/release-notes/v0.40.0.en.md)",
+      platforms: { "windows-x86_64": { url: platformUrl, signature: "signed" } },
+      bare_binary: {
+        platforms: {
+          "linux-x86_64": {
+            url: "https://github.com/shiwenwen/hope-agent/releases/download/v0.40.0/hope-agent-0.40.0-linux-x86_64.tar.gz",
+            signature: "signed",
+          },
+        },
+      },
+    }),
+  )
+  writeFileSync(assetMapPath, JSON.stringify(assetMap))
+  const script = fileURLToPath(new URL("../rewrite-manifest-for-mirror.mjs", import.meta.url))
+  const result = spawnSync(process.execPath, [script, manifestPath, "v0.40.0", "https://repo.hopeagent.ai", `--asset-map=${assetMapPath}`, `--out=${outputPath}`], { encoding: "utf8" })
+  return { tempRoot, outputPath, result }
+}
+
+test("mirror manifest resolves tauri-action v1 asset API URLs through the release map", () => {
+  const apiUrl = "https://api.github.com/repos/shiwenwen/hope-agent/releases/assets/540118898"
+  const run = runManifestRewrite({
+    platformUrl: apiUrl,
+    assetMap: { [apiUrl]: "Hope.Agent_0.40.0_x64-setup.exe" },
+  })
+  try {
+    assert.equal(run.result.status, 0, run.result.stderr)
+    const rewritten = JSON.parse(readFileSync(run.outputPath, "utf8"))
+    assert.equal(rewritten.platforms["windows-x86_64"].url, "https://repo.hopeagent.ai/download/v0.40.0/Hope.Agent_0.40.0_x64-setup.exe")
+    assert.equal(rewritten.bare_binary.platforms["linux-x86_64"].url, "https://repo.hopeagent.ai/download/v0.40.0/hope-agent-0.40.0-linux-x86_64.tar.gz")
+    assert.match(rewritten.notes, /repo\.hopeagent\.ai\/download\/v0\.40\.0\/docs\/release-notes/)
+  } finally {
+    rmSync(run.tempRoot, { recursive: true, force: true })
+  }
+})
+
+test("mirror manifest rejects unmapped asset API URLs", () => {
+  const run = runManifestRewrite({
+    platformUrl: "https://api.github.com/repos/shiwenwen/hope-agent/releases/assets/540118898",
+    assetMap: {},
+  })
+  try {
+    assert.equal(run.result.status, 1)
+    assert.match(run.result.stderr, /absent from the release asset map/)
+  } finally {
+    rmSync(run.tempRoot, { recursive: true, force: true })
+  }
+})
+
+test("mirror manifest rejects unsafe filenames in the asset map", () => {
+  const apiUrl = "https://api.github.com/repos/shiwenwen/hope-agent/releases/assets/540118898"
+  const run = runManifestRewrite({ platformUrl: apiUrl, assetMap: { [apiUrl]: "../latest.json" } })
+  try {
+    assert.equal(run.result.status, 1)
+    assert.match(run.result.stderr, /unsafe asset-map entry/)
+  } finally {
+    rmSync(run.tempRoot, { recursive: true, force: true })
   }
 })

--- a/scripts/rewrite-manifest-for-mirror.mjs
+++ b/scripts/rewrite-manifest-for-mirror.mjs
@@ -5,7 +5,8 @@
 // the two GitHub doc links inside `notes` at the mirrored copies.
 //
 // Usage:
-//   node scripts/rewrite-manifest-for-mirror.mjs <latest.json> <tag> <public-base> [--out=<path>]
+//   node scripts/rewrite-manifest-for-mirror.mjs <latest.json> <tag> <public-base> \
+//     [--asset-map=<path>] [--out=<path>]
 //
 // Example:
 //   node scripts/rewrite-manifest-for-mirror.mjs manifest/latest.json v0.26.0 \
@@ -36,7 +37,7 @@ import fs from "node:fs";
 
 function usage() {
   console.error(
-    "Usage: node scripts/rewrite-manifest-for-mirror.mjs <latest.json> <tag> <public-base> [--out=<path>]",
+    "Usage: node scripts/rewrite-manifest-for-mirror.mjs <latest.json> <tag> <public-base> [--asset-map=<path>] [--out=<path>]",
   );
   process.exit(2);
 }
@@ -44,6 +45,7 @@ function usage() {
 const argv = process.argv.slice(2);
 const outFlag = argv.find((a) => a.startsWith("--out="));
 const docsOutFlag = argv.find((a) => a.startsWith("--docs-out="));
+const assetMapFlag = argv.find((a) => a.startsWith("--asset-map="));
 const [manifestPath, tagRaw, publicBaseRaw] = argv.filter(
   (a) => !a.startsWith("--"),
 );
@@ -67,6 +69,37 @@ const mirrorBase = `${publicBase}/download/${tag}`;
 const RELEASE_ASSET_RE = new RegExp(
   `^https://github\\.com/shiwenwen/hope-agent/releases/download/${tag.replace(/\./g, "\\.")}/(.+)$`,
 );
+const RELEASE_ASSET_API_RE = /^https:\/\/api\.github\.com\/repos\/shiwenwen\/hope-agent\/releases\/assets\/\d+$/;
+
+// tauri-action v1 emits authenticated GitHub asset API URLs instead of the
+// browser download URLs used by v0.x. The numeric asset URL does not contain
+// a filename, so the release workflow supplies an offline map derived from
+// the GitHub Release for this exact tag. The map is data, not authority: only
+// the expected repository's numeric asset URLs and single-segment filenames
+// are accepted.
+const assetApiMap = new Map();
+if (assetMapFlag) {
+  const assetMapPath = assetMapFlag.slice("--asset-map=".length);
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(assetMapPath, "utf8"));
+  } catch (error) {
+    console.error(`[rewrite-manifest] cannot read asset map ${assetMapPath}: ${error.message}`);
+    process.exit(1);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    console.error("[rewrite-manifest] asset map must be a JSON object of API URL to asset name.");
+    process.exit(1);
+  }
+  for (const [url, name] of Object.entries(parsed)) {
+    const unsafeName = typeof name !== "string" || name.length === 0 || name === "." || name === ".." || name.includes("/") || name.includes("\\") || /[\u0000-\u001f\u007f]/.test(name);
+    if (!RELEASE_ASSET_API_RE.test(url) || unsafeName) {
+      console.error(`[rewrite-manifest] unsafe asset-map entry: ${JSON.stringify(url)} -> ${JSON.stringify(name)}`);
+      process.exit(1);
+    }
+    assetApiMap.set(url, name);
+  }
+}
 
 const problems = [];
 const rewrites = [];
@@ -78,12 +111,22 @@ const mirroredDocs = new Set();
 
 function rewriteAssetUrl(where, url) {
   const m = RELEASE_ASSET_RE.exec(url);
-  if (!m) {
+  let assetPath;
+  if (m) {
+    assetPath = m[1];
+  } else if (RELEASE_ASSET_API_RE.test(url)) {
+    const assetName = assetApiMap.get(url);
+    if (!assetName) {
+      problems.push(`${where}: asset API URL is absent from the release asset map — ${url}`);
+      return url;
+    }
+    assetPath = encodeURIComponent(assetName);
+  } else {
     problems.push(`${where}: not a v${version} release asset URL — ${url}`);
     return url;
   }
-  const next = `${mirrorBase}/${m[1]}`;
-  rewrites.push(`${where}: ${m[1]}`);
+  const next = `${mirrorBase}/${assetPath}`;
+  rewrites.push(`${where}: ${assetPath}`);
   return next;
 }
 
@@ -155,12 +198,16 @@ if (problems.length) {
   process.exit(1);
 }
 
-const remaining = JSON.stringify(manifest).match(
+const serializedManifest = JSON.stringify(manifest);
+const remaining = serializedManifest.match(
   /https:\/\/github\.com\/shiwenwen\/hope-agent\/releases\/download\//g,
 );
-if (remaining) {
+const remainingApi = serializedManifest.match(
+  /https:\/\/api\.github\.com\/repos\/shiwenwen\/hope-agent\/releases\/assets\//g,
+);
+if (remaining || remainingApi) {
   console.error(
-    `[rewrite-manifest] ${remaining.length} GitHub release-download URL(s) survived the rewrite — the mirror manifest must not send anyone back to github.com for bytes.`,
+    `[rewrite-manifest] ${(remaining?.length ?? 0) + (remainingApi?.length ?? 0)} GitHub asset URL(s) survived the rewrite — the mirror manifest must not send anyone back to GitHub for bytes.`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

- map tauri-action v1 numeric GitHub asset API URLs to exact release filenames before rewriting the updater manifest
- fail closed on unmapped API URLs, unexpected repositories, and unsafe asset names
- add regression coverage and pass the tag-scoped mapping into the R2 workflow

## Validation

- pre-push gate: all checks passed
- real v0.40.0 manifest replay: 16 asset URLs and 2 notes links rewritten to repo.hopeagent.ai
- regression tests: valid API URL mapping plus unmapped/unsafe fail-closed cases

## Release recovery

After merge, rerun `mirror-release-r2.yml` from `main` with `tag=v0.40.0`.