### PR TITLE
🦭 feat(provider): 支持 DeepSeek V4 视觉模型

### DIFF
--- a/crates/ha-dash/src/dashboard/cost.rs
+++ b/crates/ha-dash/src/dashboard/cost.rs
@@ -171,10 +171,11 @@ pub(super) fn estimate_cost(model_id: &str, input_tokens: u64, output_tokens: u6
         m if m.contains("mistral-medium-3-5") => (1.5, 7.5),
         m if m.contains("mistral-medium") => (0.4, 2.0),
         m if m.contains("mistral-small") => (0.15, 0.6),
-        // DeepSeek. `deepseek-chat` / `-reasoner` now alias the V4 tier.
-        m if m.contains("deepseek-v4-pro") || m.contains("DeepSeek-V4-Pro") => (0.435, 0.87),
-        m if m.contains("deepseek-v4-flash") || m.contains("DeepSeek-V4-Flash") => (0.14, 0.28),
-        m if m.contains("deepseek-chat") || m.contains("deepseek-reasoner") => (0.14, 0.28),
+        // DeepSeek. `deepseek-chat` / `-reasoner` now alias the V4 Flash tier.
+        // 2026-08-16 起采用峰谷定价；估算表只能记录一组费率，因此按高峰价保守入账。
+        m if m.contains("deepseek-v4-pro") || m.contains("DeepSeek-V4-Pro") => (1.32, 3.96),
+        m if m.contains("deepseek-v4-flash") || m.contains("DeepSeek-V4-Flash") => (0.44, 1.32),
+        m if m.contains("deepseek-chat") || m.contains("deepseek-reasoner") => (0.44, 1.32),
         m if m.contains("DeepSeek-R1") || m.contains("deepseek-r1") => (0.55, 2.19),
         m if m.contains("deepseek") || m.contains("DeepSeek") => (0.27, 1.1),
         // Qwen。价目源是阿里国内站人民币价（qwen provider 模板同源、标 CNY），表侧
@@ -615,10 +616,11 @@ mod tests {
     /// 这几项对应 templates/*.ts 里直连厂商的价格，改模板时一并改这里。
     #[test]
     fn estimator_matches_direct_provider_template_prices() {
-        assert_eq!(prices("deepseek-reasoner"), (0.14, 0.28));
-        assert_eq!(prices("deepseek-chat"), (0.14, 0.28));
-        assert_eq!(prices("deepseek-v4-pro"), (0.435, 0.87));
-        assert_eq!(prices("deepseek-v4-flash"), (0.14, 0.28));
+        assert_eq!(prices("deepseek-reasoner"), (0.44, 1.32));
+        assert_eq!(prices("deepseek-chat"), (0.44, 1.32));
+        assert_eq!(prices("deepseek-v4-pro"), (1.32, 3.96));
+        assert_eq!(prices("deepseek-v4-flash"), (0.44, 1.32));
+        assert_eq!(prices("deepseek-v4-flash-vision-exp"), (0.44, 1.32));
         assert_eq!(prices("mistral-small-latest"), (0.15, 0.6));
         assert_eq!(prices("mistral-small-2603"), (0.15, 0.6));
         assert_eq!(prices("hy3"), (1.0 / CNY_PER_USD, 4.0 / CNY_PER_USD));

--- a/docs/architecture/infra/dashboard.md
+++ b/docs/architecture/infra/dashboard.md
@@ -279,7 +279,8 @@ flowchart TD
 | | `gemini-3.5-flash` | 0.15 | 0.60 |
 | xAI | `grok-4.6` / `grok-4.5` | 2.00 | 6.00 |
 | | `grok-4` | 3.00 | 15.00 |
-| DeepSeek | `deepseek-chat` / `-reasoner` | 0.14 | 0.28 |
+| DeepSeek（按高峰价保守估算） | `deepseek-v4-flash` / `-vision-exp` / `deepseek-chat` / `-reasoner` | 0.44 | 1.32 |
+| | `deepseek-v4-pro` | 1.32 | 3.96 |
 | Qwen（CNY 换算） | `qwen3.8-max` | ¥12 / CNY_PER_USD | ¥36 / CNY_PER_USD |
 | | `qwen-max` / `qwen3-max` | ¥2.4 / CNY_PER_USD | ¥9.6 / CNY_PER_USD |
 | 豆包方舟（CNY 换算） | `doubao-seed-2-1-pro` / `-evolving` | ¥6 / CNY_PER_USD | ¥30 / CNY_PER_USD |

--- a/src/components/settings/provider-setup/templates/international.ts
+++ b/src/components/settings/provider-setup/templates/international.ts
@@ -519,6 +519,8 @@ export const internationalTemplates: ProviderTemplate[] = [
     apiKeyPlaceholder: "sk-...",
     requiresApiKey: true,
     models: [
+      // DeepSeek 自 2026-08-16 起采用峰谷定价；模型配置只能记录一组费率，
+      // 因此按高峰价保守估算，避免 Dashboard 在高峰时段低报成本。
       {
         id: "deepseek-v4-flash",
         name: "DeepSeek V4 Flash",
@@ -526,8 +528,8 @@ export const internationalTemplates: ProviderTemplate[] = [
         contextWindow: 1000000,
         maxTokens: 384000,
         reasoning: true,
-        costInput: 0.14,
-        costOutput: 0.28,
+        costInput: 0.44,
+        costOutput: 1.32,
       },
       {
         id: "deepseek-v4-pro",
@@ -536,8 +538,18 @@ export const internationalTemplates: ProviderTemplate[] = [
         contextWindow: 1000000,
         maxTokens: 384000,
         reasoning: true,
-        costInput: 0.435,
-        costOutput: 0.87,
+        costInput: 1.32,
+        costOutput: 3.96,
+      },
+      {
+        id: "deepseek-v4-flash-vision-exp",
+        name: "DeepSeek V4 Flash Vision Exp",
+        inputTypes: ["text", "image"],
+        contextWindow: 1000000,
+        maxTokens: 384000,
+        reasoning: true,
+        costInput: 0.44,
+        costOutput: 1.32,
       },
     ],
   },

--- a/src/components/settings/provider-setup/templates/templateHygiene.test.ts
+++ b/src/components/settings/provider-setup/templates/templateHygiene.test.ts
@@ -41,6 +41,26 @@ describe("provider template lifecycle hygiene", () => {
     })
   })
 
+  it("advertises only the DeepSeek vision model as image-capable", () => {
+    const provider = PROVIDER_TEMPLATES.find((template) => template.key === "deepseek")
+    expect(
+      provider?.models.find((model) => model.id === "deepseek-v4-flash-vision-exp"),
+    ).toMatchObject({
+      inputTypes: ["text", "image"],
+      contextWindow: 1_000_000,
+      maxTokens: 384_000,
+      reasoning: true,
+      costInput: 0.44,
+      costOutput: 1.32,
+    })
+    expect(provider?.models.find((model) => model.id === "deepseek-v4-flash")?.inputTypes).toEqual([
+      "text",
+    ])
+    expect(provider?.models.find((model) => model.id === "deepseek-v4-pro")?.inputTypes).toEqual([
+      "text",
+    ])
+  })
+
   it("does not offer retired direct model IDs to newly configured providers", () => {
     const templateIds = new Set(PROVIDER_TEMPLATES.flatMap((provider) => provider.models.map((m) => m.id)))
     for (const retired of RETIRED_DIRECT_MODEL_IDS) {


### PR DESCRIPTION
## 概要

- 在 DeepSeek 直连模板中加入 `deepseek-v4-flash-vision-exp`
- 声明文本与图片输入能力，复用现有 OpenAI Chat 视觉链路
- 按 DeepSeek 当前峰谷定价的高峰费率保守估算成本，避免 Dashboard 低报
- 同步 DeepSeek V4 Flash / Pro 的模板价格、后端估算表和架构文档
- 增加模型能力与价格契约测试

## 官方依据

- [DeepSeek Vision](https://api-docs.deepseek.com/guides/vision/)
- [DeepSeek Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing/)

## 验证

本地 pre-push 全套门禁通过：

- `cargo fmt --all --check`
- 全目标 `cargo clippy`
- `pnpm typecheck`
- `pnpm lint`（仅存量 warning，无 error）
- `pnpm test`：283 个文件、1632 项通过
- 全部 required Rust crate 测试与文档测试通过
- 供应链、crate 分层、agent-kernel 边界等守卫通过