### PR TITLE
chore: remove verified dead code

### DIFF
--- a/crates/ha-core/src/context_compact/estimation.rs
+++ b/crates/ha-core/src/context_compact/estimation.rs
@@ -457,26 +457,6 @@ pub(crate) fn is_user_message(msg: &Value) -> bool {
     !is_tool_result(msg)
 }
 
-/// Check if a tool name matches any pattern in the deny list.
-#[allow(dead_code)]
-pub(super) fn is_tool_denied(tool_name: &str, deny_list: &[String]) -> bool {
-    let lower = tool_name.to_lowercase();
-    deny_list.iter().any(|pattern| {
-        let p = pattern.to_lowercase();
-        if p.contains('*') {
-            // Simple glob: "memory_*" matches "memory_search"
-            let parts: Vec<&str> = p.split('*').collect();
-            if parts.len() == 2 {
-                lower.starts_with(parts[0]) && lower.ends_with(parts[1])
-            } else {
-                lower == p
-            }
-        } else {
-            lower == p
-        }
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
删除上下文压缩模块中没有调用方的内部工具名拒绝匹配函数，消除长期被告警抑制掩盖的冗余代码。运行行为不变。

## 死代码证据

- 基线：`c0bf9a2dd7a447d9defc9c0b9ba4a077947eb8b6`；远端 main 核验时间：2026-09-07 01:00:50 UTC（北京时间 09:00:50）。使用准备程序返回的独立工作树和唯一 `codex/` 分支。
- 对所有受 Git 管理的源码、测试、评测、脚本、文档和配置检索 `is_tool_denied` / `isToolDenied`，仅命中函数定义；它是私有 `estimation` 模块里的 `pub(super)` 函数，未再导出，无宏注册、字符串入口、序列化或平台条件分支。
- 临时移除该函数的 `allow(dead_code)` 后，`cargo check -p ha-core --all-targets --locked` 在库和库测试目标均报告 `function is_tool_denied is never used`。确认后才删除函数。
- 现行工具禁用裁决由 `tools::dispatch::resolve_tool_fate` 负责；上下文压缩使用现行 `toolPolicies`，均未调用此函数。

## 删除范围与保留项

- 仅删除 `crates/ha-core/src/context_compact/estimation.rs` 的 `is_tool_denied`、注释及告警抑制，共 20 行。
- 保留有测试引用的 `compact_path`、公开接口、兼容入口、未来阶段占位、序列化字段与平台分支。没有修改用户配置、数据、版本、依赖、审批或安全策略。
- 本次未改变功能、命令、模块或架构契约，没有新增用户可见行为，因此不追加发布说明或架构红线。

## 验证

- 删除后 `cargo check -p ha-core --all-targets --all-features --locked`：通过，无警告；覆盖桌面与评测 feature 的编译。
- `pnpm typecheck`、依赖守卫（生产 / 测试边）、内核边界守卫、完整 diff 审查与 `git diff --check`：通过。
- 正常 pre-push 已通过格式、clippy、内部评测编译、前端 lint / typecheck、供应链与同步守卫、Vitest（285 文件 / 1,648 测试）。Rust 测试全部通过（73 个测试汇总，5,188 通过 / 5 忽略 / 0 失败），push 成功。
- 未预先运行全套测试，未使用跳过变量、`--no-verify`、自我批准或管理员绕过。

## 风险与回滚

风险低：删除项是无外部可见性的零调用内部函数；编译器与全仓引用检索相互印证。若后续出现遗漏，可通过受保护 PR 回滚本次 squash 提交恢复这 20 行；无需数据迁移。
