### PR TITLE
release: v0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.0] - 2026-09-05
+
+### Changed
+
+- **中英文使用说明与当前功能保持一致**：补充 DeepSeek 图片理解、网页稳定快照、跨对话跳转、侧聊、IM 原生流式回复、Hook 工作区授权与工具链诊断等说明，并更正普通长工具输出在压缩后可恢复全文的旧表述。 (#699)
+
 ## [0.42.0] - 2026-09-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "ha-acp"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3096,7 +3096,7 @@ dependencies = [
 
 [[package]]
 name = "ha-agent-loop"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "ha-agent-runtime"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "ha-base"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "ha-browser"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "ha-browser-host"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "dirs 6.0.0",
@@ -3199,7 +3199,7 @@ dependencies = [
 
 [[package]]
 name = "ha-channel"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "ha-config-schema"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "ha-core"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -3340,7 +3340,7 @@ dependencies = [
 
 [[package]]
 name = "ha-cron"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3357,7 +3357,7 @@ dependencies = [
 
 [[package]]
 name = "ha-dash"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3376,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "ha-design"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3419,7 +3419,7 @@ dependencies = [
 
 [[package]]
 name = "ha-eval"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "ha-eval-runtime"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3498,7 +3498,7 @@ dependencies = [
 
 [[package]]
 name = "ha-goal"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3512,7 +3512,7 @@ dependencies = [
 
 [[package]]
 name = "ha-improve"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "ha-knowledge"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "ha-local-llm"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "ha-mac"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "ha-mcp"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "ha-media"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "ha-memory"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "ha-pet"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "ha-server"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3760,7 +3760,7 @@ dependencies = [
 
 [[package]]
 name = "ha-skills"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3781,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "ha-updater"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "ha-vcs"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "ha-weather"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "ha-base",
@@ -3845,7 +3845,7 @@ dependencies = [
 
 [[package]]
 name = "ha-workflow"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -3963,7 +3963,7 @@ checksum = "b0b3ba31f6dc772cc8221ce81dbbbd64fa1e668255a6737d95eeace59b5a8823"
 
 [[package]]
 name = "hope-agent"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/crates/ha-acp/Cargo.toml
+++ b/crates/ha-acp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-acp"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent ACP feature — ACP stdio server mode + external agent control plane (acp_spawn)"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-agent-loop/Cargo.toml
+++ b/crates/ha-agent-loop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-agent-loop"
-version = "0.42.0"
+version = "0.43.0"
 description = "Provider-neutral agent loop state machine for Hope Agent. Zero Hope crate dependencies."
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-agent-runtime/Cargo.toml
+++ b/crates/ha-agent-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-agent-runtime"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent main-turn runtime adapter"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-base/Cargo.toml
+++ b/crates/ha-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-base"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent foundation layer — paths, logging, platform primitives, security guards. Zero business logic, zero Tauri dependency."
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-browser-host/Cargo.toml
+++ b/crates/ha-browser-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-browser-host"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent Chrome Native Messaging host"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-browser/Cargo.toml
+++ b/crates/ha-browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-browser"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent browser feature — Chrome extension backend, CDP backend, broker, browser tool"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-channel/Cargo.toml
+++ b/crates/ha-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-channel"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent IM channel feature — 12 chat platform plugins, inbound worker pipeline, Feishu business tools"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-config-schema/Cargo.toml
+++ b/crates/ha-config-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-config-schema"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent config wire types — AppConfig and its full transitive type closure. Pure data definitions, no business logic."
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-core/Cargo.toml
+++ b/crates/ha-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-core"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent core business logic — zero Tauri dependency"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-cron/Cargo.toml
+++ b/crates/ha-cron/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-cron"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent scheduling feature — cron scheduler, executor, delivery and manage_cron tool"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-dash/Cargo.toml
+++ b/crates/ha-dash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-dash"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent dashboard feature — usage insights, control-plane aggregates, /recap reports"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-design/Cargo.toml
+++ b/crates/ha-design/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-design"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent design space feature — artifacts store, compile/export pipeline, design/canvas/artifact tools"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-eval-runtime/Cargo.toml
+++ b/crates/ha-eval-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-eval-runtime"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent evaluation runtime — coding eval fixture runner, evaluation orchestration store, context retrieval ranking"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-eval/Cargo.toml
+++ b/crates/ha-eval/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-eval"
-version = "0.42.0"
+version = "0.43.0"
 description = "Standalone deterministic capability evaluation runner for Hope Agent"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-goal/Cargo.toml
+++ b/crates/ha-goal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-goal"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent Goal execution machine"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-improve/Cargo.toml
+++ b/crates/ha-improve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-improve"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent learning-loop feature — coding improvement proposals, domain eval fixtures and domain quality gates"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-knowledge/Cargo.toml
+++ b/crates/ha-knowledge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-knowledge"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent knowledge space feature — index.db note cache, parser/compiler, retrieval, embedding, Layer-2 maintenance, note tools"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-local-llm/Cargo.toml
+++ b/crates/ha-local-llm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-local-llm"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent local model feature — Ollama lifecycle, model catalog, hardware budget, embedding backend"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-mac/Cargo.toml
+++ b/crates/ha-mac/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-mac"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent macOS control feature — Accessibility / screenshot / focus + mac_control tool"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-mcp/Cargo.toml
+++ b/crates/ha-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-mcp"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent MCP client feature — McpManager registry, transports, OAuth, watchdog, mcp_resource/mcp_prompt tools"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-media/Cargo.toml
+++ b/crates/ha-media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-media"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent media feature — image/audio generation adapters, STT provider engines, image_generate/audio_generate tools"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-memory/Cargo.toml
+++ b/crates/ha-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-memory"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent memory execution machines"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-pet/Cargo.toml
+++ b/crates/ha-pet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-pet"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent desktop pet feature — sprite package store, import/creator, activity projection"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-server/Cargo.toml
+++ b/crates/ha-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-server"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent HTTP/WebSocket server"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-skills/Cargo.toml
+++ b/crates/ha-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-skills"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent skill machinery — bundled-skill extraction, SKILL.md discovery/parsing, authoring, auto-review pipeline, @skill mentions, fork dispatch, the `skill` tool"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-updater/Cargo.toml
+++ b/crates/ha-updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-updater"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent self-update — manifest check, signed download, atomic binary swap, app_update tool"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-vcs/Cargo.toml
+++ b/crates/ha-vcs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-vcs"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent VCS & local-exec feature — git control plane operations, Docker/WSL sandbox machinery, SearxNG Docker deploy"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-weather/Cargo.toml
+++ b/crates/ha-weather/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-weather"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent weather feature — Open-Meteo fetch/cache, get_weather tool, prompt section"
 license.workspace = true
 authors.workspace = true

--- a/crates/ha-workflow/Cargo.toml
+++ b/crates/ha-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ha-workflow"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent Workflow parsing and execution machines"
 license.workspace = true
 authors.workspace = true

--- a/docs/release-notes/v0.43.0.en.md
+++ b/docs/release-notes/v0.43.0.en.md
@@ -1,0 +1,11 @@
+# Hope Agent 0.43.0 — Documentation updates and corrections
+
+> [简体中文](https://github.com/shiwenwen/hope-agent/blob/v0.43.0/docs/release-notes/v0.43.0.md) · **English**
+
+> Released: 2026-09-05
+
+> See [the changelog](https://github.com/shiwenwen/hope-agent/blob/v0.43.0/CHANGELOG.md#0430---2026-09-05) for the full list.
+
+This update changes documentation only; application behavior is unchanged. The English and Chinese user guides now cover existing DeepSeek image understanding, stable web snapshots, cross-session navigation, side chats, native IM streaming, Hook workspace authorization, and Toolchain Doctor behavior.
+
+It also corrects an earlier statement: ordinary long tool output cannot be fully recovered after compaction. If the tool provides a continuation cursor, you can keep reading through that cursor; otherwise, rerun the tool. Existing settings and data need no attention.

--- a/docs/release-notes/v0.43.0.md
+++ b/docs/release-notes/v0.43.0.md
@@ -1,0 +1,11 @@
+# Hope Agent 0.43.0 — 使用说明补全与更正
+
+> **简体中文** · [English](https://github.com/shiwenwen/hope-agent/blob/v0.43.0/docs/release-notes/v0.43.0.en.md)
+
+> 发布日期：2026-09-05
+
+> 完整变更见 [更新日志](https://github.com/shiwenwen/hope-agent/blob/v0.43.0/CHANGELOG.md#0430---2026-09-05)。
+
+本次更新只调整文档，不改变应用行为。中英文使用手册现已补齐 DeepSeek 图片理解、网页稳定快照、跨对话跳转、侧聊、IM 原生流式回复、Hook 工作区授权与工具链诊断等现有能力的说明。
+
+同时更正一项旧说明：普通长工具输出被压缩后不能恢复全文；如果工具本身提供可续读游标，可以继续读取，否则需要重新运行。现有设置与数据无需处理。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hope-agent",
   "private": true,
-  "version": "0.42.0",
+  "version": "0.43.0",
   "license": "MIT",
   "author": "shiwenwen",
   "homepage": "https://github.com/shiwenwen/hope-agent",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hope-agent"
-version = "0.42.0"
+version = "0.43.0"
 description = "Hope Agent - Personal AI Assistant with deep system integration"
 license.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hope Agent",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "identifier": "ai.hopeagent.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- publish the documentation synchronization merged in #699 as the next minor release
- add bilingual v0.43.0 release notes and CHANGELOG entry
- synchronize all product version sources to 0.43.0 via `pnpm version 0.43.0 --no-git-tag-version`

## Validation

- full `.husky/pre-push` gate passed
- `RELEASE_TAG=v0.43.0 node scripts/verify-release-version.mjs`
- `node scripts/sync-i18n.mjs --check`
- `node scripts/check-docs-parity.mjs`
- `node scripts/verify-updater-endpoints.mjs`
- `node scripts/check-release-paths.mjs`

Release notes: `docs/release-notes/v0.43.0.md`